### PR TITLE
feat(chart): add applyOptions() for runtime option updates

### DIFF
--- a/packages/chart/react/useTrendChart.ts
+++ b/packages/chart/react/useTrendChart.ts
@@ -131,6 +131,14 @@ export function useTrendChart(opts: UseTrendChartOptions): UseTrendChartResult {
     };
   }, []);
 
+  // Options — apply runtime-capable option changes after mount. Initial values
+  // were already consumed at chart creation, so this is a no-op on the first
+  // run but picks up any subsequent `options` prop change.
+  useEffect(() => {
+    if (!chart || !options) return;
+    chart.applyOptions(options);
+  }, [chart, options]);
+
   // Candles + fit
   useEffect(() => {
     if (!chart) return;

--- a/packages/chart/src/__tests__/apply-options.test.ts
+++ b/packages/chart/src/__tests__/apply-options.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+/**
+ * applyOptions — runtime option dispatch.
+ *
+ * Verifies that `chart.applyOptions(partial)` routes each field to the
+ * appropriate internal setter (theme/chartType/volume/etc.) and emits
+ * a warning for fields that cannot be changed at runtime.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { LIGHT_THEME } from "../core/types";
+import { createChart } from "../index";
+
+// happy-dom does not ship a canvas 2D context implementation. Stub a no-op
+// context so we can construct a real CanvasChart and exercise applyOptions.
+beforeAll(() => {
+  const noop = () => {};
+  const context2d = new Proxy(
+    {},
+    {
+      get: (_t, prop) => {
+        if (prop === "canvas") return null;
+        if (prop === "measureText") return () => ({ width: 0 }) as TextMetrics;
+        return noop;
+      },
+      set: () => true,
+    },
+  ) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as { getContext: () => unknown }).getContext = () =>
+    context2d;
+});
+
+function makeContainer(): HTMLElement {
+  const el = document.createElement("div");
+  el.style.width = "800px";
+  el.style.height = "400px";
+  document.body.appendChild(el);
+  return el;
+}
+
+describe("applyOptions", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("routes theme to setTheme", () => {
+    const chart = createChart(makeContainer(), { theme: "dark" });
+    const setTheme = vi.spyOn(chart, "setTheme");
+    chart.applyOptions({ theme: "light" });
+    expect(setTheme).toHaveBeenCalledWith("light");
+    chart.destroy();
+  });
+
+  it("routes chartType to setChartType", () => {
+    const chart = createChart(makeContainer());
+    const spy = vi.spyOn(chart, "setChartType");
+    chart.applyOptions({ chartType: "line" });
+    expect(spy).toHaveBeenCalledWith("line");
+    chart.destroy();
+  });
+
+  it("routes volume to setShowVolume", () => {
+    const chart = createChart(makeContainer());
+    const spy = vi.spyOn(chart, "setShowVolume");
+    chart.applyOptions({ volume: false });
+    expect(spy).toHaveBeenCalledWith(false);
+    chart.applyOptions({ volume: true });
+    expect(spy).toHaveBeenCalledWith(true);
+    chart.destroy();
+  });
+
+  it("accepts a custom ThemeColors object via applyOptions", () => {
+    const chart = createChart(makeContainer(), { theme: "dark" });
+    // Custom theme — just verify no throw
+    expect(() => chart.applyOptions({ theme: LIGHT_THEME })).not.toThrow();
+    chart.destroy();
+  });
+
+  it("toggles legend overlay on and off", () => {
+    const container = makeContainer();
+    const chart = createChart(container, { legend: true });
+
+    chart.applyOptions({ legend: false });
+    chart.applyOptions({ legend: true });
+    // Legend toggle should not throw and the chart continues to accept further updates
+    expect(() => chart.applyOptions({ theme: "light" })).not.toThrow();
+    chart.destroy();
+  });
+
+  it("accepts partial size updates without requiring all four dimensions", () => {
+    const container = makeContainer();
+    const chart = createChart(container, { width: 800, height: 400 });
+    chart.applyOptions({ priceAxisWidth: 80 });
+    chart.applyOptions({ width: 1000 });
+    chart.applyOptions({ height: 500, timeAxisHeight: 40 });
+    // No throw + chart stays responsive
+    expect(() => chart.applyOptions({ theme: "light" })).not.toThrow();
+    chart.destroy();
+  });
+
+  it("ignores undefined fields (no setter dispatch)", () => {
+    const chart = createChart(makeContainer());
+    const setTheme = vi.spyOn(chart, "setTheme");
+    const setChartType = vi.spyOn(chart, "setChartType");
+    chart.applyOptions({});
+    expect(setTheme).not.toHaveBeenCalled();
+    expect(setChartType).not.toHaveBeenCalled();
+    chart.destroy();
+  });
+
+  it("warns via error event for fields that cannot be changed at runtime", () => {
+    const chart = createChart(makeContainer());
+    const errors: Array<{ message: string; detail: unknown }> = [];
+    chart.on("error", (d) => errors.push(d as { message: string; detail: unknown }));
+
+    chart.applyOptions({ pixelRatio: 2, fontFamily: "monospace" });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toContain("pixelRatio");
+    expect(errors[0]?.message).toContain("fontFamily");
+    chart.destroy();
+  });
+
+  it("applies multiple fields in a single call", () => {
+    const chart = createChart(makeContainer(), { theme: "dark" });
+    const setTheme = vi.spyOn(chart, "setTheme");
+    const setChartType = vi.spyOn(chart, "setChartType");
+    const setShowVolume = vi.spyOn(chart, "setShowVolume");
+
+    chart.applyOptions({ theme: "light", chartType: "line", volume: false });
+
+    expect(setTheme).toHaveBeenCalledWith("light");
+    expect(setChartType).toHaveBeenCalledWith("line");
+    expect(setShowVolume).toHaveBeenCalledWith(false);
+    chart.destroy();
+  });
+});

--- a/packages/chart/src/core/types.ts
+++ b/packages/chart/src/core/types.ts
@@ -547,6 +547,17 @@ export type ChartInstance = {
   /** Show or hide the volume pane */
   setShowVolume(show: boolean): void;
 
+  /**
+   * Apply a partial options update at runtime.
+   *
+   * Accepts the same shape as `createChart`'s options, but applies only the
+   * provided fields. Use this from reactive wrappers to propagate option
+   * changes after chart creation. Fields that cannot be changed at runtime
+   * (e.g. `pixelRatio`, `fontFamily`, `scrollSensitivity`, `locale`,
+   * `formatInfoOverlay`) emit a warning via the `error` event and are ignored.
+   */
+  applyOptions(options: Partial<ChartOptions>): void;
+
   // Plugins
   /** Register a custom series renderer plugin */
   registerRenderer<TConfig>(plugin: import("./plugin-types").SeriesRendererPlugin<TConfig>): void;

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -71,6 +71,13 @@ export class CanvasChart implements ChartInstance {
   private _fontSize: number;
   private _priceFormatter: (price: number) => string;
   private _timeFormatter: ((time: number) => string) | undefined;
+  /** Last applied layout size — tracked so applyOptions() can compose partial size changes. */
+  private _sizeState: {
+    width: number;
+    height: number;
+    priceAxisWidth: number;
+    timeAxisHeight: number;
+  };
 
   private _data = new DataLayer();
   private _layout = new LayoutEngine();
@@ -188,11 +195,17 @@ export class CanvasChart implements ChartInstance {
     // Initial sizing
     const width = options?.width ?? container.clientWidth;
     const height = options?.height ?? DEFAULT_OPTIONS.height;
-    this._setSize(
+    this._sizeState = {
       width,
       height,
-      options?.priceAxisWidth ?? DEFAULT_OPTIONS.priceAxisWidth,
-      options?.timeAxisHeight ?? DEFAULT_OPTIONS.timeAxisHeight,
+      priceAxisWidth: options?.priceAxisWidth ?? DEFAULT_OPTIONS.priceAxisWidth,
+      timeAxisHeight: options?.timeAxisHeight ?? DEFAULT_OPTIONS.timeAxisHeight,
+    };
+    this._setSize(
+      this._sizeState.width,
+      this._sizeState.height,
+      this._sizeState.priceAxisWidth,
+      this._sizeState.timeAxisHeight,
     );
 
     // Data change listener
@@ -608,6 +621,95 @@ export class CanvasChart implements ChartInstance {
     this._needsRender = true;
   }
 
+  /**
+   * Apply a partial options update at runtime.
+   *
+   * Diffs each provided field against the chart's current state and routes to
+   * the appropriate internal setter. Fields not listed in `opts` are left alone.
+   *
+   * Runtime-capable fields: theme, chartType, volume, fontSize, watermark,
+   * animationDuration, maxCandles, legend, priceFormatter, timeFormatter,
+   * width, height, priceAxisWidth, timeAxisHeight.
+   *
+   * Fields that require re-creating the chart emit a warning and are ignored:
+   * pixelRatio, fontFamily, scrollSensitivity, locale, formatInfoOverlay.
+   */
+  applyOptions(opts: Partial<ChartOptions>): void {
+    if (opts.theme !== undefined) this.setTheme(opts.theme);
+    if (opts.chartType !== undefined) this.setChartType(opts.chartType);
+    if (opts.volume !== undefined) this.setShowVolume(opts.volume);
+
+    if (opts.fontSize !== undefined) {
+      this._fontSize = opts.fontSize;
+      this._needsRender = true;
+    }
+    if (opts.watermark !== undefined) {
+      this._watermark = opts.watermark;
+      this._needsRender = true;
+    }
+    if (opts.animationDuration !== undefined) {
+      this._animationDuration = opts.animationDuration;
+    }
+    if (opts.maxCandles !== undefined) {
+      this._data.setMaxCandles(opts.maxCandles);
+    }
+    if (opts.priceFormatter !== undefined) {
+      this._priceFormatter = opts.priceFormatter;
+      this._needsRender = true;
+    }
+    if (opts.timeFormatter !== undefined) {
+      this._timeFormatter = opts.timeFormatter;
+      this._needsRender = true;
+    }
+
+    // Legend overlay — create/destroy
+    if (opts.legend !== undefined) {
+      if (opts.legend === false && this._legendOverlay) {
+        this._legendOverlay.destroy();
+        this._legendOverlay = null;
+      } else if (opts.legend !== false && !this._legendOverlay) {
+        this._legendOverlay = new LegendOverlay(this._container, this._theme, this._locale);
+        this._legendOverlay.setOnToggle((seriesId, visible) => {
+          const series = this._data.getAllSeries().find((s) => s.id === seriesId);
+          if (series) {
+            series.visible = visible;
+            this._needsRender = true;
+          }
+        });
+      }
+      this._needsRender = true;
+    }
+
+    // Size — compose partial width/height/axis changes against stored state
+    if (
+      opts.width !== undefined ||
+      opts.height !== undefined ||
+      opts.priceAxisWidth !== undefined ||
+      opts.timeAxisHeight !== undefined
+    ) {
+      this._setSize(
+        opts.width ?? this._sizeState.width,
+        opts.height ?? this._sizeState.height,
+        opts.priceAxisWidth ?? this._sizeState.priceAxisWidth,
+        opts.timeAxisHeight ?? this._sizeState.timeAxisHeight,
+      );
+      this._needsRender = true;
+    }
+
+    // Unsupported at runtime — these bind to sub-components at construction
+    const unsupported: (keyof ChartOptions)[] = [];
+    if (opts.pixelRatio !== undefined) unsupported.push("pixelRatio");
+    if (opts.fontFamily !== undefined) unsupported.push("fontFamily");
+    if (opts.scrollSensitivity !== undefined) unsupported.push("scrollSensitivity");
+    if (opts.locale !== undefined) unsupported.push("locale");
+    if (opts.formatInfoOverlay !== undefined) unsupported.push("formatInfoOverlay");
+    if (unsupported.length > 0) {
+      this._warn(
+        `applyOptions: [${unsupported.join(", ")}] cannot be changed at runtime; re-create the chart to update them`,
+      );
+    }
+  }
+
   // ---- Public API: Series Query ----
 
   getAllSeries(): import("../core/types").SeriesInfo[] {
@@ -775,6 +877,16 @@ export class CanvasChart implements ChartInstance {
     this._ctx.scale(pr, pr);
 
     this._layout.setDimensions(w, h, priceAxisWidth, timeAxisHeight);
+
+    // Keep last-applied size so applyOptions() can compose partial changes
+    this._sizeState = {
+      width: w,
+      height: h,
+      priceAxisWidth:
+        priceAxisWidth ?? this._sizeState?.priceAxisWidth ?? DEFAULT_OPTIONS.priceAxisWidth,
+      timeAxisHeight:
+        timeAxisHeight ?? this._sizeState?.timeAxisHeight ?? DEFAULT_OPTIONS.timeAxisHeight,
+    };
     const wasFit = this._timeScale.visibleCount >= this._timeScale.totalCount;
     this._timeScale.setWidth(this._layout.dataAreaWidth);
     // Re-fit if all data was visible before resize

--- a/packages/chart/vue/useTrendChart.ts
+++ b/packages/chart/vue/useTrendChart.ts
@@ -99,8 +99,8 @@ export type UseTrendChartOptions = {
   chartType?: Reactive<ChartType | undefined>;
   layout?: Reactive<LayoutConfig | undefined>;
   theme?: Reactive<"dark" | "light" | ThemeColors | undefined>;
-  /** Chart options consumed only at creation time (width, height, fontSize, ...) */
-  options?: Omit<ChartOptions, "theme">;
+  /** Chart options — runtime-capable fields (volume, watermark, fontSize, ...) are applied via applyOptions on change */
+  options?: Reactive<Omit<ChartOptions, "theme"> | undefined>;
   fitOnLoad?: Reactive<boolean | undefined>;
   onCrosshairMove?: (data: CrosshairMoveData) => void;
   onSeriesAdded?: (data: SeriesInfo) => void;
@@ -129,7 +129,7 @@ export function useTrendChart(opts: UseTrendChartOptions): UseTrendChartResult {
   onMounted(() => {
     if (!containerRef.value) return;
     const instance = createChart(containerRef.value, {
-      ...opts.options,
+      ...toValue(opts.options),
       theme: toValue(opts.theme) ?? "dark",
     });
 
@@ -183,6 +183,14 @@ export function useTrendChart(opts: UseTrendChartOptions): UseTrendChartResult {
   });
 
   // Reactive bindings — only fire after mount because `chart.value` is null until then
+  watch(
+    () => toValue(opts.options),
+    (val) => {
+      if (val) chart.value?.applyOptions(val);
+    },
+    { deep: true },
+  );
+
   watch(
     () => toValue(opts.candles),
     (val) => {


### PR DESCRIPTION
## Summary

- Add `ChartInstance.applyOptions(partial)` that dispatches each provided field to the appropriate internal setter (theme, chartType, volume, legend, size, fontSize, watermark, animationDuration, maxCandles, formatters).
- Fields that bind at construction (pixelRatio, fontFamily, scrollSensitivity, locale, formatInfoOverlay) emit a warning via the `error` event and are ignored.
- Wire the new API into React `useTrendChart` and Vue `useTrendChart`: both now watch the `options` prop and call `applyOptions` on change. Previously init-only fields — notably `volume` — become fully reactive, fixing the half-baked Vol Overlay toggle in the examples.

## Test plan

- [x] `pnpm test`: 495 / 48 files (new `apply-options.test.ts` adds 9 cases against a real `CanvasChart` via a proxy-based 2d context stub).
- [x] `pnpm build` + `pnpm size-check` within limits (main 27.72 / 31, headless 9.17 / 11, React 24.46 / 27, Vue 24.75 / 27 kB).
- [x] `pnpm lint`.
- [x] All 4 examples build (`simple-chart`, `simple-react-chart`, `simple-vue-chart`, `indicator-showcase`).