### PR TITLE
test(chart): add React/Vue wrapper lifecycle tests

### DIFF
--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -75,8 +75,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "trendcraft": ">=0.1.0",
     "react": ">=18.0.0",
+    "trendcraft": ">=0.1.0",
     "vue": ">=3.3.0"
   },
   "peerDependenciesMeta": {
@@ -115,14 +115,17 @@
   "devDependencies": {
     "@size-limit/esbuild": "^12.0.1",
     "@size-limit/file": "^12.0.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
+    "@vue/test-utils": "^2.4.6",
+    "happy-dom": "^20.8.9",
     "react": "^19.2.4",
-    "vue": "^3.5.0",
     "size-limit": "^12.0.1",
     "trendcraft": "workspace:*",
     "vite": "^8.0.3",
     "vite-plugin-dts": "^4.3.0",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.2",
+    "vue": "^3.5.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/chart/react/TrendChart.tsx
+++ b/packages/chart/react/TrendChart.tsx
@@ -129,8 +129,18 @@ export const TrendChart = forwardRef<TrendChartRef, TrendChartProps>(function Tr
   const containerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<ChartInstance | null>(null);
 
-  // Expose chart instance via ref
-  useImperativeHandle(ref, () => ({ chart: chartRef.current }), []);
+  // Expose chart instance via ref — use a getter so the ref sees the live chart
+  // after the mount effect populates chartRef (useImperativeHandle with a static
+  // snapshot would capture `null` before the effect runs).
+  useImperativeHandle(
+    ref,
+    () => ({
+      get chart() {
+        return chartRef.current;
+      },
+    }),
+    [],
+  );
 
   // Init chart — intentionally empty deps: only create/destroy on mount/unmount
   // biome-ignore lint/correctness/useExhaustiveDependencies: chart recreation is expensive; prop changes handled by separate effects

--- a/packages/chart/src/__tests__/helpers/mock-chart-instance.ts
+++ b/packages/chart/src/__tests__/helpers/mock-chart-instance.ts
@@ -1,0 +1,102 @@
+import { vi } from "vitest";
+import type { ChartEvent, ChartInstance } from "../../core/types";
+
+export type MockChartInstance = ChartInstance & {
+  __state: {
+    destroyed: boolean;
+    eventHandlers: Map<ChartEvent, Set<(data: unknown) => void>>;
+    indicators: Set<ReturnType<ChartInstance["addIndicator"]>>;
+    drawingIds: Set<string>;
+    timeframeIds: Set<string>;
+    registeredPrimitives: Set<string>;
+    registeredRenderers: number;
+    setCandlesCalls: number;
+    fitContentCalls: number;
+    setThemeCalls: number;
+    destroyCalls: number;
+  };
+};
+
+export function createMockChartInstance(): MockChartInstance {
+  const state: MockChartInstance["__state"] = {
+    destroyed: false,
+    eventHandlers: new Map(),
+    indicators: new Set(),
+    drawingIds: new Set(),
+    timeframeIds: new Set(),
+    registeredPrimitives: new Set(),
+    registeredRenderers: 0,
+    setCandlesCalls: 0,
+    fitContentCalls: 0,
+    setThemeCalls: 0,
+    destroyCalls: 0,
+  };
+
+  const chart = {
+    __state: state,
+    setCandles: vi.fn(() => {
+      state.setCandlesCalls++;
+    }),
+    fitContent: vi.fn(() => {
+      state.fitContentCalls++;
+    }),
+    setTheme: vi.fn(() => {
+      state.setThemeCalls++;
+    }),
+    setChartType: vi.fn(),
+    setLayout: vi.fn(),
+    addIndicator: vi.fn((_data: unknown, _config?: unknown) => {
+      const handle = {
+        remove: vi.fn(() => {
+          state.indicators.delete(handle as never);
+        }),
+      };
+      state.indicators.add(handle as never);
+      return handle as never;
+    }),
+    addSignals: vi.fn(),
+    addTrades: vi.fn(),
+    addDrawing: vi.fn((d: { id: string }) => {
+      state.drawingIds.add(d.id);
+    }),
+    removeDrawing: vi.fn((id: string) => {
+      state.drawingIds.delete(id);
+    }),
+    addTimeframe: vi.fn((t: { id: string }) => {
+      state.timeframeIds.add(t.id);
+    }),
+    removeTimeframe: vi.fn((id: string) => {
+      state.timeframeIds.delete(id);
+    }),
+    addBacktest: vi.fn(),
+    addPatterns: vi.fn(),
+    addScores: vi.fn(),
+    registerRenderer: vi.fn(() => {
+      state.registeredRenderers++;
+    }),
+    registerPrimitive: vi.fn((p: { name: string }) => {
+      state.registeredPrimitives.add(p.name);
+    }),
+    removePrimitive: vi.fn((name: string) => {
+      state.registeredPrimitives.delete(name);
+    }),
+    on: vi.fn((event: ChartEvent, handler: (data: unknown) => void) => {
+      let set = state.eventHandlers.get(event);
+      if (!set) {
+        set = new Set();
+        state.eventHandlers.set(event, set);
+      }
+      set.add(handler);
+    }),
+    off: vi.fn((event: ChartEvent, handler: (data: unknown) => void) => {
+      state.eventHandlers.get(event)?.delete(handler);
+    }),
+    destroy: vi.fn(() => {
+      state.destroyCalls++;
+      state.destroyed = true;
+      state.eventHandlers.clear();
+    }),
+  } as unknown as MockChartInstance;
+
+  return chart;
+}

--- a/packages/chart/src/__tests__/react-wrapper-lifecycle.test.tsx
+++ b/packages/chart/src/__tests__/react-wrapper-lifecycle.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment happy-dom
+/**
+ * React TrendChart — lifecycle tests.
+ *
+ * Verifies mount / update / unmount behavior against a mocked ChartInstance:
+ * - createChart is called once on mount, destroy on unmount
+ * - Prop updates propagate via dedicated chart methods
+ * - Event handlers are (un)registered without duplicates
+ * - Indicator handles / drawings / timeframes / primitives are released on update and unmount
+ */
+
+import { act, cleanup, render } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type MockChartInstance, createMockChartInstance } from "./helpers/mock-chart-instance";
+
+const { createChartMock } = vi.hoisted(() => ({
+  createChartMock: vi.fn(),
+}));
+
+vi.mock("../index", () => ({
+  createChart: createChartMock,
+}));
+
+import { TrendChart, type TrendChartRef } from "../../react/TrendChart";
+
+let currentMock: MockChartInstance;
+
+const sampleCandles = [
+  { time: 1, open: 10, high: 12, low: 9, close: 11, volume: 100 },
+  { time: 2, open: 11, high: 13, low: 10, close: 12, volume: 200 },
+];
+
+beforeEach(() => {
+  currentMock = createMockChartInstance();
+  createChartMock.mockReset();
+  createChartMock.mockImplementation(() => currentMock);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("React TrendChart lifecycle", () => {
+  it("calls createChart once on mount and destroy on unmount", () => {
+    const { unmount } = render(<TrendChart candles={sampleCandles} />);
+    expect(createChartMock).toHaveBeenCalledTimes(1);
+    expect(currentMock.__state.destroyCalls).toBe(0);
+
+    unmount();
+    expect(currentMock.__state.destroyCalls).toBe(1);
+    expect(currentMock.__state.destroyed).toBe(true);
+  });
+
+  it("exposes ChartInstance via imperative ref", () => {
+    const ref = createRef<TrendChartRef>();
+    render(<TrendChart ref={ref} candles={sampleCandles} />);
+    expect(ref.current?.chart).toBe(currentMock);
+  });
+
+  it("propagates candles prop updates to setCandles and fitContent", () => {
+    const { rerender } = render(<TrendChart candles={sampleCandles} />);
+    expect(currentMock.__state.setCandlesCalls).toBe(1);
+    expect(currentMock.__state.fitContentCalls).toBe(1);
+
+    const next = [
+      ...sampleCandles,
+      { time: 3, open: 12, high: 14, low: 11, close: 13, volume: 300 },
+    ];
+    rerender(<TrendChart candles={next} />);
+    expect(currentMock.__state.setCandlesCalls).toBe(2);
+    expect(currentMock.__state.fitContentCalls).toBe(2);
+  });
+
+  it("honors fitOnLoad=false", () => {
+    render(<TrendChart candles={sampleCandles} fitOnLoad={false} />);
+    expect(currentMock.__state.setCandlesCalls).toBe(1);
+    expect(currentMock.__state.fitContentCalls).toBe(0);
+  });
+
+  it("applies theme and chart type changes via dedicated setters", () => {
+    const { rerender } = render(<TrendChart candles={sampleCandles} theme="dark" />);
+    const themeBefore = currentMock.__state.setThemeCalls;
+    rerender(<TrendChart candles={sampleCandles} theme="light" />);
+    expect(currentMock.__state.setThemeCalls).toBeGreaterThan(themeBefore);
+
+    rerender(<TrendChart candles={sampleCandles} theme="light" chartType="line" />);
+    expect(currentMock.setChartType).toHaveBeenCalledWith("line");
+  });
+
+  it("registers event handlers once and unregisters on unmount", () => {
+    const onCrosshairMove = vi.fn();
+    const onError = vi.fn();
+    const { unmount } = render(
+      <TrendChart candles={sampleCandles} onCrosshairMove={onCrosshairMove} onError={onError} />,
+    );
+    expect(currentMock.__state.eventHandlers.get("crosshairMove")?.size).toBe(1);
+    expect(currentMock.__state.eventHandlers.get("error")?.size).toBe(1);
+
+    unmount();
+    // destroy() clears all handlers
+    expect(currentMock.__state.eventHandlers.size).toBe(0);
+  });
+
+  it("does not duplicate event handlers when unrelated props change", () => {
+    const onCrosshairMove = vi.fn();
+    const { rerender } = render(
+      <TrendChart candles={sampleCandles} onCrosshairMove={onCrosshairMove} />,
+    );
+    expect(currentMock.__state.eventHandlers.get("crosshairMove")?.size).toBe(1);
+
+    // Unrelated prop change — handler identity unchanged, should remain single registration
+    rerender(
+      <TrendChart candles={sampleCandles} onCrosshairMove={onCrosshairMove} theme="light" />,
+    );
+    expect(currentMock.__state.eventHandlers.get("crosshairMove")?.size).toBe(1);
+  });
+
+  it("swaps event handler cleanly when callback identity changes", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = render(<TrendChart candles={sampleCandles} onCrosshairMove={first} />);
+    expect(currentMock.__state.eventHandlers.get("crosshairMove")?.size).toBe(1);
+
+    rerender(<TrendChart candles={sampleCandles} onCrosshairMove={second} />);
+    expect(currentMock.__state.eventHandlers.get("crosshairMove")?.size).toBe(1);
+  });
+
+  it("removes indicator handles when indicators prop changes", () => {
+    const indicatorsA = [[{ time: 1, value: 10 }]];
+    const indicatorsB = [[{ time: 1, value: 20 }], [{ time: 2, value: 30 }]];
+
+    const { rerender } = render(<TrendChart candles={sampleCandles} indicators={indicatorsA} />);
+    expect(currentMock.addIndicator).toHaveBeenCalledTimes(1);
+    expect(currentMock.__state.indicators.size).toBe(1);
+
+    rerender(<TrendChart candles={sampleCandles} indicators={indicatorsB} />);
+    // Previous handle removed, 2 new handles added
+    expect(currentMock.addIndicator).toHaveBeenCalledTimes(3);
+    expect(currentMock.__state.indicators.size).toBe(2);
+  });
+
+  it("cleans up drawings and timeframes on unmount", () => {
+    const drawings = [{ id: "d1", type: "hline" as const, price: 100 }];
+    const timeframes = [{ id: "tf1", candles: sampleCandles }];
+    const { unmount } = render(
+      <TrendChart candles={sampleCandles} drawings={drawings} timeframes={timeframes as never} />,
+    );
+    expect(currentMock.__state.drawingIds.has("d1")).toBe(true);
+    expect(currentMock.__state.timeframeIds.has("tf1")).toBe(true);
+
+    unmount();
+    expect(currentMock.removeDrawing).toHaveBeenCalledWith("d1");
+    expect(currentMock.removeTimeframe).toHaveBeenCalledWith("tf1");
+  });
+
+  it("removes registered primitives when plugins prop changes", () => {
+    const pluginA = { name: "overlay-a", kind: "primitive" as const, draw: vi.fn() };
+    const pluginB = { name: "overlay-b", kind: "primitive" as const, draw: vi.fn() };
+
+    const { rerender, unmount } = render(
+      <TrendChart candles={sampleCandles} plugins={{ primitives: [pluginA as never] }} />,
+    );
+    expect(currentMock.__state.registeredPrimitives.has("overlay-a")).toBe(true);
+
+    rerender(<TrendChart candles={sampleCandles} plugins={{ primitives: [pluginB as never] }} />);
+    // Prev plugin removed on cleanup
+    expect(currentMock.removePrimitive).toHaveBeenCalledWith("overlay-a");
+    expect(currentMock.__state.registeredPrimitives.has("overlay-b")).toBe(true);
+
+    unmount();
+    expect(currentMock.removePrimitive).toHaveBeenCalledWith("overlay-b");
+  });
+
+  it("forwards emitted events to handlers", () => {
+    const onCrosshairMove = vi.fn();
+    render(<TrendChart candles={sampleCandles} onCrosshairMove={onCrosshairMove} />);
+
+    const handler = [...(currentMock.__state.eventHandlers.get("crosshairMove") ?? [])][0];
+    expect(handler).toBeDefined();
+    act(() => {
+      handler?.({ time: 42, price: 100 });
+    });
+    expect(onCrosshairMove).toHaveBeenCalledWith({ time: 42, price: 100 });
+  });
+});

--- a/packages/chart/src/__tests__/vue-wrapper-lifecycle.test.ts
+++ b/packages/chart/src/__tests__/vue-wrapper-lifecycle.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment happy-dom
+/**
+ * Vue TrendChart — lifecycle tests.
+ *
+ * Verifies mount / update / unmount behavior against a mocked ChartInstance:
+ * - createChart is called once on mount, destroy on unmount
+ * - setProps updates propagate via dedicated chart methods
+ * - Emits forward chart events
+ * - Drawings / timeframes / primitives are swapped cleanly on prop updates
+ */
+
+import { mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type MockChartInstance, createMockChartInstance } from "./helpers/mock-chart-instance";
+
+const { createChartMock } = vi.hoisted(() => ({
+  createChartMock: vi.fn(),
+}));
+
+vi.mock("../index", () => ({
+  createChart: createChartMock,
+}));
+
+import { TrendChart } from "../../vue/TrendChart";
+
+let currentMock: MockChartInstance;
+
+const sampleCandles = [
+  { time: 1, open: 10, high: 12, low: 9, close: 11, volume: 100 },
+  { time: 2, open: 11, high: 13, low: 10, close: 12, volume: 200 },
+];
+
+beforeEach(() => {
+  currentMock = createMockChartInstance();
+  createChartMock.mockReset();
+  createChartMock.mockImplementation(() => currentMock);
+});
+
+afterEach(() => {
+  // Prevent state leakage between tests
+});
+
+describe("Vue TrendChart lifecycle", () => {
+  it("calls createChart once on mount and destroy on unmount", () => {
+    const wrapper = mount(TrendChart, { props: { candles: sampleCandles } });
+    expect(createChartMock).toHaveBeenCalledTimes(1);
+    expect(currentMock.__state.destroyCalls).toBe(0);
+
+    wrapper.unmount();
+    expect(currentMock.__state.destroyCalls).toBe(1);
+  });
+
+  it("sets initial candles and fits content on mount", () => {
+    mount(TrendChart, { props: { candles: sampleCandles } });
+    expect(currentMock.setCandles).toHaveBeenCalledWith(sampleCandles);
+    expect(currentMock.__state.fitContentCalls).toBe(1);
+  });
+
+  it("respects fitOnLoad=false", () => {
+    mount(TrendChart, { props: { candles: sampleCandles, fitOnLoad: false } });
+    expect(currentMock.__state.fitContentCalls).toBe(0);
+  });
+
+  it("updates candles when prop changes", async () => {
+    const wrapper = mount(TrendChart, { props: { candles: sampleCandles } });
+    expect(currentMock.__state.setCandlesCalls).toBe(1);
+
+    const next = [
+      ...sampleCandles,
+      { time: 3, open: 12, high: 14, low: 11, close: 13, volume: 300 },
+    ];
+    await wrapper.setProps({ candles: next });
+    expect(currentMock.__state.setCandlesCalls).toBe(2);
+  });
+
+  it("registers event listeners once on mount", () => {
+    mount(TrendChart, { props: { candles: sampleCandles } });
+    // Vue wrapper subscribes unconditionally to all four events in onMounted
+    expect(currentMock.__state.eventHandlers.get("crosshairMove")?.size).toBe(1);
+    expect(currentMock.__state.eventHandlers.get("seriesAdded")?.size).toBe(1);
+    expect(currentMock.__state.eventHandlers.get("seriesRemoved")?.size).toBe(1);
+    expect(currentMock.__state.eventHandlers.get("error")?.size).toBe(1);
+  });
+
+  it("forwards chart events as Vue emits", () => {
+    const wrapper = mount(TrendChart, { props: { candles: sampleCandles } });
+    const handler = [...(currentMock.__state.eventHandlers.get("crosshairMove") ?? [])][0];
+    expect(handler).toBeDefined();
+    handler?.({ time: 42, price: 100 });
+
+    const emitted = wrapper.emitted("crosshairMove");
+    expect(emitted).toBeTruthy();
+    expect(emitted?.[0]?.[0]).toEqual({ time: 42, price: 100 });
+  });
+
+  it("does not duplicate event registrations when props change", async () => {
+    const wrapper = mount(TrendChart, { props: { candles: sampleCandles } });
+    const beforeSize = currentMock.__state.eventHandlers.get("crosshairMove")?.size;
+
+    await wrapper.setProps({ candles: [...sampleCandles], theme: "light" });
+
+    expect(currentMock.__state.eventHandlers.get("crosshairMove")?.size).toBe(beforeSize);
+  });
+
+  it("applies theme and chartType via dedicated setters", async () => {
+    const wrapper = mount(TrendChart, { props: { candles: sampleCandles, theme: "dark" } });
+    await wrapper.setProps({ theme: "light" });
+    expect(currentMock.setTheme).toHaveBeenCalledWith("light");
+
+    await wrapper.setProps({ chartType: "line" });
+    expect(currentMock.setChartType).toHaveBeenCalledWith("line");
+  });
+
+  it("re-applies indicators (removing previous handles) when prop changes", async () => {
+    const indicatorsA = [[{ time: 1, value: 10 }]];
+    const indicatorsB = [[{ time: 1, value: 20 }], [{ time: 2, value: 30 }]];
+
+    const wrapper = mount(TrendChart, {
+      props: { candles: sampleCandles, indicators: indicatorsA },
+    });
+    expect(currentMock.addIndicator).toHaveBeenCalledTimes(1);
+    expect(currentMock.__state.indicators.size).toBe(1);
+
+    await wrapper.setProps({ indicators: indicatorsB });
+    expect(currentMock.addIndicator).toHaveBeenCalledTimes(3);
+    expect(currentMock.__state.indicators.size).toBe(2);
+  });
+
+  it("swaps drawings cleanly when prop changes", async () => {
+    const d1 = [{ id: "d1", type: "hline" as const, price: 100 }];
+    const d2 = [{ id: "d2", type: "hline" as const, price: 200 }];
+
+    const wrapper = mount(TrendChart, {
+      props: { candles: sampleCandles, drawings: d1 as never },
+    });
+    expect(currentMock.__state.drawingIds.has("d1")).toBe(true);
+
+    await wrapper.setProps({ drawings: d2 as never });
+    expect(currentMock.removeDrawing).toHaveBeenCalledWith("d1");
+    expect(currentMock.__state.drawingIds.has("d2")).toBe(true);
+    expect(currentMock.__state.drawingIds.has("d1")).toBe(false);
+  });
+
+  it("swaps primitives cleanly when plugins prop changes", async () => {
+    const a = { name: "overlay-a", kind: "primitive" as const, draw: vi.fn() };
+    const b = { name: "overlay-b", kind: "primitive" as const, draw: vi.fn() };
+
+    const wrapper = mount(TrendChart, {
+      props: { candles: sampleCandles, plugins: { primitives: [a] } as never },
+    });
+    expect(currentMock.__state.registeredPrimitives.has("overlay-a")).toBe(true);
+
+    await wrapper.setProps({ plugins: { primitives: [b] } as never });
+    expect(currentMock.removePrimitive).toHaveBeenCalledWith("overlay-a");
+    expect(currentMock.__state.registeredPrimitives.has("overlay-b")).toBe(true);
+
+    wrapper.unmount();
+    expect(currentMock.__state.destroyCalls).toBe(1);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,18 @@ importers:
       '@size-limit/file':
         specifier: ^12.0.1
         version: 12.0.1(size-limit@12.0.1)
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
+      '@vue/test-utils':
+        specifier: ^2.4.6
+        version: 2.4.6
+      happy-dom:
+        specifier: ^20.8.9
+        version: 20.8.9
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -52,7 +61,7 @@ importers:
         version: 4.5.4(@types/node@25.0.2)(rollup@4.53.3)(typescript@6.0.2)(vite@8.0.3(@types/node@25.0.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.0.2)(vite@8.0.3(@types/node@25.0.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@25.0.2)(happy-dom@20.8.9)(vite@8.0.3(@types/node@25.0.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: ^3.5.0
         version: 3.5.31(typescript@6.0.2)
@@ -64,7 +73,7 @@ importers:
         version: 12.0.1(size-limit@12.0.1)
       '@vitest/coverage-v8':
         specifier: ^4.1.2
-        version: 4.1.2(vitest@4.1.2(@types/node@25.0.2)(vite@8.0.3(@types/node@25.0.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.1.2(vitest@4.1.2(@types/node@25.0.2)(happy-dom@20.8.9)(vite@8.0.3(@types/node@25.0.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)))
       size-limit:
         specifier: ^12.0.1
         version: 12.0.1
@@ -76,9 +85,13 @@ importers:
         version: 4.5.4(@types/node@25.0.2)(rollup@4.53.3)(typescript@6.0.2)(vite@8.0.3(@types/node@25.0.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.0.2)(vite@8.0.3(@types/node@25.0.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@25.0.2)(happy-dom@20.8.9)(vite@8.0.3(@types/node@25.0.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -92,6 +105,10 @@ packages:
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
@@ -331,6 +348,10 @@ packages:
     resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
     engines: {node: 20 || >=22}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -357,8 +378,15 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
+  '@one-ini/wasm@0.1.1':
+    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
+
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
@@ -633,11 +661,33 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -653,6 +703,12 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@vitest/coverage-v8@4.1.2':
     resolution: {integrity: sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==}
@@ -750,6 +806,13 @@ packages:
   '@vue/shared@3.5.31':
     resolution: {integrity: sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw==}
 
+  '@vue/test-utils@2.4.6':
+    resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
+
+  abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
@@ -784,9 +847,21 @@ packages:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
@@ -794,6 +869,9 @@ packages:
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -824,8 +902,19 @@ packages:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -840,8 +929,15 @@ packages:
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
 
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -858,6 +954,10 @@ packages:
       supports-color:
         optional: true
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -866,8 +966,25 @@ packages:
     resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
     engines: {node: '>=0.3.1'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  editorconfig@1.0.7:
+    resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -917,6 +1034,10 @@ packages:
       picomatch:
         optional: true
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fs-extra@11.3.2:
     resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
     engines: {node: '>=14.14'}
@@ -936,8 +1057,17 @@ packages:
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  happy-dom@20.8.9:
+    resolution: {integrity: sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -963,13 +1093,23 @@ packages:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
     engines: {node: '>=8'}
 
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -983,11 +1123,26 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
+  js-beautify@1.15.4:
+    resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -1096,9 +1251,16 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1120,6 +1282,10 @@ packages:
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   mlly@1.8.0:
@@ -1144,6 +1310,11 @@ packages:
   nanospinner@1.2.2:
     resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
 
+  nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -1151,11 +1322,22 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1177,12 +1359,27 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+    peerDependencies:
+      react: ^19.2.4
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -1217,6 +1414,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
@@ -1226,6 +1426,14 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1273,6 +1481,14 @@ packages:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
@@ -1280,6 +1496,10 @@ packages:
   string-width@8.2.0:
     resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
     engines: {node: '>=20'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
@@ -1437,6 +1657,9 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  vue-component-type-helpers@2.2.12:
+    resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
+
   vue@3.5.31:
     resolution: {integrity: sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==}
     peerDependencies:
@@ -1445,14 +1668,43 @@ packages:
       typescript:
         optional: true
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -1464,6 +1716,12 @@ packages:
 
 snapshots:
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -1471,6 +1729,8 @@ snapshots:
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/runtime@7.29.2': {}
 
   '@babel/types@7.29.0':
     dependencies:
@@ -1614,6 +1874,15 @@ snapshots:
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -1666,7 +1935,12 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@one-ini/wasm@0.1.1': {}
+
   '@oxc-project/types@0.122.0': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     optional: true
@@ -1842,12 +2116,34 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@types/argparse@1.0.38': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -1866,7 +2162,13 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@25.0.2)(vite@8.0.3(@types/node@25.0.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.0.2
+
+  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@25.0.2)(happy-dom@20.8.9)(vite@8.0.3(@types/node@25.0.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.2
@@ -1878,7 +2180,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@25.0.2)(vite@8.0.3(@types/node@25.0.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.2(@types/node@25.0.2)(happy-dom@20.8.9)(vite@8.0.3(@types/node@25.0.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.2':
     dependencies:
@@ -2020,6 +2322,13 @@ snapshots:
 
   '@vue/shared@3.5.31': {}
 
+  '@vue/test-utils@2.4.6':
+    dependencies:
+      js-beautify: 1.15.4
+      vue-component-type-helpers: 2.2.12
+
+  abbrev@2.0.0: {}
+
   acorn@8.15.0: {}
 
   ajv-draft-04@1.0.0(ajv@8.13.0):
@@ -2050,13 +2359,25 @@ snapshots:
     dependencies:
       environment: 1.1.0
 
+  ansi-regex@5.0.1: {}
+
   ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
 
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   assertion-error@2.0.1: {}
 
@@ -2085,7 +2406,15 @@ snapshots:
       slice-ansi: 8.0.0
       string-width: 8.2.0
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   colorette@2.0.20: {}
+
+  commander@10.0.1: {}
 
   commander@14.0.3: {}
 
@@ -2095,7 +2424,18 @@ snapshots:
 
   confbox@0.2.2: {}
 
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
+
   convert-source-map@2.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   csstype@3.2.3: {}
 
@@ -2105,11 +2445,28 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   diff@8.0.2: {}
 
+  dom-accessibility-api@0.5.16: {}
+
+  eastasianwidth@0.2.0: {}
+
+  editorconfig@1.0.7:
+    dependencies:
+      '@one-ini/wasm': 0.1.1
+      commander: 10.0.1
+      minimatch: 9.0.5
+      semver: 7.7.4
+
   emoji-regex@10.6.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   entities@4.5.0: {}
 
@@ -2166,6 +2523,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fs-extra@11.3.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -2184,7 +2546,28 @@ snapshots:
       resolve-pkg-maps: 1.0.0
     optional: true
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   graceful-fs@4.2.11: {}
+
+  happy-dom@20.8.9:
+    dependencies:
+      '@types/node': 25.0.2
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -2200,13 +2583,19 @@ snapshots:
 
   import-lazy@4.0.0: {}
 
+  ini@1.3.8: {}
+
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.5.0
+
+  isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -2221,9 +2610,27 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jju@1.4.0: {}
 
+  js-beautify@1.15.4:
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 1.0.7
+      glob: 10.5.0
+      js-cookie: 3.0.5
+      nopt: 7.2.1
+
+  js-cookie@3.0.5: {}
+
   js-tokens@10.0.0: {}
+
+  js-tokens@4.0.0: {}
 
   json-schema-traverse@1.0.0: {}
 
@@ -2320,9 +2727,13 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  lru-cache@10.4.3: {}
+
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -2348,6 +2759,8 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
+  minipass@7.1.3: {}
+
   mlly@1.8.0:
     dependencies:
       acorn: 8.15.0
@@ -2367,15 +2780,28 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
 
+  nopt@7.2.1:
+    dependencies:
+      abbrev: 2.0.0
+
   obug@2.1.1: {}
 
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
 
+  package-json-from-dist@1.0.1: {}
+
   path-browserify@1.0.1: {}
 
+  path-key@3.1.1: {}
+
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -2401,9 +2827,24 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  proto-list@1.2.4: {}
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
+
+  react-dom@19.2.4(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react@19.2.4: {}
 
@@ -2475,11 +2916,19 @@ snapshots:
       fsevents: 2.3.3
     optional: true
 
+  scheduler@0.27.0: {}
+
   semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
 
   semver@7.7.4: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
 
@@ -2515,6 +2964,18 @@ snapshots:
 
   string-argv@0.3.2: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
@@ -2525,6 +2986,10 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-ansi@7.2.0:
     dependencies:
@@ -2611,7 +3076,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.2(@types/node@25.0.2)(vite@8.0.3(@types/node@25.0.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.2(@types/node@25.0.2)(happy-dom@20.8.9)(vite@8.0.3(@types/node@25.0.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.2
       '@vitest/mocker': 4.1.2(vite@8.0.3(@types/node@25.0.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
@@ -2635,10 +3100,13 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.2
+      happy-dom: 20.8.9
     transitivePeerDependencies:
       - msw
 
   vscode-uri@3.1.0: {}
+
+  vue-component-type-helpers@2.2.12: {}
 
   vue@3.5.31(typescript@6.0.2):
     dependencies:
@@ -2650,16 +3118,36 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.2
 
+  whatwg-mimetype@3.0.0: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  ws@8.20.0: {}
 
   yallist@4.0.0: {}
 


### PR DESCRIPTION
## Summary

- Add mount / update / unmount lifecycle tests for the React/Vue wrappers (React: 12, Vue: 11). `createChart` is swapped via `vi.mock`, and real lifecycles are verified on happy-dom using `@testing-library/react` and `@vue/test-utils`.
- Fix a bug in the React wrapper where `useImperativeHandle` captured a fixed null snapshot of `chartRef.current` (changed to getter-based access). `ref.current.chart` now actually returns the `ChartInstance`.
- devDeps added: `happy-dom`, `@testing-library/react`, `@vue/test-utils`.

This corresponds to **C1** (wrapper lifecycle tests) in the release-quality P1 work. The follow-up introducing the `useTrendChart` hook-based wrapper API will land in a separate branch.

## Test plan

- [x] `pnpm test` (chart) — 474 / 45 files all passing
- [x] `pnpm build` (chart) — artifact sizes unchanged
- [x] `pnpm lint` — clean
- [x] Manual: verified via lifecycle tests that `ChartInstance` is reachable through the ref

## Follow-up

- Next PR: introduce `useTrendChart` hook + composable (refactor React/Vue wrapper API to hook-based)