### PR TITLE
docs+test: refresh __meta examples and cover withLabelParams / kind

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -22,6 +22,27 @@ Target: **v0.2.0** — minor bump introducing live-streaming, indicator-registry
   All ~95 built-in indicators now emit a `kind`.
 - `withLabelParams(meta, params)` helper in `tag-series` for building parameterized labels when authoring custom indicators.
 
+### Migration from v0.1.0
+
+Most code doesn't need changes — passing indicators to charts, computing values, or displaying labels works the same. The only realistic breakage is code that string-compared `__meta.label`:
+
+```typescript
+// ❌ v0.1.0 style (breaks in v0.2.0 — label is now "RSI(14)")
+if (series.__meta.label === "RSI") { ... }
+
+// ✅ v0.2.0 — match by stable kind instead
+if (series.__meta?.kind === "rsi") { ... }
+
+// ✅ alternative — prefix match if you don't have kind yet
+if (series.__meta?.label.startsWith("RSI")) { ... }
+```
+
+Useful for filtering multiple-instance series by indicator type (e.g. "show me all SMAs regardless of period"):
+
+```typescript
+const smas = allSeries.filter((s) => s.__meta?.kind === "sma");
+```
+
 ### Added — Live Streaming
 
 - `createLiveCandle(options, fromState?)` — unified tick/candle aggregator with dynamically registered incremental indicators and an event bus (`tick`, `candleComplete`). Supports both tick mode (`addTick`) and candle mode (`addCandle`), with state save/restore for resumable sessions.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -639,7 +639,7 @@ Every built-in indicator output carries a non-enumerable `__meta` describing its
 import { tagSeries, rsi } from 'trendcraft';
 
 const r = rsi(candles, { period: 14 });
-r.__meta; // { label: 'RSI', overlay: false, yRange: [0, 100], referenceLines: [30, 70] }
+r.__meta; // { kind: 'rsi', label: 'RSI(14)', overlay: false, yRange: [0, 100], referenceLines: [30, 70] }
 
 // Tag a custom series with the same shape
 const my = tagSeries(myData, {

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -5605,7 +5605,7 @@ import { livePresets } from "trendcraft";
 
 const sma = livePresets.sma;
 // {
-//   meta: { label: 'SMA', overlay: true, ... },
+//   meta: { kind: 'sma', label: 'SMA', overlay: true, ... },
 //   defaultParams: { period: 20 },
 //   snapshotName: (p) => `sma${p.period}`,
 //   createFactory: (params) => (fromState) => IncrementalIndicator,
@@ -5620,7 +5620,7 @@ const indicator = factory(undefined); // 既存 state なし
 
 | フィールド | 型 | 説明 |
 |---|---|---|
-| `meta` | `SeriesMeta` | 描画メタデータ（label, overlay, yRange, referenceLines）。 |
+| `meta` | `SeriesMeta` | 描画メタデータ（kind, label, overlay, yRange, referenceLines）。 |
 | `defaultParams` | `Record<string, unknown>` | ユーザーが `{}` を渡したときのデフォルトパラメータ。 |
 | `snapshotName` | `(params) => string` | このインスタンスの snapshot キーを生成（例: `"sma20"`）。 |
 | `createFactory` | `(params) => LiveIndicatorFactory` | 指定パラメータで closure したインクリメンタルファクトリを生成。 |
@@ -5660,7 +5660,8 @@ import { tagSeries, rsi, type SeriesMeta } from "trendcraft";
 const r = rsi(candles, { period: 14 });
 r.__meta;
 // {
-//   label: "RSI",
+//   kind: "rsi",
+//   label: "RSI(14)",
 //   overlay: false,
 //   yRange: [0, 100],
 //   referenceLines: [30, 70],
@@ -5678,7 +5679,8 @@ const myCustom = tagSeries(myData, {
 
 | フィールド | 型 | 説明 |
 |---|---|---|
-| `label` | `string` | 表示ラベル（例 `"SMA 20"`）。 |
+| `kind` | `string?` | パラメータ非依存の識別子（例 `"sma"`, `"rsi"`, `"macd"`）。`indicatorPresets` のキーと一致。identity match に使う。 |
+| `label` | `string` | 表示ラベル、通常はパラメータ化される（例 `"SMA(20)"`, `"MACD(12, 26, 9)"`）。パラメータ値で変化する。 |
 | `overlay` | `boolean` | `true` = 価格スケールを共有（メインペインに重ね描画）。`false` = 独立スケール（サブペイン）が必要。 |
 | `yRange` | `[min, max]?` | Y 軸の固定レンジ（オシレーターなら例えば `[0, 100]`）。 |
 | `referenceLines` | `number[]?` | 水平参照線の値（RSI なら `[30, 70]` など）。 |

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -6181,7 +6181,7 @@ import { livePresets } from "trendcraft";
 
 const sma = livePresets.sma;
 // {
-//   meta: { label: 'SMA', overlay: true, ... },
+//   meta: { kind: 'sma', label: 'SMA', overlay: true, ... },
 //   defaultParams: { period: 20 },
 //   snapshotName: (p) => `sma${p.period}`,
 //   createFactory: (params) => (fromState) => IncrementalIndicator,
@@ -6196,7 +6196,7 @@ const rsiIndicator = factory(undefined); // no prior state
 
 | Field | Type | Description |
 |---|---|---|
-| `meta` | `SeriesMeta` | Rendering metadata (label, overlay, yRange, referenceLines). |
+| `meta` | `SeriesMeta` | Rendering metadata (kind, label, overlay, yRange, referenceLines). |
 | `defaultParams` | `Record<string, unknown>` | Default parameters when user passes `{}`. |
 | `snapshotName` | `(params) => string` | Derive the snapshot key (e.g. `"sma20"`) for this instance. |
 | `createFactory` | `(params) => LiveIndicatorFactory` | Build the incremental factory closed over the given params. |
@@ -6236,7 +6236,8 @@ import { tagSeries, rsi, type SeriesMeta } from "trendcraft";
 const r = rsi(candles, { period: 14 });
 r.__meta;
 // {
-//   label: "RSI",
+//   kind: "rsi",
+//   label: "RSI(14)",
 //   overlay: false,
 //   yRange: [0, 100],
 //   referenceLines: [30, 70],
@@ -6254,7 +6255,8 @@ const myCustom = tagSeries(myData, {
 
 | Field | Type | Description |
 |---|---|---|
-| `label` | `string` | Display label (e.g. `"SMA 20"`). |
+| `kind` | `string?` | Parameter-independent identifier (e.g. `"sma"`, `"rsi"`, `"macd"`). Matches `indicatorPresets` keys. Use for identity matching. |
+| `label` | `string` | Display label, typically parameterized (e.g. `"SMA(20)"`, `"MACD(12, 26, 9)"`). Changes with parameter values. |
 | `overlay` | `boolean` | `true` = share the price scale (overlay on main pane). `false` = needs its own scale (sub-pane). |
 | `yRange` | `[min, max]?` | Fixed Y-axis range (e.g. `[0, 100]` for oscillators). |
 | `referenceLines` | `number[]?` | Horizontal reference line values (e.g. `[30, 70]` for RSI). |

--- a/packages/core/docs/GUIDE.ja.md
+++ b/packages/core/docs/GUIDE.ja.md
@@ -2278,8 +2278,10 @@ const rsiSeries = indicatorPresets.rsi.compute(candles, { period: 14 });
 import { rsi } from 'trendcraft';
 
 const r = rsi(candles, { period: 14 });
-r.__meta; // { label: 'RSI', overlay: false, yRange: [0, 100], referenceLines: [30, 70] }
+r.__meta; // { kind: 'rsi', label: 'RSI(14)', overlay: false, yRange: [0, 100], referenceLines: [30, 70] }
 ```
+
+`kind` はパラメータ非依存の安定した識別子（`indicatorPresets` のキーと一致）— フィルタ用に `s.__meta?.kind === 'rsi'` のように使います。`label` は表示用で、パラメータで変化します。
 
 自作指標にも同じ規約を下流（UI、ダッシュボード、レンダラー）に伝えたい場合に `tagSeries` を使います。メタデータを使わない利用者は無視すれば済みます — Series は相変わらず `{ time, value }[]` のプレーンな配列です。
 

--- a/packages/core/docs/GUIDE.md
+++ b/packages/core/docs/GUIDE.md
@@ -2291,8 +2291,10 @@ Every built-in indicator output carries a non-enumerable `__meta` with display c
 import { rsi } from 'trendcraft';
 
 const r = rsi(candles, { period: 14 });
-r.__meta; // { label: 'RSI', overlay: false, yRange: [0, 100], referenceLines: [30, 70] }
+r.__meta; // { kind: 'rsi', label: 'RSI(14)', overlay: false, yRange: [0, 100], referenceLines: [30, 70] }
 ```
+
+`kind` is the stable, parameter-independent identifier (matches `indicatorPresets` keys) — use it for filtering (`s.__meta?.kind === 'rsi'`). `label` is for display and changes with parameters.
 
 Use `tagSeries` on your own indicators if you want the same conventions to flow downstream (into UIs, dashboards, renderers). Consumers that don't care about metadata can ignore it — the series is still a plain `{ time, value }[]`.
 

--- a/packages/core/llms-full.txt
+++ b/packages/core/llms-full.txt
@@ -1422,17 +1422,21 @@ Events: `tick`, `candleComplete`. Types: `LiveCandle`, `LiveCandleOptions`, `Liv
 
 ## Series Metadata & Indicator Registries (SeriesMeta / tagSeries / livePresets / indicatorPresets)
 
-Every built-in indicator output carries a non-enumerable `__meta` describing domain characteristics (label, overlay vs sub-pane, Y-range, reference lines). Any consumer may read the metadata; consumers that don't care can ignore it.
+Every built-in indicator output carries a non-enumerable `__meta` describing domain characteristics (kind, label, overlay vs sub-pane, Y-range, reference lines). Any consumer may read the metadata; consumers that don't care can ignore it.
 
 ```typescript
 import { tagSeries, rsi, type SeriesMeta } from 'trendcraft';
 
 const r = rsi(candles, { period: 14 });
 r.__meta;
-// { label: 'RSI', overlay: false, yRange: [0, 100], referenceLines: [30, 70] }
+// { kind: 'rsi', label: 'RSI(14)', overlay: false, yRange: [0, 100], referenceLines: [30, 70] }
+
+// Match by stable identity (params-independent):
+allSeries.filter(s => s.__meta?.kind === 'rsi');
 
 // Tag a custom series
 const my = tagSeries(myData, {
+  kind: 'customScore',
   label: 'Custom Score',
   overlay: false,
   yRange: [0, 1],
@@ -1440,7 +1444,7 @@ const my = tagSeries(myData, {
 });
 ```
 
-`SeriesMeta` fields: `overlay` (boolean — shares price scale if true), `label`, `yRange?` ([min, max]), `referenceLines?` (number[]).
+`SeriesMeta` fields: `kind?` (parameter-independent identifier matching `indicatorPresets` keys — use for identity matching), `overlay` (boolean — shares price scale if true), `label` (parameterized display string), `yRange?` ([min, max]), `referenceLines?` (number[]).
 
 ### livePresets (76 entries)
 

--- a/packages/core/llms.txt
+++ b/packages/core/llms.txt
@@ -533,11 +533,15 @@ live.addCandle(bar);                                             // candle mode
 ```
 
 ### Series Metadata & Indicator Registries (SeriesMeta, tagSeries, livePresets, indicatorPresets)
-All built-in indicators tag their output with `__meta` (`SeriesMeta`) describing label, whether the series shares the price scale, Y-range, and reference lines. Any consumer may read the metadata; consumers that don't care can ignore it.
+All built-in indicators tag their output with `__meta` (`SeriesMeta`) describing its `kind` (parameter-independent identifier like `"sma"`, `"rsi"`), parameterized `label`, overlay flag, Y-range, and reference lines. Any consumer may read the metadata; consumers that don't care can ignore it.
 ```typescript
 import { tagSeries, rsi, livePresets, indicatorPresets } from 'trendcraft';
 
-rsi(candles).__meta; // { label: 'RSI', overlay: false, yRange: [0, 100], referenceLines: [30, 70] }
+rsi(candles, { period: 14 }).__meta;
+// { kind: 'rsi', label: 'RSI(14)', overlay: false, yRange: [0, 100], referenceLines: [30, 70] }
+
+// Match by stable identity (kind), not the display label:
+allSeries.filter(s => s.__meta?.kind === 'rsi');
 
 // livePresets: 76 incremental indicator presets (factory + metadata + default params + snapshot-name)
 // indicatorPresets: 95 unified presets with both batch compute and incremental createFactory

--- a/packages/core/src/core/__tests__/tag-series.test.ts
+++ b/packages/core/src/core/__tests__/tag-series.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { Series, SeriesMeta } from "../../types/candle";
+import { tagSeries, withLabelParams } from "../tag-series";
+
+describe("tagSeries", () => {
+  it("attaches __meta to the series", () => {
+    const data: Series<number> = [
+      { time: 1, value: 10 },
+      { time: 2, value: 20 },
+    ];
+    const meta: SeriesMeta = { kind: "test", overlay: true, label: "Test" };
+    const tagged = tagSeries(data, meta);
+
+    expect(tagged.__meta).toEqual(meta);
+    expect(tagged.__meta?.kind).toBe("test");
+    expect(tagged.__meta?.label).toBe("Test");
+  });
+
+  it("leaves empty arrays un-tagged so tests using toEqual([]) keep passing", () => {
+    const empty: Series<number> = [];
+    const tagged = tagSeries(empty, { overlay: true, label: "X" });
+    expect(tagged).toEqual([]);
+    expect(tagged.__meta).toBeUndefined();
+  });
+
+  it("__meta is non-enumerable and not spread by ...array", () => {
+    const data: Series<number> = [{ time: 1, value: 10 }];
+    const tagged = tagSeries(data, { overlay: true, label: "X" });
+
+    const copy = [...tagged];
+    expect(copy.length).toBe(1);
+    // Spreading an array does not copy custom array properties
+    expect((copy as Series<number> & { __meta?: SeriesMeta }).__meta).toBeUndefined();
+  });
+});
+
+describe("withLabelParams", () => {
+  const base: SeriesMeta = { kind: "sma", overlay: true, label: "SMA" };
+
+  it("appends a single param in parentheses", () => {
+    expect(withLabelParams(base, [20]).label).toBe("SMA(20)");
+  });
+
+  it("joins multiple params with comma + space", () => {
+    const macd: SeriesMeta = { kind: "macd", overlay: false, label: "MACD" };
+    expect(withLabelParams(macd, [12, 26, 9]).label).toBe("MACD(12, 26, 9)");
+  });
+
+  it("preserves kind, overlay, and other fields", () => {
+    const rsi: SeriesMeta = {
+      kind: "rsi",
+      overlay: false,
+      label: "RSI",
+      yRange: [0, 100],
+      referenceLines: [30, 70],
+    };
+    const out = withLabelParams(rsi, [14]);
+    expect(out).toEqual({
+      kind: "rsi",
+      overlay: false,
+      label: "RSI(14)",
+      yRange: [0, 100],
+      referenceLines: [30, 70],
+    });
+  });
+
+  it("skips null / undefined param slots", () => {
+    expect(withLabelParams(base, [12, undefined, 9]).label).toBe("SMA(12, 9)");
+    expect(withLabelParams(base, [null, 20]).label).toBe("SMA(20)");
+  });
+
+  it("returns the meta unchanged when no visible params", () => {
+    expect(withLabelParams(base, []).label).toBe("SMA");
+    expect(withLabelParams(base, [undefined, null]).label).toBe("SMA");
+  });
+
+  it("is non-mutating — original meta object is unchanged", () => {
+    const original: SeriesMeta = { kind: "sma", overlay: true, label: "SMA" };
+    withLabelParams(original, [20]);
+    expect(original.label).toBe("SMA");
+  });
+
+  it("supports string params as well as numbers", () => {
+    const vwap: SeriesMeta = { kind: "anchoredVwap", overlay: true, label: "AVWAP" };
+    expect(withLabelParams(vwap, ["2024-01-01"]).label).toBe("AVWAP(2024-01-01)");
+  });
+});


### PR DESCRIPTION
Follow-up to #65 — polish items not strictly required for the merge.

## What's inside

1. **Docs examples refresh.** Several docs still showed the v0.1.0 \`__meta\` shape (\`{ label: 'RSI' }\`). Updated them to \`{ kind: 'rsi', label: 'RSI(14)', ... }\` and added a one-liner noting \`kind\` is the stable identifier to match on.
   Files touched:
   - \`packages/core/README.md\`
   - \`packages/core/docs/GUIDE.md\` / \`GUIDE.ja.md\`
   - \`packages/core/docs/API.md\` / \`API.ja.md\`
   - \`packages/core/llms.txt\` / \`llms-full.txt\`
2. **Migration note** in \`packages/core/CHANGELOG.md\` under Unreleased. Shows the before/after for string-matching consumers.
3. **Unit tests** for \`tag-series\` (both \`tagSeries\` and \`withLabelParams\`). 10 new tests covering:
   - Empty-array tagging is skipped (preserves \`toEqual([])\` in existing tests)
   - \`__meta\` is non-enumerable (not spread by \`...array\`)
   - Single-param / multi-param formatting
   - \`null\` / \`undefined\` skipping in param lists
   - Non-mutation of input meta
   - String params

## Verification

- \`pnpm lint\` — clean
- \`pnpm build\` — pass
- \`pnpm test\` — core 4,719 (+10) / chart 567 all pass