### PR TITLE
Chart release polish: presets, plugins, drawing helpers, publish gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ coverage/
 **/.vitepress/cache/
 *.tsbuildinfo
 
+# QA sweep output
+packages/core/qa-report.json
+
 .claude/projects/
 .plans/
 packages/core/examples/data/

--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -21,6 +21,8 @@ Draft for the initial public release. Date and final version are set at release 
 - Plugin system: `defineSeriesRenderer`, `definePrimitive`.
 - Auto-detection of TrendCraft `Series<T>` indicators via `introspect` (reads `__meta` set by core's `tagSeries`).
 - Drawing auto-injection helpers: `addAutoFibRetracement`, `addAutoFibExtension`, `addAutoTrendLine`, `addAutoChannelLine`. Consume pre-computed swing anchors and emit the chart's built-in drawing types — no primitive plugin required. Keeps the chart package runtime-free of `trendcraft`.
+- `createAndrewsPitchfork` / `connectAndrewsPitchfork` — primitive plugin that renders the three parallel pitchfork lines from three swing anchors (P0 + P1 + P2). Extends forward indefinitely across the visible range.
+- `connectSmcLayer` now accepts an optional `choch` source alongside `bos`. Both use the same per-bar shape but render with separate labels ("BOS" vs "CHoCH"), so you can feed `breakOfStructure()` and `changeOfCharacter()` simultaneously to distinguish structural breaks from trend-reversing ones.
 - SSR safety: headless exports work without a DOM; DOM exports throw a clear error in non-browser environments.
 - ARIA accessibility support via `ChartAria`.
 - Bundle size limits enforced via `size-limit` (brotli): main ≤ 31 kB, headless ≤ 11 kB, React ≤ 27 kB, Vue ≤ 27 kB.

--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -20,6 +20,7 @@ Draft for the initial public release. Date and final version are set at release 
 - 13 series types: candlestick, line, area, histogram, band, cloud, marker, heatmap, arrow, signal, zone, labels, shapes.
 - Plugin system: `defineSeriesRenderer`, `definePrimitive`.
 - Auto-detection of TrendCraft `Series<T>` indicators via `introspect` (reads `__meta` set by core's `tagSeries`).
+- Drawing auto-injection helpers: `addAutoFibRetracement`, `addAutoFibExtension`, `addAutoTrendLine`, `addAutoChannelLine`. Consume pre-computed swing anchors and emit the chart's built-in drawing types — no primitive plugin required. Keeps the chart package runtime-free of `trendcraft`.
 - SSR safety: headless exports work without a DOM; DOM exports throw a clear error in non-browser environments.
 - ARIA accessibility support via `ChartAria`.
 - Bundle size limits enforced via `size-limit` (brotli): main ≤ 31 kB, headless ≤ 11 kB, React ≤ 27 kB, Vue ≤ 27 kB.

--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -23,6 +23,7 @@ Draft for the initial public release. Date and final version are set at release 
 - Drawing auto-injection helpers: `addAutoFibRetracement`, `addAutoFibExtension`, `addAutoTrendLine`, `addAutoChannelLine`. Consume pre-computed swing anchors and emit the chart's built-in drawing types — no primitive plugin required. Keeps the chart package runtime-free of `trendcraft`.
 - `createAndrewsPitchfork` / `connectAndrewsPitchfork` — primitive plugin that renders the three parallel pitchfork lines from three swing anchors (P0 + P1 + P2). Extends forward indefinitely across the visible range.
 - `connectSmcLayer` now accepts an optional `choch` source alongside `bos`. Both use the same per-bar shape but render with separate labels ("BOS" vs "CHoCH"), so you can feed `breakOfStructure()` and `changeOfCharacter()` simultaneously to distinguish structural breaks from trend-reversing ones.
+- `createVolumeProfile` / `connectVolumeProfile` — primitive plugin that renders a horizontal volume-by-price histogram along the right edge of the chart, with separate fills for the Value Area and a dashed POC line spanning the pane. Configurable strip width (fractional or pixel), highlight toggle, and color overrides.
 - SSR safety: headless exports work without a DOM; DOM exports throw a clear error in non-browser environments.
 - ARIA accessibility support via `ChartAria`.
 - Bundle size limits enforced via `size-limit` (brotli): main ≤ 31 kB, headless ≤ 11 kB, React ≤ 27 kB, Vue ≤ 27 kB.

--- a/packages/chart/RELEASE.md
+++ b/packages/chart/RELEASE.md
@@ -1,0 +1,42 @@
+# Release checklist — `@trendcraft/chart`
+
+A per-package checklist for publishing `@trendcraft/chart` to npm.
+The full cross-package release workflow (including `trendcraft` coordination and tag naming) lives in the root `CLAUDE.md`.
+
+## Before tagging
+
+- [ ] All intended work is merged to `main`
+- [ ] `packages/chart/CHANGELOG.md` has a versioned heading (promoted from `Unreleased`) with a concrete date
+- [ ] `packages/chart/package.json` version bumped
+- [ ] If chart calls a newly-added `trendcraft` symbol, `peerDependencies.trendcraft` is bumped to `>=<that-version>` (keep `>=`, not pinned)
+- [ ] `pnpm --filter @trendcraft/chart build` succeeds
+- [ ] `pnpm --filter @trendcraft/chart test` green (56+ files / 567+ tests)
+- [ ] `pnpm --filter @trendcraft/chart verify:publish` green — confirms every `package.json#exports` subpath resolves in both ESM and CJS and exposes its advertised symbols
+- [ ] `pnpm --filter @trendcraft/chart size-check` within limits (main ≤ 31 kB, headless ≤ 11 kB, React/Vue ≤ 27 kB, brotli)
+- [ ] Docs sanity pass — `README.md`, `docs/*.md`, `llms.txt`, `llms-full.txt` reflect any new public API
+- [ ] Examples still build: `cd packages/chart/examples/simple-chart && pnpm build` (repeat for `simple-react-chart`, `simple-vue-chart`)
+
+## Publish
+
+```sh
+cd packages/chart
+pnpm publish           # runs prepublishOnly: build + test + verify:publish
+git tag chart-v<x.y.z>
+git push origin chart-v<x.y.z>
+```
+
+## After publish
+
+- [ ] `npm view @trendcraft/chart@<x.y.z> version` returns the new version
+- [ ] Spot-install into a throwaway project and import each entry point (`.`, `/headless`, `/presets`, `/react`, `/vue`) to confirm the published tarball behaves like the local build
+- [ ] Open a new `Unreleased` section in `CHANGELOG.md` for the next cycle
+
+## Rollback
+
+`pnpm` respects `npm deprecate`. If a broken build ships, deprecate the version rather than unpublishing:
+
+```sh
+npm deprecate @trendcraft/chart@<x.y.z> "broken: <reason> — use <x.y.z+1>"
+```
+
+Then cut a patch release that fixes the issue.

--- a/packages/chart/docs/API.md
+++ b/packages/chart/docs/API.md
@@ -33,6 +33,7 @@ Complete API surface for `@trendcraft/chart`. This is the reference; for concept
 - [Connection APIs](#connection-apis)
   - [`connectIndicators`](#connectindicatorschart-options)
   - [`defineIndicator`](#defineindicatorpresetid-options)
+- [Drawing auto-injection helpers](#drawing-auto-injection-helpers)
 - [Plugin helpers](#plugin-helpers)
 - [Built-in plugins](#built-in-plugins)
 - [Framework wrappers](#framework-wrappers)
@@ -338,6 +339,47 @@ conn.add(sma5);
 
 Useful when you want to pass indicator configurations around your app without coupling to a specific chart connection.
 
+## Drawing auto-injection helpers
+
+Four TrendCraft indicators (`autoTrendLine`, `channelLine`, `fibonacciRetracement`, `fibonacciExtension`) produce shape data the chart already renders via its built-in drawing types. These helpers convert raw swing anchors into `Drawing` objects and attach them — no primitive plugin required.
+
+Every helper takes pre-computed **swing anchors**, so the chart package stays runtime-free of `trendcraft`. Compose with `getAlternatingSwingPoints` (or any equivalent) on the caller side:
+
+```typescript
+import { getAlternatingSwingPoints } from 'trendcraft';
+import {
+  addAutoFibRetracement,
+  addAutoFibExtension,
+  addAutoTrendLine,
+  addAutoChannelLine,
+  type SwingAnchor,
+} from '@trendcraft/chart';
+
+// getAlternatingSwingPoints returns the SwingAnchor shape directly.
+const anchors: SwingAnchor[] = getAlternatingSwingPoints(
+  candles,
+  10,  // last N alternating swings
+  { leftBars: 10, rightBars: 10 },
+);
+
+addAutoFibRetracement(chart, anchors);              // picks latest high + latest low
+addAutoFibExtension(chart, anchors);                // picks the last three alternating
+addAutoTrendLine(chart, anchors, { line: 'resistance' });
+addAutoTrendLine(chart, anchors, { line: 'support', extendToTime: nowMs });
+addAutoChannelLine(chart, anchors, { extendToTime: nowMs });
+```
+
+| Helper | Drawing emitted | Anchors consumed |
+|---|---|---|
+| `addAutoFibRetracement` | `fibRetracement` | latest swing high + latest swing low |
+| `addAutoFibExtension` | `fibExtension` | last three alternating swings (A→B projected, C ignored by chart) |
+| `addAutoTrendLine` | `trendline` | last two same-type swings (highs → resistance, lows → support) |
+| `addAutoChannelLine` | `channel` | last three alternating swings (two same-type as base, opposite for width) |
+
+All helpers return the drawing id (so you can later `chart.removeDrawing(id)`), or `null` if insufficient anchors were supplied. `extendToTime` projects the line endpoint forward using the slope of the two base anchors.
+
+Exported constants: `DEFAULT_FIB_RETRACEMENT_LEVELS`, `DEFAULT_FIB_EXTENSION_LEVELS`.
+
 ## Plugin helpers
 
 ```typescript
@@ -372,11 +414,13 @@ Tree-shakeable visualization primitives bundled with the library:
 | Function | Description |
 |---|---|
 | `createRegimeHeatmap` / `connectRegimeHeatmap` | Background heatmap for market regimes (`trending`, `volatile`, etc.) |
-| `createSmcLayer` / `connectSmcLayer` | Smart Money Concepts: order blocks, FVG, liquidity sweeps |
+| `createSmcLayer` / `connectSmcLayer` | Smart Money Concepts: order blocks, FVG, liquidity sweeps, BOS, CHoCH |
 | `createWyckoffPhase` / `connectWyckoffPhase` | Wyckoff phase bands (accumulation, markup, etc.) |
 | `createSrConfluence` / `connectSrConfluence` | Support/resistance confluence zones |
 | `createTradeAnalysis` / `connectTradeAnalysis` | MFE/MAE, holding period, streak annotations for backtest results |
 | `createSessionZones` / `connectSessionZones` | Session backgrounds (Asian/London/NY) |
+| `createAndrewsPitchfork` / `connectAndrewsPitchfork` | Andrew's Pitchfork — median line + upper/lower handles from three swing anchors, extending forward |
+| `createVolumeProfile` / `connectVolumeProfile` | Horizontal volume-by-price histogram along the right edge, with highlighted Value Area and dashed POC line |
 
 Each `create*` returns a `PrimitivePlugin`; each `connect*` registers it and returns an update handle.
 

--- a/packages/chart/docs/GUIDE.md
+++ b/packages/chart/docs/GUIDE.md
@@ -12,6 +12,7 @@ A conceptual walkthrough of `@trendcraft/chart`. If you just want to get pixels 
 - [Render loop](#render-loop)
 - [Panes and layout](#panes-and-layout)
 - [Auto-detection from `__meta`](#auto-detection-from-__meta)
+- [Extra visualization layers](#extra-visualization-layers)
 - [Theming](#theming)
 - [Viewport and navigation](#viewport-and-navigation)
 - [Events](#events)
@@ -177,6 +178,27 @@ SeriesRegistry.addRule({
 ```
 
 Rules are consulted in registration order, with built-in rules last. Useful when you want to share conventions across a team without each caller configuring the chart.
+
+## Extra visualization layers
+
+Some indicators produce output that doesn't fit the `Series<T>` line/band model — S/R zones, regime backgrounds, Andrew's Pitchforks, volume-by-price histograms, structural breaks. These ship as **primitive plugins** instead of presets, and stay tree-shakeable.
+
+```typescript
+import {
+  connectRegimeHeatmap,
+  connectSmcLayer,
+  connectWyckoffPhase,
+  connectSrConfluence,
+  connectTradeAnalysis,
+  connectSessionZones,
+  connectAndrewsPitchfork,
+  connectVolumeProfile,
+} from '@trendcraft/chart';
+```
+
+See [API.md#built-in-plugins](./API.md#built-in-plugins) for the full list. Each `connect*` returns an update handle (`update()`, `remove()`) so the layer can refresh when new data arrives.
+
+Four indicators (`autoTrendLine`, `channelLine`, `fibonacciRetracement`, `fibonacciExtension`) have an even lighter delivery: their shape maps directly to the chart's built-in drawing types, so small helpers (`addAutoFibRetracement` etc.) convert swing anchors into `Drawing` objects you manage via `chart.addDrawing` / `removeDrawing`. See [API.md#drawing-auto-injection-helpers](./API.md#drawing-auto-injection-helpers).
 
 ## Theming
 

--- a/packages/chart/examples/indicator-showcase/src/main.ts
+++ b/packages/chart/examples/indicator-showcase/src/main.ts
@@ -12,6 +12,7 @@ import { registerTrendCraftPresets } from "@trendcraft/chart/presets";
 import { indicatorPresets } from "trendcraft";
 import type { NormalizedCandle } from "trendcraft";
 import sampleData from "../../simple-chart/data.json";
+import { createPluginsPanel } from "./plugins-panel";
 import type { SidebarEntry } from "./sidebar";
 import { createSidebar } from "./sidebar";
 
@@ -150,6 +151,9 @@ chartEl.addEventListener("click", () => {
     sidebarEl.classList.remove("open");
   }
 });
+
+// Plugins panel (appended below the indicator list)
+createPluginsPanel(sidebarEl, candles, chart);
 
 // Suppress unused variable warning
 void sidebar;

--- a/packages/chart/examples/indicator-showcase/src/main.ts
+++ b/packages/chart/examples/indicator-showcase/src/main.ts
@@ -1,9 +1,10 @@
 /**
  * Indicator Showcase — Main Entry
  *
- * Demonstrates all 77 indicators available in indicatorPresets
- * with a categorized sidebar UI, search, parameter controls, and active
- * indicator bar. The sidebar is auto-generated from indicatorPresets metadata.
+ * Demonstrates every preset available in `indicatorPresets` (96 as of 2026-04-18)
+ * with a categorized sidebar UI, search, parameter controls, and active indicator
+ * bar. The sidebar is auto-generated from indicatorPresets metadata, so the count
+ * stays accurate as the preset registry grows.
  */
 
 import { connectIndicators, createChart } from "@trendcraft/chart";

--- a/packages/chart/examples/indicator-showcase/src/plugins-panel.ts
+++ b/packages/chart/examples/indicator-showcase/src/plugins-panel.ts
@@ -1,0 +1,171 @@
+/**
+ * Plugins Panel — Toggle buttons for chart primitive plugins that don't fit
+ * the `indicatorPresets` series-line model (background heatmaps, zones,
+ * pitchfork, volume profile, etc.).
+ *
+ * Each entry computes its data from the current candles once and connects
+ * the plugin on toggle. Tuned for demo data (200 daily bars) — production
+ * callers would feed their own options/ranges.
+ */
+
+import type { ChartInstance } from "@trendcraft/chart";
+import {
+  connectAndrewsPitchfork,
+  connectRegimeHeatmap,
+  connectSessionZones,
+  connectSmcLayer,
+  connectSrConfluence,
+  connectVolumeProfile,
+  connectWyckoffPhase,
+} from "@trendcraft/chart";
+import type { NormalizedCandle } from "trendcraft";
+import {
+  fairValueGap,
+  getAlternatingSwingPoints,
+  hmmRegimes,
+  killZones,
+  liquiditySweep,
+  orderBlock,
+  srZones,
+  volumeProfile,
+  wyckoffPhases,
+} from "trendcraft";
+
+type PluginHandle = { remove: () => void };
+
+type PluginSpec = {
+  id: string;
+  label: string;
+  description: string;
+  connect: () => PluginHandle | null;
+};
+
+export function createPluginsPanel(
+  container: HTMLElement,
+  candles: NormalizedCandle[],
+  chart: ChartInstance,
+): void {
+  const active = new Map<string, PluginHandle>();
+
+  const specs: PluginSpec[] = [
+    {
+      id: "srConfluence",
+      label: "S/R Confluence",
+      description: "Multi-source support/resistance zones",
+      connect: () => {
+        const { zones } = srZones(candles);
+        return connectSrConfluence(chart, zones);
+      },
+    },
+    {
+      id: "smcLayer",
+      label: "SMC Layer",
+      description: "Order Blocks + FVG + Liquidity Sweeps",
+      connect: () =>
+        connectSmcLayer(chart, {
+          orderBlocks: orderBlock(candles),
+          fvgs: fairValueGap(candles),
+          sweeps: liquiditySweep(candles),
+        }),
+    },
+    {
+      id: "regimeHeatmap",
+      label: "Regime Heatmap",
+      description: "HMM-classified market regime background",
+      connect: () => connectRegimeHeatmap(chart, hmmRegimes(candles)),
+    },
+    {
+      id: "wyckoffPhase",
+      label: "Wyckoff Phase",
+      description: "Accumulation / markup / distribution bands",
+      connect: () => connectWyckoffPhase(chart, { phases: wyckoffPhases(candles) }),
+    },
+    {
+      id: "sessionZones",
+      label: "Session Zones",
+      description: "ICT kill-zone backgrounds (Asia / London / NY)",
+      connect: () => connectSessionZones(chart, killZones(candles)),
+    },
+    {
+      id: "andrewsPitchfork",
+      label: "Andrew's Pitchfork",
+      description: "Median + handles from the last 3 swing anchors",
+      connect: () => {
+        const last3 = getAlternatingSwingPoints(candles, 3, { leftBars: 10, rightBars: 10 });
+        if (last3.length < 3) return null;
+        return connectAndrewsPitchfork(chart, {
+          p0: { index: last3[0].index, price: last3[0].price },
+          p1: { index: last3[1].index, price: last3[1].price },
+          p2: { index: last3[2].index, price: last3[2].price },
+        });
+      },
+    },
+    {
+      id: "volumeProfile",
+      label: "Volume Profile",
+      description: "Horizontal volume-by-price histogram + POC",
+      connect: () => connectVolumeProfile(chart, volumeProfile(candles, { levels: 30 })),
+    },
+  ];
+
+  // Header
+  const header = document.createElement("div");
+  header.style.cssText =
+    "padding:10px 12px;background:#181c27;border-top:1px solid #2a2e39;border-bottom:1px solid #1e222d;font-weight:600;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;";
+  header.textContent = "▼ Plugins";
+  container.appendChild(header);
+
+  for (const spec of specs) {
+    const row = document.createElement("div");
+    row.style.cssText =
+      "padding:8px 12px 8px 24px;cursor:pointer;border-bottom:1px solid #1e222d;display:flex;align-items:flex-start;gap:10px;user-select:none;";
+
+    const checkbox = document.createElement("div");
+    checkbox.style.cssText =
+      "width:14px;height:14px;border:1px solid #4a4e59;border-radius:3px;margin-top:2px;flex-shrink:0;";
+
+    const text = document.createElement("div");
+    text.style.cssText = "flex:1;min-width:0;";
+    const title = document.createElement("div");
+    title.textContent = spec.label;
+    title.style.cssText = "font-weight:500;";
+    const desc = document.createElement("div");
+    desc.textContent = spec.description;
+    desc.style.cssText = "font-size:11px;color:#787b86;margin-top:2px;";
+    text.appendChild(title);
+    text.appendChild(desc);
+
+    row.appendChild(checkbox);
+    row.appendChild(text);
+    container.appendChild(row);
+
+    const applyActive = (isActive: boolean) => {
+      if (isActive) {
+        checkbox.style.background = "#2196F3";
+        checkbox.style.borderColor = "#2196F3";
+        row.style.background = "#1e2530";
+      } else {
+        checkbox.style.background = "transparent";
+        checkbox.style.borderColor = "#4a4e59";
+        row.style.background = "transparent";
+      }
+    };
+
+    row.addEventListener("click", () => {
+      const existing = active.get(spec.id);
+      if (existing) {
+        existing.remove();
+        active.delete(spec.id);
+        applyActive(false);
+      } else {
+        const handle = spec.connect();
+        if (!handle) {
+          console.warn(`Plugin ${spec.id} could not be connected (insufficient data)`);
+          return;
+        }
+        active.set(spec.id, handle);
+        applyActive(true);
+      }
+    });
+  }
+}

--- a/packages/chart/examples/indicator-showcase/src/sidebar.ts
+++ b/packages/chart/examples/indicator-showcase/src/sidebar.ts
@@ -24,6 +24,7 @@ const CATEGORIES: IndicatorCategory[] = [
   "Trend",
   "Volume",
   "Price",
+  "Filter",
   "Adaptive",
   "Session",
   "SMC",

--- a/packages/chart/llms-full.txt
+++ b/packages/chart/llms-full.txt
@@ -635,6 +635,10 @@ Draft for the initial public release. Date and final version are set at release 
 - 13 series types: candlestick, line, area, histogram, band, cloud, marker, heatmap, arrow, signal, zone, labels, shapes.
 - Plugin system: `defineSeriesRenderer`, `definePrimitive`.
 - Auto-detection of TrendCraft `Series<T>` indicators via `introspect` (reads `__meta` set by core's `tagSeries`).
+- Drawing auto-injection helpers: `addAutoFibRetracement`, `addAutoFibExtension`, `addAutoTrendLine`, `addAutoChannelLine`. Consume pre-computed swing anchors and emit the chart's built-in drawing types — no primitive plugin required. Keeps the chart package runtime-free of `trendcraft`.
+- `createAndrewsPitchfork` / `connectAndrewsPitchfork` — primitive plugin that renders the three parallel pitchfork lines from three swing anchors (P0 + P1 + P2). Extends forward indefinitely across the visible range.
+- `connectSmcLayer` now accepts an optional `choch` source alongside `bos`. Both use the same per-bar shape but render with separate labels ("BOS" vs "CHoCH"), so you can feed `breakOfStructure()` and `changeOfCharacter()` simultaneously to distinguish structural breaks from trend-reversing ones.
+- `createVolumeProfile` / `connectVolumeProfile` — primitive plugin that renders a horizontal volume-by-price histogram along the right edge of the chart, with separate fills for the Value Area and a dashed POC line spanning the pane. Configurable strip width (fractional or pixel), highlight toggle, and color overrides.
 - SSR safety: headless exports work without a DOM; DOM exports throw a clear error in non-browser environments.
 - ARIA accessibility support via `ChartAria`.
 - Bundle size limits enforced via `size-limit` (brotli): main ≤ 31 kB, headless ≤ 11 kB, React ≤ 27 kB, Vue ≤ 27 kB.
@@ -670,6 +674,7 @@ A conceptual walkthrough of `@trendcraft/chart`. If you just want to get pixels 
 - [Render loop](#render-loop)
 - [Panes and layout](#panes-and-layout)
 - [Auto-detection from `__meta`](#auto-detection-from-__meta)
+- [Extra visualization layers](#extra-visualization-layers)
 - [Theming](#theming)
 - [Viewport and navigation](#viewport-and-navigation)
 - [Events](#events)
@@ -835,6 +840,27 @@ SeriesRegistry.addRule({
 ```
 
 Rules are consulted in registration order, with built-in rules last. Useful when you want to share conventions across a team without each caller configuring the chart.
+
+## Extra visualization layers
+
+Some indicators produce output that doesn't fit the `Series<T>` line/band model — S/R zones, regime backgrounds, Andrew's Pitchforks, volume-by-price histograms, structural breaks. These ship as **primitive plugins** instead of presets, and stay tree-shakeable.
+
+```typescript
+import {
+  connectRegimeHeatmap,
+  connectSmcLayer,
+  connectWyckoffPhase,
+  connectSrConfluence,
+  connectTradeAnalysis,
+  connectSessionZones,
+  connectAndrewsPitchfork,
+  connectVolumeProfile,
+} from '@trendcraft/chart';
+```
+
+See [API.md#built-in-plugins](./API.md#built-in-plugins) for the full list. Each `connect*` returns an update handle (`update()`, `remove()`) so the layer can refresh when new data arrives.
+
+Four indicators (`autoTrendLine`, `channelLine`, `fibonacciRetracement`, `fibonacciExtension`) have an even lighter delivery: their shape maps directly to the chart's built-in drawing types, so small helpers (`addAutoFibRetracement` etc.) convert swing anchors into `Drawing` objects you manage via `chart.addDrawing` / `removeDrawing`. See [API.md#drawing-auto-injection-helpers](./API.md#drawing-auto-injection-helpers).
 
 ## Theming
 
@@ -1033,6 +1059,7 @@ Complete API surface for `@trendcraft/chart`. This is the reference; for concept
 - [Connection APIs](#connection-apis)
   - [`connectIndicators`](#connectindicatorschart-options)
   - [`defineIndicator`](#defineindicatorpresetid-options)
+- [Drawing auto-injection helpers](#drawing-auto-injection-helpers)
 - [Plugin helpers](#plugin-helpers)
 - [Built-in plugins](#built-in-plugins)
 - [Framework wrappers](#framework-wrappers)
@@ -1338,6 +1365,47 @@ conn.add(sma5);
 
 Useful when you want to pass indicator configurations around your app without coupling to a specific chart connection.
 
+## Drawing auto-injection helpers
+
+Four TrendCraft indicators (`autoTrendLine`, `channelLine`, `fibonacciRetracement`, `fibonacciExtension`) produce shape data the chart already renders via its built-in drawing types. These helpers convert raw swing anchors into `Drawing` objects and attach them — no primitive plugin required.
+
+Every helper takes pre-computed **swing anchors**, so the chart package stays runtime-free of `trendcraft`. Compose with `getAlternatingSwingPoints` (or any equivalent) on the caller side:
+
+```typescript
+import { getAlternatingSwingPoints } from 'trendcraft';
+import {
+  addAutoFibRetracement,
+  addAutoFibExtension,
+  addAutoTrendLine,
+  addAutoChannelLine,
+  type SwingAnchor,
+} from '@trendcraft/chart';
+
+// getAlternatingSwingPoints returns the SwingAnchor shape directly.
+const anchors: SwingAnchor[] = getAlternatingSwingPoints(
+  candles,
+  10,  // last N alternating swings
+  { leftBars: 10, rightBars: 10 },
+);
+
+addAutoFibRetracement(chart, anchors);              // picks latest high + latest low
+addAutoFibExtension(chart, anchors);                // picks the last three alternating
+addAutoTrendLine(chart, anchors, { line: 'resistance' });
+addAutoTrendLine(chart, anchors, { line: 'support', extendToTime: nowMs });
+addAutoChannelLine(chart, anchors, { extendToTime: nowMs });
+```
+
+| Helper | Drawing emitted | Anchors consumed |
+|---|---|---|
+| `addAutoFibRetracement` | `fibRetracement` | latest swing high + latest swing low |
+| `addAutoFibExtension` | `fibExtension` | last three alternating swings (A→B projected, C ignored by chart) |
+| `addAutoTrendLine` | `trendline` | last two same-type swings (highs → resistance, lows → support) |
+| `addAutoChannelLine` | `channel` | last three alternating swings (two same-type as base, opposite for width) |
+
+All helpers return the drawing id (so you can later `chart.removeDrawing(id)`), or `null` if insufficient anchors were supplied. `extendToTime` projects the line endpoint forward using the slope of the two base anchors.
+
+Exported constants: `DEFAULT_FIB_RETRACEMENT_LEVELS`, `DEFAULT_FIB_EXTENSION_LEVELS`.
+
 ## Plugin helpers
 
 ```typescript
@@ -1372,11 +1440,13 @@ Tree-shakeable visualization primitives bundled with the library:
 | Function | Description |
 |---|---|
 | `createRegimeHeatmap` / `connectRegimeHeatmap` | Background heatmap for market regimes (`trending`, `volatile`, etc.) |
-| `createSmcLayer` / `connectSmcLayer` | Smart Money Concepts: order blocks, FVG, liquidity sweeps |
+| `createSmcLayer` / `connectSmcLayer` | Smart Money Concepts: order blocks, FVG, liquidity sweeps, BOS, CHoCH |
 | `createWyckoffPhase` / `connectWyckoffPhase` | Wyckoff phase bands (accumulation, markup, etc.) |
 | `createSrConfluence` / `connectSrConfluence` | Support/resistance confluence zones |
 | `createTradeAnalysis` / `connectTradeAnalysis` | MFE/MAE, holding period, streak annotations for backtest results |
 | `createSessionZones` / `connectSessionZones` | Session backgrounds (Asian/London/NY) |
+| `createAndrewsPitchfork` / `connectAndrewsPitchfork` | Andrew's Pitchfork — median line + upper/lower handles from three swing anchors, extending forward |
+| `createVolumeProfile` / `connectVolumeProfile` | Horizontal volume-by-price histogram along the right edge, with highlighted Value Area and dashed POC line |
 
 Each `create*` returns a `PrimitivePlugin`; each `connect*` registers it and returns an update handle.
 

--- a/packages/chart/llms.txt
+++ b/packages/chart/llms.txt
@@ -8,7 +8,8 @@ Key facts for understanding the library:
 - **Peer deps (all optional)**: `trendcraft >=0.2.0` (indicator math, presets, `createLiveCandle`), `react >=19.0.0`, `vue >=3.3.0`. The chart also works with plain `{ time, value }[]` data and zero peers.
 - **Static vs live**: `createChart()` returns a `ChartInstance`. Add data via `setCandles()` + `addIndicator()`, or use `connectIndicators(chart, { presets, candles, live? })` as a single API for both static and live modes.
 - **No `connectLiveFeed`**: live wiring is unified into `connectIndicators({ live })`. Earlier drafts mentioned a separate `connectLiveFeed` — it does not exist.
-- **Plugins**: `defineSeriesRenderer` / `definePrimitive` for custom visual layers. Built-in plugins cover regime heatmap, SMC, Wyckoff phases, S/R confluence, trade analysis, and session zones.
+- **Plugins**: `defineSeriesRenderer` / `definePrimitive` for custom visual layers. Built-in plugins cover regime heatmap, SMC (including BOS/CHoCH), Wyckoff phases, S/R confluence, trade analysis, session zones, Andrew's Pitchfork, and Volume Profile.
+- **Drawing auto-injection helpers**: `addAutoFibRetracement` / `addAutoFibExtension` / `addAutoTrendLine` / `addAutoChannelLine` convert pre-computed swing anchors into the chart's built-in drawing types.
 - **Bundle sizes** (brotli, enforced via size-limit): main ≤ 31 kB, headless ≤ 11 kB, React ≤ 27 kB, Vue ≤ 27 kB.
 - **Framework components**: both React and Vue wrappers export a component named `TrendChart` plus a `useTrendChart` hook/composable.
 

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -54,7 +54,8 @@
     "lint:fix": "biome check --write .",
     "size-check": "size-limit",
     "format": "biome format --write .",
-    "prepublishOnly": "pnpm build && pnpm test"
+    "verify:publish": "node scripts/verify-publish.mjs",
+    "prepublishOnly": "pnpm build && pnpm test && pnpm verify:publish"
   },
   "keywords": [
     "chart",

--- a/packages/chart/scripts/verify-publish.mjs
+++ b/packages/chart/scripts/verify-publish.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Publish gate: verify that every entry point listed in package.json#exports
+ * resolves and produces a working module in both ESM and CJS modes.
+ *
+ * Run after `pnpm build`. Hooked from `prepublishOnly`.
+ *
+ * Catches:
+ *  - Missing dist/ artifact for an entry (stale exports map or broken build)
+ *  - ESM entry that fails to evaluate (bad re-export, circular tree-shake)
+ *  - CJS entry that fails to load via require()
+ *  - .d.ts file missing for any entry
+ *  - Any listed entry that doesn't actually expose its advertised symbols
+ */
+
+import { createRequire } from "node:module";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(__dirname, "..");
+const pkgJson = JSON.parse(readFileSync(resolve(pkgRoot, "package.json"), "utf8"));
+const exportsMap = pkgJson.exports ?? {};
+const require = createRequire(import.meta.url);
+
+/** Expected top-level symbols per entry. Kept small on purpose — just enough to catch regressions. */
+const EXPECTED_SYMBOLS = {
+  ".": ["createChart", "connectIndicators", "defineIndicator", "DARK_THEME", "LIGHT_THEME"],
+  "./headless": ["DataLayer", "TimeScale", "PriceScale", "introspect", "lttb"],
+  "./presets": ["registerTrendCraftPresets"],
+  "./react": ["TrendChart", "useTrendChart"],
+  "./vue": ["TrendChart", "useTrendChart"],
+};
+
+const failures = [];
+const pass = (msg) => console.log(`  ✓ ${msg}`);
+const fail = (msg) => {
+  console.log(`  ✗ ${msg}`);
+  failures.push(msg);
+};
+
+async function verifyEntry(subpath, entry) {
+  console.log(`\n[${subpath}]`);
+  const typesPath = resolve(pkgRoot, entry.types);
+  const esmPath = resolve(pkgRoot, entry.import);
+  const cjsPath = resolve(pkgRoot, entry.require);
+
+  // File existence
+  if (existsSync(typesPath)) pass(`types file exists (${entry.types})`);
+  else fail(`missing types file: ${entry.types}`);
+
+  if (existsSync(esmPath)) pass(`esm file exists (${entry.import})`);
+  else fail(`missing esm file: ${entry.import}`);
+
+  if (existsSync(cjsPath)) pass(`cjs file exists (${entry.require})`);
+  else fail(`missing cjs file: ${entry.require}`);
+
+  const expected = EXPECTED_SYMBOLS[subpath] ?? [];
+
+  // React/Vue entries import their peer deps — skip runtime evaluation if they're not installed.
+  const skipRuntime =
+    (subpath === "./react" && !canRequire("react")) ||
+    (subpath === "./vue" && !canRequire("vue"));
+
+  if (skipRuntime) {
+    pass(`skipping runtime eval (peer dep not installed; file checks above cover surface)`);
+    return;
+  }
+
+  // ESM evaluation
+  if (existsSync(esmPath)) {
+    try {
+      const mod = await import(pathToFileURL(esmPath).href);
+      for (const sym of expected) {
+        if (sym in mod) pass(`esm exports ${sym}`);
+        else fail(`esm missing symbol: ${sym}`);
+      }
+    } catch (err) {
+      fail(`esm eval threw: ${err.message}`);
+    }
+  }
+
+  // CJS evaluation
+  if (existsSync(cjsPath)) {
+    try {
+      const mod = require(cjsPath);
+      for (const sym of expected) {
+        if (sym in mod) pass(`cjs exports ${sym}`);
+        else fail(`cjs missing symbol: ${sym}`);
+      }
+    } catch (err) {
+      fail(`cjs eval threw: ${err.message}`);
+    }
+  }
+}
+
+function canRequire(id) {
+  try {
+    require.resolve(id, { paths: [pkgRoot] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+console.log(`Publish gate: @trendcraft/chart@${pkgJson.version}`);
+
+for (const [subpath, entry] of Object.entries(exportsMap)) {
+  if (typeof entry !== "object" || entry === null) continue;
+  await verifyEntry(subpath, entry);
+}
+
+console.log();
+if (failures.length > 0) {
+  console.error(`FAILED: ${failures.length} issue(s) found. Fix before publishing.`);
+  process.exit(1);
+}
+console.log(`OK: all ${Object.keys(exportsMap).length} entry points resolve correctly.`);

--- a/packages/chart/scripts/verify-publish.mjs
+++ b/packages/chart/scripts/verify-publish.mjs
@@ -13,8 +13,8 @@
  *  - Any listed entry that doesn't actually expose its advertised symbols
  */
 
-import { createRequire } from "node:module";
 import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -60,11 +60,10 @@ async function verifyEntry(subpath, entry) {
 
   // React/Vue entries import their peer deps — skip runtime evaluation if they're not installed.
   const skipRuntime =
-    (subpath === "./react" && !canRequire("react")) ||
-    (subpath === "./vue" && !canRequire("vue"));
+    (subpath === "./react" && !canRequire("react")) || (subpath === "./vue" && !canRequire("vue"));
 
   if (skipRuntime) {
-    pass(`skipping runtime eval (peer dep not installed; file checks above cover surface)`);
+    pass("skipping runtime eval (peer dep not installed; file checks above cover surface)");
     return;
   }
 

--- a/packages/chart/src/__tests__/andrews-pitchfork.test.ts
+++ b/packages/chart/src/__tests__/andrews-pitchfork.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PrimitiveRenderContext } from "../core/plugin-types";
+import type { PriceScale, TimeScale } from "../core/scale";
+import type { ChartInstance, PaneRect } from "../core/types";
+import {
+  type PitchforkAnchors,
+  connectAndrewsPitchfork,
+  createAndrewsPitchfork,
+} from "../plugins/andrews-pitchfork";
+
+const mockCtx = () =>
+  ({
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    rect: vi.fn(),
+    clip: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    closePath: vi.fn(),
+    fill: vi.fn(),
+    arc: vi.fn(),
+    setLineDash: vi.fn(),
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 1,
+  }) as unknown as CanvasRenderingContext2D;
+
+const mockTs = () =>
+  ({
+    startIndex: 0,
+    endIndex: 50,
+    barSpacing: 8,
+    indexToX: (i: number) => i * 8 + 4,
+  }) as TimeScale;
+
+const mockPs = () => ({ priceToY: (p: number) => 400 - p * 2 }) as PriceScale;
+const mockPane: PaneRect = { id: "main", x: 0, y: 0, width: 800, height: 400 };
+const makeCtx = (ctx: CanvasRenderingContext2D) =>
+  ({ ctx, pane: mockPane, timeScale: mockTs(), priceScale: mockPs() }) as PrimitiveRenderContext;
+
+const anchors: PitchforkAnchors = {
+  p0: { index: 5, price: 100 },
+  p1: { index: 15, price: 120 },
+  p2: { index: 25, price: 105 },
+};
+
+describe("createAndrewsPitchfork", () => {
+  it("returns a valid PrimitivePlugin", () => {
+    const plugin = createAndrewsPitchfork(anchors);
+    expect(plugin.name).toBe("andrewsPitchfork");
+    expect(plugin.pane).toBe("main");
+    expect(plugin.zOrder).toBe("below");
+  });
+
+  it("renders three parallel lines, the handle connector, and anchor dots", () => {
+    const plugin = createAndrewsPitchfork(anchors);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    // Fill for pitchfork body (one polygon) + 3 anchor dots → 4 fills
+    expect(ctx.fill).toHaveBeenCalledTimes(4);
+    // One stroke each for: handle connector, median line, two handle lines together
+    expect(ctx.stroke).toHaveBeenCalledTimes(3);
+    // Three anchor arcs
+    expect(ctx.arc).toHaveBeenCalledTimes(3);
+  });
+
+  it("bails out on a degenerate configuration where p0 aligns vertically with midpoint", () => {
+    const degenerate: PitchforkAnchors = {
+      p0: { index: 10, price: 100 },
+      p1: { index: 10, price: 110 }, // same x as p0 → midpoint x = 10 too
+      p2: { index: 10, price: 90 },
+    };
+    const plugin = createAndrewsPitchfork(degenerate);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    // Should return early without drawing anything
+    expect(ctx.stroke).not.toHaveBeenCalled();
+    expect(ctx.fill).not.toHaveBeenCalled();
+  });
+
+  it("uses custom colors when provided", () => {
+    const plugin = createAndrewsPitchfork(anchors, {
+      color: "rgba(255,0,0,1)",
+      fillColor: "rgba(255,0,0,0.2)",
+    });
+    expect(plugin.defaultState.color).toBe("rgba(255,0,0,1)");
+    expect(plugin.defaultState.fillColor).toBe("rgba(255,0,0,0.2)");
+  });
+});
+
+describe("connectAndrewsPitchfork", () => {
+  function mockChart() {
+    const registrations: Array<{ name: string }> = [];
+    const removals: string[] = [];
+    const chart = {
+      registerPrimitive: vi.fn((p: { name: string }) => {
+        registrations.push(p);
+      }),
+      removePrimitive: vi.fn((name: string) => {
+        removals.push(name);
+      }),
+    } as unknown as ChartInstance;
+    return { chart, registrations, removals };
+  }
+
+  it("registers the pitchfork primitive on connect", () => {
+    const env = mockChart();
+    connectAndrewsPitchfork(env.chart, anchors);
+    expect(env.registrations).toHaveLength(1);
+    expect(env.registrations[0].name).toBe("andrewsPitchfork");
+  });
+
+  it("re-registers with new anchors on update()", () => {
+    const env = mockChart();
+    const handle = connectAndrewsPitchfork(env.chart, anchors);
+    handle.update({
+      p0: { index: 1, price: 50 },
+      p1: { index: 2, price: 60 },
+      p2: { index: 3, price: 55 },
+    });
+    expect(env.registrations).toHaveLength(2);
+  });
+
+  it("removes via remove()", () => {
+    const env = mockChart();
+    const handle = connectAndrewsPitchfork(env.chart, anchors);
+    handle.remove();
+    expect(env.removals).toEqual(["andrewsPitchfork"]);
+  });
+});

--- a/packages/chart/src/__tests__/drawing-helpers.test.ts
+++ b/packages/chart/src/__tests__/drawing-helpers.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChartInstance, Drawing } from "../core/types";
+import {
+  DEFAULT_FIB_EXTENSION_LEVELS,
+  DEFAULT_FIB_RETRACEMENT_LEVELS,
+  type SwingAnchor,
+  addAutoChannelLine,
+  addAutoFibExtension,
+  addAutoFibRetracement,
+  addAutoTrendLine,
+} from "../integration/drawing-helpers";
+
+function mockChart() {
+  const drawings: Drawing[] = [];
+  const addDrawing = vi.fn((d: Drawing) => {
+    drawings.push(d);
+  });
+  // Minimal ChartInstance shape — only addDrawing is exercised.
+  return { chart: { addDrawing } as unknown as ChartInstance, drawings, addDrawing };
+}
+
+const anchors: SwingAnchor[] = [
+  { time: 1_000, price: 100, type: "low" },
+  { time: 2_000, price: 120, type: "high" },
+  { time: 3_000, price: 105, type: "low" },
+  { time: 4_000, price: 130, type: "high" },
+  { time: 5_000, price: 115, type: "low" },
+];
+
+describe("drawing-helpers", () => {
+  let env: ReturnType<typeof mockChart>;
+
+  beforeEach(() => {
+    env = mockChart();
+  });
+
+  describe("addAutoFibRetracement", () => {
+    it("creates a fibRetracement drawing from the latest high+low swings", () => {
+      const id = addAutoFibRetracement(env.chart, anchors);
+      expect(id).not.toBeNull();
+      expect(env.drawings).toHaveLength(1);
+      const d = env.drawings[0];
+      expect(d.type).toBe("fibRetracement");
+      if (d.type !== "fibRetracement") throw new Error();
+      // Latest high (4000/130) is older than latest low (5000/115) → start=high, end=low.
+      expect(d.startTime).toBe(4_000);
+      expect(d.startPrice).toBe(130);
+      expect(d.endTime).toBe(5_000);
+      expect(d.endPrice).toBe(115);
+      expect(d.levels).toEqual(DEFAULT_FIB_RETRACEMENT_LEVELS);
+    });
+
+    it("honors custom levels + id override", () => {
+      addAutoFibRetracement(env.chart, anchors, {
+        id: "custom-fib",
+        levels: [0, 0.5, 1],
+      });
+      expect(env.drawings[0].id).toBe("custom-fib");
+      if (env.drawings[0].type !== "fibRetracement") throw new Error();
+      expect(env.drawings[0].levels).toEqual([0, 0.5, 1]);
+    });
+
+    it("returns null when fewer than two swings provided", () => {
+      expect(addAutoFibRetracement(env.chart, [])).toBeNull();
+      expect(addAutoFibRetracement(env.chart, [anchors[0]])).toBeNull();
+      expect(env.drawings).toHaveLength(0);
+    });
+
+    it("returns null when only one side (all highs) is available", () => {
+      const highsOnly: SwingAnchor[] = [
+        { time: 1, price: 100, type: "high" },
+        { time: 2, price: 110, type: "high" },
+      ];
+      expect(addAutoFibRetracement(env.chart, highsOnly)).toBeNull();
+    });
+  });
+
+  describe("addAutoFibExtension", () => {
+    it("creates a fibExtension drawing from A→B of the last three alternating anchors", () => {
+      const id = addAutoFibExtension(env.chart, anchors);
+      expect(id).not.toBeNull();
+      expect(env.drawings).toHaveLength(1);
+      const d = env.drawings[0];
+      if (d.type !== "fibExtension") throw new Error();
+      // Last three = [3000/low/105, 4000/high/130, 5000/low/115] → A=3000, B=4000.
+      expect(d.startTime).toBe(3_000);
+      expect(d.startPrice).toBe(105);
+      expect(d.endTime).toBe(4_000);
+      expect(d.endPrice).toBe(130);
+      expect(d.levels).toEqual(DEFAULT_FIB_EXTENSION_LEVELS);
+    });
+
+    it("returns null when fewer than three anchors provided", () => {
+      expect(addAutoFibExtension(env.chart, anchors.slice(0, 2))).toBeNull();
+    });
+  });
+
+  describe("addAutoTrendLine", () => {
+    it("draws resistance through the last two highs", () => {
+      addAutoTrendLine(env.chart, anchors, { line: "resistance" });
+      const d = env.drawings[0];
+      if (d.type !== "trendline") throw new Error();
+      expect(d.startTime).toBe(2_000);
+      expect(d.startPrice).toBe(120);
+      expect(d.endTime).toBe(4_000);
+      expect(d.endPrice).toBe(130);
+    });
+
+    it("defaults to resistance when line option is omitted", () => {
+      addAutoTrendLine(env.chart, anchors);
+      const d = env.drawings[0];
+      if (d.type !== "trendline") throw new Error();
+      expect(d.startTime).toBe(2_000);
+      expect(d.endTime).toBe(4_000);
+    });
+
+    it("draws support through the last two lows", () => {
+      addAutoTrendLine(env.chart, anchors, { line: "support" });
+      const d = env.drawings[0];
+      if (d.type !== "trendline") throw new Error();
+      // Last two lows: 3000/105 → 5000/115.
+      expect(d.startTime).toBe(3_000);
+      expect(d.startPrice).toBe(105);
+      expect(d.endTime).toBe(5_000);
+      expect(d.endPrice).toBe(115);
+    });
+
+    it("projects the endpoint using the slope when extendToTime is given", () => {
+      addAutoTrendLine(env.chart, anchors, { line: "support", extendToTime: 7_000 });
+      const d = env.drawings[0];
+      if (d.type !== "trendline") throw new Error();
+      // slope = (115-105)/(5000-3000) = 0.005 per unit time.
+      // at t=7000 → 115 + 0.005 * (7000-5000) = 125.
+      expect(d.endTime).toBe(7_000);
+      expect(d.endPrice).toBeCloseTo(125, 5);
+    });
+
+    it("returns null when fewer than two same-type swings exist", () => {
+      const onlyOneHigh: SwingAnchor[] = [
+        { time: 1, price: 100, type: "high" },
+        { time: 2, price: 95, type: "low" },
+      ];
+      expect(addAutoTrendLine(env.chart, onlyOneHigh, { line: "resistance" })).toBeNull();
+    });
+  });
+
+  describe("addAutoChannelLine", () => {
+    it("draws a channel using two lows as the base and the intervening high for width", () => {
+      addAutoChannelLine(env.chart, anchors);
+      const d = env.drawings[0];
+      if (d.type !== "channel") throw new Error();
+      // trio = [3000/low/105, 4000/high/130, 5000/low/115]
+      // base = two lows: 3000/105 → 5000/115, slope = 0.005/unit
+      // opposite high @4000: line-at-4000 = 105 + 0.005*(4000-3000) = 110 → width = 130 - 110 = 20
+      expect(d.startTime).toBe(3_000);
+      expect(d.endTime).toBe(5_000);
+      expect(d.channelWidth).toBeCloseTo(20, 5);
+    });
+
+    it("extends the base line to extendToTime", () => {
+      addAutoChannelLine(env.chart, anchors, { extendToTime: 7_000 });
+      const d = env.drawings[0];
+      if (d.type !== "channel") throw new Error();
+      expect(d.endTime).toBe(7_000);
+      expect(d.endPrice).toBeCloseTo(125, 5);
+    });
+
+    it("returns null for insufficient anchors", () => {
+      expect(addAutoChannelLine(env.chart, anchors.slice(0, 2))).toBeNull();
+    });
+  });
+
+  describe("id generation", () => {
+    it("uses idPrefix to namespace auto-generated ids", () => {
+      addAutoFibRetracement(env.chart, anchors, { idPrefix: "my-fib" });
+      expect(env.drawings[0].id.startsWith("my-fib-")).toBe(true);
+    });
+
+    it("accepts an explicit id override", () => {
+      addAutoFibRetracement(env.chart, anchors, { id: "pinned" });
+      expect(env.drawings[0].id).toBe("pinned");
+    });
+  });
+});

--- a/packages/chart/src/__tests__/smc-adapter.test.ts
+++ b/packages/chart/src/__tests__/smc-adapter.test.ts
@@ -234,6 +234,23 @@ describe("extractBosLevels", () => {
   it("returns empty for empty input", () => {
     expect(extractBosLevels([])).toEqual([]);
   });
+
+  it("honors a custom label (e.g. CHoCH)", () => {
+    const data = [
+      dp({
+        bullishBos: true,
+        bearishBos: false,
+        brokenLevel: 130,
+        trend: "bullish",
+        swingHighLevel: 130,
+        swingLowLevel: 100,
+      }),
+    ];
+
+    const levels = extractBosLevels(data, "CHoCH");
+    expect(levels).toHaveLength(1);
+    expect(levels[0].label).toBe("CHoCH");
+  });
 });
 
 describe("buildSmcState", () => {
@@ -272,5 +289,34 @@ describe("buildSmcState", () => {
     expect(state.fvgZones).toEqual([]);
     expect(state.sweepMarkers).toEqual([]);
     expect(state.bosLevels).toEqual([]);
+  });
+
+  it("merges bos and choch levels into bosLevels with separate labels", () => {
+    const state = buildSmcState({
+      bos: [
+        dp({
+          bullishBos: true,
+          bearishBos: false,
+          brokenLevel: 120,
+          trend: "bullish",
+          swingHighLevel: 120,
+          swingLowLevel: 100,
+        }),
+      ],
+      choch: [
+        dp({
+          bullishBos: false,
+          bearishBos: true,
+          brokenLevel: 95,
+          trend: "bearish",
+          swingHighLevel: 120,
+          swingLowLevel: 95,
+        }),
+      ],
+    });
+
+    expect(state.bosLevels).toHaveLength(2);
+    const labels = state.bosLevels.map((l) => l.label).sort();
+    expect(labels).toEqual(["BOS", "CHoCH"]);
   });
 });

--- a/packages/chart/src/__tests__/volume-profile.test.ts
+++ b/packages/chart/src/__tests__/volume-profile.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PrimitiveRenderContext } from "../core/plugin-types";
+import type { PriceScale, TimeScale } from "../core/scale";
+import type { ChartInstance, PaneRect } from "../core/types";
+import {
+  type VolumeProfileData,
+  connectVolumeProfile,
+  createVolumeProfile,
+} from "../plugins/volume-profile";
+
+const mockCtx = () =>
+  ({
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    rect: vi.fn(),
+    clip: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    setLineDash: vi.fn(),
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 1,
+    font: "",
+    textAlign: "" as CanvasTextAlign,
+    textBaseline: "" as CanvasTextBaseline,
+  }) as unknown as CanvasRenderingContext2D;
+
+const mockTs = () =>
+  ({ startIndex: 0, endIndex: 50, barSpacing: 8, indexToX: (i: number) => i * 8 + 4 }) as TimeScale;
+
+const mockPs = () => ({ priceToY: (p: number) => 400 - p * 2 }) as PriceScale;
+const mockPane: PaneRect = { id: "main", x: 0, y: 0, width: 800, height: 400 };
+const makeCtx = (ctx: CanvasRenderingContext2D) =>
+  ({ ctx, pane: mockPane, timeScale: mockTs(), priceScale: mockPs() }) as PrimitiveRenderContext;
+
+const profile: VolumeProfileData = {
+  periodLow: 90,
+  periodHigh: 110,
+  poc: 100,
+  vah: 105,
+  val: 95,
+  levels: [
+    { priceLow: 90, priceHigh: 92, priceMid: 91, volume: 100, volumePercent: 0.05 },
+    { priceLow: 95, priceHigh: 97, priceMid: 96, volume: 300, volumePercent: 0.15 },
+    { priceLow: 99, priceHigh: 101, priceMid: 100, volume: 800, volumePercent: 0.4 },
+    { priceLow: 103, priceHigh: 105, priceMid: 104, volume: 500, volumePercent: 0.25 },
+    { priceLow: 108, priceHigh: 110, priceMid: 109, volume: 300, volumePercent: 0.15 },
+  ],
+};
+
+describe("createVolumeProfile", () => {
+  it("returns a valid PrimitivePlugin", () => {
+    const plugin = createVolumeProfile(profile);
+    expect(plugin.name).toBe("volumeProfile");
+    expect(plugin.pane).toBe("main");
+    expect(plugin.zOrder).toBe("above");
+  });
+
+  it("renders a bar per level plus a POC line when showPoc is true (default)", () => {
+    const plugin = createVolumeProfile(profile);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    // One fillRect per level
+    expect(ctx.fillRect).toHaveBeenCalledTimes(profile.levels.length);
+    // POC line + POC label + strip divider
+    expect(ctx.stroke).toHaveBeenCalledTimes(2);
+    expect(ctx.fillText).toHaveBeenCalledWith("POC", expect.any(Number), expect.any(Number));
+  });
+
+  it("omits the POC line when showPoc is false", () => {
+    const plugin = createVolumeProfile(profile, { showPoc: false });
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    // Only the divider line, no POC label
+    expect(ctx.stroke).toHaveBeenCalledTimes(1);
+    expect(ctx.fillText).not.toHaveBeenCalled();
+  });
+
+  it("no-ops on an empty profile", () => {
+    const empty: VolumeProfileData = {
+      ...profile,
+      levels: [],
+    };
+    const plugin = createVolumeProfile(empty);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    expect(ctx.fillRect).not.toHaveBeenCalled();
+    expect(ctx.stroke).not.toHaveBeenCalled();
+  });
+
+  it("accepts widthFraction as absolute pixels when > 1", () => {
+    const plugin = createVolumeProfile(profile, { widthFraction: 120 });
+    expect(plugin.defaultState.widthFraction).toBe(120);
+  });
+
+  it("uses custom colors from options", () => {
+    const plugin = createVolumeProfile(profile, {
+      barColor: "red",
+      valueAreaColor: "blue",
+      pocColor: "green",
+    });
+    expect(plugin.defaultState.barColor).toBe("red");
+    expect(plugin.defaultState.valueAreaColor).toBe("blue");
+    expect(plugin.defaultState.pocColor).toBe("green");
+  });
+});
+
+describe("connectVolumeProfile", () => {
+  function mockChart() {
+    const registrations: Array<{ name: string }> = [];
+    const removals: string[] = [];
+    const chart = {
+      registerPrimitive: vi.fn((p: { name: string }) => {
+        registrations.push(p);
+      }),
+      removePrimitive: vi.fn((name: string) => {
+        removals.push(name);
+      }),
+    } as unknown as ChartInstance;
+    return { chart, registrations, removals };
+  }
+
+  it("registers the primitive on connect", () => {
+    const env = mockChart();
+    connectVolumeProfile(env.chart, profile);
+    expect(env.registrations).toHaveLength(1);
+    expect(env.registrations[0].name).toBe("volumeProfile");
+  });
+
+  it("re-registers on update()", () => {
+    const env = mockChart();
+    const handle = connectVolumeProfile(env.chart, profile);
+    handle.update({ ...profile, poc: 102 });
+    expect(env.registrations).toHaveLength(2);
+  });
+
+  it("removes via remove()", () => {
+    const env = mockChart();
+    const handle = connectVolumeProfile(env.chart, profile);
+    handle.remove();
+    expect(env.removals).toEqual(["volumeProfile"]);
+  });
+});

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -154,3 +154,10 @@ export {
   type PitchforkAnchor,
   type PitchforkAnchors,
 } from "./plugins/andrews-pitchfork";
+export {
+  createVolumeProfile,
+  connectVolumeProfile,
+  type VolumeProfileData,
+  type VolumeProfileLevel,
+  type VolumeProfileState,
+} from "./plugins/volume-profile";

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -147,3 +147,10 @@ export { createWyckoffPhase, connectWyckoffPhase } from "./plugins/wyckoff-phase
 export { createSrConfluence, connectSrConfluence } from "./plugins/sr-confluence";
 export { createTradeAnalysis, connectTradeAnalysis } from "./plugins/trade-analysis";
 export { createSessionZones, connectSessionZones } from "./plugins/session-zones";
+export {
+  createAndrewsPitchfork,
+  connectAndrewsPitchfork,
+  type AndrewsPitchforkState,
+  type PitchforkAnchor,
+  type PitchforkAnchors,
+} from "./plugins/andrews-pitchfork";

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -114,6 +114,21 @@ export { DrawHelper, type StrokeStyle, type FillStyle } from "./core/draw-helper
 
 // Unified indicator connection
 export { connectIndicators, defineIndicator } from "./integration/connect-indicators";
+
+// Drawing auto-injection helpers — convert indicator output (fibs / trendlines / channels)
+// into built-in Drawing objects without needing a dedicated primitive plugin.
+export {
+  addAutoFibRetracement,
+  addAutoFibExtension,
+  addAutoTrendLine,
+  addAutoChannelLine,
+  DEFAULT_FIB_RETRACEMENT_LEVELS,
+  DEFAULT_FIB_EXTENSION_LEVELS,
+  type SwingAnchor,
+  type AddFibOptions,
+  type AddTrendLineOptions,
+  type AddChannelLineOptions,
+} from "./integration/drawing-helpers";
 export type {
   ConnectIndicatorsOptions,
   IndicatorConnection,

--- a/packages/chart/src/integration/drawing-helpers.ts
+++ b/packages/chart/src/integration/drawing-helpers.ts
@@ -1,0 +1,296 @@
+/**
+ * Drawing auto-injection helpers.
+ *
+ * Several TrendCraft indicators (`autoTrendLine`, `channelLine`,
+ * `fibonacciRetracement`, `fibonacciExtension`) produce shape data that the
+ * chart already knows how to render via its built-in drawing types. Instead
+ * of reinventing primitive plugins for each, these helpers convert raw swing
+ * anchors into `Drawing` objects and attach them to the chart.
+ *
+ * Design: all helpers take **pre-computed swing anchors**, so the chart package
+ * keeps zero runtime dependency on `trendcraft`. Compose with
+ * `getAlternatingSwingPoints` (or any equivalent detector) on the caller side:
+ *
+ * @example
+ * ```ts
+ * import { getAlternatingSwingPoints } from "trendcraft";
+ * import { addAutoFibRetracement } from "@trendcraft/chart";
+ *
+ * const raw = getAlternatingSwingPoints(candles, { leftBars: 10, rightBars: 10 });
+ * const anchors = raw.map(p => ({ time: p.time, price: p.value.price, type: p.value.type }));
+ * const drawingId = addAutoFibRetracement(chart, anchors);
+ * ```
+ */
+
+import type {
+  ChannelDrawing,
+  ChartInstance,
+  FibExtensionDrawing,
+  FibRetracementDrawing,
+  TrendLineDrawing,
+} from "../core/types";
+
+/** Normalized swing anchor consumed by the drawing helpers. */
+export type SwingAnchor = {
+  time: number;
+  price: number;
+  type: "high" | "low";
+};
+
+/** Default Fibonacci retracement levels matching TradingView / most trading UIs. */
+export const DEFAULT_FIB_RETRACEMENT_LEVELS = [0, 0.236, 0.382, 0.5, 0.618, 0.786, 1];
+
+/** Default Fibonacci extension levels. */
+export const DEFAULT_FIB_EXTENSION_LEVELS = [0, 0.618, 1, 1.618, 2.618];
+
+// ============================================
+// Shared helpers
+// ============================================
+
+function lastTwoOfType(
+  anchors: readonly SwingAnchor[],
+  type: "high" | "low",
+): [SwingAnchor, SwingAnchor] | null {
+  const filtered = anchors.filter((a) => a.type === type);
+  if (filtered.length < 2) return null;
+  return [filtered[filtered.length - 2], filtered[filtered.length - 1]];
+}
+
+function lastThreeAlternating(
+  anchors: readonly SwingAnchor[],
+): [SwingAnchor, SwingAnchor, SwingAnchor] | null {
+  if (anchors.length < 3) return null;
+  return [anchors[anchors.length - 3], anchors[anchors.length - 2], anchors[anchors.length - 1]];
+}
+
+let autoIdCounter = 0;
+function nextId(prefix: string): string {
+  autoIdCounter += 1;
+  return `${prefix}-${autoIdCounter}`;
+}
+
+// ============================================
+// Fibonacci retracement / extension
+// ============================================
+
+export type AddFibOptions = {
+  /** Fib ratios to draw. Defaults to DEFAULT_FIB_RETRACEMENT_LEVELS / _EXTENSION_LEVELS. */
+  levels?: number[];
+  /** Drawing stroke color. */
+  color?: string;
+  /** Drawing id prefix. Defaults to "auto-fib". */
+  idPrefix?: string;
+  /** Override drawing id completely (skips idPrefix / counter). */
+  id?: string;
+};
+
+/**
+ * Attach a Fibonacci retracement drawing between the two most recent swing
+ * anchors. The high/low order is inferred from the anchors' timestamps.
+ *
+ * Returns the drawing id, or `null` if fewer than two swings were supplied.
+ */
+export function addAutoFibRetracement(
+  chart: ChartInstance,
+  anchors: readonly SwingAnchor[],
+  options: AddFibOptions = {},
+): string | null {
+  if (anchors.length < 2) return null;
+  const pairHigh = lastTwoOfType(anchors, "high");
+  const pairLow = lastTwoOfType(anchors, "low");
+  if (!pairHigh && !pairLow) return null;
+
+  // Use the latest high + latest low as anchors (standard fib retracement).
+  const latestHigh = pairHigh ? pairHigh[1] : null;
+  const latestLow = pairLow ? pairLow[1] : null;
+  if (!latestHigh || !latestLow) return null;
+
+  // Start from the older anchor (the one forming the impulse), end at the newer.
+  const [start, end] =
+    latestHigh.time < latestLow.time ? [latestHigh, latestLow] : [latestLow, latestHigh];
+
+  const drawing: FibRetracementDrawing = {
+    id: options.id ?? nextId(options.idPrefix ?? "auto-fib"),
+    type: "fibRetracement",
+    startTime: start.time,
+    startPrice: start.price,
+    endTime: end.time,
+    endPrice: end.price,
+    levels: options.levels ?? DEFAULT_FIB_RETRACEMENT_LEVELS,
+    ...(options.color ? { color: options.color } : {}),
+  };
+  chart.addDrawing(drawing);
+  return drawing.id;
+}
+
+/**
+ * Attach a Fibonacci extension drawing. Extension needs three anchors
+ * (A, B, C) — pass the last three alternating swings.
+ *
+ * The chart's `fibExtension` drawing type takes A → B as the primary
+ * impulse; levels project from B along the A→B direction. We pick the
+ * last three alternating anchors in order and draw A→B.
+ */
+export function addAutoFibExtension(
+  chart: ChartInstance,
+  anchors: readonly SwingAnchor[],
+  options: AddFibOptions = {},
+): string | null {
+  const trio = lastThreeAlternating(anchors);
+  if (!trio) return null;
+  const [a, b] = trio;
+
+  const drawing: FibExtensionDrawing = {
+    id: options.id ?? nextId(options.idPrefix ?? "auto-fibext"),
+    type: "fibExtension",
+    startTime: a.time,
+    startPrice: a.price,
+    endTime: b.time,
+    endPrice: b.price,
+    levels: options.levels ?? DEFAULT_FIB_EXTENSION_LEVELS,
+    ...(options.color ? { color: options.color } : {}),
+  };
+  chart.addDrawing(drawing);
+  return drawing.id;
+}
+
+// ============================================
+// Auto trend line (resistance / support)
+// ============================================
+
+export type AddTrendLineOptions = {
+  /** Which line to draw. Defaults to "resistance". */
+  line?: "resistance" | "support";
+  /** Extend the line's endpoint to this time. If omitted, uses the last anchor. */
+  extendToTime?: number;
+  /** Drawing stroke color. */
+  color?: string;
+  /** Drawing id prefix. Defaults to "auto-trend". */
+  idPrefix?: string;
+  /** Override drawing id completely. */
+  id?: string;
+};
+
+/**
+ * Attach a trend line connecting the two most recent swing highs (resistance)
+ * or swing lows (support). Returns the drawing id, or `null` if fewer than
+ * two same-type swings were supplied.
+ */
+export function addAutoTrendLine(
+  chart: ChartInstance,
+  anchors: readonly SwingAnchor[],
+  options: AddTrendLineOptions = {},
+): string | null {
+  const wanted = options.line ?? "resistance";
+  const type = wanted === "resistance" ? "high" : "low";
+  const pair = lastTwoOfType(anchors, type);
+  if (!pair) return null;
+  const [a, b] = pair;
+
+  // Compute slope-projected price at extendToTime (if past b).
+  let endTime = b.time;
+  let endPrice = b.price;
+  if (options.extendToTime != null && options.extendToTime > b.time && b.time !== a.time) {
+    const slope = (b.price - a.price) / (b.time - a.time);
+    endTime = options.extendToTime;
+    endPrice = b.price + slope * (options.extendToTime - b.time);
+  }
+
+  const drawing: TrendLineDrawing = {
+    id: options.id ?? nextId(options.idPrefix ?? `auto-${wanted}`),
+    type: "trendline",
+    startTime: a.time,
+    startPrice: a.price,
+    endTime,
+    endPrice,
+    ...(options.color ? { color: options.color } : {}),
+  };
+  chart.addDrawing(drawing);
+  return drawing.id;
+}
+
+// ============================================
+// Channel line
+// ============================================
+
+export type AddChannelLineOptions = {
+  /** Extend the channel's endpoint to this time. */
+  extendToTime?: number;
+  /** Drawing stroke color. */
+  color?: string;
+  /** Fill color for the channel interior. */
+  fillColor?: string;
+  /** Drawing id prefix. Defaults to "auto-channel". */
+  idPrefix?: string;
+  /** Override drawing id completely. */
+  id?: string;
+};
+
+/**
+ * Attach a parallel channel drawn between the two most recent swing highs
+ * and offset by the distance to the most recent intervening swing low (or
+ * vice versa for a descending channel). The base line goes through the
+ * primary anchor pair; `channelWidth` is the perpendicular price distance
+ * to the opposing swing.
+ *
+ * Returns the drawing id, or `null` if insufficient anchors were supplied.
+ */
+export function addAutoChannelLine(
+  chart: ChartInstance,
+  anchors: readonly SwingAnchor[],
+  options: AddChannelLineOptions = {},
+): string | null {
+  const trio = lastThreeAlternating(anchors);
+  if (!trio) return null;
+
+  // Determine direction: two highs + one low = descending (upper = highs, lower offset)
+  // two lows + one high   = ascending  (lower = lows, upper offset)
+  const highs = trio.filter((a) => a.type === "high");
+  const lows = trio.filter((a) => a.type === "low");
+
+  let baseA: SwingAnchor;
+  let baseB: SwingAnchor;
+  let oppositeAnchor: SwingAnchor;
+  if (highs.length === 2 && lows.length === 1) {
+    baseA = highs[0];
+    baseB = highs[1];
+    oppositeAnchor = lows[0];
+  } else if (lows.length === 2 && highs.length === 1) {
+    baseA = lows[0];
+    baseB = lows[1];
+    oppositeAnchor = highs[0];
+  } else {
+    // Shouldn't happen given alternating input, but fall back to null safely.
+    return null;
+  }
+
+  // Base line slope
+  let endTime = baseB.time;
+  let endPrice = baseB.price;
+  let slope = 0;
+  if (baseB.time !== baseA.time) {
+    slope = (baseB.price - baseA.price) / (baseB.time - baseA.time);
+  }
+  if (options.extendToTime != null && options.extendToTime > baseB.time) {
+    endTime = options.extendToTime;
+    endPrice = baseB.price + slope * (options.extendToTime - baseB.time);
+  }
+
+  // Perpendicular price offset at the opposite swing's time
+  const lineAtOppositeTime = baseA.price + slope * (oppositeAnchor.time - baseA.time);
+  const channelWidth = oppositeAnchor.price - lineAtOppositeTime;
+
+  const drawing: ChannelDrawing = {
+    id: options.id ?? nextId(options.idPrefix ?? "auto-channel"),
+    type: "channel",
+    startTime: baseA.time,
+    startPrice: baseA.price,
+    endTime,
+    endPrice,
+    channelWidth,
+    ...(options.color ? { color: options.color } : {}),
+    ...(options.fillColor ? { fillColor: options.fillColor } : {}),
+  };
+  chart.addDrawing(drawing);
+  return drawing.id;
+}

--- a/packages/chart/src/integration/drawing-helpers.ts
+++ b/packages/chart/src/integration/drawing-helpers.ts
@@ -16,8 +16,8 @@
  * import { getAlternatingSwingPoints } from "trendcraft";
  * import { addAutoFibRetracement } from "@trendcraft/chart";
  *
- * const raw = getAlternatingSwingPoints(candles, { leftBars: 10, rightBars: 10 });
- * const anchors = raw.map(p => ({ time: p.time, price: p.value.price, type: p.value.type }));
+ * // getAlternatingSwingPoints already returns { time, price, type, index }[]
+ * const anchors = getAlternatingSwingPoints(candles, 6, { leftBars: 10, rightBars: 10 });
  * const drawingId = addAutoFibRetracement(chart, anchors);
  * ```
  */

--- a/packages/chart/src/plugins/andrews-pitchfork.ts
+++ b/packages/chart/src/plugins/andrews-pitchfork.ts
@@ -17,14 +17,13 @@
  * const chart = createChart(el);
  * chart.setCandles(candles);
  *
- * const timeToIndex = new Map(candles.map((c, i) => [c.time, i]));
- * const swings = getAlternatingSwingPoints(candles, { leftBars: 10, rightBars: 10 });
- * if (swings.length >= 3) {
- *   const last3 = swings.slice(-3);
- *   const handle = connectAndrewsPitchfork(chart, {
- *     p0: { index: timeToIndex.get(last3[0].time)!, price: last3[0].value.price },
- *     p1: { index: timeToIndex.get(last3[1].time)!, price: last3[1].value.price },
- *     p2: { index: timeToIndex.get(last3[2].time)!, price: last3[2].value.price },
+ * // getAlternatingSwingPoints already carries `index` for every swing.
+ * const last3 = getAlternatingSwingPoints(candles, 3, { leftBars: 10, rightBars: 10 });
+ * if (last3.length === 3) {
+ *   connectAndrewsPitchfork(chart, {
+ *     p0: { index: last3[0].index, price: last3[0].price },
+ *     p1: { index: last3[1].index, price: last3[1].price },
+ *     p2: { index: last3[2].index, price: last3[2].price },
  *   });
  * }
  * ```

--- a/packages/chart/src/plugins/andrews-pitchfork.ts
+++ b/packages/chart/src/plugins/andrews-pitchfork.ts
@@ -1,0 +1,199 @@
+/**
+ * Andrew's Pitchfork Plugin — Renders three parallel trend lines from a
+ * median pivot (P0) through the midpoint of two subsequent swings (P1, P2).
+ *
+ * Unlike the drawing-level `trendline` type, the pitchfork uses three swing
+ * anchors directly and extends forward indefinitely, so a dedicated primitive
+ * plugin is the natural fit rather than a static drawing.
+ *
+ * Anchors use candle **indices** (matching the chart's index-based x-axis),
+ * so the caller maps `time → index` via the candles array on their side.
+ *
+ * @example
+ * ```typescript
+ * import { createChart, connectAndrewsPitchfork } from '@trendcraft/chart';
+ * import { getAlternatingSwingPoints } from 'trendcraft';
+ *
+ * const chart = createChart(el);
+ * chart.setCandles(candles);
+ *
+ * const timeToIndex = new Map(candles.map((c, i) => [c.time, i]));
+ * const swings = getAlternatingSwingPoints(candles, { leftBars: 10, rightBars: 10 });
+ * if (swings.length >= 3) {
+ *   const last3 = swings.slice(-3);
+ *   const handle = connectAndrewsPitchfork(chart, {
+ *     p0: { index: timeToIndex.get(last3[0].time)!, price: last3[0].value.price },
+ *     p1: { index: timeToIndex.get(last3[1].time)!, price: last3[1].value.price },
+ *     p2: { index: timeToIndex.get(last3[2].time)!, price: last3[2].value.price },
+ *   });
+ * }
+ * ```
+ */
+
+import { definePrimitive } from "../core/plugin-types";
+import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
+import type { ChartInstance } from "../core/types";
+
+// ---- Public types ----
+
+export type PitchforkAnchor = {
+  /** Candle index (0-based) along the chart's x-axis. */
+  index: number;
+  /** Price value along the y-axis. */
+  price: number;
+};
+
+export type PitchforkAnchors = {
+  p0: PitchforkAnchor;
+  p1: PitchforkAnchor;
+  p2: PitchforkAnchor;
+};
+
+export type AndrewsPitchforkState = {
+  anchors: PitchforkAnchors;
+  /** Stroke color for the three parallel lines (rgba or named). */
+  color?: string;
+  /** Fill color for the area between upper and lower handles. */
+  fillColor?: string;
+};
+
+// ---- Render ----
+
+function renderAndrewsPitchfork(
+  { ctx, pane, timeScale, priceScale }: PrimitiveRenderContext,
+  state: AndrewsPitchforkState,
+): void {
+  const { p0, p1, p2 } = state.anchors;
+
+  const x0 = timeScale.indexToX(p0.index);
+  const x1 = timeScale.indexToX(p1.index);
+  const x2 = timeScale.indexToX(p2.index);
+
+  const y0 = priceScale.priceToY(p0.price);
+  const y1 = priceScale.priceToY(p1.price);
+  const y2 = priceScale.priceToY(p2.price);
+
+  // Midpoint of P1-P2 in pixel space
+  const midX = (x1 + x2) / 2;
+  const midY = (y1 + y2) / 2;
+
+  // Median line: P0 → midpoint, extended to the right edge
+  const rightEdgeX = pane.x + pane.width;
+  const dxMed = midX - x0;
+  const dyMed = midY - y0;
+  if (dxMed === 0) return; // Degenerate: anchors too close vertically
+
+  const extendRatio = (rightEdgeX - x0) / dxMed;
+  const medianEndX = x0 + dxMed * extendRatio;
+  const medianEndY = y0 + dyMed * extendRatio;
+
+  // Upper handle: parallel to median, passing through whichever of P1/P2 is higher
+  // (lower Y value in pixel space since Y grows downward).
+  const upperAnchorX = y1 < y2 ? x1 : x2;
+  const upperAnchorY = y1 < y2 ? y1 : y2;
+  const lowerAnchorX = y1 < y2 ? x2 : x1;
+  const lowerAnchorY = y1 < y2 ? y2 : y1;
+
+  // Parallel line through (ax, ay) with same direction as median: end at rightEdgeX.
+  const upperEndX = rightEdgeX;
+  const upperEndY = upperAnchorY + (dyMed / dxMed) * (rightEdgeX - upperAnchorX);
+  const lowerEndX = rightEdgeX;
+  const lowerEndY = lowerAnchorY + (dyMed / dxMed) * (rightEdgeX - lowerAnchorX);
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(pane.x, pane.y, pane.width, pane.height);
+  ctx.clip();
+
+  const stroke = state.color ?? "rgba(100,149,237,0.9)";
+  const fill = state.fillColor ?? "rgba(100,149,237,0.08)";
+
+  // Fill the region between upper and lower handles (from their anchor points forward).
+  ctx.fillStyle = fill;
+  ctx.beginPath();
+  ctx.moveTo(upperAnchorX, upperAnchorY);
+  ctx.lineTo(upperEndX, upperEndY);
+  ctx.lineTo(lowerEndX, lowerEndY);
+  ctx.lineTo(lowerAnchorX, lowerAnchorY);
+  ctx.closePath();
+  ctx.fill();
+
+  // Handle connector (P1 ↔ P2 short dashed segment)
+  ctx.strokeStyle = stroke;
+  ctx.lineWidth = 1;
+  ctx.setLineDash([3, 3]);
+  ctx.beginPath();
+  ctx.moveTo(x1, y1);
+  ctx.lineTo(x2, y2);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  // Median line (solid)
+  ctx.lineWidth = 1.5;
+  ctx.beginPath();
+  ctx.moveTo(x0, y0);
+  ctx.lineTo(medianEndX, medianEndY);
+  ctx.stroke();
+
+  // Upper + lower handle lines (solid, thinner)
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(upperAnchorX, upperAnchorY);
+  ctx.lineTo(upperEndX, upperEndY);
+  ctx.moveTo(lowerAnchorX, lowerAnchorY);
+  ctx.lineTo(lowerEndX, lowerEndY);
+  ctx.stroke();
+
+  // Small anchor dots
+  ctx.fillStyle = stroke;
+  for (const [ax, ay] of [
+    [x0, y0],
+    [x1, y1],
+    [x2, y2],
+  ]) {
+    ctx.beginPath();
+    ctx.arc(ax, ay, 2.5, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  ctx.restore();
+}
+
+// ---- Factory ----
+
+export function createAndrewsPitchfork(
+  anchors: PitchforkAnchors,
+  options: { color?: string; fillColor?: string } = {},
+): PrimitivePlugin<AndrewsPitchforkState> {
+  return definePrimitive<AndrewsPitchforkState>({
+    name: "andrewsPitchfork",
+    pane: "main",
+    zOrder: "below",
+    defaultState: { anchors, color: options.color, fillColor: options.fillColor },
+    render: renderAndrewsPitchfork,
+  });
+}
+
+// ---- Convenience connector ----
+
+type AndrewsPitchforkHandle = {
+  update(anchors: PitchforkAnchors, options?: { color?: string; fillColor?: string }): void;
+  remove(): void;
+};
+
+export function connectAndrewsPitchfork(
+  chart: ChartInstance,
+  anchors: PitchforkAnchors,
+  options: { color?: string; fillColor?: string } = {},
+): AndrewsPitchforkHandle {
+  chart.registerPrimitive(createAndrewsPitchfork(anchors, options));
+
+  return {
+    update(newAnchors, newOptions) {
+      chart.registerPrimitive(createAndrewsPitchfork(newAnchors, newOptions ?? options));
+    },
+    remove() {
+      chart.removePrimitive("andrewsPitchfork");
+    },
+  };
+}

--- a/packages/chart/src/plugins/smc-adapter.ts
+++ b/packages/chart/src/plugins/smc-adapter.ts
@@ -165,10 +165,15 @@ export function extractSweepMarkers(data: readonly DataPoint<unknown>[]): SmcMar
 // ---- Break of Structure ----
 
 /**
- * Extract SmcLevel[] from breakOfStructure() output.
- * Creates levels at bars where bullishBos or bearishBos is true.
+ * Extract SmcLevel[] from breakOfStructure() or changeOfCharacter() output.
+ * Creates levels at bars where bullishBos or bearishBos is true. Both indicators
+ * return the same `BosValue` shape — `changeOfCharacter` only emits on trend-
+ * reversing breaks, so the caller chooses which feed to pass in.
  */
-export function extractBosLevels(data: readonly DataPoint<unknown>[]): SmcLevel[] {
+export function extractBosLevels(
+  data: readonly DataPoint<unknown>[],
+  label: "BOS" | "CHoCH" = "BOS",
+): SmcLevel[] {
   const levels: SmcLevel[] = [];
 
   for (let i = 0; i < data.length; i++) {
@@ -187,7 +192,7 @@ export function extractBosLevels(data: readonly DataPoint<unknown>[]): SmcLevel[
       price: rec.brokenLevel as number,
       startIndex: i,
       endIndex: null,
-      label: "BOS",
+      label,
     });
   }
 
@@ -198,17 +203,22 @@ export function extractBosLevels(data: readonly DataPoint<unknown>[]): SmcLevel[
 
 /**
  * Build SmcState from multiple indicator outputs.
+ * `bos` and `choch` levels are merged in the output; they share a render
+ * path but are labeled differently ("BOS" vs "CHoCH") for visual clarity.
  */
 export function buildSmcState(sources: {
   orderBlocks?: readonly DataPoint<unknown>[];
   fvgs?: readonly DataPoint<unknown>[];
   sweeps?: readonly DataPoint<unknown>[];
   bos?: readonly DataPoint<unknown>[];
+  choch?: readonly DataPoint<unknown>[];
 }): SmcState {
+  const bosLevels = sources.bos ? extractBosLevels(sources.bos, "BOS") : [];
+  const chochLevels = sources.choch ? extractBosLevels(sources.choch, "CHoCH") : [];
   return {
     orderBlocks: sources.orderBlocks ? extractOrderBlocks(sources.orderBlocks) : [],
     fvgZones: sources.fvgs ? extractFvgZones(sources.fvgs) : [],
     sweepMarkers: sources.sweeps ? extractSweepMarkers(sources.sweeps) : [],
-    bosLevels: sources.bos ? extractBosLevels(sources.bos) : [],
+    bosLevels: [...bosLevels, ...chochLevels],
   };
 }

--- a/packages/chart/src/plugins/smc-layer.ts
+++ b/packages/chart/src/plugins/smc-layer.ts
@@ -7,7 +7,7 @@
  * @example
  * ```typescript
  * import { createChart, connectSmcLayer } from '@trendcraft/chart';
- * import { orderBlock, fairValueGap, liquiditySweep, breakOfStructure } from 'trendcraft';
+ * import { orderBlock, fairValueGap, liquiditySweep, breakOfStructure, changeOfCharacter } from 'trendcraft';
  *
  * const chart = createChart(el);
  * chart.setCandles(candles);
@@ -16,6 +16,7 @@
  *   fvgs: fairValueGap(candles),
  *   sweeps: liquiditySweep(candles),
  *   bos: breakOfStructure(candles),
+ *   choch: changeOfCharacter(candles),  // optional — trend-reversing breaks only
  * });
  * // Later: handle.remove();
  * ```
@@ -273,6 +274,8 @@ type SmcLayerSources = {
   fvgs?: readonly DataPoint<unknown>[];
   sweeps?: readonly DataPoint<unknown>[];
   bos?: readonly DataPoint<unknown>[];
+  /** Change of Character — same shape as `bos` but rendered with a "CHoCH" label. */
+  choch?: readonly DataPoint<unknown>[];
 };
 
 type SmcLayerHandle = {

--- a/packages/chart/src/plugins/volume-profile.ts
+++ b/packages/chart/src/plugins/volume-profile.ts
@@ -1,0 +1,199 @@
+/**
+ * Volume Profile Plugin — Renders a horizontal histogram of volume by price
+ * level along the right edge of the chart.
+ *
+ * Each price bucket becomes a horizontal bar whose length is proportional
+ * to the volume traded at that level. The Point of Control (POC) and
+ * Value Area (VAH/VAL) are highlighted separately so the fair-value band
+ * reads at a glance.
+ *
+ * @example
+ * ```typescript
+ * import { createChart, connectVolumeProfile } from '@trendcraft/chart';
+ * import { volumeProfile } from 'trendcraft';
+ *
+ * const chart = createChart(el);
+ * chart.setCandles(candles);
+ *
+ * const profile = volumeProfile(candles, { levels: 30, period: 60 });
+ * const handle = connectVolumeProfile(chart, profile);
+ * // Later: handle.remove();
+ * ```
+ */
+
+import { definePrimitive } from "../core/plugin-types";
+import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
+import type { ChartInstance } from "../core/types";
+
+// ---- Public types ----
+
+/**
+ * Minimal duck-typed shape matching core's `VolumeProfileValue`.
+ * Defined locally so the chart package stays runtime-free of `trendcraft`.
+ */
+export type VolumeProfileLevel = {
+  priceLow: number;
+  priceHigh: number;
+  priceMid: number;
+  volume: number;
+  volumePercent: number;
+};
+
+export type VolumeProfileData = {
+  levels: readonly VolumeProfileLevel[];
+  poc: number;
+  vah: number;
+  val: number;
+  periodHigh: number;
+  periodLow: number;
+};
+
+export type VolumeProfileState = {
+  profile: VolumeProfileData;
+  /**
+   * Width allocated to the histogram as a fraction of the pane width (0-1),
+   * or as an absolute pixel count (> 1). Default 0.18 (18% of pane).
+   */
+  widthFraction?: number;
+  /** Whether to draw inside the value area differently. Default true. */
+  highlightValueArea?: boolean;
+  /** Whether to draw a horizontal line at the POC. Default true. */
+  showPoc?: boolean;
+  /** Bar fill color (outside the value area). */
+  barColor?: string;
+  /** Bar fill color inside the value area (overrides barColor when highlightValueArea). */
+  valueAreaColor?: string;
+  /** POC line color. */
+  pocColor?: string;
+};
+
+// ---- Defaults ----
+
+const DEFAULT_BAR_COLOR = "rgba(100,149,237,0.35)";
+const DEFAULT_VALUE_AREA_COLOR = "rgba(100,149,237,0.55)";
+const DEFAULT_POC_COLOR = "rgba(255,193,7,0.85)";
+
+// ---- Render ----
+
+function renderVolumeProfile(
+  { ctx, pane, priceScale }: PrimitiveRenderContext,
+  state: VolumeProfileState,
+): void {
+  const {
+    profile,
+    widthFraction = 0.18,
+    highlightValueArea = true,
+    showPoc = true,
+    barColor = DEFAULT_BAR_COLOR,
+    valueAreaColor = DEFAULT_VALUE_AREA_COLOR,
+    pocColor = DEFAULT_POC_COLOR,
+  } = state;
+
+  if (profile.levels.length === 0) return;
+
+  // Max percent for normalization. Falls back to any positive value so a
+  // single-level profile still renders.
+  let maxPercent = 0;
+  for (const lvl of profile.levels) {
+    if (lvl.volumePercent > maxPercent) maxPercent = lvl.volumePercent;
+  }
+  if (maxPercent <= 0) return;
+
+  // Reserve a strip on the right side of the pane for the histogram.
+  const reservedWidth =
+    widthFraction > 1 ? Math.min(widthFraction, pane.width) : pane.width * widthFraction;
+  if (reservedWidth <= 0) return;
+  const rightEdge = pane.x + pane.width;
+  const stripLeft = rightEdge - reservedWidth;
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(pane.x, pane.y, pane.width, pane.height);
+  ctx.clip();
+
+  for (const level of profile.levels) {
+    const topY = priceScale.priceToY(level.priceHigh);
+    const bottomY = priceScale.priceToY(level.priceLow);
+    const barHeight = Math.max(1, bottomY - topY);
+
+    const barLen = (level.volumePercent / maxPercent) * reservedWidth;
+    if (barLen <= 0) continue;
+
+    const inValueArea = level.priceMid >= profile.val && level.priceMid <= profile.vah;
+    ctx.fillStyle = highlightValueArea && inValueArea ? valueAreaColor : barColor;
+
+    // Bar extends leftward from the right edge.
+    ctx.fillRect(rightEdge - barLen, topY, barLen, barHeight);
+  }
+
+  // POC line — thin horizontal line across the entire pane width.
+  if (showPoc) {
+    const pocY = priceScale.priceToY(profile.poc);
+    ctx.strokeStyle = pocColor;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 3]);
+    ctx.beginPath();
+    ctx.moveTo(pane.x, pocY);
+    ctx.lineTo(rightEdge, pocY);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // POC label
+    ctx.fillStyle = pocColor;
+    ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
+    ctx.textAlign = "right";
+    ctx.textBaseline = "bottom";
+    ctx.fillText("POC", rightEdge - 4, pocY - 2);
+  }
+
+  // Subtle divider between chart and histogram strip.
+  ctx.strokeStyle = "rgba(128,128,128,0.2)";
+  ctx.lineWidth = 0.5;
+  ctx.beginPath();
+  ctx.moveTo(stripLeft, pane.y);
+  ctx.lineTo(stripLeft, pane.y + pane.height);
+  ctx.stroke();
+
+  ctx.restore();
+}
+
+// ---- Factory ----
+
+type VolumeProfileOptions = Omit<VolumeProfileState, "profile">;
+
+export function createVolumeProfile(
+  profile: VolumeProfileData,
+  options: VolumeProfileOptions = {},
+): PrimitivePlugin<VolumeProfileState> {
+  return definePrimitive<VolumeProfileState>({
+    name: "volumeProfile",
+    pane: "main",
+    zOrder: "above",
+    defaultState: { profile, ...options },
+    render: renderVolumeProfile,
+  });
+}
+
+// ---- Convenience connector ----
+
+type VolumeProfileHandle = {
+  update(profile: VolumeProfileData, options?: VolumeProfileOptions): void;
+  remove(): void;
+};
+
+export function connectVolumeProfile(
+  chart: ChartInstance,
+  profile: VolumeProfileData,
+  options: VolumeProfileOptions = {},
+): VolumeProfileHandle {
+  chart.registerPrimitive(createVolumeProfile(profile, options));
+
+  return {
+    update(newProfile, newOptions) {
+      chart.registerPrimitive(createVolumeProfile(newProfile, newOptions ?? options));
+    },
+    remove() {
+      chart.removePrimitive("volumeProfile");
+    },
+  };
+}

--- a/packages/chart/src/presets.ts
+++ b/packages/chart/src/presets.ts
@@ -506,6 +506,22 @@ const TRENDCRAFT_PRESETS: [string, IndicatorPreset][] = [
 
   // SMC
   ["liquiditySweep", { color: "#e91e63" }],
+
+  // Filter (Ehlers)
+  ["superSmoother", { pane: "main", color: "#4dd0e1", lineWidth: 1.5 }],
+  ["roofingFilter", { pane: "sub", color: "#4dd0e1", referenceLines: [0] }],
+
+  // Price utilities
+  ["highest", { pane: "main", color: "#ef5350", lineWidth: 1 }],
+  ["lowest", { pane: "main", color: "#26a69a", lineWidth: 1 }],
+  ["returns", { pane: "sub", color: "#9575cd", referenceLines: [0] }],
+  ["cumulativeReturns", { pane: "sub", color: "#7986cb" }],
+  ["medianPrice", { pane: "main", color: "#ffb74d", lineWidth: 1 }],
+  ["typicalPrice", { pane: "main", color: "#ba68c8", lineWidth: 1 }],
+  ["weightedClose", { pane: "main", color: "#f06292", lineWidth: 1 }],
+
+  // Volatility (additional)
+  ["atrPercent", { pane: "sub", color: "#ff8a65" }],
 ];
 
 // ============================================

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -10,12 +10,16 @@
 - **移動平均**: SMA, EMA, WMA, VWMA, KAMA, T3, HMA（ハル移動平均）, McGinley Dynamic, EMA Ribbon, DEMA, TEMA, ZLEMA, FRAMA, ALMA
 - **トレンド**: 一目均衡表, Supertrend, パラボリックSAR, Vortex, Schaff Trend Cycle, Linear Regression
 - **モメンタム**: RSI, MACD, ストキャスティクス (Fast/Slow), DMI/ADX, ADXR, Stoch RSI, CCI, Williams %R, ROC, TRIX, Aroon, DPO, Hurst Exponent, コナーズRSI, IMI, Ultimate Oscillator, Awesome Oscillator, Mass Index, KST, Coppock Curve, TSI, PPO, CMO, Balance of Power, QStick
-- **ボラティリティ**: ボリンジャーバンド, ATR, ドンチャンチャネル, ケルトナーチャネル, シャンデリアイグジット, ボラティリティレジーム, チョッピネスインデックス, Ulcer Index, Historical Volatility, Garman-Klass, Standard Deviation
-- **出来高**: OBV, MFI, VWAP（バンド対応）, 出来高移動平均, CMF, 出来高異常検出, Volume Profile, 出来高トレンド確認, ADL, アンカードVWAP, Elder Force Index, Ease of Movement, Klinger, TWAP, Weis Wave, Market Profile, PVT, NVI
-- **価格**: 最高値/最安値, リターン, ピボットポイント, スイングポイント, フラクタル, Zigzag, フィボナッチリトレースメント/エクステンション, 平均足, オープニングレンジブレイクアウト, ギャップ分析, Median Price, Typical Price, Weighted Close
+- **ボラティリティ**: ボリンジャーバンド, ATR, ドンチャンチャネル, ケルトナーチャネル, シャンデリアイグジット, ボラティリティレジーム, チョッピネスインデックス, Ulcer Index, Historical Volatility, Garman-Klass, Standard Deviation, ATR Stops, ATR Percent, EWMA Volatility
+- **出来高**: OBV, MFI, VWAP（バンド対応）, 出来高移動平均, CMF, 出来高異常検出, Volume Profile, 出来高トレンド確認, ADL, アンカードVWAP, Elder Force Index, Ease of Movement, Klinger, TWAP, Weis Wave, Market Profile, PVT, NVI, CVD（+ シグナル / ダイバージェンス）
+- **価格**: Highest/Lowest, 最高値, 最安値, リターン, 累積リターン, ピボットポイント, スイングポイント, フラクタル, Zigzag, フィボナッチリトレースメント/エクステンション, アンドリュースピッチフォーク, オートトレンドライン, チャネルライン, 平均足, オープニングレンジブレイクアウト, ギャップ分析, Median Price, Typical Price, Weighted Close, BOS / CHoCH, FVG, S/Rゾーンクラスタリング
 - **スマートマネーコンセプト (SMC)**: Order Block, Liquidity Sweep
-- **フィルター**: Super Smoother, Roofing Filter (Ehlers)
-- **相対力**: Benchmark RS, RS Rating, RS Ranking
+- **フィルター (Ehlers)**: Super Smoother, Roofing Filter
+- **適応型**: Adaptive RSI, Adaptive Bollinger, Adaptive MA (ER連動), Adaptive Stochastics (ADX連動)
+- **セッション / ICT**: セッション検出, キルゾーン（アジア / ロンドン / NY）, セッション統計, セッションブレイクアウト
+- **Wyckoff**: VSA (Volume Spread Analysis), Wyckoffフェーズ検出
+- **レジーム**: HMMレジーム検出 (Baum-Welch / Viterbi), レジーム遷移行列
+- **相対力**: Benchmark RS, RS Rating, RS Ranking, マルチシンボルRS (`rankByRS` / `topByRS` / `filterByRSPercentile` / `compareRS`)
 
 ### シグナル検出
 - **クロス検出**: ゴールデンクロス、デッドクロス、カスタムクロスオーバー

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -10,12 +10,16 @@ A TypeScript library for technical analysis of financial data. Calculate indicat
 - **Moving Averages**: SMA, EMA, WMA, VWMA, KAMA, T3, HMA (Hull), McGinley Dynamic, EMA Ribbon, DEMA, TEMA, ZLEMA, FRAMA, ALMA
 - **Trend**: Ichimoku Cloud, Supertrend, Parabolic SAR, Vortex, Schaff Trend Cycle, Linear Regression
 - **Momentum**: RSI, MACD, Stochastics (Fast/Slow), DMI/ADX, ADXR, Stoch RSI, CCI, Williams %R, ROC, TRIX, Aroon, DPO, Hurst Exponent, Connors RSI, IMI, Ultimate Oscillator, Awesome Oscillator, Mass Index, KST, Coppock Curve, TSI, PPO, CMO, Balance of Power, QStick
-- **Volatility**: Bollinger Bands, ATR, Donchian Channel, Keltner Channel, Chandelier Exit, Volatility Regime, Choppiness Index, Ulcer Index, Historical Volatility, Garman-Klass, Standard Deviation
-- **Volume**: OBV, MFI, VWAP (with Bands), Volume MA, CMF, Volume Anomaly, Volume Profile, Volume Trend, ADL, Anchored VWAP, Elder Force Index, Ease of Movement, Klinger, TWAP, Weis Wave, Market Profile, PVT, NVI
-- **Price**: Highest/Lowest, Returns, Pivot Points, Swing Points, Fractals, Zigzag, Fibonacci Retracement/Extension, Heikin-Ashi, Opening Range Breakout, Gap Analysis, Median Price, Typical Price, Weighted Close
+- **Volatility**: Bollinger Bands, ATR, Donchian Channel, Keltner Channel, Chandelier Exit, Volatility Regime, Choppiness Index, Ulcer Index, Historical Volatility, Garman-Klass, Standard Deviation, ATR Stops, ATR Percent, EWMA Volatility
+- **Volume**: OBV, MFI, VWAP (with Bands), Volume MA, CMF, Volume Anomaly, Volume Profile, Volume Trend, ADL, Anchored VWAP, Elder Force Index, Ease of Movement, Klinger, TWAP, Weis Wave, Market Profile, PVT, NVI, CVD (+ signal / divergence)
+- **Price**: Highest/Lowest, Highest, Lowest, Returns, Cumulative Returns, Pivot Points, Swing Points, Fractals, Zigzag, Fibonacci Retracement/Extension, Andrews Pitchfork, Auto Trend Line, Channel Line, Heikin-Ashi, Opening Range Breakout, Gap Analysis, Median Price, Typical Price, Weighted Close, BOS / CHoCH, FVG, S/R Zone Clustering
 - **Smart Money Concepts (SMC)**: Order Block, Liquidity Sweep
-- **Filter**: Super Smoother, Roofing Filter (Ehlers)
-- **Relative Strength**: Benchmark RS, RS Rating, RS Ranking
+- **Filter (Ehlers)**: Super Smoother, Roofing Filter
+- **Adaptive**: Adaptive RSI, Adaptive Bollinger, Adaptive MA (ER-based), Adaptive Stochastics (ADX-based)
+- **Session / ICT**: Session Detection, Kill Zones (Asia / London / NY), Session Stats, Session Breakout
+- **Wyckoff**: VSA (Volume Spread Analysis), Wyckoff Phase Detection
+- **Regime**: HMM Regime Detection (Baum-Welch / Viterbi), Regime Transition Matrix
+- **Relative Strength**: Benchmark RS, RS Rating, RS Ranking, Multi-symbol RS (`rankByRS` / `topByRS` / `filterByRSPercentile` / `compareRS`)
 
 ### Signal Detection
 - **Cross Detection**: Golden Cross, Dead Cross, custom crossovers

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,7 @@
     "test:crossval": "vitest run cross-validation",
     "bench": "vitest bench",
     "size": "size-limit",
+    "qa:indicators": "node scripts/qa-sweep.mjs",
     "prepublishOnly": "pnpm build && pnpm test"
   },
   "keywords": [

--- a/packages/core/scripts/qa-sweep.mjs
+++ b/packages/core/scripts/qa-sweep.mjs
@@ -28,7 +28,10 @@ function makeCandles(n = 400) {
   const out = [];
   let price = 100;
   let seed = 42;
-  const rng = () => (seed = (seed * 9301 + 49297) % 233280) / 233280;
+  const rng = () => {
+    seed = (seed * 9301 + 49297) % 233280;
+    return seed / 233280;
+  };
   for (let i = 0; i < n; i++) {
     price += Math.sin(i / 20) * 1.5 + (rng() - 0.5) * 1.2;
     const o = price;
@@ -37,8 +40,11 @@ function makeCandles(n = 400) {
     const l = Math.min(o, c) - rng() * 1.5;
     out.push({
       time: Date.UTC(2024, 0, 1) + i * 86_400_000,
-      open: o, high: h, low: l, close: c,
-      volume: 1000 + (rng() * 5000 | 0),
+      open: o,
+      high: h,
+      low: l,
+      close: c,
+      volume: 1000 + ((rng() * 5000) | 0),
     });
   }
   return out;
@@ -48,11 +54,15 @@ function parseIndicatorList() {
   const src = readFileSync(INDICATOR_BARREL, "utf8");
   const names = [];
   const re = /export\s+\{([^}]+)\}\s+from\s+"\.\/[a-z-]+"/g;
-  let m;
-  while ((m = re.exec(src)) !== null) {
+  while (true) {
+    const m = re.exec(src);
+    if (m === null) break;
     // Strip line comments inside the block
     const body = m[1].replace(/\/\/[^\n]*/g, "");
-    const entries = body.split(",").map((s) => s.trim()).filter(Boolean);
+    const entries = body
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
     for (const e of entries) {
       const name = e.split(/\s+as\s+/)[0].trim();
       if (name && /^[a-zA-Z_$][\w$]*$/.test(name)) names.push(name);
@@ -64,15 +74,26 @@ function parseIndicatorList() {
 // Minimal sensible options for indicators that require a second argument.
 // Anything NOT listed gets `undefined` — expected to work with candles only.
 const DEFAULT_OPTS = {
-  sma: { period: 20 }, ema: { period: 20 }, wma: { period: 20 }, vwma: { period: 20 },
-  volumeMa: { period: 20 }, highestLowest: { period: 20 }, superSmoother: { period: 20 },
+  sma: { period: 20 },
+  ema: { period: 20 },
+  wma: { period: 20 },
+  vwma: { period: 20 },
+  volumeMa: { period: 20 },
+  highestLowest: { period: 20 },
+  superSmoother: { period: 20 },
   anchoredVwap: { anchorTime: Date.UTC(2024, 0, 1) },
 };
 
 // Indicators that take TWO series args. For these we synthesize a benchmark.
 const NEEDS_BENCHMARK = new Set([
-  "benchmarkRS", "calculateRSRating", "isOutperforming", "rankByRS", "topByRS",
-  "bottomByRS", "filterByRSPercentile", "compareRS",
+  "benchmarkRS",
+  "calculateRSRating",
+  "isOutperforming",
+  "rankByRS",
+  "topByRS",
+  "bottomByRS",
+  "filterByRSPercentile",
+  "compareRS",
 ]);
 // regimeTransitionMatrix takes a regime-labeled series, not candles.
 const SPECIAL = new Set(["regimeTransitionMatrix", "filterStocksByAtr"]);
@@ -88,7 +109,13 @@ async function runOne(name) {
   }
   const candles = makeCandles();
   if (SPECIAL.has(name)) {
-    console.log(JSON.stringify({ name, status: "skipped", reason: "requires specialized input (not candles)" }));
+    console.log(
+      JSON.stringify({
+        name,
+        status: "skipped",
+        reason: "requires specialized input (not candles)",
+      }),
+    );
     return;
   }
   let args;
@@ -106,7 +133,9 @@ async function runOne(name) {
   try {
     res = fn(...args);
   } catch (err) {
-    console.log(JSON.stringify({ name, status: "throw", error: err.message, ms: performance.now() - t0 }));
+    console.log(
+      JSON.stringify({ name, status: "throw", error: err.message, ms: performance.now() - t0 }),
+    );
     return;
   }
   const ms = performance.now() - t0;
@@ -134,8 +163,12 @@ function sweepOne(name, scriptPath) {
     });
     let out = "";
     let err = "";
-    child.stdout.on("data", (d) => { out += d; });
-    child.stderr.on("data", (d) => { err += d; });
+    child.stdout.on("data", (d) => {
+      out += d;
+    });
+    child.stderr.on("data", (d) => {
+      err += d;
+    });
 
     const timer = setTimeout(() => {
       child.kill("SIGKILL");
@@ -151,7 +184,12 @@ function sweepOne(name, scriptPath) {
       try {
         resolve(JSON.parse(line));
       } catch {
-        resolve({ name, status: "crash", error: err.trim().split("\n").slice(-3).join(" | "), exitCode: code });
+        resolve({
+          name,
+          status: "crash",
+          error: err.trim().split("\n").slice(-3).join(" | "),
+          exitCode: code,
+        });
       }
     });
   });
@@ -176,7 +214,7 @@ async function main() {
     const r = await sweepOne(name, scriptPath);
     results.push(r);
   }
-  process.stdout.write("\r".padEnd(80) + "\r");
+  process.stdout.write(`${"\r".padEnd(80)}\r`);
 
   writeFileSync(REPORT_PATH, JSON.stringify(results, null, 2));
 
@@ -195,4 +233,7 @@ async function main() {
   }
 }
 
-main().catch((err) => { console.error(err); process.exit(1); });
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/core/scripts/qa-sweep.mjs
+++ b/packages/core/scripts/qa-sweep.mjs
@@ -1,0 +1,198 @@
+/**
+ * Developer QA sweep for trendcraft.
+ * Parses src/indicators/index.ts to get the canonical indicator list,
+ * then runs each in a child worker with a per-call timeout. Writes a JSON report.
+ *
+ * Run from the core package root:
+ *   pnpm qa:indicators                 # sweeps all indicators
+ *   node scripts/qa-sweep.mjs          # same thing, direct invocation
+ *   node scripts/qa-sweep.mjs <name>   # runs one (used internally by workers)
+ *
+ * Requires `pnpm build` to have run first — the sweep exercises the built
+ * bundle under dist/ so it reflects what npm consumers actually get.
+ */
+
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(__dirname, "..");
+const INDICATOR_BARREL = resolve(pkgRoot, "src/indicators/index.ts");
+const DIST_ENTRY = resolve(pkgRoot, "dist/index.js");
+const PER_CALL_TIMEOUT_MS = 8000;
+const REPORT_PATH = resolve(pkgRoot, "qa-report.json");
+
+function makeCandles(n = 400) {
+  const out = [];
+  let price = 100;
+  let seed = 42;
+  const rng = () => (seed = (seed * 9301 + 49297) % 233280) / 233280;
+  for (let i = 0; i < n; i++) {
+    price += Math.sin(i / 20) * 1.5 + (rng() - 0.5) * 1.2;
+    const o = price;
+    const c = price + (rng() - 0.5) * 2;
+    const h = Math.max(o, c) + rng() * 1.5;
+    const l = Math.min(o, c) - rng() * 1.5;
+    out.push({
+      time: Date.UTC(2024, 0, 1) + i * 86_400_000,
+      open: o, high: h, low: l, close: c,
+      volume: 1000 + (rng() * 5000 | 0),
+    });
+  }
+  return out;
+}
+
+function parseIndicatorList() {
+  const src = readFileSync(INDICATOR_BARREL, "utf8");
+  const names = [];
+  const re = /export\s+\{([^}]+)\}\s+from\s+"\.\/[a-z-]+"/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    // Strip line comments inside the block
+    const body = m[1].replace(/\/\/[^\n]*/g, "");
+    const entries = body.split(",").map((s) => s.trim()).filter(Boolean);
+    for (const e of entries) {
+      const name = e.split(/\s+as\s+/)[0].trim();
+      if (name && /^[a-zA-Z_$][\w$]*$/.test(name)) names.push(name);
+    }
+  }
+  return [...new Set(names)];
+}
+
+// Minimal sensible options for indicators that require a second argument.
+// Anything NOT listed gets `undefined` — expected to work with candles only.
+const DEFAULT_OPTS = {
+  sma: { period: 20 }, ema: { period: 20 }, wma: { period: 20 }, vwma: { period: 20 },
+  volumeMa: { period: 20 }, highestLowest: { period: 20 }, superSmoother: { period: 20 },
+  anchoredVwap: { anchorTime: Date.UTC(2024, 0, 1) },
+};
+
+// Indicators that take TWO series args. For these we synthesize a benchmark.
+const NEEDS_BENCHMARK = new Set([
+  "benchmarkRS", "calculateRSRating", "isOutperforming", "rankByRS", "topByRS",
+  "bottomByRS", "filterByRSPercentile", "compareRS",
+]);
+// regimeTransitionMatrix takes a regime-labeled series, not candles.
+const SPECIAL = new Set(["regimeTransitionMatrix", "filterStocksByAtr"]);
+
+// --- child-mode: run one indicator and print JSON ---
+
+async function runOne(name) {
+  const tc = await import(pathToFileURL(DIST_ENTRY).href);
+  const fn = tc[name];
+  if (typeof fn !== "function") {
+    console.log(JSON.stringify({ name, status: "not-a-function", valueType: typeof fn }));
+    return;
+  }
+  const candles = makeCandles();
+  if (SPECIAL.has(name)) {
+    console.log(JSON.stringify({ name, status: "skipped", reason: "requires specialized input (not candles)" }));
+    return;
+  }
+  let args;
+  if (NEEDS_BENCHMARK.has(name)) {
+    const bench = makeCandles();
+    // Most RS functions take (target, benchmark[, options]) where both are Series/candles.
+    args = [candles, bench];
+  } else if (DEFAULT_OPTS[name]) {
+    args = [candles, DEFAULT_OPTS[name]];
+  } else {
+    args = [candles];
+  }
+  const t0 = performance.now();
+  let res;
+  try {
+    res = fn(...args);
+  } catch (err) {
+    console.log(JSON.stringify({ name, status: "throw", error: err.message, ms: performance.now() - t0 }));
+    return;
+  }
+  const ms = performance.now() - t0;
+  let shape;
+  if (res == null) shape = "null/undefined";
+  else if (Array.isArray(res)) {
+    const definedCount = res.filter((p) => p && p.value !== undefined && p.value !== null).length;
+    shape = `Series len=${res.length} defined=${definedCount}`;
+  } else if (typeof res === "object") {
+    const keys = Object.keys(res);
+    const seriesKeys = keys.filter((k) => Array.isArray(res[k]));
+    shape = seriesKeys.length
+      ? `Obj<${seriesKeys.join(",")}>${seriesKeys[0] ? ` len=${res[seriesKeys[0]].length}` : ""}`
+      : `Obj{${keys.slice(0, 4).join(",")}${keys.length > 4 ? ",..." : ""}}`;
+  } else shape = typeof res;
+  console.log(JSON.stringify({ name, status: "ok", shape, ms: Math.round(ms) }));
+}
+
+// --- parent-mode: spawn one child per indicator ---
+
+function sweepOne(name, scriptPath) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [scriptPath, name], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let out = "";
+    let err = "";
+    child.stdout.on("data", (d) => { out += d; });
+    child.stderr.on("data", (d) => { err += d; });
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+    }, PER_CALL_TIMEOUT_MS);
+
+    child.on("exit", (code, signal) => {
+      clearTimeout(timer);
+      if (signal === "SIGKILL") {
+        resolve({ name, status: "timeout", ms: PER_CALL_TIMEOUT_MS });
+        return;
+      }
+      const line = out.trim().split("\n").pop() ?? "";
+      try {
+        resolve(JSON.parse(line));
+      } catch {
+        resolve({ name, status: "crash", error: err.trim().split("\n").slice(-3).join(" | "), exitCode: code });
+      }
+    });
+  });
+}
+
+async function main() {
+  const arg = process.argv[2];
+  if (arg) {
+    await runOne(arg);
+    return;
+  }
+
+  const scriptPath = fileURLToPath(import.meta.url);
+  const names = parseIndicatorList();
+  console.log(`Parsed ${names.length} value exports from indicators/index.ts`);
+
+  const results = [];
+  let i = 0;
+  for (const name of names) {
+    i++;
+    process.stdout.write(`\r[${i}/${names.length}] ${name.padEnd(40)}`);
+    const r = await sweepOne(name, scriptPath);
+    results.push(r);
+  }
+  process.stdout.write("\r".padEnd(80) + "\r");
+
+  writeFileSync(REPORT_PATH, JSON.stringify(results, null, 2));
+
+  const by = { ok: 0, throw: 0, timeout: 0, crash: 0, "not-a-function": 0, other: 0 };
+  for (const r of results) by[r.status] = (by[r.status] ?? 0) + 1;
+  console.log(`\nResults: ${JSON.stringify(by)}`);
+  console.log(`Report: ${REPORT_PATH}`);
+
+  const fails = results.filter((r) => r.status !== "ok");
+  if (fails.length) {
+    console.log(`\n${fails.length} issue(s):`);
+    for (const r of fails) {
+      const detail = r.error ? ` — ${r.error}` : r.ms ? ` (${r.ms}ms)` : "";
+      console.log(`  ${r.status.padEnd(14)} ${r.name}${detail}`);
+    }
+  }
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/packages/core/src/streaming/indicator-presets.ts
+++ b/packages/core/src/streaming/indicator-presets.ts
@@ -30,6 +30,8 @@ import {
   anchoredVwap,
   aroon,
   atr,
+  // 10 previously un-presetified batch indicators (added 2026-04-18)
+  atrPercentSeries,
   atrStops,
   awesomeOscillator,
   balanceOfPower,
@@ -41,6 +43,7 @@ import {
   cmo,
   connorsRsi,
   coppockCurve,
+  cumulativeReturns,
   cvd,
   cvdWithSignal,
   dema,
@@ -59,6 +62,7 @@ import {
   gapAnalysis,
   garmanKlass,
   heikinAshi,
+  highest,
   highestLowest,
   historicalVolatility,
   hma,
@@ -71,10 +75,12 @@ import {
   kst,
   linearRegression,
   liquiditySweep,
+  lowest,
   macd,
   marketProfile,
   massIndex,
   mcginleyDynamic,
+  medianPrice,
   mfi,
   nvi,
   obv,
@@ -85,7 +91,9 @@ import {
   ppo,
   pvt,
   qstick,
+  returns,
   roc,
+  roofingFilter,
   rsi,
   schaffTrendCycle,
   sessionBreakout,
@@ -94,6 +102,7 @@ import {
   standardDeviation,
   stochRsi,
   stochastics,
+  superSmoother,
   supertrend,
   swingPoints,
   t3,
@@ -101,6 +110,7 @@ import {
   trix,
   tsi,
   twap,
+  typicalPrice,
   ulcerIndex,
   ultimateOscillator,
   volatilityRegime,
@@ -111,6 +121,7 @@ import {
   vsa as vsaBatch,
   vwap,
   vwma,
+  weightedClose,
   weisWave,
   williamsR,
   wma,
@@ -158,7 +169,8 @@ export type IndicatorCategory =
   | "Wyckoff"
   | "Adaptive"
   | "Session"
-  | "SMC";
+  | "SMC"
+  | "Filter";
 
 /** Parameter schema for UI controls */
 export type ParamSchema = {
@@ -1934,5 +1946,140 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
         step: 1,
       },
     ],
+  },
+
+  // ============================================
+  // Filter (Ehlers)
+  // ============================================
+  superSmoother: {
+    meta: { kind: "superSmoother", overlay: true, label: "SuperSmoother" },
+    defaultParams: { period: 10 },
+    snapshotName: (p: Record<string, unknown>) => `ss${p.period}`,
+    compute: (c, p) => superSmoother(c, { period: (p.period as number) ?? 10 }),
+    category: "Filter",
+    name: "Super Smoother (Ehlers)",
+    description: "Low-pass filter that smooths price with minimal lag via 2-pole IIR.",
+    paramSchema: [period(10, 2, 100)],
+  },
+  roofingFilter: {
+    meta: { kind: "roofingFilter", overlay: false, label: "Roofing" },
+    defaultParams: { highPassPeriod: 48, lowPassPeriod: 10 },
+    snapshotName: (p: Record<string, unknown>) => `roof${p.highPassPeriod}-${p.lowPassPeriod}`,
+    compute: (c, p) =>
+      roofingFilter(c, {
+        highPassPeriod: (p.highPassPeriod as number) ?? 48,
+        lowPassPeriod: (p.lowPassPeriod as number) ?? 10,
+      }),
+    category: "Filter",
+    name: "Roofing Filter (Ehlers)",
+    description: "Bandpass that isolates medium-frequency cycles by removing trend and noise.",
+    paramSchema: [
+      {
+        key: "highPassPeriod",
+        label: "High-Pass Period",
+        type: "number",
+        default: 48,
+        min: 10,
+        max: 200,
+        step: 1,
+      },
+      {
+        key: "lowPassPeriod",
+        label: "Low-Pass Period",
+        type: "number",
+        default: 10,
+        min: 2,
+        max: 50,
+        step: 1,
+      },
+    ],
+  },
+
+  // ============================================
+  // Additional Price utilities
+  // ============================================
+  highest: {
+    meta: { kind: "highest", overlay: true, label: "Highest" },
+    defaultParams: { period: 20 },
+    snapshotName: (p: Record<string, unknown>) => `hi${p.period}`,
+    compute: (c, p) => highest(c, (p.period as number) ?? 20),
+    category: "Price",
+    name: "Highest High",
+    description: "Rolling maximum of candle highs over N bars.",
+    paramSchema: [period(20, 2, 500)],
+  },
+  lowest: {
+    meta: { kind: "lowest", overlay: true, label: "Lowest" },
+    defaultParams: { period: 20 },
+    snapshotName: (p: Record<string, unknown>) => `lo${p.period}`,
+    compute: (c, p) => lowest(c, (p.period as number) ?? 20),
+    category: "Price",
+    name: "Lowest Low",
+    description: "Rolling minimum of candle lows over N bars.",
+    paramSchema: [period(20, 2, 500)],
+  },
+  returns: {
+    meta: { kind: "returns", overlay: false, label: "Returns" },
+    defaultParams: { period: 1, type: "simple" },
+    snapshotName: (p: Record<string, unknown>) => `ret${p.period}-${p.type ?? "simple"}`,
+    compute: (c, p) =>
+      returns(c, {
+        period: (p.period as number) ?? 1,
+        type: (p.type as "simple" | "log") ?? "simple",
+      }),
+    category: "Price",
+    name: "Returns",
+    description: "Bar-over-bar percentage or log returns of close prices.",
+    paramSchema: [period(1, 1, 100)],
+  },
+  cumulativeReturns: {
+    meta: { kind: "cumulativeReturns", overlay: false, label: "Cum. Returns" },
+    defaultParams: { type: "simple" },
+    snapshotName: (p: Record<string, unknown>) => `cumret-${p.type ?? "simple"}`,
+    compute: (c, p) => cumulativeReturns(c, (p.type as "simple" | "log") ?? "simple"),
+    category: "Price",
+    name: "Cumulative Returns",
+    description: "Growth of $1 invested at the first bar's close.",
+  },
+  medianPrice: {
+    meta: { kind: "medianPrice", overlay: true, label: "Median Price" },
+    defaultParams: {},
+    snapshotName: "median",
+    compute: (c) => medianPrice(c),
+    category: "Price",
+    name: "Median Price",
+    description: "(High + Low) / 2, a common MA source.",
+  },
+  typicalPrice: {
+    meta: { kind: "typicalPrice", overlay: true, label: "Typical Price" },
+    defaultParams: {},
+    snapshotName: "typical",
+    compute: (c) => typicalPrice(c),
+    category: "Price",
+    name: "Typical Price",
+    description: "(High + Low + Close) / 3, used as input to CCI and volume-weighted studies.",
+  },
+  weightedClose: {
+    meta: { kind: "weightedClose", overlay: true, label: "Weighted Close" },
+    defaultParams: {},
+    snapshotName: "wclose",
+    compute: (c) => weightedClose(c),
+    category: "Price",
+    name: "Weighted Close",
+    description: "(High + Low + 2 × Close) / 4, gives extra weight to the close.",
+  },
+
+  // ============================================
+  // Additional Volatility utilities
+  // ============================================
+  atrPercent: {
+    meta: { kind: "atrPercent", overlay: false, label: "ATR%" },
+    defaultParams: { period: 14 },
+    snapshotName: (p: Record<string, unknown>) => `atrpct${p.period}`,
+    compute: (c, p) => atrPercentSeries(c, (p.period as number) ?? 14),
+    category: "Volatility",
+    name: "ATR Percent",
+    description: "ATR expressed as a percentage of price — normalized volatility metric.",
+    paramSchema: [period(14, 2, 100)],
   },
 };


### PR DESCRIPTION
Follow-up to the `@trendcraft/chart` v0.1.0 documentation sync (PR #67). This branch works through a pre-release audit of the `130+` indicator claim and closes the gaps between "exists in the barrel" and "discoverable via the chart's public API".

## Summary

- **Publish gate** (`packages/chart/scripts/verify-publish.mjs`): walks every `package.json#exports` subpath, checks the `types` / `import` / `require` files exist, dynamically evaluates them through both ESM `import()` and CJS `require()`, and asserts a minimal expected symbol set. Hooked into `prepublishOnly` so a misconfigured exports map or a bundle that silently drops a public symbol fails fast.
- **Per-package release checklist** (`packages/chart/RELEASE.md`): pre-tag checks, publish command, post-publish verification, rollback via `npm deprecate`.
- **QA sweep** (`packages/core/scripts/qa-sweep.mjs`, `pnpm qa:indicators`): parses `src/indicators/index.ts`, spawns one isolated child per indicator with an 8s timeout (a runaway indicator previously pegged three cores at 100%), supplies sensible defaults for indicators that require options, synthesizes a benchmark series for the portfolio-level RS helpers, and writes a JSON report. Current result: 144 ok / 4 expected-throw (multi-series portfolio helpers) / 1 constant / 2 intentionally-skipped.
- **+10 `indicatorPresets`** (96 → 106): Ehlers `superSmoother` / `roofingFilter` under a new `Filter` category, price utilities `highest` / `lowest` / `returns` / `cumulativeReturns` / `medianPrice` / `typicalPrice` / `weightedClose`, and `atrPercent` in Volatility. Each has inline `meta`, `defaultParams`, `snapshotName`, `category`, `name`, `description`, and (where applicable) `paramSchema`. Corresponding brand colors added to `@trendcraft/chart/presets`' `TRENDCRAFT_PRESETS` map so multi-instance setups still auto-cycle while single instances look consistent with the rest of the library.
- **Drawing auto-injection helpers** (chart main entry): `addAutoFibRetracement`, `addAutoFibExtension`, `addAutoTrendLine` (resistance / support), `addAutoChannelLine`. Take pre-computed `SwingAnchor[]` and emit the chart's built-in `Drawing` types, keeping the chart package runtime-free of `trendcraft`. `extendToTime` projects the endpoint using the slope of the two base anchors.
- **Andrew's Pitchfork plugin**: `createAndrewsPitchfork` / `connectAndrewsPitchfork` primitive plugin that draws median + upper/lower handles from three pivot anchors, extending forward to the right edge. Bails out on degenerate configurations.
- **CHoCH in SMC layer**: `connectSmcLayer` now accepts an optional `choch` source alongside `bos`. Both share the same `BosValue` shape but render with separate labels ("BOS" vs "CHoCH") so you can feed `breakOfStructure()` and `changeOfCharacter()` simultaneously.
- **Volume Profile plugin**: `createVolumeProfile` / `connectVolumeProfile` — horizontal volume-by-price histogram along the right edge of the chart with a highlighted Value Area, a dashed POC line spanning the pane, and configurable strip width (fractional or pixel).
- **Showcase + docs + llms.txt sync**: `indicator-showcase` surfaces the Filter category and has a new Plugins panel that toggles all 7 primitive plugins. `docs/API.md` gets a Drawing auto-injection helpers section; `docs/GUIDE.md` grows an Extra visualization layers section. `llms.txt` / `llms-full.txt` regenerated. Core `README.md` / `README.ja.md` expand the Indicators (130+) list so the previously-omitted Adaptive / Session / Wyckoff / Regime categories and the price-structure indicators (BOS / CHoCH / FVG / autoTrendLine / channelLine / pitchfork / S/R zones) are visible in the headline feature list.

## Test plan

- [x] `pnpm --filter trendcraft build` passes
- [x] `pnpm --filter @trendcraft/chart build` passes
- [x] `pnpm --filter trendcraft test` — 302 files / 4719 tests
- [x] `pnpm --filter @trendcraft/chart test` — 59 files / 601 tests (+54 from main)
- [x] `pnpm --filter @trendcraft/chart verify:publish` — all 5 entry points resolve in ESM+CJS with advertised symbols
- [x] `pnpm --filter @trendcraft/chart size-check` — main 28.84 / 31 kB, headless 8.22 / 11, React 24.48 / 27, Vue 24.78 / 27 brotli (all under budget)
- [x] `pnpm --filter trendcraft qa:indicators` — 144 ok / 4 expected-throw / 1 constant / 2 skipped (identical to pre-branch baseline, no regression)
- [x] All four examples (`simple-chart`, `simple-react-chart`, `simple-vue-chart`, `indicator-showcase`) build cleanly
- [x] `indicator-showcase` booted headlessly: all 11 sidebar categories render (including new `Filter`), all 7 plugin toggles and all 10 new presets cycle on/off without runtime errors