### PR TITLE
ci: add chart bundle size check and publish quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
         if: matrix.node-version == 22
         run: cd packages/core && pnpm test:crossval
 
-      - name: Bundle size check
+      - name: Bundle size check (core)
         if: matrix.node-version == 22
         run: cd packages/core && pnpm exec size-limit
+
+      - name: Bundle size check (chart)
+        if: matrix.node-version == 22
+        run: cd packages/chart && pnpm size-check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,9 +29,17 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - run: pnpm lint
+
       - run: pnpm build
 
       - run: pnpm test
+
+      - name: Bundle size check (core)
+        run: cd packages/core && pnpm exec size-limit
+
+      - name: Bundle size check (chart)
+        run: cd packages/chart && pnpm size-check
 
   publish-core:
     needs: build-and-test


### PR DESCRIPTION
## Summary
- Add `pnpm size-check` for chart package to CI workflow (Node 22 only, alongside existing core size-limit)
- Add `pnpm lint` + bundle size checks (core + chart) to publish workflow's pre-publish validation

Previously, only `packages/core` had bundle size enforcement in CI. Chart's `size-check` script existed but was never run in CI or before publishing.

## Test plan
- [x] CI workflow runs chart size-check on this PR
- [x] Publish workflow now gates on lint + size for both packages