### PR TITLE
test(chart): add unit tests for previously-uncovered modules

### DIFF
--- a/packages/chart/src/__tests__/animation.test.ts
+++ b/packages/chart/src/__tests__/animation.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ViewTransition } from "../core/animation";
+
+describe("ViewTransition", () => {
+  let now = 0;
+  let rafQueue: Array<(now: number) => void> = [];
+
+  beforeEach(() => {
+    now = 1000;
+    rafQueue = [];
+    vi.stubGlobal("performance", { now: () => now });
+    vi.stubGlobal("requestAnimationFrame", (cb: (now: number) => void) => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    });
+    vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+      rafQueue[id - 1] = () => {};
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function flush(dt: number): void {
+    now += dt;
+    const batch = rafQueue;
+    rafQueue = [];
+    for (const cb of batch) cb(now);
+  }
+
+  it("isRunning starts false", () => {
+    const v = new ViewTransition();
+    expect(v.isRunning).toBe(false);
+  });
+
+  it("skips animation when duration <= 0 (synchronous onFrame + onDone)", () => {
+    const v = new ViewTransition();
+    const onFrame = vi.fn();
+    const onDone = vi.fn();
+    v.animate(0, 10, 50, 10, 800, 0, onFrame, onDone);
+    expect(onFrame).toHaveBeenCalledWith(50, 10);
+    expect(onDone).toHaveBeenCalled();
+    expect(v.isRunning).toBe(false);
+  });
+
+  it("skips animation when center + count diff < 0.5", () => {
+    const v = new ViewTransition();
+    const onFrame = vi.fn();
+    const onDone = vi.fn();
+    v.animate(0, 10, 0.1, 10, 800, 500, onFrame, onDone);
+    expect(onFrame).toHaveBeenCalledTimes(1);
+    expect(onDone).toHaveBeenCalled();
+    expect(v.isRunning).toBe(false);
+  });
+
+  it("runs animation over multiple RAF ticks", () => {
+    const v = new ViewTransition();
+    const onFrame = vi.fn();
+    const onDone = vi.fn();
+    v.animate(0, 10, 50, 20, 800, 300, onFrame, onDone);
+    expect(v.isRunning).toBe(true);
+    flush(100); // 33%
+    expect(onFrame).toHaveBeenCalled();
+    expect(v.isRunning).toBe(true);
+    flush(200); // 100%
+    expect(onDone).toHaveBeenCalled();
+    expect(v.isRunning).toBe(false);
+  });
+
+  it("cancel stops the loop and clears callbacks", () => {
+    const v = new ViewTransition();
+    const onFrame = vi.fn();
+    const onDone = vi.fn();
+    v.animate(0, 10, 50, 20, 800, 300, onFrame, onDone);
+    v.cancel();
+    expect(v.isRunning).toBe(false);
+    flush(500);
+    // onDone should not fire after cancel
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("animate called twice cancels the first", () => {
+    const v = new ViewTransition();
+    const a = vi.fn();
+    const b = vi.fn();
+    v.animate(0, 10, 50, 20, 800, 300, a);
+    v.animate(0, 10, 80, 15, 800, 300, b);
+    flush(300);
+    // only b should receive frames
+    expect(a).not.toHaveBeenCalled();
+    expect(b).toHaveBeenCalled();
+  });
+
+  it("handles toSpacing of 0 via max(0.1, spacing) clamp", () => {
+    const v = new ViewTransition();
+    const onFrame = vi.fn();
+    expect(() => v.animate(0, 10, 50, 0, 800, 200, onFrame)).not.toThrow();
+    flush(200);
+    expect(onFrame).toHaveBeenCalled();
+  });
+});

--- a/packages/chart/src/__tests__/backtest-renderer.test.ts
+++ b/packages/chart/src/__tests__/backtest-renderer.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it, type vi } from "vitest";
+import { DataLayer } from "../core/data-layer";
+import { DARK_THEME } from "../core/types";
+import {
+  type BacktestResultData,
+  renderBacktestSummary,
+  renderBacktestTrades,
+  renderEquityCurve,
+} from "../renderer/backtest-renderer";
+import { makeCandle, makePane, makePriceScale, makeTimeScale, mockCtx } from "./helpers/mock-ctx";
+
+function dl(): DataLayer {
+  const d = new DataLayer();
+  d.setCandles(Array.from({ length: 20 }, (_, i) => makeCandle(i * 60_000, 100 + i)));
+  return d;
+}
+
+function baseResult(trades: BacktestResultData["trades"] = []): BacktestResultData {
+  return {
+    initialCapital: 10_000,
+    finalCapital: 11_000,
+    totalReturnPercent: 10,
+    tradeCount: trades.length,
+    winRate: 60,
+    maxDrawdown: 5,
+    sharpeRatio: 1.2,
+    profitFactor: 1.8,
+    trades,
+    drawdownPeriods: [],
+  };
+}
+
+describe("renderBacktestTrades", () => {
+  const paneRects = [makePane("main", 300)];
+  const ts = makeTimeScale(20, 800);
+  const ps = makePriceScale(300, 90, 130);
+  const priceScales = new Map([["main", ps]]);
+
+  it("no-op when main pane missing", () => {
+    const ctx = mockCtx();
+    renderBacktestTrades(
+      ctx,
+      baseResult([
+        { entryTime: 0, entryPrice: 100, exitTime: 60_000, exitPrice: 110, returnPercent: 10 },
+      ]),
+      [makePane("other", 300)],
+      priceScales,
+      ts,
+      dl(),
+    );
+    expect(ctx.arc).not.toHaveBeenCalled();
+  });
+
+  it("no-op when main price scale missing", () => {
+    const ctx = mockCtx();
+    renderBacktestTrades(
+      ctx,
+      baseResult([
+        { entryTime: 0, entryPrice: 100, exitTime: 60_000, exitPrice: 110, returnPercent: 10 },
+      ]),
+      paneRects,
+      new Map(),
+      ts,
+      dl(),
+    );
+    expect(ctx.arc).not.toHaveBeenCalled();
+  });
+
+  it("renders winning trade with green shading", () => {
+    const ctx = mockCtx();
+    const fills: string[] = [];
+    Object.defineProperty(ctx, "fillStyle", {
+      set(v: string) {
+        fills.push(v);
+      },
+      get() {
+        return "";
+      },
+    });
+    renderBacktestTrades(
+      ctx,
+      baseResult([
+        {
+          entryTime: 0,
+          entryPrice: 100,
+          exitTime: 600_000,
+          exitPrice: 110,
+          returnPercent: 10,
+          exitReason: "takeProfit",
+        },
+      ]),
+      paneRects,
+      priceScales,
+      ts,
+      dl(),
+    );
+    expect(fills.some((c) => c.startsWith("rgba(38,166,154"))).toBe(true);
+    expect(ctx.arc).toHaveBeenCalledTimes(2); // entry + exit
+  });
+
+  it("renders losing trade with red shading", () => {
+    const ctx = mockCtx();
+    const fills: string[] = [];
+    Object.defineProperty(ctx, "fillStyle", {
+      set(v: string) {
+        fills.push(v);
+      },
+      get() {
+        return "";
+      },
+    });
+    renderBacktestTrades(
+      ctx,
+      baseResult([
+        {
+          entryTime: 0,
+          entryPrice: 100,
+          exitTime: 600_000,
+          exitPrice: 95,
+          returnPercent: -5,
+          exitReason: "stopLoss",
+        },
+      ]),
+      paneRects,
+      priceScales,
+      ts,
+      dl(),
+    );
+    expect(fills.some((c) => c.startsWith("rgba(239,83,80"))).toBe(true);
+  });
+
+  it("falls back on unknown exitReason to default grey", () => {
+    const ctx = mockCtx();
+    const strokes: string[] = [];
+    Object.defineProperty(ctx, "strokeStyle", {
+      set(v: string) {
+        strokes.push(v);
+      },
+      get() {
+        return "";
+      },
+    });
+    renderBacktestTrades(
+      ctx,
+      baseResult([
+        {
+          entryTime: 0,
+          entryPrice: 100,
+          exitTime: 600_000,
+          exitPrice: 110,
+          returnPercent: 10,
+          exitReason: "mysterious",
+        },
+      ]),
+      paneRects,
+      priceScales,
+      ts,
+      dl(),
+    );
+    expect(strokes.some((c) => c.startsWith("#787b86"))).toBe(true);
+  });
+
+  it("uses signal color when exitReason is undefined", () => {
+    const ctx = mockCtx();
+    const fills: string[] = [];
+    Object.defineProperty(ctx, "fillStyle", {
+      set(v: string) {
+        fills.push(v);
+      },
+      get() {
+        return "";
+      },
+    });
+    renderBacktestTrades(
+      ctx,
+      baseResult([
+        { entryTime: 0, entryPrice: 100, exitTime: 600_000, exitPrice: 110, returnPercent: 10 },
+      ]),
+      paneRects,
+      priceScales,
+      ts,
+      dl(),
+    );
+    // default 'signal' blue used for exit marker
+    expect(fills).toContain("#2196F3");
+  });
+});
+
+describe("renderEquityCurve", () => {
+  const pane = makePane("equity", 200);
+  const ts = makeTimeScale(20, 800);
+  const ps = makePriceScale(200, 9000, 12000);
+
+  it("handles empty trades (just flat line from start to end)", () => {
+    const ctx = mockCtx();
+    renderEquityCurve(ctx, baseResult(), pane, ps, ts, dl(), DARK_THEME);
+    expect(ctx.stroke).toHaveBeenCalled();
+  });
+
+  it("shades drawdown periods with red", () => {
+    const ctx = mockCtx();
+    const fills: string[] = [];
+    Object.defineProperty(ctx, "fillStyle", {
+      set(v: string) {
+        fills.push(v);
+      },
+      get() {
+        return "";
+      },
+    });
+    const result: BacktestResultData = {
+      ...baseResult(),
+      drawdownPeriods: [
+        {
+          startTime: 0,
+          troughTime: 120_000,
+          recoveryTime: 300_000,
+          maxDepthPercent: 5,
+          peakEquity: 10000,
+          troughEquity: 9500,
+        },
+      ],
+    };
+    renderEquityCurve(ctx, result, pane, ps, ts, dl(), DARK_THEME);
+    expect(fills).toContain("rgba(239,83,80,0.15)");
+  });
+
+  it("extends drawdown to last candle if recoveryTime missing", () => {
+    const ctx = mockCtx();
+    const result: BacktestResultData = {
+      ...baseResult(),
+      drawdownPeriods: [
+        {
+          startTime: 0,
+          troughTime: 120_000,
+          maxDepthPercent: 5,
+          peakEquity: 10000,
+          troughEquity: 9500,
+        },
+      ],
+    };
+    expect(() => renderEquityCurve(ctx, result, pane, ps, ts, dl(), DARK_THEME)).not.toThrow();
+    expect(ctx.fillRect).toHaveBeenCalled();
+  });
+});
+
+describe("renderBacktestSummary", () => {
+  it("uses upColor for positive return, downColor for negative", () => {
+    const ctx = mockCtx();
+    const fills: string[] = [];
+    Object.defineProperty(ctx, "fillStyle", {
+      set(v: string) {
+        fills.push(v);
+      },
+      get() {
+        return "";
+      },
+    });
+    renderBacktestSummary(ctx, baseResult(), 0, 0, DARK_THEME, 11);
+    expect(fills).toContain(DARK_THEME.upColor);
+
+    const ctx2 = mockCtx();
+    const fills2: string[] = [];
+    Object.defineProperty(ctx2, "fillStyle", {
+      set(v: string) {
+        fills2.push(v);
+      },
+      get() {
+        return "";
+      },
+    });
+    renderBacktestSummary(ctx2, { ...baseResult(), totalReturnPercent: -3 }, 0, 0, DARK_THEME, 11);
+    expect(fills2).toContain(DARK_THEME.downColor);
+  });
+
+  it("uses locale labels when provided", () => {
+    const ctx = mockCtx();
+    const texts: string[] = [];
+    (ctx.fillText as ReturnType<typeof vi.fn>).mockImplementation((t: string) => {
+      texts.push(t);
+    });
+    renderBacktestSummary(ctx, baseResult(), 0, 0, DARK_THEME, 11, {
+      return_: "R",
+      win: "W",
+      sharpe: "S",
+      maxDD: "DD",
+      pf: "PF",
+      trades: "T",
+    } as never);
+    expect(texts.some((t) => t.startsWith("R:"))).toBe(true);
+    expect(texts.some((t) => t.startsWith("W:"))).toBe(true);
+  });
+});

--- a/packages/chart/src/__tests__/box-series.test.ts
+++ b/packages/chart/src/__tests__/box-series.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { DataLayer } from "../core/data-layer";
+import type { DataPoint } from "../core/types";
+import { renderBoxes } from "../series/box";
+import { makeCandle, makePriceScale, makeTimeScale, mockCtx } from "./helpers/mock-ctx";
+
+function withZone(
+  time: number,
+  type: "bullish" | "bearish",
+  zone: { start: number; end: number; high: number; low: number },
+): DataPoint<unknown> {
+  return { time, value: { type, zone } };
+}
+
+describe("renderBoxes", () => {
+  const dl = new DataLayer();
+  dl.setCandles([0, 1, 2, 3, 4, 5].map((i) => makeCandle(i * 60_000, 100 + i)));
+
+  it("skips points without object value", () => {
+    const ctx = mockCtx();
+    const ts = makeTimeScale(6, 600);
+    const ps = makePriceScale(300, 90, 120);
+    const data: DataPoint<unknown>[] = [
+      { time: 0, value: null },
+      { time: 60_000, value: 42 },
+      { time: 120_000, value: undefined },
+      { time: 180_000, value: "str" },
+      { time: 240_000, value: {} }, // object but no zone
+      { time: 300_000, value: { type: "bullish" } }, // no zone
+    ];
+    renderBoxes(ctx, data, ts, ps, dl);
+    expect(ctx.fillRect).not.toHaveBeenCalled();
+    expect(ctx.strokeRect).not.toHaveBeenCalled();
+  });
+
+  it("draws bullish rect with green tint", () => {
+    const ctx = mockCtx();
+    const ts = makeTimeScale(6, 600);
+    const ps = makePriceScale(300, 90, 120);
+    const fillStyles: string[] = [];
+    Object.defineProperty(ctx, "fillStyle", {
+      set(v: string) {
+        fillStyles.push(v);
+      },
+      get() {
+        return "";
+      },
+    });
+    const data = [withZone(0, "bullish", { start: 0, end: 180_000, high: 110, low: 105 })];
+    // Pad to index 0 being inside visible range
+    renderBoxes(ctx, [...data, { time: 60_000, value: null }], ts, ps, dl);
+    expect(ctx.fillRect).toHaveBeenCalled();
+    expect(ctx.strokeRect).toHaveBeenCalled();
+    expect(fillStyles.some((c) => c.startsWith("rgba(38,166,154"))).toBe(true);
+  });
+
+  it("draws bearish rect with red tint", () => {
+    const ctx = mockCtx();
+    const ts = makeTimeScale(6, 600);
+    const ps = makePriceScale(300, 90, 120);
+    const strokeStyles: string[] = [];
+    Object.defineProperty(ctx, "strokeStyle", {
+      set(v: string) {
+        strokeStyles.push(v);
+      },
+      get() {
+        return "";
+      },
+    });
+    const data = [withZone(0, "bearish", { start: 0, end: 300_000, high: 115, low: 100 })];
+    renderBoxes(ctx, data, ts, ps, dl);
+    expect(strokeStyles.some((c) => c.startsWith("rgba(239,83,80"))).toBe(true);
+  });
+
+  it("respects custom borderWidth option", () => {
+    const ctx = mockCtx();
+    const ts = makeTimeScale(6, 600);
+    const ps = makePriceScale(300, 90, 120);
+    const widths: number[] = [];
+    Object.defineProperty(ctx, "lineWidth", {
+      set(v: number) {
+        widths.push(v);
+      },
+      get() {
+        return 1;
+      },
+    });
+    const data = [withZone(0, "bullish", { start: 0, end: 120_000, high: 110, low: 105 })];
+    renderBoxes(ctx, data, ts, ps, dl, { borderWidth: 3 });
+    expect(widths).toContain(3);
+  });
+});

--- a/packages/chart/src/__tests__/heatmap-series.test.ts
+++ b/packages/chart/src/__tests__/heatmap-series.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderHeatmap } from "../series/heatmap";
+import { makePriceScale, makeTimeScale, mockCtx } from "./helpers/mock-ctx";
+
+describe("renderHeatmap", () => {
+  it("no channels → no draw (but resets line dash)", () => {
+    const ctx = mockCtx();
+    const ts = makeTimeScale(5, 800);
+    const ps = makePriceScale(300, 100, 200);
+    renderHeatmap(ctx, new Map(), ts, ps, 800);
+    expect(ctx.stroke).not.toHaveBeenCalled();
+    expect(ctx.setLineDash).toHaveBeenCalledWith([]);
+  });
+
+  it("draws POC on the first non-null value, then stops", () => {
+    const ctx = mockCtx();
+    const ts = makeTimeScale(5, 800);
+    const ps = makePriceScale(300, 100, 200);
+    renderHeatmap(ctx, new Map([["poc", [null, null, 150, 160, 170]]]), ts, ps, 800);
+    // POC draws once (single stroke call minimum for POC)
+    expect(ctx.stroke).toHaveBeenCalledTimes(1);
+  });
+
+  it("all-null POC draws nothing", () => {
+    const ctx = mockCtx();
+    const ts = makeTimeScale(4, 800);
+    const ps = makePriceScale(300, 100, 200);
+    renderHeatmap(ctx, new Map([["poc", [null, null, null, null]]]), ts, ps, 800);
+    expect(ctx.stroke).not.toHaveBeenCalled();
+  });
+
+  it("draws VAH + VAL when both present (2 strokes)", () => {
+    const ctx = mockCtx();
+    const ts = makeTimeScale(3, 800);
+    const ps = makePriceScale(300, 100, 200);
+    renderHeatmap(
+      ctx,
+      new Map([
+        ["vah", [180, null, null]],
+        ["val", [120, null, null]],
+      ]),
+      ts,
+      ps,
+      800,
+    );
+    expect(ctx.stroke).toHaveBeenCalledTimes(2);
+  });
+
+  it("POC color overridden by options", () => {
+    const ctx = mockCtx();
+    const ts = makeTimeScale(3, 800);
+    const ps = makePriceScale(300, 100, 200);
+    const colors: string[] = [];
+    Object.defineProperty(ctx, "strokeStyle", {
+      set(v: string) {
+        colors.push(v);
+      },
+      get() {
+        return "";
+      },
+    });
+    renderHeatmap(ctx, new Map([["poc", [150, 150, 150]]]), ts, ps, 800, { pocColor: "#FF0000" });
+    expect(colors).toContain("#FF0000");
+  });
+});

--- a/packages/chart/src/__tests__/pattern-renderer.test.ts
+++ b/packages/chart/src/__tests__/pattern-renderer.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, type vi } from "vitest";
+import { DataLayer } from "../core/data-layer";
+import { DARK_THEME } from "../core/types";
+import { type ChartPatternSignal, renderPatterns } from "../renderer/pattern-renderer";
+import { makeCandle, makePane, makePriceScale, makeTimeScale, mockCtx } from "./helpers/mock-ctx";
+
+function dl(): DataLayer {
+  const d = new DataLayer();
+  d.setCandles(Array.from({ length: 30 }, (_, i) => makeCandle(i * 60_000, 100 + i)));
+  return d;
+}
+
+function pat(overrides: Partial<ChartPatternSignal> = {}): ChartPatternSignal {
+  return {
+    time: 0,
+    type: "double_top",
+    pattern: {
+      startTime: 0,
+      endTime: 600_000,
+      keyPoints: [
+        { time: 60_000, index: 1, price: 110, label: "A" },
+        { time: 180_000, index: 3, price: 120, label: "B" },
+        { time: 300_000, index: 5, price: 115, label: "C" },
+      ],
+    },
+    confidence: 85,
+    confirmed: true,
+    ...overrides,
+  };
+}
+
+describe("renderPatterns", () => {
+  const panes = [makePane("main", 300)];
+  const ts = makeTimeScale(30, 800);
+  const ps = makePriceScale(300, 90, 130);
+  const priceScales = new Map([["main", ps]]);
+
+  it("no-ops on empty array", () => {
+    const ctx = mockCtx();
+    renderPatterns(ctx, [], panes, priceScales, ts, dl(), DARK_THEME, 11);
+    expect(ctx.save).not.toHaveBeenCalled();
+  });
+
+  it("no-op without main pane", () => {
+    const ctx = mockCtx();
+    renderPatterns(ctx, [pat()], [makePane("other")], priceScales, ts, dl(), DARK_THEME, 11);
+    expect(ctx.stroke).not.toHaveBeenCalled();
+  });
+
+  it("no-op without main price scale", () => {
+    const ctx = mockCtx();
+    renderPatterns(ctx, [pat()], panes, new Map(), ts, dl(), DARK_THEME, 11);
+    expect(ctx.stroke).not.toHaveBeenCalled();
+  });
+
+  it("skips patterns with fewer than 2 key points", () => {
+    const ctx = mockCtx();
+    renderPatterns(
+      ctx,
+      [
+        pat({
+          pattern: {
+            startTime: 0,
+            endTime: 60_000,
+            keyPoints: [{ time: 0, index: 0, price: 100, label: "X" }],
+          },
+        }),
+      ],
+      panes,
+      priceScales,
+      ts,
+      dl(),
+      DARK_THEME,
+      11,
+    );
+    // save/restore still happens; but no stroke for outline
+    expect(ctx.stroke).not.toHaveBeenCalled();
+  });
+
+  it("draws bullish pattern with green color", () => {
+    const ctx = mockCtx();
+    const strokes: string[] = [];
+    Object.defineProperty(ctx, "strokeStyle", {
+      set(v: string) {
+        strokes.push(v);
+      },
+      get() {
+        return "";
+      },
+    });
+    renderPatterns(
+      ctx,
+      [pat({ type: "inverse_head_and_shoulders" })],
+      panes,
+      priceScales,
+      ts,
+      dl(),
+      DARK_THEME,
+      11,
+    );
+    expect(strokes).toContain("#26a69a");
+  });
+
+  it("draws bearish pattern with red color", () => {
+    const ctx = mockCtx();
+    const strokes: string[] = [];
+    Object.defineProperty(ctx, "strokeStyle", {
+      set(v: string) {
+        strokes.push(v);
+      },
+      get() {
+        return "";
+      },
+    });
+    renderPatterns(
+      ctx,
+      [pat({ type: "double_top" })],
+      panes,
+      priceScales,
+      ts,
+      dl(),
+      DARK_THEME,
+      11,
+    );
+    expect(strokes).toContain("#ef5350");
+  });
+
+  it("draws neutral pattern with orange color", () => {
+    const ctx = mockCtx();
+    const strokes: string[] = [];
+    Object.defineProperty(ctx, "strokeStyle", {
+      set(v: string) {
+        strokes.push(v);
+      },
+      get() {
+        return "";
+      },
+    });
+    renderPatterns(
+      ctx,
+      [pat({ type: "symmetrical_triangle" })],
+      panes,
+      priceScales,
+      ts,
+      dl(),
+      DARK_THEME,
+      11,
+    );
+    expect(strokes).toContain("#FF9800");
+  });
+
+  it.each([
+    ["bullish_flag", "bullish"],
+    ["ascending_triangle", "bullish"],
+    ["double_bottom", "bullish"],
+    ["falling_wedge", "bullish"],
+    ["descending_triangle", "bearish"],
+    ["rising_wedge", "bearish"],
+    ["bear_pennant", "bearish"],
+  ])("classifies %s as %s", (type, expected) => {
+    const ctx = mockCtx();
+    const strokes: string[] = [];
+    Object.defineProperty(ctx, "strokeStyle", {
+      set(v: string) {
+        strokes.push(v);
+      },
+      get() {
+        return "";
+      },
+    });
+    renderPatterns(ctx, [pat({ type })], panes, priceScales, ts, dl(), DARK_THEME, 11);
+    const expectedColor = expected === "bullish" ? "#26a69a" : "#ef5350";
+    expect(strokes).toContain(expectedColor);
+  });
+
+  it("draws neckline when present", () => {
+    const ctx = mockCtx();
+    const dashes: number[][] = [];
+    (ctx.setLineDash as ReturnType<typeof vi.fn>).mockImplementation((d: number[]) => {
+      dashes.push([...d]);
+    });
+    renderPatterns(
+      ctx,
+      [
+        pat({
+          pattern: {
+            ...pat().pattern,
+            neckline: { startPrice: 110, endPrice: 112, slope: 0.01, currentPrice: 111 },
+          },
+        }),
+      ],
+      panes,
+      priceScales,
+      ts,
+      dl(),
+      DARK_THEME,
+      11,
+    );
+    expect(dashes).toEqual(expect.arrayContaining([[6, 3]]));
+  });
+
+  it("draws target line and label when target present", () => {
+    const ctx = mockCtx();
+    const texts: string[] = [];
+    (ctx.fillText as ReturnType<typeof vi.fn>).mockImplementation((t: string) => {
+      texts.push(t);
+    });
+    renderPatterns(
+      ctx,
+      [pat({ pattern: { ...pat().pattern, target: 130 } })],
+      panes,
+      priceScales,
+      ts,
+      dl(),
+      DARK_THEME,
+      11,
+    );
+    expect(texts.some((t) => t.startsWith("T:"))).toBe(true);
+  });
+
+  it("includes pattern name and confidence in label", () => {
+    const ctx = mockCtx();
+    const texts: string[] = [];
+    (ctx.fillText as ReturnType<typeof vi.fn>).mockImplementation((t: string) => {
+      texts.push(t);
+    });
+    renderPatterns(
+      ctx,
+      [pat({ type: "head_and_shoulders", confidence: 72 })],
+      panes,
+      priceScales,
+      ts,
+      dl(),
+      DARK_THEME,
+      11,
+    );
+    expect(texts.some((t) => t.includes("head and shoulders") && t.includes("72%"))).toBe(true);
+  });
+});

--- a/packages/chart/src/__tests__/pointer.test.ts
+++ b/packages/chart/src/__tests__/pointer.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getPointerPos, onTap } from "../core/pointer";
+
+function makeEl(rect: Partial<DOMRect> = {}): HTMLElement {
+  const el = document.createElement("div");
+  const full = {
+    left: 10,
+    top: 20,
+    right: 810,
+    bottom: 620,
+    width: 800,
+    height: 600,
+    x: 10,
+    y: 20,
+    toJSON: () => ({}),
+    ...rect,
+  } as DOMRect;
+  el.getBoundingClientRect = () => full;
+  return el;
+}
+
+describe("getPointerPos", () => {
+  it("subtracts rect offset for MouseEvent", () => {
+    const el = makeEl();
+    const ev = new MouseEvent("click", { clientX: 110, clientY: 120 });
+    const p = getPointerPos(ev, el);
+    expect(p).toEqual({ x: 100, y: 100, isTouch: false });
+  });
+
+  it("treats Touch-like object (no button) as isTouch=true", () => {
+    const el = makeEl();
+    const touch = { clientX: 50, clientY: 40 } as unknown as Touch;
+    const p = getPointerPos(touch, el);
+    expect(p).toEqual({ x: 40, y: 20, isTouch: true });
+  });
+});
+
+describe("onTap", () => {
+  let el: HTMLElement;
+  let handler: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    el = makeEl();
+    handler = vi.fn();
+  });
+
+  it("fires on short click", () => {
+    const off = onTap(el, handler);
+    el.dispatchEvent(new MouseEvent("mousedown", { clientX: 100, clientY: 100 }));
+    el.dispatchEvent(new MouseEvent("click", { clientX: 101, clientY: 101 }));
+    expect(handler).toHaveBeenCalledWith({ x: 91, y: 81, isTouch: false });
+    off();
+  });
+
+  it("suppresses click when movement exceeds drag threshold", () => {
+    const off = onTap(el, handler);
+    el.dispatchEvent(new MouseEvent("mousedown", { clientX: 100, clientY: 100 }));
+    el.dispatchEvent(new MouseEvent("click", { clientX: 150, clientY: 150 }));
+    expect(handler).not.toHaveBeenCalled();
+    off();
+  });
+
+  it("fires click when no prior mousedown (downPos null branch)", () => {
+    const off = onTap(el, handler);
+    el.dispatchEvent(new MouseEvent("click", { clientX: 200, clientY: 200 }));
+    expect(handler).toHaveBeenCalledTimes(1);
+    off();
+  });
+
+  it("fires on single-finger tap via touchend", () => {
+    const off = onTap(el, handler);
+    const start = new Event("touchstart") as unknown as TouchEvent;
+    Object.defineProperty(start, "touches", { value: [{ clientX: 50, clientY: 60 }] });
+    el.dispatchEvent(start);
+    const end = new Event("touchend") as unknown as TouchEvent;
+    Object.defineProperty(end, "changedTouches", { value: [{ clientX: 51, clientY: 61 }] });
+    el.dispatchEvent(end);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0].isTouch).toBe(true);
+    off();
+  });
+
+  it("ignores multi-touch starts", () => {
+    const off = onTap(el, handler);
+    const start = new Event("touchstart") as unknown as TouchEvent;
+    Object.defineProperty(start, "touches", {
+      value: [
+        { clientX: 1, clientY: 1 },
+        { clientX: 2, clientY: 2 },
+      ],
+    });
+    el.dispatchEvent(start);
+    const end = new Event("touchend") as unknown as TouchEvent;
+    Object.defineProperty(end, "changedTouches", { value: [{ clientX: 1, clientY: 1 }] });
+    el.dispatchEvent(end);
+    expect(handler).not.toHaveBeenCalled();
+    off();
+  });
+
+  it("suppresses tap when finger moves beyond threshold", () => {
+    const off = onTap(el, handler);
+    const start = new Event("touchstart") as unknown as TouchEvent;
+    Object.defineProperty(start, "touches", { value: [{ clientX: 100, clientY: 100 }] });
+    el.dispatchEvent(start);
+    const end = new Event("touchend") as unknown as TouchEvent;
+    Object.defineProperty(end, "changedTouches", { value: [{ clientX: 150, clientY: 150 }] });
+    el.dispatchEvent(end);
+    expect(handler).not.toHaveBeenCalled();
+    off();
+  });
+
+  it("handles touchend with empty changedTouches", () => {
+    const off = onTap(el, handler);
+    const start = new Event("touchstart") as unknown as TouchEvent;
+    Object.defineProperty(start, "touches", { value: [{ clientX: 100, clientY: 100 }] });
+    el.dispatchEvent(start);
+    const end = new Event("touchend") as unknown as TouchEvent;
+    Object.defineProperty(end, "changedTouches", { value: [] });
+    expect(() => el.dispatchEvent(end)).not.toThrow();
+    expect(handler).not.toHaveBeenCalled();
+    off();
+  });
+
+  it("touchend without prior touchstart is ignored", () => {
+    const off = onTap(el, handler);
+    const end = new Event("touchend") as unknown as TouchEvent;
+    Object.defineProperty(end, "changedTouches", { value: [{ clientX: 1, clientY: 1 }] });
+    el.dispatchEvent(end);
+    expect(handler).not.toHaveBeenCalled();
+    off();
+  });
+
+  it("cleanup removes all listeners", () => {
+    const off = onTap(el, handler);
+    off();
+    el.dispatchEvent(new MouseEvent("click", { clientX: 100, clientY: 100 }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/chart/src/__tests__/range-utils.test.ts
+++ b/packages/chart/src/__tests__/range-utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { resolveRangeDuration } from "../core/range-utils";
+
+describe("resolveRangeDuration", () => {
+  const LAST = Date.UTC(2026, 3, 14, 12, 0, 0);
+  const DAY = 86_400_000;
+
+  it("ALL → null (caller should fitContent)", () => {
+    expect(resolveRangeDuration("ALL", LAST)).toBeNull();
+  });
+
+  it.each<[string, number]>([
+    ["1D", 1 * DAY],
+    ["1W", 7 * DAY],
+    ["1M", 30 * DAY],
+    ["3M", 90 * DAY],
+    ["6M", 180 * DAY],
+    ["1Y", 365 * DAY],
+  ])("%s subtracts expected ms", (dur, delta) => {
+    // @ts-expect-error — string literal match
+    expect(resolveRangeDuration(dur, LAST)).toBe(LAST - delta);
+  });
+
+  it("YTD returns UTC Jan 1 of lastTime year", () => {
+    const got = resolveRangeDuration("YTD", LAST);
+    expect(got).toBe(Date.UTC(2026, 0, 1));
+    expect(got).toBeLessThan(LAST);
+  });
+
+  it("YTD independent of sub-day components", () => {
+    const a = resolveRangeDuration("YTD", Date.UTC(2027, 6, 15, 3, 14));
+    const b = resolveRangeDuration("YTD", Date.UTC(2027, 11, 31, 23, 59));
+    expect(a).toBe(b);
+    expect(a).toBe(Date.UTC(2027, 0, 1));
+  });
+});

--- a/packages/chart/src/__tests__/score-renderer.test.ts
+++ b/packages/chart/src/__tests__/score-renderer.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, type vi } from "vitest";
+import type { DataPoint, PaneRect } from "../core/types";
+import { renderScoreHeatmap } from "../renderer/score-renderer";
+import { makePane, makeTimeScale, mockCtx } from "./helpers/mock-ctx";
+
+function scores(vals: (number | null)[]): DataPoint<number | null>[] {
+  return vals.map((v, i) => ({ time: i * 60_000, value: v }));
+}
+
+describe("renderScoreHeatmap", () => {
+  it("skips null / undefined / missing points", () => {
+    const ctx = mockCtx();
+    const ts = makeTimeScale(5, 800);
+    const pane: PaneRect = makePane("main", 300);
+    renderScoreHeatmap(ctx, scores([null, null, null, null, null]), ts, pane);
+    // Only clip save/restore should happen; no fillRect
+    expect(ctx.fillRect as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+    expect(ctx.save).toHaveBeenCalled();
+    expect(ctx.restore).toHaveBeenCalled();
+  });
+
+  it("renders a rect per scored bar and clamps score to [0,100]", () => {
+    const ctx = mockCtx();
+    const ts = makeTimeScale(4, 800);
+    const pane = makePane("main", 200);
+    renderScoreHeatmap(ctx, scores([0, 50, 100, 150]), ts, pane);
+    const fillRect = ctx.fillRect as ReturnType<typeof vi.fn>;
+    expect(fillRect).toHaveBeenCalledTimes(4);
+    // last point value 150 should have been clamped (doesn't throw, produces a color)
+  });
+
+  it("color ramp: low score is red-ish, high score is green-ish", () => {
+    // Inspect fillStyle set sequence by capturing string assignments
+    const colors: string[] = [];
+    const proxy = mockCtx();
+    Object.defineProperty(proxy, "fillStyle", {
+      set(v: string) {
+        colors.push(v);
+      },
+      get() {
+        return "";
+      },
+    });
+    const ts = makeTimeScale(3, 800);
+    renderScoreHeatmap(proxy, scores([0, 50, 100]), ts, makePane("main", 100));
+    expect(colors.length).toBeGreaterThanOrEqual(3);
+    // Score 0 → red dominant (r high, g/b low)
+    expect(colors[0]).toMatch(/rgb\(239,83,80\)/);
+    // Score 50 → yellow (r=239, g=255, b=0)
+    expect(colors[1]).toMatch(/rgb\(239,255,0\)/);
+    // Score 100 → green (38,166,154)
+    expect(colors[2]).toMatch(/rgb\(38,166,154\)/);
+  });
+
+  it("clips to paneRect via save/rect/clip/restore", () => {
+    const ctx = mockCtx();
+    const ts = makeTimeScale(2, 800);
+    renderScoreHeatmap(ctx, scores([10, 90]), ts, makePane("main", 100));
+    expect(ctx.save).toHaveBeenCalled();
+    expect(ctx.rect).toHaveBeenCalled();
+    expect(ctx.clip).toHaveBeenCalled();
+    expect(ctx.restore).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 8 test files covering modules that previously had **zero** test coverage
- Lifts chart package branch coverage from **56.1% → 61.8%** (+132 branches, +68 test cases)
- Each targeted file now reaches **94–100% branch coverage**

## Files added
| Target module | New test | Branch % |
|---|---|---|
| `core/range-utils.ts` | `range-utils.test.ts` | 100% |
| `core/pointer.ts` | `pointer.test.ts` | 100% |
| `core/animation.ts` | `animation.test.ts` | 100% |
| `renderer/score-renderer.ts` | `score-renderer.test.ts` | 100% |
| `series/box.ts` | `box-series.test.ts` | 100% |
| `series/heatmap.ts` | `heatmap-series.test.ts` | 94% |
| `renderer/backtest-renderer.ts` | `backtest-renderer.test.ts` | 94% |
| `renderer/pattern-renderer.ts` | `pattern-renderer.test.ts` | 97% |

All tests use the existing `helpers/mock-ctx.ts` Canvas stub (no real DOM needed, except `pointer` / `animation` which use happy-dom).

## Test plan
- [x] \`pnpm vitest run\` — 563 passed (was 495)
- [x] \`pnpm vitest run --coverage\` — branches 61.79%
- [x] \`pnpm build\` — builds cleanly