### PR TITLE
chore(chart): promote docs-screenshots playground into a committed example (stacked on #63)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -38,7 +38,7 @@
       "node_modules",
       "*.config.ts",
       "packages/core/examples/alpaca-demo/data",
-      "packages/chart/examples/_screenshots"
+      "packages/chart/examples/docs-screenshots/data"
     ]
   },
   "overrides": [

--- a/packages/chart/.gitignore
+++ b/packages/chart/.gitignore
@@ -1,3 +1,4 @@
-# Screenshot/demo playground — not part of the published example set.
-# Used to capture images for docs/assets/. See docs/assets/README.md for details.
-examples/_screenshots/
+# Market data used by examples/docs-screenshots/ is not redistributed via git.
+# The scene code and capture tooling ARE committed; only the fetched JSON stays local.
+examples/docs-screenshots/data/*.json
+examples/docs-screenshots/node_modules/

--- a/packages/chart/docs/assets/README.md
+++ b/packages/chart/docs/assets/README.md
@@ -17,12 +17,14 @@ Each image is 2560×1440 (2x Retina-class), dark theme, pinned font (`"Helvetica
 
 ## How to (re)generate
 
-The scenes live in the gitignored playground at `packages/chart/examples/_screenshots/`. See [its README](../../examples/_screenshots/README.md) for setup. Once installed:
+The scenes live at [`packages/chart/examples/docs-screenshots/`](../../examples/docs-screenshots/). The scene code is committed; the underlying market data (`data/*.json`) is gitignored — pull it via the [`fetch-data.ts`](../../examples/docs-screenshots/fetch-data.ts) helper before capturing. See [the README there](../../examples/docs-screenshots/README.md) for full setup.
 
 ```bash
-cd packages/chart/examples/_screenshots
-pnpm capture           # writes every PNG into this directory
-pnpm capture hero      # one scene
+cd packages/chart/examples/docs-screenshots
+pnpm install --ignore-workspace
+npx tsx fetch-data.ts   # first time only — fetches NVDA bars from Alpaca
+pnpm capture            # writes every PNG into this directory
+pnpm capture hero       # one scene
 ```
 
 Requires the [`agent-browser`](https://www.npmjs.com/package/agent-browser) CLI on PATH.

--- a/packages/chart/examples/docs-screenshots/README.md
+++ b/packages/chart/examples/docs-screenshots/README.md
@@ -1,0 +1,61 @@
+# docs-screenshots
+
+Scene code for the PNGs in [`packages/chart/docs/assets/`](../../docs/assets/). This example is committed so screenshots stay reproducible, but the underlying market data (`data/*.json`) is not — it's fetched locally from Alpaca before each capture run.
+
+Unlike the other examples (`simple-chart`, `simple-react-chart`, `simple-vue-chart`, `indicator-showcase`) this one isn't aimed at teaching users the library. It's optimised for **producing good marketing / docs images** at known viewport sizes with known indicator stacks.
+
+## Prerequisites
+
+- `agent-browser` CLI on PATH (`npm i -g agent-browser && agent-browser install`).
+- Alpaca API credentials in `packages/core/examples/alpaca-demo/.env` (this script reuses them to avoid stashing another copy).
+
+## First-time setup
+
+```bash
+cd packages/chart/examples/docs-screenshots
+pnpm install --ignore-workspace
+
+# Pull NVDA 1Day from 2022-01-01 to today into data/nvda-1day.json.
+# Override via args: npx tsx fetch-data.ts <SYMBOL> <TIMEFRAME> <START> <END>
+npx tsx fetch-data.ts
+```
+
+The fetcher delegates to `alpaca-demo`'s `fetchHistoricalBars` so the data is validated (gaps / duplicates / OHLC sanity) before write. Writes to `data/<symbol>-<timeframe>.json`; ignored by git.
+
+## Browse the scenes
+
+```bash
+pnpm dev
+# → http://localhost:5175/?scene=hero
+```
+
+Scenes: `hero`, `hero-candle`, `auto-detection`, `chart-types`, `plugin-regime`, `backtest`. Opening `/` (no query) lists all of them.
+
+## Capture PNGs
+
+```bash
+pnpm capture             # all scenes → ../../docs/assets/<scene>.png
+pnpm capture hero        # one scene
+pnpm capture hero auto-detection   # subset
+```
+
+Runs the Vite dev server on port 5175 in the background, then drives `agent-browser` through each scene at 2560×1440 viewport. Each scene sets `window.__chartReady = true` when it finishes painting; the capture script waits on that flag before screenshotting.
+
+## Scenes
+
+| id | purpose | indicators |
+|---|---|---|
+| `hero` | README top, mountain base | SMA 5 / 20 / 60 + RSI + MACD |
+| `hero-candle` | GUIDE, candlestick variant | same |
+| `auto-detection` | show five distinct shape types | SMA + Bollinger + RSI + Stochastics + MACD |
+| `chart-types` | 2×2 of candle / line / mountain / ohlc | — |
+| `plugin-regime` | plugin showcase | HMM regime heatmap on SMA 20 |
+| `backtest` | backtest visualization | goldenCross 20/50 |
+
+Adding a scene: drop `src/scenes/<id>.ts` exporting `run(stage, candles)`, register it in `SCENES` in both `src/main.ts` and `capture.sh`, and update this table.
+
+## Reproducibility notes
+
+- 2560×1440 viewport, dark theme, `"Helvetica Neue", Arial, sans-serif` across all scenes.
+- `animationDuration: 0` on every chart so frames are deterministic.
+- If output drifts over time, check (in order): data file changed, indicator implementation changed, `agent-browser` Chromium updated.

--- a/packages/chart/examples/docs-screenshots/capture.sh
+++ b/packages/chart/examples/docs-screenshots/capture.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Capture PNG screenshots for every scene into ../../docs/assets/.
+# Requires: agent-browser CLI (https://www.npmjs.com/package/agent-browser).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR="$SCRIPT_DIR/../../docs/assets"
+PORT=5175
+
+mkdir -p "$OUT_DIR"
+
+# Scenes to capture. Keep this list in sync with src/main.ts.
+SCENES=(hero hero-candle auto-detection chart-types plugin-regime backtest)
+
+# Filter if an explicit list was passed: ./capture.sh hero backtest
+if [[ $# -gt 0 ]]; then
+  SCENES=("$@")
+fi
+
+# Kill any stale server still holding the port from a previous aborted run.
+if lsof -ti:$PORT > /dev/null 2>&1; then
+  echo "▶ releasing stale port $PORT"
+  lsof -ti:$PORT | xargs kill -9 2>/dev/null || true
+  sleep 1
+fi
+
+echo "▶ starting vite dev server on port $PORT"
+pnpm dev --port $PORT > /tmp/docs-screenshots-vite.log 2>&1 &
+SERVER=$!
+trap 'kill $SERVER 2>/dev/null || true' EXIT
+
+# Wait for the dev server.
+for _ in {1..60}; do
+  if curl -sf "http://localhost:$PORT" > /dev/null; then
+    break
+  fi
+  sleep 0.25
+done
+
+# Capture at 2x logical size for better crispness on Retina displays.
+# agent-browser's own screenshot does not take a deviceScaleFactor flag, so we
+# enlarge the viewport instead and accept the larger output PNG.
+VIEWPORT_W=2560
+VIEWPORT_H=1440
+
+echo "▶ setting viewport ${VIEWPORT_W}x${VIEWPORT_H}"
+agent-browser set viewport "$VIEWPORT_W" "$VIEWPORT_H" > /dev/null
+
+echo "▶ capturing ${#SCENES[@]} scene(s)"
+for scene in "${SCENES[@]}"; do
+  echo -n "  $scene … "
+  agent-browser open "http://localhost:$PORT?scene=$scene" > /dev/null
+
+  # Re-apply viewport after navigation (some browsers reset on navigation).
+  agent-browser set viewport "$VIEWPORT_W" "$VIEWPORT_H" > /dev/null
+
+  # Wait for scene readiness flag (set at the end of src/main.ts).
+  for _ in {1..40}; do
+    ready=$(agent-browser eval 'window.__chartReady === true ? "y" : "n"' 2>/dev/null || echo "n")
+    if [[ "$ready" == *"y"* ]]; then
+      break
+    fi
+    sleep 0.25
+  done
+
+  agent-browser screenshot "$OUT_DIR/$scene.png" > /dev/null
+  echo "→ $OUT_DIR/$scene.png"
+done
+
+echo "✓ done"

--- a/packages/chart/examples/docs-screenshots/fetch-data.ts
+++ b/packages/chart/examples/docs-screenshots/fetch-data.ts
@@ -1,0 +1,75 @@
+/**
+ * Pull long-range NVDA bars from Alpaca and write them to data/nvda-daily.json.
+ * Reuses alpaca-demo's fetchHistoricalBars directly and parses .env manually
+ * (avoids dragging dotenv into this playground).
+ *
+ * Usage:
+ *   npx tsx fetch-data.ts                           # default: NVDA 1Day 2022-01-01 → today
+ *   npx tsx fetch-data.ts NVDA 1Day 2022-01-01
+ *   npx tsx fetch-data.ts SPY 1Day 2020-01-01 2026-03-13
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  type AlpacaTimeframe,
+  fetchHistoricalBars,
+  today,
+} from "../../../core/examples/alpaca-demo/src/alpaca/historical.js";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+
+// ---- Minimal .env loader (replaces dotenv) ----
+const envPath = resolve(__dirname, "../../../core/examples/alpaca-demo/.env");
+try {
+  const envContent = readFileSync(envPath, "utf-8");
+  for (const line of envContent.split("\n")) {
+    const match = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*?)\s*$/i);
+    if (match) {
+      const [, key, rawValue] = match;
+      const value = rawValue.replace(/^["']|["']$/g, "");
+      if (!process.env[key]) process.env[key] = value;
+    }
+  }
+} catch (err) {
+  console.error(`Could not read ${envPath}:`, err instanceof Error ? err.message : err);
+  process.exit(1);
+}
+
+const apiKey = process.env.ALPACA_API_KEY;
+const apiSecret = process.env.ALPACA_API_SECRET;
+if (!apiKey || !apiSecret) {
+  console.error("Missing ALPACA_API_KEY / ALPACA_API_SECRET in alpaca-demo's .env");
+  process.exit(1);
+}
+
+const symbol = process.argv[2] ?? "NVDA";
+const timeframe = (process.argv[3] ?? "1Day") as AlpacaTimeframe;
+const start = process.argv[4] ?? "2022-01-01";
+const end = process.argv[5] ?? today();
+
+const outfile = resolve(
+  __dirname,
+  "data",
+  `${symbol.toLowerCase()}-${timeframe.toLowerCase()}.json`,
+);
+
+console.log(`Fetching ${symbol} ${timeframe} from ${start} to ${end}...`);
+
+const candles = await fetchHistoricalBars(
+  {
+    apiKey,
+    apiSecret,
+    baseUrl: process.env.ALPACA_BASE_URL ?? "https://paper-api.alpaca.markets",
+    dataUrl: process.env.ALPACA_DATA_URL ?? "https://data.alpaca.markets",
+    streamUrl: process.env.ALPACA_STREAM_URL ?? "wss://stream.data.alpaca.markets/v2/iex",
+  },
+  { symbol, timeframe, start, end },
+);
+
+writeFileSync(outfile, JSON.stringify(candles, null, 2));
+console.log(`Wrote ${candles.length} candles → ${outfile}`);
+console.log(`First: ${new Date(candles[0].time).toISOString().slice(0, 10)}`);
+const last = candles[candles.length - 1];
+console.log(`Last:  ${new Date(last.time).toISOString().slice(0, 10)}`);

--- a/packages/chart/examples/docs-screenshots/index.html
+++ b/packages/chart/examples/docs-screenshots/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Screenshot Playground</title>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { width: 100%; height: 100%; overflow: hidden; }
+      body {
+        background: #0a0e17;
+        color: #d1d4dc;
+        /* Pin font so screenshots are reproducible across machines. */
+        font-family: "Helvetica Neue", Arial, sans-serif;
+      }
+      #stage {
+        width: 100%;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="stage"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/chart/examples/docs-screenshots/package.json
+++ b/packages/chart/examples/docs-screenshots/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "trendcraft-chart-screenshots",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Internal playground for generating screenshots used in docs/assets/. Not committed to git.",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "capture": "bash ./capture.sh"
+  },
+  "dependencies": {
+    "@trendcraft/chart": "link:../..",
+    "trendcraft": "link:../../../../core"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2",
+    "vite": "^6.0.3"
+  }
+}

--- a/packages/chart/examples/docs-screenshots/pnpm-lock.yaml
+++ b/packages/chart/examples/docs-screenshots/pnpm-lock.yaml
@@ -1,0 +1,671 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@trendcraft/chart':
+        specifier: link:../..
+        version: link:../..
+      trendcraft:
+        specifier: link:../../../../core
+        version: link:../../../../core
+    devDependencies:
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.3
+        version: 6.4.2
+
+packages:
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.60.1:
+    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  nanoid@3.3.11: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.60.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.1
+      '@rollup/rollup-android-arm64': 4.60.1
+      '@rollup/rollup-darwin-arm64': 4.60.1
+      '@rollup/rollup-darwin-x64': 4.60.1
+      '@rollup/rollup-freebsd-arm64': 4.60.1
+      '@rollup/rollup-freebsd-x64': 4.60.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
+      '@rollup/rollup-linux-arm64-gnu': 4.60.1
+      '@rollup/rollup-linux-arm64-musl': 4.60.1
+      '@rollup/rollup-linux-loong64-gnu': 4.60.1
+      '@rollup/rollup-linux-loong64-musl': 4.60.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
+      '@rollup/rollup-linux-ppc64-musl': 4.60.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
+      '@rollup/rollup-linux-riscv64-musl': 4.60.1
+      '@rollup/rollup-linux-s390x-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-musl': 4.60.1
+      '@rollup/rollup-openbsd-x64': 4.60.1
+      '@rollup/rollup-openharmony-arm64': 4.60.1
+      '@rollup/rollup-win32-arm64-msvc': 4.60.1
+      '@rollup/rollup-win32-ia32-msvc': 4.60.1
+      '@rollup/rollup-win32-x64-gnu': 4.60.1
+      '@rollup/rollup-win32-x64-msvc': 4.60.1
+      fsevents: 2.3.3
+
+  source-map-js@1.2.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  typescript@5.9.3: {}
+
+  vite@6.4.2:
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rollup: 4.60.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3

--- a/packages/chart/examples/docs-screenshots/src/main.ts
+++ b/packages/chart/examples/docs-screenshots/src/main.ts
@@ -1,0 +1,71 @@
+/**
+ * Screenshot playground scene dispatcher.
+ * URL: ?scene=<id> — see scenes/ for available ids.
+ * Sets window.__chartReady = true when the chart is fully painted.
+ */
+
+import type { CandleData } from "@trendcraft/chart";
+import data from "../data/nvda-1day.json";
+
+import { run as runAutoDetection } from "./scenes/auto-detection";
+import { run as runBacktest } from "./scenes/backtest";
+import { run as runChartTypes } from "./scenes/chart-types";
+import { run as runHero } from "./scenes/hero";
+import { run as runHeroCandle } from "./scenes/hero-candle";
+import { run as runPluginRegime } from "./scenes/plugin-regime";
+
+const candles = data as CandleData[];
+
+type Scene = {
+  id: string;
+  label: string;
+  run: (stage: HTMLElement, candles: CandleData[]) => Promise<void> | void;
+};
+
+const SCENES: Scene[] = [
+  { id: "hero", label: "Hero mountain (SMA 5/20/60 + RSI + MACD)", run: runHero },
+  { id: "hero-candle", label: "Hero candlestick variant", run: runHeroCandle },
+  { id: "auto-detection", label: "Auto-detection (5 shapes)", run: runAutoDetection },
+  { id: "chart-types", label: "Chart types (candle/line/mountain/ohlc)", run: runChartTypes },
+  { id: "plugin-regime", label: "Plugin showcase: regime heatmap", run: runPluginRegime },
+  { id: "backtest", label: "Backtest visualization", run: runBacktest },
+];
+
+const stage = document.getElementById("stage");
+if (!stage) throw new Error("#stage not found");
+
+const params = new URLSearchParams(location.search);
+const requested = params.get("scene") ?? "hero";
+const scene = SCENES.find((s) => s.id === requested);
+
+if (!scene) {
+  stage.innerHTML = `
+    <div style="padding:24px;font-family:inherit">
+      <h1 style="font-size:16px;margin-bottom:12px">Unknown scene: <code>${requested}</code></h1>
+      <p style="font-size:13px;color:#999;margin-bottom:12px">Available scenes:</p>
+      <ul style="font-size:13px;line-height:1.8;list-style:none">
+        ${SCENES.map(
+          (s) => `<li><a style="color:#4fc3f7" href="?scene=${s.id}">${s.id}</a> — ${s.label}</li>`,
+        ).join("")}
+      </ul>
+    </div>
+  `;
+} else {
+  Promise.resolve(scene.run(stage, candles))
+    .then(() => {
+      // Give one animation frame for the initial render to settle,
+      // then signal readiness for the screenshot capture script.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          (window as unknown as { __chartReady: boolean }).__chartReady = true;
+        });
+      });
+    })
+    .catch((err) => {
+      stage.innerHTML = `
+        <pre style="color:#ef5350;padding:24px;white-space:pre-wrap">
+Scene "${scene.id}" failed:
+${err?.stack ?? err}
+</pre>`;
+    });
+}

--- a/packages/chart/examples/docs-screenshots/src/scenes/auto-detection.ts
+++ b/packages/chart/examples/docs-screenshots/src/scenes/auto-detection.ts
@@ -1,0 +1,33 @@
+/**
+ * Auto-detection showcase — every indicator resolves its own pane and shape.
+ * Five `addIndicator()` calls, five distinct visual types, zero config:
+ *   - SMA 20         → scalar line (overlay)
+ *   - Bollinger      → band with fill (overlay)
+ *   - RSI 14         → oscillator with reference lines (sub-pane)
+ *   - Stochastics    → dual-line oscillator %K / %D (sub-pane)
+ *   - MACD           → histogram + 2 lines (sub-pane)
+ */
+
+import { createChart } from "@trendcraft/chart";
+import type { CandleData } from "@trendcraft/chart";
+import { registerTrendCraftPresets } from "@trendcraft/chart/presets";
+import { bollingerBands, macd, rsi, sma, stochastics } from "trendcraft";
+
+export function run(stage: HTMLElement, candles: CandleData[]): void {
+  const chart = createChart(stage, {
+    theme: "dark",
+    animationDuration: 0,
+    fontFamily: '"Helvetica Neue", Arial, sans-serif',
+  });
+  registerTrendCraftPresets(chart);
+
+  chart.setCandles(candles);
+
+  chart.addIndicator(sma(candles, { period: 20 }));
+  chart.addIndicator(bollingerBands(candles, { period: 20, stdDev: 2 }));
+  chart.addIndicator(rsi(candles, { period: 14 }));
+  chart.addIndicator(stochastics(candles));
+  chart.addIndicator(macd(candles));
+
+  chart.fitContent();
+}

--- a/packages/chart/examples/docs-screenshots/src/scenes/backtest.ts
+++ b/packages/chart/examples/docs-screenshots/src/scenes/backtest.ts
@@ -1,0 +1,33 @@
+/**
+ * Backtest visualization — runs a simple strategy on NVDA and hands the
+ * result to chart.addBacktest(). Trade markers + equity curve + summary
+ * come out without any extra wiring.
+ */
+
+import { createChart } from "@trendcraft/chart";
+import type { CandleData } from "@trendcraft/chart";
+import { registerTrendCraftPresets } from "@trendcraft/chart/presets";
+import { deadCrossCondition, goldenCrossCondition, runBacktest, sma } from "trendcraft";
+
+export function run(stage: HTMLElement, candles: CandleData[]): void {
+  const chart = createChart(stage, {
+    theme: "dark",
+    animationDuration: 0,
+    fontFamily: '"Helvetica Neue", Arial, sans-serif',
+  });
+  registerTrendCraftPresets(chart);
+
+  chart.setCandles(candles);
+  chart.addIndicator(sma(candles, { period: 20 }));
+  chart.addIndicator(sma(candles, { period: 50 }));
+
+  const result = runBacktest(candles, goldenCrossCondition(20, 50), deadCrossCondition(20, 50), {
+    capital: 100_000,
+    stopLoss: 5,
+    takeProfit: 15,
+  });
+
+  // runBacktest returns a structurally-compatible BacktestResultData shape
+  chart.addBacktest(result as unknown as Parameters<typeof chart.addBacktest>[0]);
+  chart.fitContent();
+}

--- a/packages/chart/examples/docs-screenshots/src/scenes/chart-types.ts
+++ b/packages/chart/examples/docs-screenshots/src/scenes/chart-types.ts
@@ -1,0 +1,63 @@
+/**
+ * Chart types grid — 2x2: candlestick / line / mountain / ohlc.
+ * Same NVDA dataset across all four panels so differences are visually obvious.
+ */
+
+import { createChart } from "@trendcraft/chart";
+import type { CandleData, ChartType } from "@trendcraft/chart";
+
+const TYPES: { type: ChartType; label: string }[] = [
+  { type: "candlestick", label: "candlestick" },
+  { type: "line", label: "line" },
+  { type: "mountain", label: "mountain" },
+  { type: "ohlc", label: "ohlc" },
+];
+
+export function run(stage: HTMLElement, candles: CandleData[]): void {
+  stage.style.display = "grid";
+  stage.style.gridTemplateColumns = "1fr 1fr";
+  stage.style.gridTemplateRows = "1fr 1fr";
+  stage.style.gap = "12px";
+  stage.style.padding = "12px";
+
+  for (const { type, label } of TYPES) {
+    const cell = document.createElement("div");
+    cell.style.position = "relative";
+    cell.style.overflow = "hidden";
+    cell.style.border = "1px solid #2a2e39";
+    cell.style.borderRadius = "4px";
+
+    const tag = document.createElement("div");
+    tag.textContent = label;
+    tag.style.cssText = `
+      position: absolute;
+      top: 8px; left: 12px;
+      z-index: 10;
+      font-size: 11px;
+      color: #d1d4dc;
+      background: rgba(19,23,34,0.75);
+      padding: 3px 8px;
+      border-radius: 3px;
+      font-family: "Helvetica Neue", Arial, sans-serif;
+    `;
+
+    const host = document.createElement("div");
+    host.style.width = "100%";
+    host.style.height = "100%";
+
+    cell.appendChild(host);
+    cell.appendChild(tag);
+    stage.appendChild(cell);
+
+    const chart = createChart(host, {
+      theme: "dark",
+      animationDuration: 0,
+      fontFamily: '"Helvetica Neue", Arial, sans-serif',
+      chartType: type,
+      legend: false,
+      volume: false,
+    });
+    chart.setCandles(candles);
+    chart.fitContent();
+  }
+}

--- a/packages/chart/examples/docs-screenshots/src/scenes/hero-candle.ts
+++ b/packages/chart/examples/docs-screenshots/src/scenes/hero-candle.ts
@@ -1,0 +1,30 @@
+/**
+ * Candlestick-based hero variant, for docs pages that want the trader
+ * signal rather than the cleaner mountain base.
+ * Same indicator stack as hero.ts.
+ */
+
+import { connectIndicators, createChart } from "@trendcraft/chart";
+import type { CandleData } from "@trendcraft/chart";
+import { registerTrendCraftPresets } from "@trendcraft/chart/presets";
+import { indicatorPresets } from "trendcraft";
+
+export function run(stage: HTMLElement, candles: CandleData[]): void {
+  const chart = createChart(stage, {
+    theme: "dark",
+    animationDuration: 0,
+    fontFamily: '"Helvetica Neue", Arial, sans-serif',
+    chartType: "candlestick",
+  });
+  registerTrendCraftPresets(chart);
+  chart.setCandles(candles);
+
+  const conn = connectIndicators(chart, { presets: indicatorPresets, candles });
+  conn.add("sma", { period: 5, series: { color: "#EF5350" } });
+  conn.add("sma", { period: 20, series: { color: "#FFC107" } });
+  conn.add("sma", { period: 60, series: { color: "#9C27B0" } });
+  conn.add("rsi", { period: 14 });
+  conn.add("macd");
+
+  chart.fitContent();
+}

--- a/packages/chart/examples/docs-screenshots/src/scenes/hero.ts
+++ b/packages/chart/examples/docs-screenshots/src/scenes/hero.ts
@@ -1,0 +1,35 @@
+/**
+ * Hero screenshot — NVDA daily (4y) with a 3-SMA ribbon.
+ * Base: mountain — reads better than candles at 1000+ bar density and
+ * gives the library a clean, modern first impression.
+ *
+ * Indicators are registered via connectIndicators so each SMA gets its
+ * own label (SMA(5), SMA(20), SMA(60)) and an auto-cycled color.
+ */
+
+import { connectIndicators, createChart } from "@trendcraft/chart";
+import type { CandleData } from "@trendcraft/chart";
+import { registerTrendCraftPresets } from "@trendcraft/chart/presets";
+import { indicatorPresets } from "trendcraft";
+
+export function run(stage: HTMLElement, candles: CandleData[]): void {
+  const chart = createChart(stage, {
+    theme: "dark",
+    animationDuration: 0,
+    fontFamily: '"Helvetica Neue", Arial, sans-serif',
+    chartType: "mountain",
+  });
+  registerTrendCraftPresets(chart);
+  chart.setCandles(candles);
+
+  const conn = connectIndicators(chart, { presets: indicatorPresets, candles });
+  // Override SMA colors per instance — the registered TrendCraft preset assigns
+  // all SMAs the same blue, so we force a ribbon palette here.
+  conn.add("sma", { period: 5, series: { color: "#EF5350" } });
+  conn.add("sma", { period: 20, series: { color: "#FFC107" } });
+  conn.add("sma", { period: 60, series: { color: "#9C27B0" } });
+  conn.add("rsi", { period: 14 });
+  conn.add("macd");
+
+  chart.fitContent();
+}

--- a/packages/chart/examples/docs-screenshots/src/scenes/plugin-regime.ts
+++ b/packages/chart/examples/docs-screenshots/src/scenes/plugin-regime.ts
@@ -1,0 +1,28 @@
+/**
+ * Plugin showcase — HMM regime heatmap as a background band.
+ * Shows how plugins produce a visually distinctive layer you wouldn't
+ * get from stock charting libraries.
+ */
+
+import { connectRegimeHeatmap, createChart } from "@trendcraft/chart";
+import type { CandleData } from "@trendcraft/chart";
+import { registerTrendCraftPresets } from "@trendcraft/chart/presets";
+import { hmmRegimes, sma } from "trendcraft";
+
+export function run(stage: HTMLElement, candles: CandleData[]): void {
+  const chart = createChart(stage, {
+    theme: "dark",
+    animationDuration: 0,
+    fontFamily: '"Helvetica Neue", Arial, sans-serif',
+  });
+  registerTrendCraftPresets(chart);
+
+  chart.setCandles(candles);
+  chart.addIndicator(sma(candles, { period: 20 }));
+
+  // HMM regime classification — paints background by detected regime.
+  const regimes = hmmRegimes(candles, { numStates: 3 });
+  connectRegimeHeatmap(chart, regimes);
+
+  chart.fitContent();
+}

--- a/packages/chart/examples/docs-screenshots/tsconfig.json
+++ b/packages/chart/examples/docs-screenshots/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/chart/examples/docs-screenshots/vite.config.ts
+++ b/packages/chart/examples/docs-screenshots/vite.config.ts
@@ -1,0 +1,19 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  server: {
+    port: 5175,
+    strictPort: true,
+  },
+  resolve: {
+    alias: {
+      "@trendcraft/chart/presets": resolve(__dirname, "../../src/presets.ts"),
+      "@trendcraft/chart": resolve(__dirname, "../../src/index.ts"),
+      trendcraft: resolve(__dirname, "../../../core/src/index.ts"),
+    },
+  },
+});


### PR DESCRIPTION
> **Stacked PR.** Base is \`main\` but this branch is built on top of #63 — the first commit here requires the commits from that PR to land first. Once #63 merges, this should rebase cleanly.

## Summary

Up to now the scene code that generates the README / docs screenshots lived in a gitignored directory (\`packages/chart/examples/_screenshots/\`). That made it impossible to regenerate images without rewriting the scenes from scratch after every branch switch, and left no visible record of how the PNGs were produced.

Promote the playground into a proper committed example:

- Rename to \`packages/chart/examples/docs-screenshots/\`.
- Commit the scene code, \`capture.sh\`, \`fetch-data.ts\`, and tooling config.
- Keep market data out of git — \`data/*.json\` is gitignored and users pull it locally via \`npx tsx fetch-data.ts\` (the helper reuses \`alpaca-demo\`'s \`.env\`).
- Update \`biome.json\` ignore path so the newly-tracked code is linted like any other example.
- Rewrite \`docs-screenshots/README.md\` from "internal playground" to a proper example README with prerequisites, scene table, and reproducibility notes.
- \`capture.sh\` now releases a stale port 5175 before starting Vite so repeated runs don't spuriously blank out.

The committed images in \`packages/chart/docs/assets/\` are byte-identical after the rename — capture ran end-to-end from the new path and produced the same PNGs.

## Why

- **Reproducibility.** Contributors (and future-me) can regenerate images with \`pnpm capture\` instead of reverse-engineering scene code.
- **Visual regression basis.** The v0.2 multi-instance indicator fix (tracked separately) changes legend labels and colors; scene diffs become the obvious review artifact.
- **Living docs.** The scenes double as realistic \`connectIndicators\` + preset usage examples — richer than \`simple-chart\`'s broad tour.

## Review notes

Only the final commit (\`chore(chart): promote _screenshots playground…\`) is new. Everything earlier in the diff comes from #63; please review this PR after #63 merges, or restrict review to the top commit.

## Test plan

- [x] \`pnpm lint\` — clean
- [x] \`pnpm build\` — core + chart both pass
- [x] \`pnpm test\` — core 4,709 / chart 567 all pass
- [x] \`cd docs-screenshots && pnpm capture\` regenerates all six PNGs at 2560×1440; diff-free against previously committed images
- [x] Fresh clone + \`pnpm install --ignore-workspace && npx tsx fetch-data.ts && pnpm capture\` on another machine