### PR TITLE
fix(chart,showcase): plugin visibility, intraday timeframe, Market Profile plugin refactor

### DIFF
--- a/packages/chart/examples/indicator-showcase/index.html
+++ b/packages/chart/examples/indicator-showcase/index.html
@@ -74,6 +74,7 @@
         <span class="toolbar-title">@trendcraft/chart</span>
         <span class="toolbar-tag">Indicator Showcase</span>
         <span class="toolbar-spacer"></span>
+        <button class="toolbar-btn" id="btn-timeframe">Daily</button>
         <button class="toolbar-btn" id="btn-type">Candle</button>
         <button class="toolbar-btn" id="btn-fit">Fit</button>
         <button class="toolbar-btn" id="btn-export">Export PNG</button>

--- a/packages/chart/examples/indicator-showcase/src/data-intraday.ts
+++ b/packages/chart/examples/indicator-showcase/src/data-intraday.ts
@@ -1,0 +1,92 @@
+/**
+ * Synthetic intraday (1-hour bar) data generator.
+ *
+ * Produces 14 days × 24 hours = 336 hourly candles starting at a fixed
+ * UTC midnight, so every ICT kill zone window (Asia / London Open /
+ * NY Open / London Close) is represented multiple times.
+ *
+ * Uses a seeded PRNG so the dataset is stable between reloads.
+ */
+
+import type { NormalizedCandle } from "trendcraft";
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAYS = 14;
+const BARS_PER_DAY = 24;
+
+/** Mulberry32 — tiny deterministic PRNG */
+function makeRng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Start at 2026-03-01 00:00 UTC — a Sunday, so the 14-day span covers a full business cycle. */
+const START_TIME_MS = Date.UTC(2026, 2, 1, 0, 0, 0);
+
+export function generateIntradayCandles(): NormalizedCandle[] {
+  const rng = makeRng(20260301);
+  const out: NormalizedCandle[] = [];
+  let price = 100;
+
+  for (let d = 0; d < DAYS; d++) {
+    for (let h = 0; h < BARS_PER_DAY; h++) {
+      const time = START_TIME_MS + (d * BARS_PER_DAY + h) * HOUR_MS;
+
+      // Volatility profile: wider moves during London Open (7-9) and NY Open (12-14)
+      const baseVol = 0.25;
+      const sessionVol =
+        (h >= 7 && h < 9) || (h >= 12 && h < 14)
+          ? 0.7
+          : h >= 15 && h < 17
+            ? 0.55
+            : h >= 0 && h < 5
+              ? 0.3
+              : 0.2;
+      const vol = baseVol + sessionVol;
+
+      const drift = (rng() - 0.5) * vol;
+      const open = price;
+      const close = Math.max(1, open + drift + (rng() - 0.5) * 0.15);
+      const wickUp = rng() * vol * 0.6;
+      const wickDn = rng() * vol * 0.6;
+      const high = Math.max(open, close) + wickUp;
+      const low = Math.min(open, close) - wickDn;
+
+      // Volume: higher during NY open, Asian is quieter
+      const volumeBase =
+        h >= 12 && h < 14
+          ? 1_500_000
+          : h >= 7 && h < 9
+            ? 1_200_000
+            : h >= 15 && h < 17
+              ? 900_000
+              : h >= 0 && h < 5
+                ? 400_000
+                : 600_000;
+      const volume = Math.round(volumeBase * (0.6 + rng() * 0.8));
+
+      out.push({
+        time,
+        open: round3(open),
+        high: round3(high),
+        low: round3(low),
+        close: round3(close),
+        volume,
+      });
+
+      price = close;
+    }
+  }
+
+  return out;
+}
+
+function round3(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}

--- a/packages/chart/examples/indicator-showcase/src/main.ts
+++ b/packages/chart/examples/indicator-showcase/src/main.ts
@@ -5,22 +5,26 @@
  * with a categorized sidebar UI, search, parameter controls, and active indicator
  * bar. The sidebar is auto-generated from indicatorPresets metadata, so the count
  * stays accurate as the preset registry grows.
+ *
+ * A Daily / 1H timeframe toggle swaps between the bundled daily sample data and
+ * a synthetic intraday dataset (see `data-intraday.ts`) so intraday-only plugins
+ * such as Session Zones can be demo'd meaningfully.
  */
 
-import { connectIndicators, createChart } from "@trendcraft/chart";
+import { type IndicatorConnection, connectIndicators, createChart } from "@trendcraft/chart";
 import { registerTrendCraftPresets } from "@trendcraft/chart/presets";
 import { indicatorPresets } from "trendcraft";
 import type { NormalizedCandle } from "trendcraft";
-import sampleData from "../../simple-chart/data.json";
-import { createPluginsPanel } from "./plugins-panel";
+import dailySampleData from "../../simple-chart/data.json";
+import { generateIntradayCandles } from "./data-intraday";
+import { type PluginsPanelHandle, createPluginsPanel } from "./plugins-panel";
 import type { SidebarEntry } from "./sidebar";
 import { createSidebar } from "./sidebar";
 
-// ============================================
-// Data
-// ============================================
+type Timeframe = "daily" | "intraday";
 
-const candles = sampleData as NormalizedCandle[];
+const dailyCandles = dailySampleData as NormalizedCandle[];
+const intradayCandles = generateIntradayCandles();
 
 // ============================================
 // Build sidebar catalog from indicatorPresets
@@ -45,49 +49,78 @@ for (const [id, preset] of Object.entries(indicatorPresets)) {
 // ============================================
 
 const chartEl = document.getElementById("chart") as HTMLElement;
+const sidebarEl = document.getElementById("sidebar") as HTMLElement;
 const chart = createChart(chartEl, { theme: "dark" });
 registerTrendCraftPresets(chart);
-chart.setCandles(candles);
 
 // ============================================
-// Indicator Connection
+// Timeframe-scoped state (re-created on switch)
 // ============================================
 
-const conn = connectIndicators(chart, { presets: indicatorPresets, candles });
+let currentTimeframe: Timeframe = "daily";
+let currentCandles: NormalizedCandle[] = dailyCandles;
+let conn: IndicatorConnection;
+let pluginsPanel: PluginsPanelHandle;
 
-// ============================================
-// Sidebar
-// ============================================
+function mount(timeframe: Timeframe): void {
+  currentTimeframe = timeframe;
+  currentCandles = timeframe === "daily" ? dailyCandles : intradayCandles;
 
-const sidebarEl = document.getElementById("sidebar") as HTMLElement;
+  chart.setCandles(currentCandles);
+  conn = connectIndicators(chart, { presets: indicatorPresets, candles: currentCandles });
 
-const sidebar = createSidebar(sidebarEl, catalog, {
-  onToggle(id, active, params) {
-    if (active) {
+  // Sidebar is rebuilt from scratch — its DOM/state are reset by createSidebar.
+  // We still need to wipe the container because the plugins panel is a sibling
+  // appended below it.
+  sidebarEl.innerHTML = "";
+
+  createSidebar(sidebarEl, catalog, {
+    onToggle(id, active, params) {
+      if (active) {
+        const finalParams = resolveParams(id, params);
+        conn.add(id, finalParams);
+      } else {
+        conn.remove(id);
+      }
+    },
+    onParamChange(id, params) {
+      conn.remove(id);
       const finalParams = resolveParams(id, params);
       conn.add(id, finalParams);
-    } else {
-      conn.remove(id);
-    }
-  },
-  onParamChange(id, params) {
-    conn.remove(id);
-    const finalParams = resolveParams(id, params);
-    conn.add(id, finalParams);
-  },
-});
+    },
+  });
+
+  pluginsPanel = createPluginsPanel(sidebarEl, currentCandles, chart);
+  chart.fitContent();
+}
+
+function unmount(): void {
+  pluginsPanel?.destroy();
+  conn?.disconnect();
+}
 
 /** Resolve special-case params for specific indicators */
 function resolveParams(id: string, params: Record<string, unknown>): Record<string, unknown> {
-  if (id === "anchoredVwap" && candles.length > 100) {
-    return { ...params, anchorTime: candles[100].time };
+  if (id === "anchoredVwap" && currentCandles.length > 100) {
+    return { ...params, anchorTime: currentCandles[100].time };
   }
   return params;
 }
 
+mount("daily");
+
 // ============================================
 // Toolbar Controls
 // ============================================
+
+// Timeframe toggle
+const timeframeBtn = document.getElementById("btn-timeframe") as HTMLElement;
+timeframeBtn.addEventListener("click", () => {
+  const next: Timeframe = currentTimeframe === "daily" ? "intraday" : "daily";
+  unmount();
+  mount(next);
+  timeframeBtn.textContent = next === "daily" ? "Daily" : "1H";
+});
 
 // Theme toggle
 const themeBtn = document.getElementById("btn-theme") as HTMLElement;
@@ -151,9 +184,3 @@ chartEl.addEventListener("click", () => {
     sidebarEl.classList.remove("open");
   }
 });
-
-// Plugins panel (appended below the indicator list)
-createPluginsPanel(sidebarEl, candles, chart);
-
-// Suppress unused variable warning
-void sidebar;

--- a/packages/chart/examples/indicator-showcase/src/plugins-panel.ts
+++ b/packages/chart/examples/indicator-showcase/src/plugins-panel.ts
@@ -3,9 +3,9 @@
  * the `indicatorPresets` series-line model (background heatmaps, zones,
  * pitchfork, volume profile, etc.).
  *
- * Each entry computes its data from the current candles once and connects
- * the plugin on toggle. Tuned for demo data (200 daily bars) — production
- * callers would feed their own options/ranges.
+ * Each entry computes its data from the current candles on toggle and
+ * connects the plugin. The panel can be rebuilt against a new candle set
+ * (e.g. daily ↔ intraday switch) via `destroy()` + re-create.
  */
 
 import type { ChartInstance } from "@trendcraft/chart";
@@ -37,85 +37,98 @@ type PluginSpec = {
   id: string;
   label: string;
   description: string;
-  connect: () => PluginHandle | null;
+  connect: (candles: NormalizedCandle[]) => PluginHandle | null;
 };
+
+export type PluginsPanelHandle = {
+  /** Remove the panel DOM + detach every active plugin from the chart. */
+  destroy(): void;
+};
+
+const SPECS: PluginSpec[] = [
+  {
+    id: "srConfluence",
+    label: "S/R Confluence",
+    description: "Multi-source support/resistance zones",
+    connect: (candles) => {
+      const { zones } = srZones(candles);
+      return connectSrConfluence(chartRef, zones);
+    },
+  },
+  {
+    id: "smcLayer",
+    label: "SMC Layer",
+    description: "Order Blocks + FVG + Liquidity Sweeps",
+    connect: (candles) =>
+      connectSmcLayer(chartRef, {
+        orderBlocks: orderBlock(candles),
+        fvgs: fairValueGap(candles),
+        sweeps: liquiditySweep(candles),
+      }),
+  },
+  {
+    id: "regimeHeatmap",
+    label: "Regime Heatmap",
+    description: "HMM-classified market regime background",
+    connect: (candles) => connectRegimeHeatmap(chartRef, hmmRegimes(candles)),
+  },
+  {
+    id: "wyckoffPhase",
+    label: "Wyckoff Phase",
+    description: "Phase timeline bar at pane bottom",
+    connect: (candles) => connectWyckoffPhase(chartRef, { phases: wyckoffPhases(candles) }),
+  },
+  {
+    id: "sessionZones",
+    label: "Session Zones",
+    description: "ICT kill-zone backgrounds (needs intraday data)",
+    connect: (candles) => connectSessionZones(chartRef, killZones(candles)),
+  },
+  {
+    id: "andrewsPitchfork",
+    label: "Andrew's Pitchfork",
+    description: "Median + handles from the last 3 swing anchors",
+    connect: (candles) => {
+      const last3 = getAlternatingSwingPoints(candles, 3, { leftBars: 10, rightBars: 10 });
+      if (last3.length < 3) return null;
+      return connectAndrewsPitchfork(chartRef, {
+        p0: { index: last3[0].index, price: last3[0].price },
+        p1: { index: last3[1].index, price: last3[1].price },
+        p2: { index: last3[2].index, price: last3[2].price },
+      });
+    },
+  },
+  {
+    id: "volumeProfile",
+    label: "Volume Profile",
+    description: "Horizontal volume-by-price histogram + POC",
+    connect: (candles) => connectVolumeProfile(chartRef, volumeProfile(candles, { levels: 30 })),
+  },
+];
+
+// The specs above close over a mutable `chartRef`. The panel factory sets it
+// on every mount so SPECS can stay a single module-level list.
+let chartRef: ChartInstance = null as unknown as ChartInstance;
 
 export function createPluginsPanel(
   container: HTMLElement,
   candles: NormalizedCandle[],
   chart: ChartInstance,
-): void {
+): PluginsPanelHandle {
+  chartRef = chart;
   const active = new Map<string, PluginHandle>();
-
-  const specs: PluginSpec[] = [
-    {
-      id: "srConfluence",
-      label: "S/R Confluence",
-      description: "Multi-source support/resistance zones",
-      connect: () => {
-        const { zones } = srZones(candles);
-        return connectSrConfluence(chart, zones);
-      },
-    },
-    {
-      id: "smcLayer",
-      label: "SMC Layer",
-      description: "Order Blocks + FVG + Liquidity Sweeps",
-      connect: () =>
-        connectSmcLayer(chart, {
-          orderBlocks: orderBlock(candles),
-          fvgs: fairValueGap(candles),
-          sweeps: liquiditySweep(candles),
-        }),
-    },
-    {
-      id: "regimeHeatmap",
-      label: "Regime Heatmap",
-      description: "HMM-classified market regime background",
-      connect: () => connectRegimeHeatmap(chart, hmmRegimes(candles)),
-    },
-    {
-      id: "wyckoffPhase",
-      label: "Wyckoff Phase",
-      description: "Accumulation / markup / distribution bands",
-      connect: () => connectWyckoffPhase(chart, { phases: wyckoffPhases(candles) }),
-    },
-    {
-      id: "sessionZones",
-      label: "Session Zones",
-      description: "ICT kill-zone backgrounds (Asia / London / NY)",
-      connect: () => connectSessionZones(chart, killZones(candles)),
-    },
-    {
-      id: "andrewsPitchfork",
-      label: "Andrew's Pitchfork",
-      description: "Median + handles from the last 3 swing anchors",
-      connect: () => {
-        const last3 = getAlternatingSwingPoints(candles, 3, { leftBars: 10, rightBars: 10 });
-        if (last3.length < 3) return null;
-        return connectAndrewsPitchfork(chart, {
-          p0: { index: last3[0].index, price: last3[0].price },
-          p1: { index: last3[1].index, price: last3[1].price },
-          p2: { index: last3[2].index, price: last3[2].price },
-        });
-      },
-    },
-    {
-      id: "volumeProfile",
-      label: "Volume Profile",
-      description: "Horizontal volume-by-price histogram + POC",
-      connect: () => connectVolumeProfile(chart, volumeProfile(candles, { levels: 30 })),
-    },
-  ];
+  const panelRoot = document.createElement("div");
+  panelRoot.dataset.role = "plugins-panel";
+  container.appendChild(panelRoot);
 
   // Header
   const header = document.createElement("div");
   header.style.cssText =
     "padding:10px 12px;background:#181c27;border-top:1px solid #2a2e39;border-bottom:1px solid #1e222d;font-weight:600;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;";
-  header.textContent = "▼ Plugins";
-  container.appendChild(header);
+  header.textContent = "\u25BC Plugins";
+  panelRoot.appendChild(header);
 
-  for (const spec of specs) {
+  for (const spec of SPECS) {
     const row = document.createElement("div");
     row.style.cssText =
       "padding:8px 12px 8px 24px;cursor:pointer;border-bottom:1px solid #1e222d;display:flex;align-items:flex-start;gap:10px;user-select:none;";
@@ -137,7 +150,7 @@ export function createPluginsPanel(
 
     row.appendChild(checkbox);
     row.appendChild(text);
-    container.appendChild(row);
+    panelRoot.appendChild(row);
 
     const applyActive = (isActive: boolean) => {
       if (isActive) {
@@ -158,7 +171,7 @@ export function createPluginsPanel(
         active.delete(spec.id);
         applyActive(false);
       } else {
-        const handle = spec.connect();
+        const handle = spec.connect(candles);
         if (!handle) {
           console.warn(`Plugin ${spec.id} could not be connected (insufficient data)`);
           return;
@@ -168,4 +181,12 @@ export function createPluginsPanel(
       }
     });
   }
+
+  return {
+    destroy() {
+      for (const h of active.values()) h.remove();
+      active.clear();
+      panelRoot.remove();
+    },
+  };
 }

--- a/packages/chart/examples/indicator-showcase/src/plugins-panel.ts
+++ b/packages/chart/examples/indicator-showcase/src/plugins-panel.ts
@@ -30,6 +30,7 @@ import {
   orderBlock,
   srZones,
   volumeProfile,
+  vsa,
   wyckoffPhases,
 } from "trendcraft";
 
@@ -78,8 +79,13 @@ const SPECS: PluginSpec[] = [
   {
     id: "wyckoffPhase",
     label: "Wyckoff Phase",
-    description: "Phase timeline bar at pane bottom",
-    connect: (candles) => connectWyckoffPhase(chartRef, { phases: wyckoffPhases(candles) }),
+    description: "Range boxes + PS/SC/SOS/... event labels + phase badge",
+    connect: (candles) =>
+      connectWyckoffPhase(chartRef, {
+        phases: wyckoffPhases(candles),
+        vsa: vsa(candles),
+        candles,
+      }),
   },
   {
     id: "sessionZones",

--- a/packages/chart/examples/indicator-showcase/src/plugins-panel.ts
+++ b/packages/chart/examples/indicator-showcase/src/plugins-panel.ts
@@ -59,8 +59,9 @@ const SPECS: PluginSpec[] = [
   },
   {
     id: "smcLayer",
-    label: "SMC Layer",
-    description: "Order Blocks + FVG + Liquidity Sweeps",
+    label: "SMC Layer (bundle)",
+    description:
+      "OB + FVG + Sweeps in one pass — use the individual SMC presets for per-indicator params",
     connect: (candles) =>
       connectSmcLayer(chartRef, {
         orderBlocks: orderBlock(candles),

--- a/packages/chart/examples/indicator-showcase/src/plugins-panel.ts
+++ b/packages/chart/examples/indicator-showcase/src/plugins-panel.ts
@@ -11,6 +11,7 @@
 import type { ChartInstance } from "@trendcraft/chart";
 import {
   connectAndrewsPitchfork,
+  connectMarketProfile,
   connectRegimeHeatmap,
   connectSessionZones,
   connectSmcLayer,
@@ -25,6 +26,7 @@ import {
   hmmRegimes,
   killZones,
   liquiditySweep,
+  marketProfile,
   orderBlock,
   srZones,
   volumeProfile,
@@ -103,6 +105,12 @@ const SPECS: PluginSpec[] = [
     label: "Volume Profile",
     description: "Horizontal volume-by-price histogram + POC",
     connect: (candles) => connectVolumeProfile(chartRef, volumeProfile(candles, { levels: 30 })),
+  },
+  {
+    id: "marketProfile",
+    label: "Market Profile",
+    description: "TPO-based time-at-price + POC / VAH / VAL",
+    connect: (candles) => connectMarketProfile(chartRef, marketProfile(candles)),
   },
 ];
 

--- a/packages/chart/src/__tests__/regime-heatmap.test.ts
+++ b/packages/chart/src/__tests__/regime-heatmap.test.ts
@@ -150,9 +150,9 @@ describe("createRegimeHeatmap", () => {
       plugin.defaultState,
     );
 
-    // confidence=0 → alpha=0.06, confidence=1 → alpha=0.18
-    expect(fillStyles[0]).toContain("0.060");
-    expect(fillStyles[1]).toContain("0.180");
+    // confidence=0 → alpha=0.15, confidence=1 → alpha=0.40
+    expect(fillStyles[0]).toContain("0.150");
+    expect(fillStyles[1]).toContain("0.400");
   });
 });
 

--- a/packages/chart/src/__tests__/session-zones.test.ts
+++ b/packages/chart/src/__tests__/session-zones.test.ts
@@ -13,6 +13,7 @@ const mockCtx = () =>
     clip: vi.fn(),
     fillRect: vi.fn(),
     fillText: vi.fn(),
+    measureText: vi.fn((text: string) => ({ width: text.length * 5.5 })),
     fillStyle: "",
     font: "",
     textAlign: "" as CanvasTextAlign,
@@ -66,7 +67,35 @@ describe("createSessionZones", () => {
     expect(ctx.fillRect).not.toHaveBeenCalled();
   });
 
-  it("renders labels for different zone spans", () => {
+  it("uses short labels (Asia, LON, NY, Close)", () => {
+    const data = [{ time: 1000, value: { zone: "Asian KZ", inKillZone: true } }];
+    const plugin = createSessionZones(data);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx, mockTs(0, 1)), plugin.defaultState);
+
+    const call = (ctx.fillText as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call?.[0]).toBe("Asia");
+  });
+
+  it("renders labels for well-separated spans", () => {
+    // Two 1-bar spans 50 bars apart (barSpacing=8 → 400px gap) so both fit.
+    const data: Array<{ time: number; value: { zone: string | null; inKillZone: boolean } }> = [];
+    data.push({ time: 0, value: { zone: "Asian KZ", inKillZone: true } });
+    for (let i = 1; i < 50; i++) {
+      data.push({ time: i * 60, value: { zone: null, inKillZone: false } });
+    }
+    data.push({ time: 50 * 60, value: { zone: "NY Open KZ", inKillZone: true } });
+
+    const plugin = createSessionZones(data);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx, mockTs(0, data.length)), plugin.defaultState);
+
+    expect(ctx.fillText).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips overlapping labels when spans are too dense", () => {
+    // Two adjacent 1-bar spans: midX 4 and 12 (barSpacing=8). "Asia" width ≈ 22,
+    // so label halves overlap and the second label must be skipped.
     const data = [
       { time: 1000, value: { zone: "Asian KZ", inKillZone: true } },
       { time: 1060, value: { zone: "London Open KZ", inKillZone: true } },
@@ -75,8 +104,7 @@ describe("createSessionZones", () => {
     const ctx = mockCtx();
     plugin.render(makeCtx(ctx, mockTs(0, 2)), plugin.defaultState);
 
-    // 2 different zones → 2 labels (1 at transition + 1 at end)
-    expect(ctx.fillText).toHaveBeenCalledTimes(2);
+    expect(ctx.fillText).toHaveBeenCalledTimes(1);
   });
 
   it("handles empty data", () => {

--- a/packages/chart/src/__tests__/wyckoff-phase.test.ts
+++ b/packages/chart/src/__tests__/wyckoff-phase.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { PrimitiveRenderContext } from "../core/plugin-types";
-import type { TimeScale } from "../core/scale";
+import type { PriceScale, TimeScale } from "../core/scale";
 import type { ChartInstance, PaneRect } from "../core/types";
 import { connectWyckoffPhase, createWyckoffPhase } from "../plugins/wyckoff-phase";
 
@@ -12,10 +12,21 @@ const mockCtx = () =>
     rect: vi.fn(),
     clip: vi.fn(),
     fill: vi.fn(),
+    stroke: vi.fn(),
     fillRect: vi.fn(),
+    strokeRect: vi.fn(),
     arc: vi.fn(),
-    fillStyle: "",
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    setLineDash: vi.fn(),
     fillText: vi.fn(),
+    measureText: vi.fn((text: string) => ({ width: text.length * 5.5 })),
+    fillStyle: "",
+    strokeStyle: "",
+    font: "",
+    lineWidth: 1,
+    textAlign: "" as CanvasTextAlign,
+    textBaseline: "" as CanvasTextBaseline,
   }) as unknown as CanvasRenderingContext2D;
 
 const mockTs = (start = 0, end = 5) =>
@@ -26,10 +37,12 @@ const mockTs = (start = 0, end = 5) =>
     indexToX: (i: number) => i * 8 + 4,
   }) as TimeScale;
 
+const mockPs = () => ({ priceToY: (p: number) => 400 - p * 2 }) as PriceScale;
+
 const mockPane = { id: "main", x: 0, y: 0, width: 800, height: 400 } as PaneRect;
 
-const makeCtx = (ctx: CanvasRenderingContext2D) =>
-  ({ ctx, pane: mockPane, timeScale: mockTs() }) as PrimitiveRenderContext;
+const makeCtx = (ctx: CanvasRenderingContext2D, ts = mockTs(), ps = mockPs()) =>
+  ({ ctx, pane: mockPane, timeScale: ts, priceScale: ps }) as PrimitiveRenderContext;
 
 describe("createWyckoffPhase", () => {
   it("returns a valid PrimitivePlugin", () => {
@@ -39,7 +52,7 @@ describe("createWyckoffPhase", () => {
     expect(plugin.zOrder).toBe("above");
   });
 
-  it("renders phase bar for each data point", () => {
+  it("renders timeline bar for each data point", () => {
     const phases = [
       { time: 1000, value: { phase: "accumulation", confidence: 80 } },
       { time: 1060, value: { phase: "markup", confidence: 60 } },
@@ -47,8 +60,68 @@ describe("createWyckoffPhase", () => {
     ];
     const plugin = createWyckoffPhase(phases);
     const ctx = mockCtx();
-    plugin.render(makeCtx(ctx), plugin.defaultState);
-    expect(ctx.fillRect).toHaveBeenCalledTimes(3);
+    plugin.render(makeCtx(ctx, mockTs(0, 3)), plugin.defaultState);
+    // Each bar in timeline bar → 3 fillRects (at minimum; the corner badge
+    // adds one more). Confirm timeline rendered at least 3.
+    const fillRectCalls = (ctx.fillRect as unknown as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(fillRectCalls).toBeGreaterThanOrEqual(3);
+  });
+
+  it("draws a range box when accumulation/distribution has valid rangeHigh/rangeLow", () => {
+    const phases = [
+      {
+        time: 1000,
+        value: { phase: "accumulation", confidence: 50, rangeHigh: 110, rangeLow: 100 },
+      },
+      {
+        time: 1060,
+        value: { phase: "accumulation", confidence: 60, rangeHigh: 110, rangeLow: 100 },
+      },
+      {
+        time: 1120,
+        value: { phase: "accumulation", confidence: 70, rangeHigh: 110, rangeLow: 100 },
+      },
+    ];
+    const plugin = createWyckoffPhase(phases);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx, mockTs(0, 3)), plugin.defaultState);
+    // At least one strokeRect call for the range box border.
+    expect(ctx.strokeRect).toHaveBeenCalled();
+  });
+
+  it("renders event label text at the bar where an event fires", () => {
+    const phases = [
+      {
+        time: 1000,
+        value: {
+          phase: "accumulation",
+          confidence: 40,
+          event: "SC",
+          rangeHigh: 110,
+          rangeLow: 100,
+        },
+      },
+    ];
+    const plugin = createWyckoffPhase(phases);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx, mockTs(0, 1)), plugin.defaultState);
+    // Event label "SC" should have been drawn (at least once).
+    const calls = (ctx.fillText as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.some((c) => c[0] === "SC")).toBe(true);
+  });
+
+  it("renders the corner phase badge with current phase text", () => {
+    const phases = [
+      { time: 1000, value: { phase: "distribution", confidence: 72, subPhase: "phase_B" } },
+    ];
+    const plugin = createWyckoffPhase(phases);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx, mockTs(0, 1)), plugin.defaultState);
+    const calls = (ctx.fillText as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const badgeCall = calls.find((c) => typeof c[0] === "string" && c[0].includes("Wyckoff:"));
+    expect(badgeCall).toBeDefined();
+    expect(badgeCall?.[0]).toContain("Distribution");
+    expect(badgeCall?.[0]).toContain("72");
   });
 
   it("renders VSA event markers as dots", () => {
@@ -56,7 +129,7 @@ describe("createWyckoffPhase", () => {
     const vsa = [{ time: 1000, value: { barType: "spring", isEffortDivergence: false } }];
     const plugin = createWyckoffPhase(phases, vsa);
     const ctx = mockCtx();
-    plugin.render(makeCtx(ctx), plugin.defaultState);
+    plugin.render(makeCtx(ctx, mockTs(0, 1)), plugin.defaultState);
     expect(ctx.arc).toHaveBeenCalled();
     expect(ctx.fill).toHaveBeenCalled();
   });
@@ -64,9 +137,11 @@ describe("createWyckoffPhase", () => {
   it("skips normal VSA bars", () => {
     const phases = [{ time: 1000, value: { phase: "accumulation" } }];
     const vsa = [{ time: 1000, value: { barType: "normal", isEffortDivergence: false } }];
-    const plugin = createWyckoffPhase(phases, vsa);
+    const plugin = createWyckoffPhase(phases, vsa, [], {
+      showEventLabels: false, // event-label dots use arc too, so disable to isolate VSA check
+    });
     const ctx = mockCtx();
-    plugin.render(makeCtx(ctx), plugin.defaultState);
+    plugin.render(makeCtx(ctx, mockTs(0, 1)), plugin.defaultState);
     expect(ctx.arc).not.toHaveBeenCalled();
   });
 

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -161,3 +161,10 @@ export {
   type VolumeProfileLevel,
   type VolumeProfileState,
 } from "./plugins/volume-profile";
+export {
+  createMarketProfile,
+  connectMarketProfile,
+  type MarketProfileValue,
+  type MarketProfileSeries,
+  type MarketProfileOptions,
+} from "./plugins/market-profile";

--- a/packages/chart/src/plugins/index.ts
+++ b/packages/chart/src/plugins/index.ts
@@ -7,3 +7,4 @@ export { createWyckoffPhase, connectWyckoffPhase } from "./wyckoff-phase";
 export { createSrConfluence, connectSrConfluence } from "./sr-confluence";
 export { createTradeAnalysis, connectTradeAnalysis } from "./trade-analysis";
 export { createSessionZones, connectSessionZones } from "./session-zones";
+export { createMarketProfile, connectMarketProfile } from "./market-profile";

--- a/packages/chart/src/plugins/market-profile.ts
+++ b/packages/chart/src/plugins/market-profile.ts
@@ -1,0 +1,213 @@
+/**
+ * Market Profile (TPO) Plugin — Renders a horizontal time-at-price
+ * histogram on the left side of the chart pane, plus horizontal lines at
+ * POC / VAH / VAL.
+ *
+ * Accepts the last non-null value from a `Series<MarketProfileValue>` (the
+ * output of core's `marketProfile()`), or a single `MarketProfileValue`.
+ * Using a series lets the histogram advance as new TPO sessions complete;
+ * the plugin internally reads the most recent completed profile within the
+ * current visible range.
+ *
+ * @example
+ * ```typescript
+ * import { createChart, connectMarketProfile } from '@trendcraft/chart';
+ * import { marketProfile } from 'trendcraft';
+ *
+ * const chart = createChart(el);
+ * chart.setCandles(candles);
+ * const handle = connectMarketProfile(chart, marketProfile(candles));
+ * ```
+ */
+
+import { definePrimitive } from "../core/plugin-types";
+import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
+import type { ChartInstance } from "../core/types";
+
+// ---- Types (duck-typed to avoid a core dependency) ----
+
+/** Matches core's `MarketProfileValue`. */
+export type MarketProfileValue = {
+  poc: number | null;
+  valueAreaHigh: number | null;
+  valueAreaLow: number | null;
+  profile: Map<number, number> | null;
+};
+
+export type MarketProfileSeries = ReadonlyArray<{ time: number; value: MarketProfileValue }>;
+
+export type MarketProfileOptions = {
+  /** Strip width as pane-width fraction (0-1) or absolute px (>1). Default 0.15. */
+  widthFraction?: number;
+  /** Fill color for bars outside the value area. */
+  barColor?: string;
+  /** Fill color for bars inside the value area. */
+  valueAreaColor?: string;
+  /** Fill + line color for POC. */
+  pocColor?: string;
+  /** VAH / VAL line color. */
+  vaEdgeColor?: string;
+};
+
+type MarketProfileState = {
+  data: MarketProfileSeries;
+  options: Required<MarketProfileOptions>;
+};
+
+// ---- Defaults ----
+
+const DEFAULTS: Required<MarketProfileOptions> = {
+  widthFraction: 0.15,
+  barColor: "rgba(33,150,243,0.07)",
+  valueAreaColor: "rgba(33,150,243,0.22)",
+  pocColor: "rgba(255,152,0,0.85)",
+  vaEdgeColor: "rgba(255,152,0,0.4)",
+};
+
+// ---- Render ----
+
+function renderMarketProfile(
+  { ctx, pane, priceScale, timeScale }: PrimitiveRenderContext,
+  state: MarketProfileState,
+): void {
+  const { data, options } = state;
+  if (data.length === 0) return;
+
+  const lastIdx = Math.min(timeScale.endIndex - 1, data.length - 1);
+  if (lastIdx < 0) return;
+
+  // Walk backwards to find the most recent non-empty profile — near the
+  // start of a session the latest bar's profile may still be empty.
+  let value: MarketProfileValue | null = null;
+  for (let i = lastIdx; i >= Math.max(0, timeScale.startIndex); i--) {
+    const v = data[i]?.value;
+    if (v?.profile && v.profile.size > 0) {
+      value = v;
+      break;
+    }
+  }
+  if (!value?.profile || value.profile.size === 0) return;
+
+  const { poc, valueAreaHigh, valueAreaLow, profile } = value;
+
+  let maxCount = 0;
+  for (const count of profile.values()) if (count > maxCount) maxCount = count;
+  if (maxCount === 0) return;
+
+  const reservedWidth =
+    options.widthFraction > 1
+      ? Math.min(options.widthFraction, pane.width)
+      : pane.width * options.widthFraction;
+  if (reservedWidth <= 0) return;
+  const barLeft = pane.x + 8;
+  const profileRight = barLeft + reservedWidth;
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(pane.x, pane.y, pane.width, pane.height);
+  ctx.clip();
+
+  const prices = [...profile.keys()].sort((a, b) => a - b);
+  const tickSize = prices.length > 1 ? prices[1] - prices[0] : 1;
+  const barH = Math.max(2, Math.abs(priceScale.priceToY(0) - priceScale.priceToY(tickSize)) - 1);
+
+  for (const [price, count] of profile) {
+    const y = priceScale.priceToY(price);
+    const barW = (count / maxCount) * reservedWidth;
+    const isPoc = price === poc;
+    const inVA =
+      valueAreaLow != null &&
+      valueAreaHigh != null &&
+      price >= valueAreaLow &&
+      price <= valueAreaHigh;
+
+    ctx.fillStyle = isPoc ? options.pocColor : inVA ? options.valueAreaColor : options.barColor;
+    ctx.fillRect(barLeft, y - barH / 2, barW, barH);
+
+    if (isPoc) {
+      ctx.strokeStyle = options.pocColor;
+      ctx.lineWidth = 1;
+      ctx.strokeRect(barLeft, y - barH / 2, barW, barH);
+    }
+  }
+
+  // VAH / VAL dashed lines + labels
+  ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
+  ctx.textBaseline = "bottom";
+  for (const [label, price] of [
+    ["VAH", valueAreaHigh],
+    ["VAL", valueAreaLow],
+  ] as const) {
+    if (price == null) continue;
+    const y = Math.round(priceScale.priceToY(price)) + 0.5;
+    ctx.strokeStyle = options.vaEdgeColor;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 3]);
+    ctx.beginPath();
+    ctx.moveTo(barLeft, y);
+    ctx.lineTo(profileRight + 20, y);
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.fillStyle = options.vaEdgeColor;
+    ctx.fillText(label, profileRight + 4, y - 2);
+  }
+
+  // POC solid line + label
+  if (poc != null) {
+    const y = Math.round(priceScale.priceToY(poc)) + 0.5;
+    ctx.strokeStyle = options.pocColor;
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(barLeft, y);
+    ctx.lineTo(profileRight + 20, y);
+    ctx.stroke();
+    ctx.fillStyle = options.pocColor;
+    ctx.font = "bold 10px -apple-system, BlinkMacSystemFont, sans-serif";
+    ctx.fillText("POC", profileRight + 4, y - 2);
+  }
+
+  ctx.restore();
+}
+
+// ---- Factory ----
+
+function resolveOptions(options: MarketProfileOptions = {}): Required<MarketProfileOptions> {
+  return { ...DEFAULTS, ...options };
+}
+
+export function createMarketProfile(
+  data: MarketProfileSeries,
+  options: MarketProfileOptions = {},
+): PrimitivePlugin<MarketProfileState> {
+  return definePrimitive<MarketProfileState>({
+    name: "marketProfile",
+    pane: "main",
+    zOrder: "above",
+    defaultState: { data, options: resolveOptions(options) },
+    render: renderMarketProfile,
+  });
+}
+
+// ---- Convenience connector ----
+
+type MarketProfileHandle = {
+  update(data: MarketProfileSeries, options?: MarketProfileOptions): void;
+  remove(): void;
+};
+
+export function connectMarketProfile(
+  chart: ChartInstance,
+  data: MarketProfileSeries,
+  options: MarketProfileOptions = {},
+): MarketProfileHandle {
+  chart.registerPrimitive(createMarketProfile(data, options));
+
+  return {
+    update(newData, newOptions) {
+      chart.registerPrimitive(createMarketProfile(newData, newOptions ?? options));
+    },
+    remove() {
+      chart.removePrimitive("marketProfile");
+    },
+  };
+}

--- a/packages/chart/src/plugins/regime-heatmap.ts
+++ b/packages/chart/src/plugins/regime-heatmap.ts
@@ -77,7 +77,7 @@ function renderRegimeHeatmap(
 
     const { regime, label, confidence } = point.value;
     const rgb = regimeToRgb(regime, label);
-    const alpha = 0.06 + (confidence ?? 0.5) * 0.12;
+    const alpha = 0.15 + (confidence ?? 0.5) * 0.25;
     const x = timeScale.indexToX(i);
 
     ctx.fillStyle = `rgba(${rgb},${alpha.toFixed(3)})`;

--- a/packages/chart/src/plugins/session-zones.ts
+++ b/packages/chart/src/plugins/session-zones.ts
@@ -49,8 +49,24 @@ const ZONE_COLORS: Record<string, string> = {
   "NY PM": "255,152,0",
 };
 
+/** Shortened display forms — keeps intraday timelines readable when every
+ * day repeats the same four zones. */
+const ZONE_SHORT_LABELS: Record<string, string> = {
+  "Asian KZ": "Asia",
+  "London Open KZ": "LON",
+  "NY Open KZ": "NY",
+  "London Close KZ": "Close",
+};
+
+/** Horizontal padding between consecutive labels before the next one is skipped. */
+const LABEL_GAP_PX = 6;
+
 function zoneToRgb(zone: string): string {
   return ZONE_COLORS[zone] ?? "120,123,134";
+}
+
+function zoneToShortLabel(zone: string): string {
+  return ZONE_SHORT_LABELS[zone] ?? zone;
 }
 
 // ---- Render ----
@@ -71,7 +87,10 @@ function renderSessionZones(
   ctx.rect(pane.x, pane.y, pane.width, pane.height);
   ctx.clip();
 
-  // Track zone spans for label placement
+  // Collect spans first, then render labels with collision avoidance so
+  // dense intraday ranges don't produce an unreadable wall of text.
+  type Span = { zone: string; startIndex: number; endIndex: number };
+  const spans: Span[] = [];
   let spanStart = -1;
   let spanZone = "";
 
@@ -88,61 +107,60 @@ function renderSessionZones(
       ctx.fillStyle = `rgba(${rgb},0.18)`;
       ctx.fillRect(x - barWidth / 2, pane.y, barWidth, pane.height);
 
-      // Track span for label
       if (zone !== spanZone) {
-        // Render label for previous span
         if (spanStart >= 0 && spanZone) {
-          renderZoneLabel(ctx, spanZone, spanStart, timeScale.indexToX(i - 1), pane.y);
+          spans.push({ zone: spanZone, startIndex: spanStart, endIndex: i - 1 });
         }
         spanStart = i;
         spanZone = zone;
       }
-    } else {
-      // End of span
-      if (spanStart >= 0 && spanZone) {
-        renderZoneLabel(
-          ctx,
-          spanZone,
-          timeScale.indexToX(spanStart),
-          timeScale.indexToX(i - 1),
-          pane.y,
-        );
-        spanStart = -1;
-        spanZone = "";
-      }
+    } else if (spanStart >= 0 && spanZone) {
+      spans.push({ zone: spanZone, startIndex: spanStart, endIndex: i - 1 });
+      spanStart = -1;
+      spanZone = "";
     }
   }
-
-  // Render label for last span if still open
   if (spanStart >= 0 && spanZone) {
     const lastIdx = Math.min(end - 1, data.length - 1);
-    renderZoneLabel(
-      ctx,
-      spanZone,
-      timeScale.indexToX(spanStart),
-      timeScale.indexToX(lastIdx),
-      pane.y,
-    );
+    spans.push({ zone: spanZone, startIndex: spanStart, endIndex: lastIdx });
   }
+
+  renderZoneLabels(ctx, spans, timeScale, pane.y);
 
   ctx.restore();
 }
 
-function renderZoneLabel(
+function renderZoneLabels(
   ctx: CanvasRenderingContext2D,
-  zone: string,
-  startX: number,
-  endX: number,
+  spans: Array<{ zone: string; startIndex: number; endIndex: number }>,
+  timeScale: { indexToX: (i: number) => number },
   paneY: number,
 ): void {
-  const midX = (startX + endX) / 2;
-  const rgb = zoneToRgb(zone);
+  if (spans.length === 0) return;
 
-  ctx.fillStyle = `rgba(${rgb},0.4)`;
   ctx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
   ctx.textAlign = "center";
   ctx.textBaseline = "top";
-  ctx.fillText(zone, midX, paneY + 3);
+
+  let lastLabelRight = Number.NEGATIVE_INFINITY;
+
+  for (const span of spans) {
+    const startX = timeScale.indexToX(span.startIndex);
+    const endX = timeScale.indexToX(span.endIndex);
+    const midX = (startX + endX) / 2;
+    const text = zoneToShortLabel(span.zone);
+    const width = ctx.measureText(text).width;
+    const leftEdge = midX - width / 2;
+    const rightEdge = midX + width / 2;
+
+    // Skip if this label would overlap the previously drawn one.
+    if (leftEdge < lastLabelRight + LABEL_GAP_PX) continue;
+
+    const rgb = zoneToRgb(span.zone);
+    ctx.fillStyle = `rgba(${rgb},0.4)`;
+    ctx.fillText(text, midX, paneY + 3);
+    lastLabelRight = rightEdge;
+  }
 }
 
 // ---- Factory ----

--- a/packages/chart/src/plugins/session-zones.ts
+++ b/packages/chart/src/plugins/session-zones.ts
@@ -85,7 +85,7 @@ function renderSessionZones(
       const rgb = zoneToRgb(zone);
       const x = timeScale.indexToX(i);
 
-      ctx.fillStyle = `rgba(${rgb},0.06)`;
+      ctx.fillStyle = `rgba(${rgb},0.18)`;
       ctx.fillRect(x - barWidth / 2, pane.y, barWidth, pane.height);
 
       // Track span for label

--- a/packages/chart/src/plugins/sr-confluence.ts
+++ b/packages/chart/src/plugins/sr-confluence.ts
@@ -58,7 +58,7 @@ function strengthToRgb(strength: number): string {
 // ---- Render ----
 
 function renderSrConfluence(
-  { ctx, pane, timeScale, priceScale }: PrimitiveRenderContext,
+  { ctx, pane, priceScale }: PrimitiveRenderContext,
   state: SrConfluenceState,
 ): void {
   const { zones } = state;
@@ -69,9 +69,12 @@ function renderSrConfluence(
   ctx.rect(pane.x, pane.y, pane.width, pane.height);
   ctx.clip();
 
-  const startX = timeScale.indexToX(timeScale.startIndex);
-  const endX = timeScale.indexToX(timeScale.endIndex);
-  const width = endX - startX;
+  // Bands fill the entire pane horizontally and labels pin to the right
+  // edge of the pane — both are independent of the visible index range so
+  // they don't flicker as the user pans/zooms.
+  const left = pane.x;
+  const right = pane.x + pane.width;
+  const width = pane.width;
 
   for (const zone of zones) {
     const topY = priceScale.priceToY(zone.high);
@@ -82,28 +85,24 @@ function renderSrConfluence(
     const rgb = strengthToRgb(zone.strength);
     const alpha = 0.06 + (zone.strength / 100) * 0.12;
 
-    // Filled band
     ctx.fillStyle = `rgba(${rgb},${alpha.toFixed(3)})`;
-    ctx.fillRect(startX, topY, width, h);
+    ctx.fillRect(left, topY, width, h);
 
-    // Border lines at top and bottom
     ctx.strokeStyle = `rgba(${rgb},${(alpha * 2.5).toFixed(3)})`;
     ctx.lineWidth = 0.5;
     ctx.beginPath();
-    ctx.moveTo(startX, topY);
-    ctx.lineTo(startX + width, topY);
-    ctx.moveTo(startX, bottomY);
-    ctx.lineTo(startX + width, bottomY);
+    ctx.moveTo(left, topY);
+    ctx.lineTo(right, topY);
+    ctx.moveTo(left, bottomY);
+    ctx.lineTo(right, bottomY);
     ctx.stroke();
 
-    // Strength label on the right
     const centerY = (topY + bottomY) / 2;
     ctx.fillStyle = `rgba(${rgb},0.7)`;
     ctx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
     ctx.textAlign = "right";
     ctx.textBaseline = "middle";
-    const label = `S${zone.strength.toFixed(0)}`;
-    ctx.fillText(label, startX + width - 4, centerY);
+    ctx.fillText(`S${zone.strength.toFixed(0)}`, right - 4, centerY);
   }
 
   ctx.restore();

--- a/packages/chart/src/plugins/wyckoff-phase.ts
+++ b/packages/chart/src/plugins/wyckoff-phase.ts
@@ -1,22 +1,29 @@
 /**
- * Wyckoff Phase Timeline Plugin — Visualizes Wyckoff phases as colored bar
- * at the bottom of the chart pane + optional VSA bar classification markers.
+ * Wyckoff Phase Plugin — Visualizes Wyckoff method analysis using the
+ * conventions that `Wyckoff` traders expect:
  *
- * Phase colors:
- * - accumulation → green
- * - markup → blue
- * - distribution → red
- * - markdown → orange
- * - unknown → gray
+ *  1. A colored **range box** over each accumulation / distribution trading
+ *     range (green for accumulation, red for distribution)
+ *  2. **Event labels** (PS, SC, AR, ST, Spring, SOS, LPS / PSY, BC, UT,
+ *     UTAD, SOW, LPSY) anchored at the bar where each event was detected
+ *  3. An optional **corner badge** showing the current phase + confidence
+ *  4. An optional **bottom timeline bar** for at-a-glance scanning of long
+ *     histories (phase color per bar)
+ *  5. Optional **VSA event markers** (small dots above the timeline bar)
+ *     when VSA data is supplied
  *
  * @example
  * ```typescript
  * import { createChart, connectWyckoffPhase } from '@trendcraft/chart';
- * import { wyckoffPhases } from 'trendcraft';
+ * import { wyckoffPhases, vsa } from 'trendcraft';
  *
  * const chart = createChart(el);
  * chart.setCandles(candles);
- * const handle = connectWyckoffPhase(chart, { phases: wyckoffPhases(candles) });
+ * const handle = connectWyckoffPhase(chart, {
+ *   phases: wyckoffPhases(candles),
+ *   candles,           // optional, improves event-label placement
+ *   vsa: vsa(candles), // optional, enables VSA dots
+ * });
  * ```
  */
 
@@ -26,12 +33,30 @@ import type { ChartInstance, DataPoint } from "../core/types";
 
 // ---- Types (duck-typed) ----
 
+type WyckoffEventName =
+  | "PS"
+  | "SC"
+  | "AR"
+  | "ST"
+  | "spring"
+  | "test"
+  | "SOS"
+  | "LPS"
+  | "BU"
+  | "PSY"
+  | "BC"
+  | "SOW"
+  | "LPSY"
+  | "UT"
+  | "UTAD";
+
 type WyckoffDataPoint = DataPoint<{
   phase: string;
   confidence?: number;
-  event?: string | null;
+  event?: WyckoffEventName | string | null;
   rangeHigh?: number | null;
   rangeLow?: number | null;
+  subPhase?: string | null;
 }>;
 
 type VsaDataPoint = DataPoint<{
@@ -39,9 +64,24 @@ type VsaDataPoint = DataPoint<{
   isEffortDivergence?: boolean;
 }>;
 
+type CandleLike = { time: number; high: number; low: number };
+
+type WyckoffPhaseOptions = {
+  /** Draw the colored range box over accumulation / distribution ranges. Default true. */
+  showRangeBox?: boolean;
+  /** Draw PS/SC/AR/... text labels at the bar where each event fired. Default true. */
+  showEventLabels?: boolean;
+  /** Show a corner badge with the current phase. Default true. */
+  showPhaseBadge?: boolean;
+  /** Show the thin timeline bar at the pane bottom. Default true (useful for scanning). */
+  showTimelineBar?: boolean;
+};
+
 type WyckoffPhaseState = {
   phases: readonly WyckoffDataPoint[];
   vsa: readonly VsaDataPoint[];
+  candles: readonly CandleLike[];
+  options: Required<WyckoffPhaseOptions>;
 };
 
 // ---- Colors ----
@@ -52,6 +92,14 @@ const PHASE_COLORS: Record<string, string> = {
   distribution: "239,83,80",
   markdown: "255,152,0",
   unknown: "120,123,134",
+};
+
+const PHASE_LABELS: Record<string, string> = {
+  accumulation: "Accumulation",
+  markup: "Markup",
+  distribution: "Distribution",
+  markdown: "Markdown",
+  unknown: "Unknown",
 };
 
 const VSA_MARKER_COLORS: Record<string, string> = {
@@ -65,60 +113,236 @@ const VSA_MARKER_COLORS: Record<string, string> = {
   noDemand: "244,67,54",
 };
 
+/** Event label placement: whether the text goes above the high or below the low of its bar. */
+const EVENT_PLACEMENT: Record<string, "above" | "below"> = {
+  // Accumulation
+  PS: "below",
+  SC: "below",
+  AR: "above",
+  ST: "below",
+  spring: "below",
+  test: "below",
+  SOS: "above",
+  LPS: "below",
+  BU: "above",
+  // Distribution
+  PSY: "above",
+  BC: "above",
+  SOW: "below",
+  LPSY: "above",
+  UT: "above",
+  UTAD: "above",
+};
+
+const DEFAULT_OPTIONS: Required<WyckoffPhaseOptions> = {
+  showRangeBox: true,
+  showEventLabels: true,
+  showPhaseBadge: true,
+  showTimelineBar: true,
+};
+
 const PHASE_BAR_HEIGHT = 6;
+
+// ---- Span aggregation ----
+
+type PhaseSpan = {
+  phase: string;
+  startIndex: number;
+  endIndex: number;
+  rangeHigh: number;
+  rangeLow: number;
+};
+
+/** Collapse consecutive bars sharing the same phase + range into single spans. */
+function collectPhaseSpans(phases: readonly WyckoffDataPoint[]): PhaseSpan[] {
+  const spans: PhaseSpan[] = [];
+  let current: PhaseSpan | null = null;
+
+  for (let i = 0; i < phases.length; i++) {
+    const v = phases[i]?.value;
+    if (!v) continue;
+    const { phase, rangeHigh, rangeLow } = v;
+
+    const valid =
+      (phase === "accumulation" || phase === "distribution") &&
+      rangeHigh != null &&
+      rangeLow != null &&
+      rangeHigh > rangeLow;
+
+    if (!valid) {
+      if (current) {
+        spans.push(current);
+        current = null;
+      }
+      continue;
+    }
+
+    // At this point `rangeHigh` and `rangeLow` are guaranteed non-null by the
+    // `valid` guard above.
+    const high = rangeHigh as number;
+    const low = rangeLow as number;
+
+    if (!current || current.phase !== phase) {
+      if (current) spans.push(current);
+      current = { phase, startIndex: i, endIndex: i, rangeHigh: high, rangeLow: low };
+    } else {
+      current.endIndex = i;
+      // Track the widest range observed across the span.
+      current.rangeHigh = Math.max(current.rangeHigh, high);
+      current.rangeLow = Math.min(current.rangeLow, low);
+    }
+  }
+  if (current) spans.push(current);
+  return spans;
+}
 
 // ---- Render ----
 
 function renderWyckoffPhase(
-  { ctx, pane, timeScale }: PrimitiveRenderContext,
+  { ctx, pane, timeScale, priceScale }: PrimitiveRenderContext,
   state: WyckoffPhaseState,
 ): void {
-  const { phases, vsa } = state;
+  const { phases, vsa, candles, options } = state;
   if (phases.length === 0) return;
 
   const start = timeScale.startIndex;
   const end = timeScale.endIndex;
   const barWidth = Math.max(1, timeScale.barSpacing);
-  const barY = pane.y + pane.height - PHASE_BAR_HEIGHT;
+  const last = phases[phases.length - 1]?.value;
 
   ctx.save();
   ctx.beginPath();
   ctx.rect(pane.x, pane.y, pane.width, pane.height);
   ctx.clip();
 
-  // Phase bar at bottom
-  for (let i = start; i < end && i < phases.length; i++) {
-    const point = phases[i];
-    if (!point?.value) continue;
+  // ----- 1. Range boxes -----
+  if (options.showRangeBox) {
+    const spans = collectPhaseSpans(phases);
+    for (const span of spans) {
+      if (span.endIndex < start || span.startIndex >= end) continue;
+      const rgb = PHASE_COLORS[span.phase] ?? PHASE_COLORS.unknown;
+      const x1 = timeScale.indexToX(span.startIndex);
+      const x2 = timeScale.indexToX(span.endIndex);
+      const y1 = priceScale.priceToY(span.rangeHigh);
+      const y2 = priceScale.priceToY(span.rangeLow);
+      const w = x2 - x1;
+      const h = y2 - y1;
+      if (w <= 0 || h <= 0) continue;
 
-    const { phase, confidence } = point.value;
-    const rgb = PHASE_COLORS[phase] ?? PHASE_COLORS.unknown;
-    const alpha = 0.4 + ((confidence ?? 50) / 100) * 0.5;
-    const x = timeScale.indexToX(i);
+      ctx.fillStyle = `rgba(${rgb},0.08)`;
+      ctx.fillRect(x1, y1, w, h);
 
-    ctx.fillStyle = `rgba(${rgb},${alpha.toFixed(3)})`;
-    ctx.fillRect(x - barWidth / 2, barY, barWidth, PHASE_BAR_HEIGHT);
+      ctx.strokeStyle = `rgba(${rgb},0.55)`;
+      ctx.lineWidth = 1;
+      ctx.setLineDash([4, 3]);
+      ctx.strokeRect(x1, y1, w, h);
+      ctx.setLineDash([]);
+    }
   }
 
-  // VSA event markers (small dots above phase bar)
-  if (vsa.length > 0) {
-    const markerY = barY - 4;
-    for (let i = start; i < end && i < vsa.length; i++) {
-      const point = vsa[i];
-      if (!point?.value) continue;
+  // ----- 2. Event labels -----
+  if (options.showEventLabels) {
+    ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
+    ctx.textAlign = "center";
+    for (let i = start; i < end && i < phases.length; i++) {
+      const point = phases[i];
+      const event = point?.value?.event;
+      if (!event) continue;
 
-      const { barType } = point.value;
-      if (barType === "normal") continue;
-
-      const rgb = VSA_MARKER_COLORS[barType];
-      if (!rgb) continue;
-
+      const placement = EVENT_PLACEMENT[event] ?? "above";
       const x = timeScale.indexToX(i);
-      ctx.fillStyle = `rgba(${rgb},0.8)`;
+
+      // Prefer candle high/low for precise placement; fall back to the
+      // phase's range boundaries when candles weren't provided.
+      const candle = candles[i];
+      const rangeHigh = point.value?.rangeHigh ?? null;
+      const rangeLow = point.value?.rangeLow ?? null;
+      const anchorPrice =
+        placement === "above"
+          ? (candle?.high ?? rangeHigh ?? rangeLow)
+          : (candle?.low ?? rangeLow ?? rangeHigh);
+      if (anchorPrice == null) continue;
+
+      const anchorY = priceScale.priceToY(anchorPrice);
+      const y = placement === "above" ? anchorY - 4 : anchorY + 12;
+
+      const phaseKey =
+        point.value?.phase && PHASE_COLORS[point.value.phase] ? point.value.phase : "unknown";
+      const rgb = PHASE_COLORS[phaseKey];
+
+      // Small dot at the anchor price
+      ctx.fillStyle = `rgba(${rgb},0.9)`;
       ctx.beginPath();
-      ctx.arc(x, markerY, 2, 0, Math.PI * 2);
+      ctx.arc(x, anchorY, 2, 0, Math.PI * 2);
       ctx.fill();
+
+      // Text label
+      ctx.fillStyle = `rgba(${rgb},0.95)`;
+      ctx.textBaseline = placement === "above" ? "bottom" : "top";
+      ctx.fillText(event, x, y);
     }
+  }
+
+  // ----- 3. Bottom timeline bar -----
+  if (options.showTimelineBar) {
+    const barY = pane.y + pane.height - PHASE_BAR_HEIGHT;
+    for (let i = start; i < end && i < phases.length; i++) {
+      const point = phases[i];
+      if (!point?.value) continue;
+      const { phase, confidence } = point.value;
+      const rgb = PHASE_COLORS[phase] ?? PHASE_COLORS.unknown;
+      const alpha = 0.4 + ((confidence ?? 50) / 100) * 0.5;
+      const x = timeScale.indexToX(i);
+      ctx.fillStyle = `rgba(${rgb},${alpha.toFixed(3)})`;
+      ctx.fillRect(x - barWidth / 2, barY, barWidth, PHASE_BAR_HEIGHT);
+    }
+
+    // VSA event dots just above the timeline bar
+    if (vsa.length > 0) {
+      const markerY = barY - 4;
+      for (let i = start; i < end && i < vsa.length; i++) {
+        const point = vsa[i];
+        if (!point?.value) continue;
+        const { barType } = point.value;
+        if (barType === "normal") continue;
+        const rgb = VSA_MARKER_COLORS[barType];
+        if (!rgb) continue;
+        const x = timeScale.indexToX(i);
+        ctx.fillStyle = `rgba(${rgb},0.8)`;
+        ctx.beginPath();
+        ctx.arc(x, markerY, 2, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+  }
+
+  // ----- 4. Corner badge (top-left) -----
+  if (options.showPhaseBadge && last) {
+    const label = PHASE_LABELS[last.phase] ?? last.phase;
+    const conf = last.confidence ?? 0;
+    const subPhase = last.subPhase ? ` · ${last.subPhase}` : "";
+    const text = `Wyckoff: ${label} (${conf.toFixed(0)})${subPhase}`;
+    const rgb = PHASE_COLORS[last.phase] ?? PHASE_COLORS.unknown;
+
+    ctx.font = "bold 11px -apple-system, BlinkMacSystemFont, sans-serif";
+    ctx.textAlign = "left";
+    ctx.textBaseline = "top";
+    const textWidth = ctx.measureText(text).width;
+    const padX = 8;
+    const padY = 4;
+    const boxW = textWidth + padX * 2;
+    const boxH = 18;
+    const boxX = pane.x + 8;
+    const boxY = pane.y + 8;
+
+    ctx.fillStyle = "rgba(22,26,37,0.85)";
+    ctx.fillRect(boxX, boxY, boxW, boxH);
+    ctx.strokeStyle = `rgba(${rgb},0.7)`;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(boxX, boxY, boxW, boxH);
+
+    ctx.fillStyle = `rgba(${rgb},0.95)`;
+    ctx.fillText(text, boxX + padX, boxY + padY);
   }
 
   ctx.restore();
@@ -126,15 +350,21 @@ function renderWyckoffPhase(
 
 // ---- Factory ----
 
+function resolveOptions(options: WyckoffPhaseOptions = {}): Required<WyckoffPhaseOptions> {
+  return { ...DEFAULT_OPTIONS, ...options };
+}
+
 export function createWyckoffPhase(
   phases: readonly WyckoffDataPoint[],
   vsa: readonly VsaDataPoint[] = [],
+  candles: readonly CandleLike[] = [],
+  options: WyckoffPhaseOptions = {},
 ): PrimitivePlugin<WyckoffPhaseState> {
   return definePrimitive<WyckoffPhaseState>({
     name: "wyckoffPhase",
     pane: "main",
     zOrder: "above",
-    defaultState: { phases, vsa },
+    defaultState: { phases, vsa, candles, options: resolveOptions(options) },
     render: renderWyckoffPhase,
   });
 }
@@ -142,19 +372,38 @@ export function createWyckoffPhase(
 // ---- Convenience connector ----
 
 type WyckoffPhaseHandle = {
-  update(phases: readonly WyckoffDataPoint[], vsa?: readonly VsaDataPoint[]): void;
+  update(sources: {
+    phases: readonly WyckoffDataPoint[];
+    vsa?: readonly VsaDataPoint[];
+    candles?: readonly CandleLike[];
+    options?: WyckoffPhaseOptions;
+  }): void;
   remove(): void;
 };
 
 export function connectWyckoffPhase(
   chart: ChartInstance,
-  sources: { phases: readonly WyckoffDataPoint[]; vsa?: readonly VsaDataPoint[] },
+  sources: {
+    phases: readonly WyckoffDataPoint[];
+    vsa?: readonly VsaDataPoint[];
+    candles?: readonly CandleLike[];
+    options?: WyckoffPhaseOptions;
+  },
 ): WyckoffPhaseHandle {
-  chart.registerPrimitive(createWyckoffPhase(sources.phases, sources.vsa));
+  chart.registerPrimitive(
+    createWyckoffPhase(sources.phases, sources.vsa ?? [], sources.candles ?? [], sources.options),
+  );
 
   return {
-    update(phases, vsa = []) {
-      chart.registerPrimitive(createWyckoffPhase(phases, vsa));
+    update(newSources) {
+      chart.registerPrimitive(
+        createWyckoffPhase(
+          newSources.phases,
+          newSources.vsa ?? [],
+          newSources.candles ?? [],
+          newSources.options,
+        ),
+      );
     },
     remove() {
       chart.removePrimitive("wyckoffPhase");

--- a/packages/chart/src/plugins/wyckoff-phase.ts
+++ b/packages/chart/src/plugins/wyckoff-phase.ts
@@ -332,8 +332,9 @@ function renderWyckoffPhase(
     const padY = 4;
     const boxW = textWidth + padX * 2;
     const boxH = 18;
+    // Offset below the chart's OHLC legend row (typically ~22 px from top).
     const boxX = pane.x + 8;
-    const boxY = pane.y + 8;
+    const boxY = pane.y + 32;
 
     ctx.fillStyle = "rgba(22,26,37,0.85)";
     ctx.fillRect(boxX, boxY, boxW, boxH);

--- a/packages/chart/src/presets.ts
+++ b/packages/chart/src/presets.ts
@@ -312,16 +312,6 @@ const TRENDCRAFT_RULES: IntrospectionRule[] = [
     defaultPane: "sub",
     decompose: (v) => ({ value: v.atrPercentile }),
   },
-
-  // Market Profile ({poc, valueAreaHigh, valueAreaLow, profile})
-  {
-    name: "marketProfile",
-    test: (v) => hasKeys(v, ["poc", "valueAreaHigh", "valueAreaLow", "profile"]),
-    seriesType: "heatmap",
-    defaultPane: "main",
-    // Heatmap renderer reads s.data directly
-    decompose: () => ({}),
-  },
 ];
 
 // ============================================
@@ -490,8 +480,6 @@ const TRENDCRAFT_PRESETS: [string, IndicatorPreset][] = [
   // Additional Volume
   ["volumeMa", { color: "#26a69a" }],
   ["cvdWithSignal", { channelColors: { cvd: "#2196F3", signal: "#FF9800" } }],
-  ["marketProfile", { channelColors: { poc: "#FF9800", vah: "#ef5350", val: "#26a69a" } }],
-
   // Additional Momentum
   ["fastStochastics", { color: "#2196F3" }],
   ["slowStochastics", { color: "#FF9800" }],
@@ -717,96 +705,6 @@ const TRENDCRAFT_RENDERERS: SeriesRendererPlugin[] = [
         ctx.stroke();
         ctx.fillStyle = color;
         ctx.fillRect(x - halfBody, bodyTop, bodyWidth, bodyH);
-      }
-      ctx.restore();
-    },
-    priceRange: () => [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY],
-  }),
-
-  // Market Profile TPO Histogram
-  defineSeriesRenderer({
-    type: "marketProfile",
-    render: ({ ctx, series, timeScale, priceScale, paneWidth }: SeriesRenderContext) => {
-      const data = series.data as { value: unknown }[];
-      const lastIdx = Math.min(timeScale.endIndex - 1, data.length - 1);
-      if (lastIdx < 0) return;
-      const val = data[lastIdx]?.value as {
-        poc?: number | null;
-        valueAreaHigh?: number | null;
-        valueAreaLow?: number | null;
-        profile?: Map<number, number> | null;
-      } | null;
-      if (!val?.profile || val.profile.size === 0) return;
-      const { poc, valueAreaHigh, valueAreaLow, profile } = val;
-      let maxCount = 0;
-      for (const count of profile.values()) if (count > maxCount) maxCount = count;
-      if (maxCount === 0) return;
-
-      const maxBarWidth = paneWidth * 0.15;
-      const barLeft = 8;
-      const profileRight = barLeft + maxBarWidth;
-      const prices = [...profile.keys()].sort((a, b) => a - b);
-      const tickSize = prices.length > 1 ? prices[1] - prices[0] : 1;
-      const barH = Math.max(
-        2,
-        Math.abs(priceScale.priceToY(0) - priceScale.priceToY(tickSize)) - 1,
-      );
-
-      for (const [price, count] of profile) {
-        const y = priceScale.priceToY(price);
-        const barW = (count / maxCount) * maxBarWidth;
-        const isPoc = price === poc;
-        const inVA =
-          valueAreaLow != null &&
-          valueAreaHigh != null &&
-          price >= valueAreaLow &&
-          price <= valueAreaHigh;
-        ctx.fillStyle = isPoc
-          ? "rgba(255,152,0,0.35)"
-          : inVA
-            ? "rgba(33,150,243,0.18)"
-            : "rgba(33,150,243,0.07)";
-        ctx.fillRect(barLeft, y - barH / 2, barW, barH);
-        if (isPoc) {
-          ctx.strokeStyle = "rgba(255,152,0,0.6)";
-          ctx.lineWidth = 1;
-          ctx.strokeRect(barLeft, y - barH / 2, barW, barH);
-        }
-      }
-      // VAH/VAL lines + labels
-      ctx.save();
-      ctx.font = "10px sans-serif";
-      ctx.textBaseline = "bottom";
-      for (const [label, price] of [
-        ["VAH", valueAreaHigh],
-        ["VAL", valueAreaLow],
-      ] as const) {
-        if (price == null) continue;
-        const y = Math.round(priceScale.priceToY(price)) + 0.5;
-        ctx.strokeStyle = "rgba(255,152,0,0.4)";
-        ctx.lineWidth = 1;
-        ctx.setLineDash([4, 3]);
-        ctx.beginPath();
-        ctx.moveTo(barLeft, y);
-        ctx.lineTo(profileRight + 20, y);
-        ctx.stroke();
-        ctx.setLineDash([]);
-        ctx.fillStyle = "rgba(255,152,0,0.7)";
-        ctx.fillText(label, profileRight + 4, y - 2);
-      }
-      // POC line + label
-      if (poc != null) {
-        const y = Math.round(priceScale.priceToY(poc)) + 0.5;
-        ctx.strokeStyle = "rgba(255,152,0,0.7)";
-        ctx.lineWidth = 1.5;
-        ctx.setLineDash([]);
-        ctx.beginPath();
-        ctx.moveTo(barLeft, y);
-        ctx.lineTo(profileRight + 20, y);
-        ctx.stroke();
-        ctx.fillStyle = "rgba(255,152,0,0.9)";
-        ctx.font = "bold 10px sans-serif";
-        ctx.fillText("POC", profileRight + 4, y - 2);
       }
       ctx.restore();
     },

--- a/packages/core/src/indicators/indicator-meta.ts
+++ b/packages/core/src/indicators/indicator-meta.ts
@@ -451,11 +451,6 @@ export const CVD_SIGNAL_META: SeriesMeta = {
   overlay: false,
   label: "CVD Signal",
 };
-export const MARKET_PROFILE_META: SeriesMeta = {
-  kind: "marketProfile",
-  overlay: true,
-  label: "Market Profile",
-};
 
 // ============================================
 // Additional Momentum

--- a/packages/core/src/streaming/indicator-presets.ts
+++ b/packages/core/src/streaming/indicator-presets.ts
@@ -77,7 +77,6 @@ import {
   liquiditySweep,
   lowest,
   macd,
-  marketProfile,
   massIndex,
   mcginleyDynamic,
   medianPrice,
@@ -139,7 +138,6 @@ import {
   HEIKIN_ASHI_META,
   LINEAR_REG_META,
   LIQUIDITY_SWEEP_META,
-  MARKET_PROFILE_META,
   ORDER_BLOCK_META,
   SESSION_BREAKOUT_META,
   SLOW_STOCH_META,
@@ -1746,33 +1744,6 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
       },
     ],
   },
-  marketProfile: {
-    meta: MARKET_PROFILE_META,
-    defaultParams: { tickSize: 0, sessionResetPeriod: 0 },
-    snapshotName: "mktProfile",
-    compute: (c, p) => {
-      const reset = (p.sessionResetPeriod as number) ?? 0;
-      return marketProfile(c, {
-        tickSize: (p.tickSize as number) ?? 0,
-        sessionResetPeriod: reset > 0 ? reset : c.length + 1,
-      });
-    },
-    category: "Volume",
-    name: "Market Profile",
-    description: "TPO-based profile showing POC, value area high/low.",
-    paramSchema: [
-      {
-        key: "sessionResetPeriod",
-        label: "Reset Bars",
-        type: "number",
-        default: 0,
-        min: 0,
-        max: 500,
-        step: 10,
-      },
-    ],
-  },
-
   // ============================================
   // Additional Momentum
   // ============================================


### PR DESCRIPTION
## Summary

Round of chart plugin polish discovered while reviewing `indicator-showcase` plugin correctness. Five focused fixes on the branch:

- **Plugin visibility** — Regime Heatmap alpha `0.06-0.18 → 0.15-0.40`, Session Zones alpha `0.06 → 0.18`. Both were near-invisible at the old alpha
- **Intraday timeframe toggle in showcase** — Adds a Daily ⇄ 1H switch backed by a deterministic 14-day synthetic 1-hour dataset (`data-intraday.ts`). Session Zones and Regime Heatmap can now be demo'd on data where they actually trigger
- **Session Zones label declutter** — Shorten to `Asia / LON / NY / Close` and drop overlapping labels. Density now scales with zoom instead of piling up at the top edge
- **Market Profile moved from preset to plugin** (**breaking**, pre-publish) — `marketProfile` returned `{poc, vah, val, profile: Map}` per bar but was shoehorned into `indicatorPresets` via a one-off `seriesType: "heatmap"` rule + a dedicated renderer that only ever read the last visible bar. That is the Volume Profile plugin contract. New `connectMarketProfile` / `createMarketProfile` in `@trendcraft/chart`. Core's `marketProfile()` function is unchanged
- **S/R Confluence flicker fix** — Bands and "S\<n\>" labels were drawn between `timeScale.indexToX(startIndex..endIndex)`, making both the right edge and labels jitter on every pan/zoom. Pinned both to `pane.x` / `pane.x + pane.width`
- **SMC Layer description** — Clarified as a quick-bundle shortcut so users aren't surprised when toggling individual SMC presets (`orderBlock` / `fvg` / `liquiditySweep`) duplicates the rendering

## Breaking changes

- `indicatorPresets.marketProfile` is removed. Users who mounted it through `connectIndicators` must switch to `connectMarketProfile`. `@trendcraft/chart` is not yet on npm, so no migration window is needed

## Test plan

- [x] `pnpm test` — 5322 passed (core 4719 + chart 603)
- [x] `pnpm lint` — clean
- [x] `pnpm build` (core + chart)
- [x] `pnpm size-check` — main 28.84 kB, headless 8.22 kB, React 24.49 kB, Vue 24.8 kB (all under limits)
- [x] Visual verification in `indicator-showcase`: all 8 plugins render correctly on both Daily and 1H; S/R labels are stable under pan/zoom; Session Zones shows 4 distinct kill zones on 1H

## Commits

- `d05e31e` plugin visibility + intraday timeframe toggle
- `d1533f8` session zones label declutter
- `ba2da16` Market Profile preset → plugin refactor
- `b120e6e` SMC Layer description
- `1dd796e` S/R Confluence pane-anchored bands/labels