### PR TITLE
fix(chart): resolve sub-pane label clipping and alignment (#48)

### DIFF
--- a/packages/chart/examples/indicator-showcase/index.html
+++ b/packages/chart/examples/indicator-showcase/index.html
@@ -76,6 +76,7 @@
         <span class="toolbar-spacer"></span>
         <button class="toolbar-btn" id="btn-type">Candle</button>
         <button class="toolbar-btn" id="btn-fit">Fit</button>
+        <button class="toolbar-btn" id="btn-export">Export PNG</button>
         <button class="toolbar-btn" id="btn-theme">Light</button>
       </div>
       <div class="main">

--- a/packages/chart/examples/indicator-showcase/src/main.ts
+++ b/packages/chart/examples/indicator-showcase/src/main.ts
@@ -115,6 +115,25 @@ fitBtn.addEventListener("click", () => {
   chart.fitContent();
 });
 
+// Export PNG button — demonstrates toImage() with pane titles composited
+const exportBtn = document.getElementById("btn-export") as HTMLElement;
+exportBtn.addEventListener("click", async () => {
+  try {
+    const blob = await chart.toImage("image/png");
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `chart-${Date.now()}.png`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  } catch (err) {
+    console.error("Export failed:", err);
+    alert(`Export failed: ${(err as Error).message}`);
+  }
+});
+
 // ============================================
 // Responsive sidebar toggle
 // ============================================

--- a/packages/chart/src/__tests__/react-wrapper.test.ts
+++ b/packages/chart/src/__tests__/react-wrapper.test.ts
@@ -14,7 +14,7 @@ describe("React TrendChart wrapper", () => {
   it("is a valid React forwardRef component", () => {
     expect(TrendChart).toBeDefined();
     // forwardRef components have $$typeof and render properties
-    expect((TrendChart as Record<string, unknown>).$$typeof).toBeDefined();
+    expect((TrendChart as unknown as Record<string, unknown>).$$typeof).toBeDefined();
   });
 
   it("accepts expected prop types (compile-time check)", () => {

--- a/packages/chart/src/core/i18n.ts
+++ b/packages/chart/src/core/i18n.ts
@@ -4,12 +4,14 @@
  */
 
 export type ChartLocale = {
-  // OHLCV labels
+  // OHLCV labels (short, used inline in the OHLCV overlay)
   open: string;
   high: string;
   low: string;
   close: string;
   volume: string;
+  // Full label for the volume pane title (longer form)
+  volumePaneTitle: string;
 
   // Month abbreviations (12)
   months: readonly string[];
@@ -40,6 +42,7 @@ export const DEFAULT_LOCALE: ChartLocale = {
   low: "L",
   close: "C",
   volume: "V",
+  volumePaneTitle: "Volume",
 
   months: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
 

--- a/packages/chart/src/presets.ts
+++ b/packages/chart/src/presets.ts
@@ -683,8 +683,8 @@ const TRENDCRAFT_RENDERERS: SeriesRendererPlugin[] = [
       const end = timeScale.endIndex;
       const bodyWidth = Math.max(1, timeScale.barSpacing * 0.6);
       const halfBody = bodyWidth / 2;
-      const upColor = theme?.candleUp ?? "#26a69a";
-      const downColor = theme?.candleDown ?? "#ef5350";
+      const upColor = theme?.upColor ?? "#26a69a";
+      const downColor = theme?.downColor ?? "#ef5350";
       ctx.save();
       ctx.globalAlpha = 0.5;
       for (let i = start; i < end && i < data.length; i++) {

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -42,6 +42,7 @@ import { ChartAria } from "./chart-aria";
 import { DrawingTool } from "./drawing-tool";
 import { InfoOverlay } from "./info-overlay";
 import { LegendOverlay } from "./legend-overlay";
+import { renderPaneTitles } from "./overlay-renderer";
 import { renderFrame } from "./render-pipeline";
 
 // ============================================
@@ -664,6 +665,12 @@ export class CanvasChart implements ChartInstance {
   async toImage(type = "image/png", quality = 1, timeoutMs = 0): Promise<Blob> {
     // Force a synchronous render
     this._render();
+
+    // Composite pane titles onto an offscreen canvas so the on-screen DOM
+    // InfoOverlay (which is not captured by toBlob) does not leave exports
+    // without sub-pane labels. The on-screen canvas is never mutated.
+    const exportCanvas = this._composeExportCanvas();
+
     return new Promise((resolve, reject) => {
       let settled = false;
       const timer =
@@ -676,7 +683,7 @@ export class CanvasChart implements ChartInstance {
             }, timeoutMs)
           : undefined;
 
-      this._canvas.toBlob(
+      exportCanvas.toBlob(
         (blob) => {
           if (settled) return;
           settled = true;
@@ -692,6 +699,32 @@ export class CanvasChart implements ChartInstance {
         quality,
       );
     });
+  }
+
+  /**
+   * Build an offscreen canvas containing the current frame plus Canvas-drawn
+   * pane titles. Used by toImage() to embed labels that are normally rendered
+   * via the DOM InfoOverlay and therefore excluded from toBlob captures.
+   */
+  private _composeExportCanvas(): HTMLCanvasElement {
+    const src = this._canvas;
+    const off = document.createElement("canvas");
+    off.width = src.width;
+    off.height = src.height;
+    const ctx = off.getContext("2d");
+    if (!ctx) return src;
+
+    ctx.drawImage(src, 0, 0);
+    ctx.setTransform(this._pixelRatio, 0, 0, this._pixelRatio, 0, 0);
+    renderPaneTitles(
+      ctx,
+      this._layout.paneRects,
+      this._data,
+      this._theme,
+      this._fontSize,
+      this._locale,
+    );
+    return off;
   }
 
   // ---- Public API: Lifecycle ----

--- a/packages/chart/src/renderer/info-overlay.ts
+++ b/packages/chart/src/renderer/info-overlay.ts
@@ -76,62 +76,63 @@ export class InfoOverlay {
     paneRects: readonly PaneRect[],
     seriesByPane: Map<string, InternalSeries[]>,
   ): void {
-    if (index === null || index < 0 || index >= candles.length) {
-      this._mainInfo.textContent = "";
-      for (const el of this._paneInfos.values()) el.textContent = "";
-      return;
-    }
+    const hasIndex = index !== null && index >= 0 && index < candles.length;
 
-    const candle = candles[index];
-    const isUp = candle.close >= candle.open;
-    const color = isUp ? this._theme.upColor : this._theme.downColor;
-    const fmtP = (n: number) => escapeHtml(this._priceFormatter(n));
-
-    // Main pane: OHLCV
-    const mainSeries = seriesByPane.get("main") ?? [];
-
-    // Try custom formatter first
-    let mainHtml: string | null = null;
+    // Main pane: OHLCV + indicators (only when crosshair is active)
+    let mainHtml = "";
     let mainCustom = false;
-    if (this._formatInfoOverlay) {
-      const seriesData = mainSeries.map((s) => ({
-        label: s.config.label ?? "",
-        color: s.config.color ?? this._theme.text,
-        value: s.data[index]?.value ?? null,
-      }));
-      mainHtml = this._formatInfoOverlay({ candle, index, paneId: "main", series: seriesData });
-      mainCustom = mainHtml !== null;
-    }
+    if (hasIndex) {
+      const i = index as number;
+      const candle = candles[i];
+      const isUp = candle.close >= candle.open;
+      const color = isUp ? this._theme.upColor : this._theme.downColor;
+      const fmtP = (n: number) => escapeHtml(this._priceFormatter(n));
+      const mainSeries = seriesByPane.get("main") ?? [];
 
-    if (mainHtml === null) {
-      const indicatorParts = mainSeries
-        .map((s) => this.formatSeriesValue(s, index))
-        .filter(Boolean);
-      const l = this._locale;
-      mainHtml = [
-        `<span style="color:${this._theme.textSecondary}">${escapeHtml(l.open)}</span> <span style="color:${color}">${fmtP(candle.open)}</span>`,
-        `<span style="color:${this._theme.textSecondary}">${escapeHtml(l.high)}</span> <span style="color:${color}">${fmtP(candle.high)}</span>`,
-        `<span style="color:${this._theme.textSecondary}">${escapeHtml(l.low)}</span> <span style="color:${color}">${fmtP(candle.low)}</span>`,
-        `<span style="color:${this._theme.textSecondary}">${escapeHtml(l.close)}</span> <span style="color:${color}">${fmtP(candle.close)}</span>`,
-        `<span style="color:${this._theme.textSecondary}">${escapeHtml(l.volume)}</span> <span style="color:${this._theme.text}">${fmtVol(candle.volume)}</span>`,
-        ...indicatorParts,
-      ].join("&nbsp;&nbsp;");
+      let customHtml: string | null = null;
+      if (this._formatInfoOverlay) {
+        const seriesData = mainSeries.map((s) => ({
+          label: s.config.label ?? "",
+          color: s.config.color ?? this._theme.text,
+          value: s.data[i]?.value ?? null,
+        }));
+        customHtml = this._formatInfoOverlay({
+          candle,
+          index: i,
+          paneId: "main",
+          series: seriesData,
+        });
+        mainCustom = customHtml !== null;
+      }
+
+      if (customHtml !== null) {
+        mainHtml = customHtml;
+      } else {
+        const indicatorParts = mainSeries.map((s) => this.formatSeriesValue(s, i)).filter(Boolean);
+        const l = this._locale;
+        mainHtml = [
+          `<span style="color:${this._theme.textSecondary}">${escapeHtml(l.open)}</span> <span style="color:${color}">${fmtP(candle.open)}</span>`,
+          `<span style="color:${this._theme.textSecondary}">${escapeHtml(l.high)}</span> <span style="color:${color}">${fmtP(candle.high)}</span>`,
+          `<span style="color:${this._theme.textSecondary}">${escapeHtml(l.low)}</span> <span style="color:${color}">${fmtP(candle.low)}</span>`,
+          `<span style="color:${this._theme.textSecondary}">${escapeHtml(l.close)}</span> <span style="color:${color}">${fmtP(candle.close)}</span>`,
+          `<span style="color:${this._theme.textSecondary}">${escapeHtml(l.volume)}</span> <span style="color:${this._theme.text}">${fmtVol(candle.volume)}</span>`,
+          ...indicatorParts,
+        ].join("&nbsp;&nbsp;");
+      }
     }
 
     if (mainHtml !== this._lastMainHtml) {
       if (mainCustom) {
-        // Custom formatter output is treated as plain text to prevent XSS
         this._mainInfo.textContent = mainHtml;
       } else {
-        // Internal builder produces pre-escaped HTML
         this._mainInfo.innerHTML = mainHtml;
       }
       this._lastMainHtml = mainHtml;
     }
 
-    // Sub panes: indicator values
+    // Sub panes (+ volume): always show labels; add values when crosshair is active
     for (const pane of paneRects) {
-      if (pane.id === "main" || pane.id === "volume") continue;
+      if (pane.id === "main") continue;
 
       let el = this._paneInfos.get(pane.id);
       if (!el) {
@@ -139,12 +140,15 @@ export class InfoOverlay {
         this._container.appendChild(el);
         this._paneInfos.set(pane.id, el);
       }
-      el.style.top = `${pane.y + 4}px`;
+      el.style.top = `${pane.y + 6}px`;
       el.style.left = "4px";
 
-      const paneSeries = seriesByPane.get(pane.id) ?? [];
-      const parts = paneSeries.map((s) => this.formatSeriesValue(s, index)).filter(Boolean);
-      const paneHtml = parts.join("&nbsp;&nbsp;");
+      const paneHtml = this.buildPaneHtml(
+        pane.id,
+        seriesByPane,
+        hasIndex ? (index as number) : null,
+        candles,
+      );
       if (paneHtml !== this._lastPaneHtml.get(pane.id)) {
         el.innerHTML = paneHtml;
         this._lastPaneHtml.set(pane.id, paneHtml);
@@ -156,8 +160,47 @@ export class InfoOverlay {
       if (!paneRects.some((p) => p.id === id)) {
         el.remove();
         this._paneInfos.delete(id);
+        this._lastPaneHtml.delete(id);
       }
     }
+  }
+
+  /**
+   * Build the HTML for a sub-pane label (and values when crosshair is active).
+   * Volume pane uses the localized "Volume" title; other panes join series labels.
+   */
+  private buildPaneHtml(
+    paneId: string,
+    seriesByPane: Map<string, InternalSeries[]>,
+    index: number | null,
+    candles: readonly CandleData[],
+  ): string {
+    if (paneId === "volume") {
+      const title = `<span style="color:${escapeHtml(this._theme.textSecondary)}">${escapeHtml(this._locale.volumePaneTitle)}</span>`;
+      if (index === null) return title;
+      const vol = candles[index]?.volume;
+      if (vol === undefined || vol === null) return title;
+      return `${title}&nbsp;&nbsp;<span style="color:${escapeHtml(this._theme.text)}">${escapeHtml(formatVolume(vol))}</span>`;
+    }
+
+    const paneSeries = seriesByPane.get(paneId) ?? [];
+    if (index === null) {
+      // Labels only
+      return paneSeries
+        .map((s) => {
+          const label = s.config.label;
+          if (!label) return "";
+          const color = escapeHtml(s.config.color ?? this._theme.text);
+          return `<span style="color:${color}">${escapeHtml(label)}</span>`;
+        })
+        .filter(Boolean)
+        .join("&nbsp;&nbsp;");
+    }
+    // Labels + values
+    return paneSeries
+      .map((s) => this.formatSeriesValue(s, index))
+      .filter(Boolean)
+      .join("&nbsp;&nbsp;");
   }
 
   private formatSeriesValue(s: InternalSeries, index: number): string {

--- a/packages/chart/src/renderer/overlay-renderer.ts
+++ b/packages/chart/src/renderer/overlay-renderer.ts
@@ -266,23 +266,33 @@ export function renderPaneTitles(
   fontSize: number,
   locale?: import("../core/i18n").ChartLocale,
 ): void {
-  ctx.fillStyle = theme.textSecondary;
   ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
   ctx.textAlign = "left";
   ctx.textBaseline = "top";
 
+  // Gap between adjacent labels, matching the DOM InfoOverlay which joins
+  // entries with two non-breaking spaces.
+  const GAP = 8;
+
   for (const pane of paneRects) {
     if (pane.id === "main") continue;
+    const y = pane.y + 6;
+
+    if (pane.id === "volume") {
+      ctx.fillStyle = theme.textSecondary;
+      ctx.fillText(locale?.volumePaneTitle ?? "Volume", 4, y);
+      continue;
+    }
+
+    // Render each series label in its own color, matching the DOM InfoOverlay.
     const paneSeries = dataLayer.getSeriesForPane(pane.id);
-    const title =
-      pane.id === "volume"
-        ? (locale?.volume ?? "Volume")
-        : paneSeries
-            .map((s) => s.config.label ?? "")
-            .filter(Boolean)
-            .join(", ");
-    if (title) {
-      ctx.fillText(title, 4, pane.y + 4);
+    let x = 4;
+    for (const s of paneSeries) {
+      const label = s.config.label;
+      if (!label) continue;
+      ctx.fillStyle = s.config.color ?? theme.text;
+      ctx.fillText(label, x, y);
+      x += ctx.measureText(label).width + GAP;
     }
   }
 }

--- a/packages/chart/src/renderer/render-pipeline.ts
+++ b/packages/chart/src/renderer/render-pipeline.ts
@@ -25,7 +25,6 @@ import {
 import { renderCrosshair } from "./crosshair-renderer";
 import { renderDrawings } from "./drawing-renderer";
 import {
-  renderPaneTitles,
   renderPriceLine,
   renderSignals,
   renderTimeframeOverlays,
@@ -415,8 +414,8 @@ export function renderFrame(rc: RenderContext): RenderResult {
     }
   }
 
-  // Pane titles
-  renderPaneTitles(ctx, paneRects, data, theme, rc.fontSize, rc.locale);
+  // Pane titles are rendered by InfoOverlay (DOM) to keep a single source of
+  // truth and avoid Canvas/DOM alignment drift.
 
   // Scrollbar
   if (layout.scrollbarHeight > 0) {


### PR DESCRIPTION
## Summary

Closes #48.

Sub-pane indicator labels (e.g. "RSI(14) 27.679") appeared clipped at the top edge of their panes. While investigating, I found that Canvas `renderPaneTitles` (always-on, label only) and DOM `InfoOverlay` (on hover, label + value) were both drawing at the same position, overlapping each other with a ~2px drift caused by Canvas `textBaseline=top` vs DOM `line-height:1.4`. This PR consolidates everything onto the DOM side.

### Key changes

- **Unified to DOM**: drop `renderPaneTitles` from the live render pipeline; `InfoOverlay` now renders pane labels at all times. No more hover-on/off position jump.
- **Volume pane handled by DOM**: shows a "Volume" title plus the volume value on hover. New locale key `volumePaneTitle` distinguishes the long form from the short `volume: "V"` used in the OHLCV overlay.
- **`toImage()` preserved**: since the DOM is not captured by `canvas.toBlob`, `toImage()` now composites labels onto an offscreen canvas before `toBlob`. The on-screen canvas is never mutated, and the exported labels use per-series colors so the image matches what's on screen.
- **Breathing room**: label Y offset bumped from `pane.y + 4` to `pane.y + 6`.

### Other fixes bundled

- `presets.ts`: Heikin-Ashi preset was referencing `theme.candleUp/candleDown`; correct fields are `upColor/downColor`. Existing build error resolved.
- `react-wrapper.test.ts`: forwardRef cast routed through `unknown` to appease TS2352.

### Indicator Showcase

Added an **Export PNG** button so `chart.toImage()` can be verified visually end-to-end.

## Test plan

- [x] `pnpm test` — 43 files / 451 assertions pass
- [x] `pnpm build` — clean
- [x] In Indicator Showcase, enable RSI / MACD / AO sub-panes and verify:
  - [x] Label top is no longer touching the pane edge
  - [x] No position jump when the crosshair moves on/off
  - [x] Volume pane shows "Volume" + value on hover
  - [x] Export PNG output contains the labels, with colors matching the on-screen view