### PR TITLE
Showcase Signals panel + multi-instance sidebar + chart polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ pnpm size-check   # Check bundle size limits (esbuild, brotli-compressed)
 - All indicators return `Series<T>` type (`{ time: number, value: T }[]`)
 - Uses Wilder's smoothing method (RSI, ATR, etc.)
 - Functions should have JSDoc comments with @example
-- `@trendcraft/chart`: Bundle size limits enforced via `size-limit` + `@size-limit/esbuild` (brotli-compressed). Main ≤ 31 kB, Headless ≤ 11 kB, React/Vue ≤ 27 kB. Zero runtime dependencies; `trendcraft`, `react`, `vue` are optional peer deps
+- `@trendcraft/chart`: Bundle size limits enforced via `size-limit` + `@size-limit/esbuild` (brotli-compressed). Main ≤ 32 kB, Headless ≤ 11 kB, React/Vue ≤ 27 kB. Zero runtime dependencies; `trendcraft`, `react`, `vue` are optional peer deps
 
 ## Testing & Validation
 

--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -24,9 +24,10 @@ Draft for the initial public release. Date and final version are set at release 
 - `createAndrewsPitchfork` / `connectAndrewsPitchfork` — primitive plugin that renders the three parallel pitchfork lines from three swing anchors (P0 + P1 + P2). Extends forward indefinitely across the visible range.
 - `connectSmcLayer` now accepts an optional `choch` source alongside `bos`. Both use the same per-bar shape but render with separate labels ("BOS" vs "CHoCH"), so you can feed `breakOfStructure()` and `changeOfCharacter()` simultaneously to distinguish structural breaks from trend-reversing ones.
 - `createVolumeProfile` / `connectVolumeProfile` — primitive plugin that renders a horizontal volume-by-price histogram along the right edge of the chart, with separate fills for the Value Area and a dashed POC line spanning the pane. Configurable strip width (fractional or pixel), highlight toggle, and color overrides.
+- `createSqueezeDots` / `connectSqueezeDots` — primitive plugin that renders TTM-style squeeze dots along the bottom of the price pane: red dot per active-squeeze bar, green dot at each release. Consumes `bollingerSqueeze()` output (or any compatible `{ time }`-keyed signal list).
 - SSR safety: headless exports work without a DOM; DOM exports throw a clear error in non-browser environments.
 - ARIA accessibility support via `ChartAria`.
-- Bundle size limits enforced via `size-limit` (brotli): main ≤ 31 kB, headless ≤ 11 kB, React ≤ 27 kB, Vue ≤ 27 kB.
+- Bundle size limits enforced via `size-limit` (brotli): main ≤ 32 kB, headless ≤ 11 kB, React ≤ 27 kB, Vue ≤ 27 kB.
 
 ### Changed
 

--- a/packages/chart/examples/indicator-showcase/src/main.ts
+++ b/packages/chart/examples/indicator-showcase/src/main.ts
@@ -20,6 +20,7 @@ import { generateIntradayCandles } from "./data-intraday";
 import { type PluginsPanelHandle, createPluginsPanel } from "./plugins-panel";
 import type { SidebarEntry } from "./sidebar";
 import { createSidebar } from "./sidebar";
+import { type SignalsPanelHandle, createSignalsPanel } from "./signals-panel";
 
 type Timeframe = "daily" | "intraday";
 
@@ -61,6 +62,7 @@ let currentTimeframe: Timeframe = "daily";
 let currentCandles: NormalizedCandle[] = dailyCandles;
 let conn: IndicatorConnection;
 let pluginsPanel: PluginsPanelHandle;
+let signalsPanel: SignalsPanelHandle;
 
 function mount(timeframe: Timeframe): void {
   currentTimeframe = timeframe;
@@ -74,27 +76,53 @@ function mount(timeframe: Timeframe): void {
   // appended below it.
   sidebarEl.innerHTML = "";
 
-  createSidebar(sidebarEl, catalog, {
+  const sidebarAPI = createSidebar(sidebarEl, catalog, {
     onToggle(id, active, params) {
       if (active) {
         const finalParams = resolveParams(id, params);
-        conn.add(id, finalParams);
+        // Force the primary's snapshotName = presetId so editing params
+        // later removes just this instance (not every SMA, etc.).
+        conn.add(id, { ...finalParams, snapshotName: id });
       } else {
         conn.remove(id);
       }
     },
     onParamChange(id, params) {
+      // Preserve the current color across the remove+add round-trip so
+      // editing a period in the active-bar pill doesn't re-roll the palette
+      // and hand the same instance a different color mid-session.
+      const oldColor = conn.get(id)?.color;
       conn.remove(id);
       const finalParams = resolveParams(id, params);
-      conn.add(id, finalParams);
+      const overrides: Record<string, unknown> = { ...finalParams, snapshotName: id };
+      if (oldColor) overrides.series = { color: oldColor };
+      conn.add(id, overrides);
+    },
+    onAddExtra({ presetId, snapshotName, params }) {
+      const finalParams = resolveParams(presetId, params);
+      conn.add(presetId, { ...finalParams, snapshotName });
+    },
+    onRemoveExtra(snapshotName) {
+      conn.remove(snapshotName);
+    },
+    onChangeExtraParams({ presetId, snapshotName, params }) {
+      const oldColor = conn.get(snapshotName)?.color;
+      conn.remove(snapshotName);
+      const finalParams = resolveParams(presetId, params);
+      const overrides: Record<string, unknown> = { ...finalParams, snapshotName };
+      if (oldColor) overrides.series = { color: oldColor };
+      conn.add(presetId, overrides);
     },
   });
 
-  pluginsPanel = createPluginsPanel(sidebarEl, currentCandles, chart);
+  const scrollSlot = sidebarAPI.getScrollSlot();
+  pluginsPanel = createPluginsPanel(scrollSlot, currentCandles, chart);
+  signalsPanel = createSignalsPanel(scrollSlot, currentCandles, chart);
   chart.fitContent();
 }
 
 function unmount(): void {
+  signalsPanel?.destroy();
   pluginsPanel?.destroy();
   conn?.disconnect();
 }

--- a/packages/chart/examples/indicator-showcase/src/sidebar.ts
+++ b/packages/chart/examples/indicator-showcase/src/sidebar.ts
@@ -2,6 +2,14 @@
  * Sidebar UI Component
  *
  * Renders a categorized, searchable indicator panel with parameter controls.
+ *
+ * Multi-instance support:
+ * - Primary instance: created by row click. Its snapshotName matches the
+ *   preset's own default (e.g. `"sma20"`). Toggles on/off like before.
+ * - Extra instances: created via the "+" button next to each row. Each extra
+ *   gets an auto-generated snapshotName (`${presetId}#${n}`) so the chart can
+ *   hold SMA(5) and SMA(25) simultaneously. Extras are removed via their own
+ *   pill in the active bar (independent lifecycle from the primary).
  */
 
 import type { IndicatorCategory, ParamSchema } from "trendcraft";
@@ -31,13 +39,31 @@ const CATEGORIES: IndicatorCategory[] = [
   "Wyckoff",
 ];
 
+/** Params change for the primary instance (no explicit snapshotName). */
+type ExtraInstance = {
+  presetId: string;
+  snapshotName: string;
+  params: Record<string, unknown>;
+};
+
 export type SidebarCallbacks = {
+  /** Toggle the primary (default-snapshotName) instance for this preset. */
   onToggle: (id: string, active: boolean, params: Record<string, unknown>) => void;
+  /** Change params for the primary instance (only fires if active). */
   onParamChange: (id: string, params: Record<string, unknown>) => void;
+  /** Add an extra instance with an explicit snapshotName. */
+  onAddExtra: (extra: ExtraInstance) => void;
+  /** Remove an extra instance by its snapshotName. */
+  onRemoveExtra: (snapshotName: string) => void;
+  /** Change params of an extra instance by its snapshotName. */
+  onChangeExtraParams: (extra: ExtraInstance) => void;
 };
 
 export type SidebarAPI = {
   updateActive: (activeIds: Set<string>) => void;
+  /** Element that auxiliary panels (plugins, signals) should be appended into
+   * so they share the sidebar's single scroll viewport. */
+  getScrollSlot: () => HTMLElement;
 };
 
 export function createSidebar(
@@ -48,6 +74,8 @@ export function createSidebar(
   const activeIds = new Set<string>();
   const expandedParams = new Set<string>();
   const currentParams = new Map<string, Record<string, unknown>>();
+  const extraInstances = new Map<string, ExtraInstance>();
+  const extraCounters = new Map<string, number>();
 
   // Initialize default params
   for (const entry of catalog) {
@@ -95,15 +123,22 @@ export function createSidebar(
   searchBox.appendChild(searchInput);
   container.appendChild(searchBox);
 
-  // Scrollable list
+  // Scroll wrapper: contains the indicator list AND any panels appended by
+  // the caller (plugins / signals). main.ts appends those panels to this
+  // wrapper via `getScrollSlot()` so the three share one scroll context and
+  // the active bar below can stay pinned.
+  const scrollSlot = document.createElement("div");
+  scrollSlot.dataset.role = "sidebar-scroll";
+  scrollSlot.style.cssText = "flex:1 1 auto;overflow-y:auto;overflow-x:hidden;";
+  container.appendChild(scrollSlot);
   const listEl = document.createElement("div");
-  listEl.style.cssText = "flex:1;overflow-y:auto;overflow-x:hidden;";
-  container.appendChild(listEl);
+  listEl.style.cssText = "flex:0 0 auto;";
+  scrollSlot.appendChild(listEl);
 
-  // Active bar (bottom)
+  // Active bar — pinned at the bottom of the sidebar (outside the scroll area)
   const activeBar = document.createElement("div");
   activeBar.style.cssText =
-    "padding:8px 12px;border-top:1px solid #2a2e39;flex-shrink:0;display:flex;flex-wrap:wrap;gap:4px;align-items:center;min-height:36px;";
+    "padding:8px 12px;border-top:1px solid #2a2e39;flex-shrink:0;display:flex;flex-wrap:wrap;gap:4px;align-items:center;min-height:36px;background:#131722;";
   container.appendChild(activeBar);
 
   function matchesSearch(entry: SidebarEntry): boolean {
@@ -119,6 +154,44 @@ export function createSidebar(
 
   function getParams(id: string): Record<string, unknown> {
     return { ...(currentParams.get(id) ?? {}) };
+  }
+
+  function nextExtraKey(presetId: string): string {
+    const n = (extraCounters.get(presetId) ?? 1) + 1;
+    extraCounters.set(presetId, n);
+    return `${presetId}#${n}`;
+  }
+
+  /**
+   * When the user clicks "+" repeatedly without editing params, we'd end up
+   * with identical overlapping instances. Auto-bump the first numeric param
+   * until the resulting param tuple doesn't collide with any existing
+   * instance (primary or extra) for this preset.
+   */
+  function differentiateParams(
+    entry: SidebarEntry,
+    params: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const used: string[] = [];
+    if (activeIds.has(entry.id)) used.push(JSON.stringify(getParams(entry.id)));
+    for (const ex of extraInstances.values()) {
+      if (ex.presetId === entry.id) used.push(JSON.stringify(ex.params));
+    }
+    const firstNumericKey = entry.params.find((p) => typeof p.default === "number")?.key;
+    if (!firstNumericKey) return params;
+
+    const result = { ...params };
+    const schema = entry.params.find((p) => p.key === firstNumericKey);
+    const step = typeof schema?.step === "number" ? schema.step : 1;
+    const max = typeof schema?.max === "number" ? schema.max : Number.POSITIVE_INFINITY;
+    for (let i = 0; i < 50; i++) {
+      if (!used.includes(JSON.stringify(result))) return result;
+      const cur = Number(result[firstNumericKey] ?? 0);
+      const next = cur + Math.max(step, Math.round(cur * 0.5));
+      if (next > max) break;
+      result[firstNumericKey] = next;
+    }
+    return result;
   }
 
   function renderList() {
@@ -213,6 +286,33 @@ export function createSidebar(
           row.appendChild(badge);
         }
 
+        // "+" button: add another instance with current form params
+        if (hasParams) {
+          const addBtn = document.createElement("span");
+          addBtn.style.cssText =
+            "font-size:14px;color:#787b86;flex-shrink:0;padding:2px 6px;border:1px solid #2a2e39;border-radius:4px;line-height:1;";
+          addBtn.textContent = "+";
+          addBtn.title = "Add another instance with the current parameters";
+          addBtn.addEventListener("mouseenter", () => {
+            addBtn.style.color = "#2196F3";
+            addBtn.style.borderColor = "#2196F3";
+          });
+          addBtn.addEventListener("mouseleave", () => {
+            addBtn.style.color = "#787b86";
+            addBtn.style.borderColor = "#2a2e39";
+          });
+          addBtn.addEventListener("click", (e) => {
+            e.stopPropagation();
+            const params = differentiateParams(entry, getParams(entry.id));
+            const snapshotName = nextExtraKey(entry.id);
+            const extra: ExtraInstance = { presetId: entry.id, snapshotName, params };
+            extraInstances.set(snapshotName, extra);
+            callbacks.onAddExtra(extra);
+            renderActiveBar();
+          });
+          row.appendChild(addBtn);
+        }
+
         // Params expand button
         if (hasParams) {
           const expandBtn = document.createElement("span");
@@ -303,9 +403,104 @@ export function createSidebar(
     return input;
   }
 
+  /**
+   * Render an active-indicator pill. The shortName prefix is static; the
+   * first numeric param is editable inline — click the number to turn it
+   * into an input, then press Enter or blur to apply via `onEditNumeric`.
+   * The × on the right removes the instance.
+   */
+  function makePill(
+    shortName: string,
+    currentParams: Record<string, unknown>,
+    editableKey: string | null,
+    onEditNumeric: (newValue: number) => void,
+    onRemove: () => void,
+  ): HTMLSpanElement {
+    const pill = document.createElement("span");
+    pill.style.cssText =
+      "display:inline-flex;align-items:center;gap:4px;padding:2px 4px 2px 8px;background:#1a2332;border:1px solid #2196F3;border-radius:12px;font-size:11px;color:#2196F3;white-space:nowrap;";
+
+    const prefix = document.createElement("span");
+    prefix.textContent = shortName;
+    pill.appendChild(prefix);
+
+    if (editableKey !== null) {
+      const open = document.createElement("span");
+      open.textContent = "(";
+      pill.appendChild(open);
+
+      const numericEl = document.createElement("span");
+      numericEl.textContent = String(currentParams[editableKey] ?? "");
+      numericEl.title = "Click to edit";
+      numericEl.style.cssText =
+        "cursor:text;padding:0 2px;border-radius:2px;background:rgba(33,150,243,0.12);";
+      numericEl.addEventListener("click", (e) => {
+        e.stopPropagation();
+        // Swap span → input for inline editing
+        const input = document.createElement("input");
+        input.type = "number";
+        input.value = numericEl.textContent ?? "";
+        input.style.cssText =
+          "width:40px;padding:0 2px;background:#0f1421;border:1px solid #2196F3;border-radius:2px;color:#2196F3;font-size:11px;text-align:center;outline:none;";
+        numericEl.replaceWith(input);
+        input.focus();
+        input.select();
+        const commit = () => {
+          const v = Number.parseFloat(input.value);
+          if (!Number.isNaN(v)) onEditNumeric(v);
+          else renderActiveBar();
+        };
+        input.addEventListener("blur", commit);
+        input.addEventListener("keydown", (ev) => {
+          if (ev.key === "Enter") input.blur();
+          else if (ev.key === "Escape") {
+            input.value = numericEl.textContent ?? "";
+            renderActiveBar();
+          }
+        });
+      });
+      pill.appendChild(numericEl);
+
+      const close = document.createElement("span");
+      close.textContent = ")";
+      pill.appendChild(close);
+    } else {
+      const summary = paramsSummaryRaw(currentParams);
+      if (summary) {
+        const s = document.createElement("span");
+        s.textContent = summary;
+        pill.appendChild(s);
+      }
+    }
+
+    const removeBtn = document.createElement("span");
+    removeBtn.textContent = "\u00D7";
+    removeBtn.style.cssText =
+      "font-size:14px;line-height:1;opacity:0.7;cursor:pointer;padding:0 4px;margin-left:2px;";
+    removeBtn.addEventListener("mouseenter", () => {
+      removeBtn.style.opacity = "1";
+    });
+    removeBtn.addEventListener("mouseleave", () => {
+      removeBtn.style.opacity = "0.7";
+    });
+    removeBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      onRemove();
+    });
+    pill.appendChild(removeBtn);
+
+    return pill;
+  }
+
+  function paramsSummaryRaw(params: Record<string, unknown>): string {
+    const vals = Object.values(params);
+    if (vals.length === 0) return "";
+    return `(${vals.join(", ")})`;
+  }
+
   function renderActiveBar() {
     activeBar.innerHTML = "";
-    if (activeIds.size === 0) {
+    if (activeIds.size === 0 && extraInstances.size === 0) {
       const hint = document.createElement("span");
       hint.style.cssText = "font-size:11px;color:#787b86;";
       hint.textContent = "Click an indicator to add it to the chart";
@@ -313,42 +508,59 @@ export function createSidebar(
       return;
     }
 
+    // Primary instances first
     for (const id of activeIds) {
       const entry = catalog.find((e) => e.id === id);
       if (!entry) continue;
-
-      const pill = document.createElement("span");
-      pill.style.cssText =
-        "display:inline-flex;align-items:center;gap:4px;padding:2px 8px;background:#1a2332;border:1px solid #2196F3;border-radius:12px;font-size:11px;color:#2196F3;cursor:pointer;white-space:nowrap;";
-
-      const pillLabel = document.createElement("span");
-      pillLabel.textContent = entry.shortName;
-      pill.appendChild(pillLabel);
-
-      const removeBtn = document.createElement("span");
-      removeBtn.textContent = "\u00D7";
-      removeBtn.style.cssText = "font-size:14px;line-height:1;opacity:0.7;";
-      removeBtn.addEventListener("mouseenter", () => {
-        removeBtn.style.opacity = "1";
-      });
-      removeBtn.addEventListener("mouseleave", () => {
-        removeBtn.style.opacity = "0.7";
-      });
-      pill.appendChild(removeBtn);
-
-      pill.addEventListener("click", () => {
-        activeIds.delete(id);
-        callbacks.onToggle(id, false, getParams(id));
-        renderList();
-        renderActiveBar();
-      });
-
+      const editKey = entry.params.find((p) => typeof p.default === "number")?.key ?? null;
+      const pill = makePill(
+        entry.shortName,
+        getParams(id),
+        editKey,
+        (newVal) => {
+          const paramMap = currentParams.get(id);
+          if (paramMap && editKey) paramMap[editKey] = newVal;
+          callbacks.onParamChange(id, getParams(id));
+          renderList();
+          renderActiveBar();
+        },
+        () => {
+          activeIds.delete(id);
+          callbacks.onToggle(id, false, getParams(id));
+          renderList();
+          renderActiveBar();
+        },
+      );
       activeBar.appendChild(pill);
     }
 
+    // Extra instances
+    for (const extra of extraInstances.values()) {
+      const entry = catalog.find((e) => e.id === extra.presetId);
+      if (!entry) continue;
+      const editKey = entry.params.find((p) => typeof p.default === "number")?.key ?? null;
+      const pill = makePill(
+        entry.shortName,
+        extra.params,
+        editKey,
+        (newVal) => {
+          if (editKey) extra.params = { ...extra.params, [editKey]: newVal };
+          callbacks.onChangeExtraParams(extra);
+          renderActiveBar();
+        },
+        () => {
+          extraInstances.delete(extra.snapshotName);
+          callbacks.onRemoveExtra(extra.snapshotName);
+          renderActiveBar();
+        },
+      );
+      activeBar.appendChild(pill);
+    }
+
+    const total = activeIds.size + extraInstances.size;
     const count = document.createElement("span");
     count.style.cssText = "font-size:11px;color:#787b86;margin-left:auto;";
-    count.textContent = `${activeIds.size} active`;
+    count.textContent = `${total} active`;
     activeBar.appendChild(count);
   }
 
@@ -372,6 +584,9 @@ export function createSidebar(
       for (const id of ids) activeIds.add(id);
       renderList();
       renderActiveBar();
+    },
+    getScrollSlot() {
+      return scrollSlot;
     },
   };
 }

--- a/packages/chart/examples/indicator-showcase/src/signals-panel.ts
+++ b/packages/chart/examples/indicator-showcase/src/signals-panel.ts
@@ -1,0 +1,609 @@
+/**
+ * Signals Panel — Toggle buttons for derived trading signals (crossovers,
+ * divergences, squeezes, price patterns) layered on top of the chart.
+ *
+ * Signals don't fit the `indicatorPresets` series-line model — they're sparse
+ * events with their own visual idiom (markers, connecting lines, background
+ * shading). Each entry computes signals from the current candles on toggle
+ * and registers a primitive plugin that paints them on the main pane.
+ *
+ * Visual conventions follow the standard chart-pattern idiom (zigzag connectors
+ * + neckline + measured-move target labels for price patterns; teal #26a69a /
+ * coral #ef5350 color-pair with shape never relying on color alone).
+ */
+
+import type { ChartInstance, PrimitiveRenderContext } from "@trendcraft/chart";
+import { connectSqueezeDots, definePrimitive } from "@trendcraft/chart";
+import type { NormalizedCandle, PatternSignal } from "trendcraft";
+import {
+  bollingerSqueeze,
+  deadCross,
+  doubleBottom,
+  doubleTop,
+  goldenCross,
+  headAndShoulders,
+  inverseHeadAndShoulders,
+  rsiDivergence,
+} from "trendcraft";
+
+type PluginHandle = { remove: () => void };
+
+type SignalSpec = {
+  id: string;
+  label: string;
+  description: string;
+  connect: (candles: NormalizedCandle[]) => PluginHandle | null;
+};
+
+export type SignalsPanelHandle = {
+  destroy(): void;
+};
+
+// ---- Color tokens -----------------------------------------------------------
+
+const BULL = "#26a69a";
+const BEAR = "#ef5350";
+const BULL_RGB = "38,166,154";
+const BEAR_RGB = "239,83,80";
+
+// ---- Render helpers ---------------------------------------------------------
+
+function clipToPane(ctx: CanvasRenderingContext2D, pane: PrimitiveRenderContext["pane"]): void {
+  ctx.beginPath();
+  ctx.rect(pane.x, pane.y, pane.width, pane.height);
+  ctx.clip();
+}
+
+function drawTriangle(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  size: number,
+  direction: "up" | "down",
+  fill: string,
+): void {
+  ctx.fillStyle = fill;
+  ctx.beginPath();
+  if (direction === "up") {
+    ctx.moveTo(x, y);
+    ctx.lineTo(x - size, y + size * 1.4);
+    ctx.lineTo(x + size, y + size * 1.4);
+  } else {
+    ctx.moveTo(x, y);
+    ctx.lineTo(x - size, y - size * 1.4);
+    ctx.lineTo(x + size, y - size * 1.4);
+  }
+  ctx.closePath();
+  ctx.fill();
+}
+
+/**
+ * Pill-shaped label with a small triangular tail pointing back toward (anchorX, anchorY).
+ * The pill itself is offset; the tail visually connects label → anchor.
+ */
+function drawAnchoredLabel(
+  ctx: CanvasRenderingContext2D,
+  anchorX: number,
+  anchorY: number,
+  text: string,
+  bg: string,
+  placement: "above" | "below",
+): void {
+  ctx.font = "11px system-ui, sans-serif";
+  const padX = 6;
+  const padY = 3;
+  const w = ctx.measureText(text).width + padX * 2;
+  const h = 18;
+  const gap = 12;
+  const labelY = placement === "above" ? anchorY - gap - h : anchorY + gap;
+  const labelX = anchorX - w / 2;
+  const r = 3;
+
+  ctx.fillStyle = bg;
+  ctx.beginPath();
+  ctx.moveTo(labelX + r, labelY);
+  ctx.lineTo(labelX + w - r, labelY);
+  ctx.quadraticCurveTo(labelX + w, labelY, labelX + w, labelY + r);
+  ctx.lineTo(labelX + w, labelY + h - r);
+  ctx.quadraticCurveTo(labelX + w, labelY + h, labelX + w - r, labelY + h);
+  ctx.lineTo(labelX + r, labelY + h);
+  ctx.quadraticCurveTo(labelX, labelY + h, labelX, labelY + h - r);
+  ctx.lineTo(labelX, labelY + r);
+  ctx.quadraticCurveTo(labelX, labelY, labelX + r, labelY);
+  ctx.closePath();
+  ctx.fill();
+
+  // Small tail
+  ctx.beginPath();
+  if (placement === "above") {
+    ctx.moveTo(anchorX - 4, labelY + h);
+    ctx.lineTo(anchorX + 4, labelY + h);
+    ctx.lineTo(anchorX, labelY + h + 4);
+  } else {
+    ctx.moveTo(anchorX - 4, labelY);
+    ctx.lineTo(anchorX + 4, labelY);
+    ctx.lineTo(anchorX, labelY - 4);
+  }
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = "#fff";
+  ctx.textBaseline = "middle";
+  ctx.textAlign = "center";
+  ctx.fillText(text, anchorX, labelY + h / 2);
+  ctx.textAlign = "start";
+}
+
+// ---- Signal: MA Cross (5/25) -----------------------------------------------
+
+type CrossEvent = { index: number; price: number; type: "golden" | "dead" };
+
+function makeMaCrossPlugin(candles: NormalizedCandle[]) {
+  const gc = goldenCross(candles);
+  const dc = deadCross(candles);
+  const events: CrossEvent[] = [];
+  for (let i = 0; i < candles.length; i++) {
+    if (gc[i]?.value) events.push({ index: i, price: candles[i].low, type: "golden" });
+    if (dc[i]?.value) events.push({ index: i, price: candles[i].high, type: "dead" });
+  }
+  if (events.length === 0) return null;
+
+  return definePrimitive<{ events: CrossEvent[] }>({
+    name: "showcase-ma-cross",
+    pane: "main",
+    zOrder: "above",
+    defaultState: { events },
+    render({ ctx, pane, timeScale, priceScale }, state) {
+      ctx.save();
+      clipToPane(ctx, pane);
+      const start = timeScale.startIndex;
+      const end = timeScale.endIndex;
+      for (const ev of state.events) {
+        if (ev.index < start || ev.index >= end) continue;
+        const x = timeScale.indexToX(ev.index);
+        const y = priceScale.priceToY(ev.price);
+        if (ev.type === "golden") {
+          drawTriangle(ctx, x, y + 6, 6, "up", BULL);
+        } else {
+          drawTriangle(ctx, x, y - 6, 6, "down", BEAR);
+        }
+      }
+      ctx.restore();
+    },
+  });
+}
+
+// ---- Signal: RSI Divergence (drawn on price pane) --------------------------
+
+/**
+ * Build a divergence-drawing primitive for either the price pane or the RSI
+ * sub-pane. The price pane uses `price.first`/`price.second`; the RSI pane
+ * uses `indicator.first`/`indicator.second`. Both anchor to the same swing
+ * indices so the two lines are visually mirrored.
+ */
+function makeDivergencePrimitive(
+  signals: ReturnType<typeof rsiDivergence>,
+  paneId: string,
+  name: string,
+  pickValue: (sig: (typeof signals)[number]) => { first: number; second: number },
+  withLabel: boolean,
+) {
+  return definePrimitive<{ signals: typeof signals }>({
+    name,
+    pane: paneId,
+    zOrder: "above",
+    defaultState: { signals },
+    render({ ctx, pane, timeScale, priceScale }, state) {
+      ctx.save();
+      clipToPane(ctx, pane);
+      const start = timeScale.startIndex;
+      const end = timeScale.endIndex;
+      for (const sig of state.signals) {
+        if (sig.secondIdx < start || sig.firstIdx >= end) continue;
+        const v = pickValue(sig);
+        const x1 = timeScale.indexToX(sig.firstIdx);
+        const x2 = timeScale.indexToX(sig.secondIdx);
+        const y1 = priceScale.priceToY(v.first);
+        const y2 = priceScale.priceToY(v.second);
+        const color = sig.type === "bullish" ? BULL : BEAR;
+        const rgb = sig.type === "bullish" ? BULL_RGB : BEAR_RGB;
+
+        ctx.save();
+        ctx.setLineDash([4, 3]);
+        ctx.strokeStyle = color;
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.moveTo(x1, y1);
+        ctx.lineTo(x2, y2);
+        ctx.stroke();
+        ctx.restore();
+
+        ctx.fillStyle = color;
+        ctx.beginPath();
+        ctx.arc(x1, y1, 3, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.beginPath();
+        ctx.arc(x2, y2, 3, 0, Math.PI * 2);
+        ctx.fill();
+
+        if (withLabel) {
+          const label = sig.type === "bullish" ? "Bull Div" : "Bear Div";
+          drawAnchoredLabel(
+            ctx,
+            x2,
+            y2,
+            label,
+            `rgba(${rgb},0.9)`,
+            sig.type === "bullish" ? "below" : "above",
+          );
+        }
+      }
+      ctx.restore();
+    },
+  });
+}
+
+/**
+ * Connect RSI divergence visualization. Always draws on the price pane (the
+ * label-bearing primitive). Additionally, if the user has enabled the default
+ * RSI(14) indicator, draws a mirrored connector on the RSI sub-pane — this is
+ * the TradingView-standard "both panes" rendering.
+ */
+function connectRsiDivergence(candles: NormalizedCandle[]): PluginHandle | null {
+  const signals = rsiDivergence(candles);
+  if (signals.length === 0) return null;
+
+  const pricePlugin = makeDivergencePrimitive(
+    signals,
+    "main",
+    "showcase-rsi-divergence-price",
+    (s) => s.price,
+    true,
+  );
+  chartRef.registerPrimitive(pricePlugin);
+
+  // Pane id for the default RSI(14) preset matches its snapshotName "rsi14"
+  // (see `helpers.ts:97` + `live-presets.ts` snapshotName fn). If no RSI is
+  // mounted the registered primitive is harmless — the chart simply has no
+  // such pane to render into.
+  const rsiPlugin = makeDivergencePrimitive(
+    signals,
+    "rsi14",
+    "showcase-rsi-divergence-rsi",
+    (s) => s.indicator,
+    false,
+  );
+  chartRef.registerPrimitive(rsiPlugin);
+
+  return {
+    remove: () => {
+      chartRef.removePrimitive(pricePlugin.name);
+      chartRef.removePrimitive(rsiPlugin.name);
+    },
+  };
+}
+
+// ---- Signal: Bollinger Squeeze (TTM-style dots via chart plugin) -----------
+
+// ---- Signal: Price Patterns (Double Top/Bottom + H&S) ----------------------
+//
+// The "山" idiom: connect each pattern's keyPoints with a continuous zigzag
+// line, draw the neckline as a dashed reference, shade the pattern body, and
+// label the salient anchors (e.g. "Bottom 1" / "Bottom 2" / "Target").
+
+type PatternRender = {
+  signal: PatternSignal;
+  bullish: boolean;
+};
+
+const ANCHOR_LABEL_MAP: Record<string, string> = {
+  "First Trough": "Bottom 1",
+  "Second Trough": "Bottom 2",
+  "First Peak": "Top 1",
+  "Second Peak": "Top 2",
+  "Left Shoulder": "L. Shoulder",
+  Head: "Head",
+  "Right Shoulder": "R. Shoulder",
+};
+
+function makePricePatternsPlugin(candles: NormalizedCandle[]) {
+  const all: PatternSignal[] = [
+    ...doubleBottom(candles),
+    ...doubleTop(candles),
+    ...inverseHeadAndShoulders(candles),
+    ...headAndShoulders(candles),
+  ];
+  if (all.length === 0) return null;
+
+  // Dedup overlapping detections by keeping the highest-confidence pattern in
+  // each [startTime, endTime] envelope. Filter low-confidence noise and cap
+  // the total so dense regions don't pile up overlays.
+  const MIN_CONFIDENCE = 60;
+  const MAX_PATTERNS = 8;
+  const sorted = all
+    .filter((s) => s.confidence >= MIN_CONFIDENCE)
+    .sort((a, b) => b.confidence - a.confidence);
+  const accepted: PatternSignal[] = [];
+  for (const sig of sorted) {
+    if (accepted.length >= MAX_PATTERNS) break;
+    const overlaps = accepted.some(
+      (acc) =>
+        sig.pattern.startTime <= acc.pattern.endTime &&
+        sig.pattern.endTime >= acc.pattern.startTime,
+    );
+    if (!overlaps) accepted.push(sig);
+  }
+  if (accepted.length === 0) return null;
+  const renders: PatternRender[] = accepted.map((signal) => ({
+    signal,
+    bullish: signal.type === "double_bottom" || signal.type === "inverse_head_shoulders",
+  }));
+
+  return definePrimitive<{ renders: PatternRender[] }>({
+    name: "showcase-price-patterns",
+    pane: "main",
+    zOrder: "above",
+    defaultState: { renders },
+    render({ ctx, pane, timeScale, priceScale }, state) {
+      ctx.save();
+      clipToPane(ctx, pane);
+      const start = timeScale.startIndex;
+      const end = timeScale.endIndex;
+
+      for (const { signal, bullish } of state.renders) {
+        const kps = signal.pattern.keyPoints;
+        if (kps.length === 0) continue;
+        if (kps[kps.length - 1].index < start || kps[0].index >= end) continue;
+
+        const color = bullish ? BULL : BEAR;
+        const rgb = bullish ? BULL_RGB : BEAR_RGB;
+
+        // Filter keyPoints that are actual price extremes (skip neckline
+        // intersection points which sit on the neckline, not on the swing).
+        const extremes = kps.filter(
+          (k) => k.label !== "Neckline Start" && k.label !== "Neckline End",
+        );
+
+        // Body shading (light fill under the zigzag, between min and max y)
+        const xs = extremes.map((k) => timeScale.indexToX(k.index));
+        const ys = extremes.map((k) => priceScale.priceToY(k.price));
+        const necklineY = signal.pattern.neckline
+          ? priceScale.priceToY(signal.pattern.neckline.currentPrice)
+          : null;
+
+        if (necklineY !== null && xs.length >= 2) {
+          ctx.fillStyle = `rgba(${rgb},0.08)`;
+          ctx.beginPath();
+          ctx.moveTo(xs[0], necklineY);
+          for (let i = 0; i < xs.length; i++) ctx.lineTo(xs[i], ys[i]);
+          ctx.lineTo(xs[xs.length - 1], necklineY);
+          ctx.closePath();
+          ctx.fill();
+        }
+
+        // Zigzag connector through the price extremes
+        ctx.strokeStyle = color;
+        ctx.lineWidth = 1.8;
+        ctx.beginPath();
+        for (let i = 0; i < xs.length; i++) {
+          if (i === 0) ctx.moveTo(xs[i], ys[i]);
+          else ctx.lineTo(xs[i], ys[i]);
+        }
+        ctx.stroke();
+
+        // Neckline (dashed, horizontal-ish)
+        if (signal.pattern.neckline && xs.length >= 2) {
+          const nl = signal.pattern.neckline;
+          const x1 = xs[0];
+          const x2 = xs[xs.length - 1];
+          // Approximate slope using start/end of neckline if available
+          const yNeckLeft = priceScale.priceToY(nl.startPrice);
+          const yNeckRight = priceScale.priceToY(nl.endPrice);
+          ctx.save();
+          ctx.setLineDash([5, 4]);
+          ctx.strokeStyle = `rgba(${rgb},0.85)`;
+          ctx.lineWidth = 1.5;
+          ctx.beginPath();
+          ctx.moveTo(x1, yNeckLeft);
+          ctx.lineTo(x2, yNeckRight);
+          ctx.stroke();
+          ctx.restore();
+        }
+
+        // Anchor labels at each notable extreme. Resolve horizontal collisions
+        // by stacking labels vertically when their x-positions are too close.
+        const labels: { x: number; y: number; text: string }[] = [];
+        for (const k of extremes) {
+          const mapped = ANCHOR_LABEL_MAP[k.label];
+          if (!mapped) continue;
+          labels.push({
+            x: timeScale.indexToX(k.index),
+            y: priceScale.priceToY(k.price),
+            text: mapped,
+          });
+        }
+        const placement = bullish ? "below" : "above";
+        const stackDir = bullish ? 1 : -1;
+        const STACK_GAP = 22;
+        const MIN_X_SEP = 60;
+        for (let i = 0; i < labels.length; i++) {
+          let stackLevel = 0;
+          for (let j = 0; j < i; j++) {
+            if (Math.abs(labels[i].x - labels[j].x) < MIN_X_SEP) stackLevel++;
+          }
+          drawAnchoredLabel(
+            ctx,
+            labels[i].x,
+            labels[i].y + stackLevel * STACK_GAP * stackDir,
+            labels[i].text,
+            `rgba(${rgb},0.92)`,
+            placement,
+          );
+        }
+
+        // Measured-move target — dashed projector + Target pill
+        if (signal.pattern.target != null && xs.length >= 1) {
+          const lastX = xs[xs.length - 1];
+          const targetY = priceScale.priceToY(signal.pattern.target);
+          const lastY = ys[ys.length - 1];
+          ctx.save();
+          ctx.setLineDash([3, 3]);
+          ctx.strokeStyle = `rgba(${rgb},0.9)`;
+          ctx.lineWidth = 1;
+          ctx.beginPath();
+          ctx.moveTo(lastX, lastY);
+          ctx.lineTo(lastX, targetY);
+          ctx.stroke();
+          ctx.restore();
+          drawAnchoredLabel(
+            ctx,
+            lastX,
+            targetY,
+            "Target",
+            `rgba(${rgb},0.92)`,
+            bullish ? "above" : "below",
+          );
+        }
+      }
+      ctx.restore();
+    },
+  });
+}
+
+// ---- Specs ------------------------------------------------------------------
+
+const SPECS: SignalSpec[] = [
+  {
+    id: "maCross",
+    label: "MA Cross (5/25)",
+    description: "Golden / Death cross of SMA(5) and SMA(25) — triangle markers",
+    connect: (candles) => {
+      const plugin = makeMaCrossPlugin(candles);
+      if (!plugin) return null;
+      chartRef.registerPrimitive(plugin);
+      return { remove: () => chartRef.removePrimitive(plugin.name) };
+    },
+  },
+  {
+    id: "rsiDivergence",
+    label: "RSI Divergence",
+    description: "Mirrored dashed connectors on price pane + RSI(14) sub-pane (enable RSI to see)",
+    connect: (candles) => connectRsiDivergence(candles),
+  },
+  {
+    id: "bbSqueeze",
+    label: "Bollinger Squeeze",
+    description: "TTM-style dots along the pane bottom — red = active squeeze, green = release",
+    connect: (candles) => {
+      const sigs = bollingerSqueeze(candles, { threshold: 10 });
+      if (sigs.length === 0) return null;
+      return connectSqueezeDots(chartRef, sigs, candles);
+    },
+  },
+  {
+    id: "pricePatterns",
+    label: "Price Patterns",
+    description:
+      "Double Top/Bottom + Head & Shoulders rendered as zigzag + neckline + measured-move target",
+    connect: (candles) => {
+      const plugin = makePricePatternsPlugin(candles);
+      if (!plugin) return null;
+      chartRef.registerPrimitive(plugin);
+      return { remove: () => chartRef.removePrimitive(plugin.name) };
+    },
+  },
+];
+
+let chartRef: ChartInstance = null as unknown as ChartInstance;
+
+export function createSignalsPanel(
+  container: HTMLElement,
+  candles: NormalizedCandle[],
+  chart: ChartInstance,
+): SignalsPanelHandle {
+  chartRef = chart;
+  const active = new Map<string, PluginHandle>();
+  const panelRoot = document.createElement("div");
+  panelRoot.dataset.role = "signals-panel";
+  container.appendChild(panelRoot);
+
+  const header = document.createElement("div");
+  header.style.cssText =
+    "padding:10px 12px;background:#181c27;border-top:1px solid #2a2e39;border-bottom:1px solid #1e222d;font-weight:600;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;";
+  header.textContent = "\u25BC Signals";
+  panelRoot.appendChild(header);
+
+  for (const spec of SPECS) {
+    const row = document.createElement("div");
+    row.style.cssText =
+      "padding:8px 12px 8px 24px;cursor:pointer;border-bottom:1px solid #1e222d;display:flex;align-items:flex-start;gap:10px;user-select:none;";
+
+    const checkbox = document.createElement("div");
+    checkbox.style.cssText =
+      "width:14px;height:14px;border:1px solid #4a4e59;border-radius:3px;margin-top:2px;flex-shrink:0;";
+
+    const text = document.createElement("div");
+    text.style.cssText = "flex:1;min-width:0;";
+    const title = document.createElement("div");
+    title.textContent = spec.label;
+    title.style.cssText = "font-weight:500;";
+    const desc = document.createElement("div");
+    desc.textContent = spec.description;
+    desc.style.cssText = "font-size:11px;color:#787b86;margin-top:2px;";
+    text.appendChild(title);
+    text.appendChild(desc);
+
+    row.appendChild(checkbox);
+    row.appendChild(text);
+    panelRoot.appendChild(row);
+
+    const applyActive = (isActive: boolean) => {
+      if (isActive) {
+        checkbox.style.background = "#2196F3";
+        checkbox.style.borderColor = "#2196F3";
+        row.style.background = "#1e2530";
+      } else {
+        checkbox.style.background = "transparent";
+        checkbox.style.borderColor = "#4a4e59";
+        row.style.background = "transparent";
+      }
+    };
+
+    const flashEmpty = () => {
+      const original = desc.textContent;
+      const originalColor = desc.style.color;
+      desc.textContent = "No events detected on the current dataset";
+      desc.style.color = "#ef5350";
+      setTimeout(() => {
+        desc.textContent = original;
+        desc.style.color = originalColor;
+      }, 1800);
+    };
+
+    row.addEventListener("click", () => {
+      const existing = active.get(spec.id);
+      if (existing) {
+        existing.remove();
+        active.delete(spec.id);
+        applyActive(false);
+      } else {
+        const handle = spec.connect(candles);
+        if (!handle) {
+          console.warn(`Signal ${spec.id} produced no events for the current dataset`);
+          flashEmpty();
+          return;
+        }
+        active.set(spec.id, handle);
+        applyActive(true);
+      }
+    });
+  }
+
+  return {
+    destroy() {
+      for (const h of active.values()) h.remove();
+      active.clear();
+      panelRoot.remove();
+    },
+  };
+}

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -99,7 +99,7 @@
     {
       "name": "Main (createChart + all exports)",
       "path": "dist/index.js",
-      "limit": "31 kB"
+      "limit": "32 kB"
     },
     {
       "name": "Headless API",

--- a/packages/chart/src/__tests__/squeeze-dots.test.ts
+++ b/packages/chart/src/__tests__/squeeze-dots.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PrimitiveRenderContext } from "../core/plugin-types";
+import type { PriceScale, TimeScale } from "../core/scale";
+import type { PaneRect, ThemeColors } from "../core/types";
+import { createSqueezeDots } from "../plugins/squeeze-dots";
+
+function mockCtx() {
+  return {
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    rect: vi.fn(),
+    clip: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    arc: vi.fn(),
+    fillRect: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    setLineDash: vi.fn(),
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 1,
+  } as unknown as CanvasRenderingContext2D;
+}
+
+const mockTimeScale = {
+  startIndex: 0,
+  endIndex: 50,
+  barSpacing: 8,
+  indexToX: (i: number) => i * 8 + 4,
+} as TimeScale;
+
+const mockPriceScale = { priceToY: (p: number) => 400 - p * 2 } as PriceScale;
+
+const mockPane = { id: "main", x: 0, y: 0, width: 800, height: 400 } as PaneRect;
+const mockTheme = { text: "#fff", textSecondary: "#888" } as ThemeColors;
+
+function makeCtx(ctx: CanvasRenderingContext2D): PrimitiveRenderContext {
+  return {
+    ctx,
+    pane: mockPane,
+    timeScale: mockTimeScale,
+    priceScale: mockPriceScale,
+    theme: mockTheme,
+  } as PrimitiveRenderContext;
+}
+
+const candles = Array.from({ length: 30 }, (_, i) => ({ time: 1000 + i }));
+
+describe("createSqueezeDots", () => {
+  it("returns a primitive plugin with correct identity", () => {
+    const plugin = createSqueezeDots([], candles);
+    expect(plugin.name).toBe("squeezeDots");
+    expect(plugin.pane).toBe("main");
+    expect(plugin.zOrder).toBe("above");
+  });
+
+  it("renders nothing when no signals are present", () => {
+    const plugin = createSqueezeDots([], candles);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+    expect(ctx.fillRect).not.toHaveBeenCalled();
+  });
+
+  it("draws a dot for each squeeze bar plus a release dot after the run", () => {
+    const signals = [
+      { time: 1005, type: "squeeze" as const },
+      { time: 1006, type: "squeeze" as const },
+      { time: 1007, type: "squeeze" as const },
+    ];
+    const plugin = createSqueezeDots(signals, candles);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+    // 3 squeeze bars + 1 release bar at index 1008 = 4 fillRect calls
+    expect(ctx.fillRect).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not emit a release dot when the squeeze runs to the last candle", () => {
+    const lastIdx = candles.length - 1;
+    const signals = [{ time: candles[lastIdx].time, type: "squeeze" as const }];
+    const plugin = createSqueezeDots(signals, candles);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+    // 1 squeeze bar, no release bar
+    expect(ctx.fillRect).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects showRail option", () => {
+    const signals = [{ time: 1005, type: "squeeze" as const }];
+    const plugin = createSqueezeDots(signals, candles, { showRail: false });
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+    expect(ctx.setLineDash).not.toHaveBeenCalled();
+  });
+});

--- a/packages/chart/src/core/data-layer.ts
+++ b/packages/chart/src/core/data-layer.ts
@@ -173,6 +173,13 @@ export class DataLayer {
 
     const handle: SeriesHandle = {
       id,
+      // `internal.config` is mutated in-place by the chart after this handle
+      // is returned (notably by the palette-rotation pass in canvas-chart).
+      // Using a getter + closure keeps the handle in sync without snapshotting
+      // stale values.
+      get config() {
+        return internal.config;
+      },
       update: (point: DataPoint) => {
         const s = this._series.get(id);
         if (!s) return;

--- a/packages/chart/src/core/types.ts
+++ b/packages/chart/src/core/types.ts
@@ -211,6 +211,13 @@ export type SeriesConfig = {
   referenceLines?: number[];
   /** Per-channel colors for multi-channel series (e.g., { upper: "#2196F3", lower: "#2196F3" } for bands) */
   channelColors?: Record<string, string>;
+  /**
+   * Palette hint used by the auto-color rotation when `color` is not set.
+   * Populated from an indicator preset's `color` field when it's an array.
+   * Each new series using this same palette instance picks the next entry
+   * (wrapping), so stacking e.g. multiple SMAs produces distinct colors.
+   */
+  colorPalette?: readonly string[];
 };
 
 // ============================================
@@ -220,6 +227,11 @@ export type SeriesConfig = {
 export type SeriesHandle = {
   /** Unique series id */
   readonly id: string;
+  /**
+   * Resolved series config (after preset defaults, palette rotation, and
+   * introspection). Useful for reading back the auto-assigned color.
+   */
+  readonly config: Readonly<SeriesConfig>;
   /** Push a single data point (streaming). Accepts scalar or compound values. */
   update(point: DataPoint<unknown>): void;
   /** Replace all data */

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -168,3 +168,8 @@ export {
   type MarketProfileSeries,
   type MarketProfileOptions,
 } from "./plugins/market-profile";
+export {
+  createSqueezeDots,
+  connectSqueezeDots,
+  type SqueezeDotsOptions,
+} from "./plugins/squeeze-dots";

--- a/packages/chart/src/integration/connect-indicators.ts
+++ b/packages/chart/src/integration/connect-indicators.ts
@@ -458,6 +458,7 @@ export function connectIndicators(
       snapshotName: handle.snapshotName,
       staticOnly: false,
       handle,
+      color: handle.color,
       removed: true,
     };
   }

--- a/packages/chart/src/integration/connect-indicators.ts
+++ b/packages/chart/src/integration/connect-indicators.ts
@@ -131,6 +131,13 @@ export type IndicatorHandle = {
   readonly presetId: string;
   /** Effective parameters (defaultParams merged with overrides) */
   readonly params: Readonly<Record<string, unknown>>;
+  /**
+   * The assigned line color (either explicit or palette-rotated). Useful for
+   * preserving an instance's color across a remove+add params-change cycle.
+   * `undefined` when the indicator uses `channelColors` (multi-channel series)
+   * or when no color has been resolved yet.
+   */
+  readonly color: string | undefined;
   /** Underlying chart series handle. Escape hatch for advanced use cases. */
   readonly series: SeriesHandle;
   /** True once this instance has been removed */
@@ -199,6 +206,8 @@ type ActiveEntry = {
   staticOnly: boolean;
   /** User-facing wrapper, lazily assigned after creation */
   handle: IndicatorHandle;
+  /** Snapshot of the resolved primary color at creation time */
+  color: string | undefined;
   removed: boolean;
 };
 
@@ -319,6 +328,9 @@ export function connectIndicators(
       get series() {
         return entry.series;
       },
+      get color() {
+        return entry.color;
+      },
       get removed() {
         return entry.removed;
       },
@@ -399,6 +411,7 @@ export function connectIndicators(
       snapshotName,
       staticOnly,
       handle: null as unknown as IndicatorHandle,
+      color: seriesHandle.config?.color,
       removed: false,
     };
     entry.handle = createHandle(entry);

--- a/packages/chart/src/integration/helpers.ts
+++ b/packages/chart/src/integration/helpers.ts
@@ -93,15 +93,22 @@ export function buildSeriesConfig(
   presetId?: string,
 ): SeriesConfig {
   const chartPreset = presetId ? INDICATOR_PRESETS.get(presetId) : undefined;
+  // preset.color may be a palette array. Split it so the chart's auto-color
+  // rotation (canvas-chart.addIndicator) can cycle through it per-series.
+  const presetColor = chartPreset?.color;
+  const presetPalette = Array.isArray(presetColor) ? presetColor : undefined;
+  const presetColorString = typeof presetColor === "string" ? presetColor : undefined;
   return {
     pane: overrides?.pane ?? (meta.overlay ? "main" : snapshotName),
-    color: overrides?.color ?? chartPreset?.color,
+    color: overrides?.color ?? presetColorString,
+    colorPalette: overrides?.color ? undefined : presetPalette,
     lineWidth: overrides?.lineWidth ?? chartPreset?.lineWidth,
-    // meta.label already carries any parameter suffix (e.g. "SMA(20)") because
-    // trendcraft's indicators emit a fully-formed label via withLabelParams.
-    // Use it directly; fall back to the legacy (period)-wrap only when meta
-    // was produced by older callers that didn't include the period.
-    label: overrides?.label ?? meta.label,
+    // Deliberately leave `label` undefined here: the chart's `introspect()`
+    // reads the data array's own `__meta.label` (set by `withLabelParams`),
+    // which already carries the parametric suffix (e.g. `"SMA(20)"`). If we
+    // passed `meta.label` from the static preset meta (`"SMA"`) it would win
+    // in the user-config precedence and erase the parametric suffix.
+    label: overrides?.label,
     yRange: overrides?.yRange ?? meta.yRange,
     referenceLines: overrides?.referenceLines ?? meta.referenceLines,
     type: overrides?.type,

--- a/packages/chart/src/integration/indicator-presets.ts
+++ b/packages/chart/src/integration/indicator-presets.ts
@@ -13,8 +13,17 @@ export type IndicatorPreset = {
   seriesType?: SeriesType;
   /** Default pane placement */
   pane?: "main" | "sub";
-  /** Primary color */
-  color?: string;
+  /**
+   * Primary color. Accepts either:
+   * - a single string → used as the fixed color for every instance of this
+   *   preset (appropriate for single-purpose indicators).
+   * - an array of colors → treated as a palette. The first instance uses
+   *   `color[0]`, the next `color[1]`, etc., wrapping at the array length.
+   *   Useful for catch-all presets (e.g. the `"number"` preset) so that
+   *   stacking multiple plain scalar indicators (SMA, RSI, ...) doesn't
+   *   collapse into one color.
+   */
+  color?: string | readonly string[];
   /** Line width */
   lineWidth?: number;
   /** Display label */
@@ -185,13 +194,29 @@ export const INDICATOR_PRESETS = new Map<string, IndicatorPreset>([
     },
   ],
 
-  // Simple number (RSI, CCI, ATR, etc.) — default for scalar series
+  // Simple number (RSI, CCI, ATR, etc.) — default for scalar series.
+  // `color` here is an array palette: the first instance of any scalar
+  // indicator picks #2196F3, the next #FF9800, and so on. Stacking multiple
+  // SMAs / RSIs produces distinct colors instead of collapsing into one.
   [
     "number",
     {
       pane: "sub",
       label: "Indicator",
-      color: "#2196F3",
+      color: [
+        "#2196F3",
+        "#FF9800",
+        "#26a69a",
+        "#ef5350",
+        "#9c27b0",
+        "#FF5722",
+        "#00bcd4",
+        "#8bc34a",
+        "#e91e63",
+        "#607d8b",
+        "#ffc107",
+        "#3f51b5",
+      ],
       lineWidth: 1.5,
     },
   ],

--- a/packages/chart/src/integration/series-introspector.ts
+++ b/packages/chart/src/integration/series-introspector.ts
@@ -78,12 +78,20 @@ export function introspect<T>(
   // Resolve label: user config > __meta > preset > rule name
   const label: string = userConfig?.label ?? meta?.label ?? preset?.label ?? rule?.name ?? "Series";
 
+  // Resolve color. preset.color may be a string (fixed) or an array (palette).
+  // A palette array flows through as `colorPalette`; the chart's auto-color
+  // rotation in canvas-chart picks the next entry per-palette.
+  const presetColor = preset?.color;
+  const presetPalette = Array.isArray(presetColor) ? presetColor : undefined;
+  const presetColorString = typeof presetColor === "string" ? presetColor : undefined;
+
   // Merge config (including channelColors from preset)
   const config: SeriesConfig = {
     pane,
     scaleId: userConfig?.scaleId,
     type: seriesType,
-    color: userConfig?.color ?? preset?.color,
+    color: userConfig?.color ?? presetColorString,
+    colorPalette: userConfig?.color ? undefined : presetPalette,
     lineWidth: userConfig?.lineWidth ?? preset?.lineWidth,
     label,
     visible: userConfig?.visible,

--- a/packages/chart/src/plugins/index.ts
+++ b/packages/chart/src/plugins/index.ts
@@ -8,3 +8,4 @@ export { createSrConfluence, connectSrConfluence } from "./sr-confluence";
 export { createTradeAnalysis, connectTradeAnalysis } from "./trade-analysis";
 export { createSessionZones, connectSessionZones } from "./session-zones";
 export { createMarketProfile, connectMarketProfile } from "./market-profile";
+export { createSqueezeDots, connectSqueezeDots, type SqueezeDotsOptions } from "./squeeze-dots";

--- a/packages/chart/src/plugins/squeeze-dots.ts
+++ b/packages/chart/src/plugins/squeeze-dots.ts
@@ -1,0 +1,203 @@
+/**
+ * Squeeze Dots Plugin — Visualizes Bollinger squeeze events as a horizontal
+ * row of dots at the bottom of the price pane, modeled after the TTM Squeeze
+ * convention (Carter): red dot on bars where volatility is in the lowest
+ * percentile (squeeze active), green dot on the bar where the squeeze
+ * releases.
+ *
+ * The dots ride along a faint guide rail near the pane's bottom edge so they
+ * never collide with candles.
+ *
+ * @example
+ * ```typescript
+ * import { createChart, connectSqueezeDots } from '@trendcraft/chart';
+ * import { bollingerSqueeze } from 'trendcraft';
+ *
+ * const chart = createChart(el);
+ * chart.setCandles(candles);
+ * const signals = bollingerSqueeze(candles);
+ * const handle = connectSqueezeDots(chart, signals, candles);
+ * // Later: handle.remove();
+ * ```
+ */
+
+import { definePrimitive } from "../core/plugin-types";
+import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
+import type { ChartInstance } from "../core/types";
+
+// ---- Types (duck-typed; no core dependency) ----
+
+type SqueezeSignal = {
+  time: number;
+  type: "squeeze";
+  bandwidth?: number;
+  percentile?: number;
+};
+
+type CandleRef = { time: number };
+
+export type SqueezeDotsOptions = {
+  /** Color for active-squeeze dots (rgba components, e.g. "239,83,80") */
+  squeezeColor?: string;
+  /** Color for release dots (rgba components) */
+  releaseColor?: string;
+  /** Dot radius in pixels */
+  radius?: number;
+  /** Vertical offset from the pane's bottom edge */
+  offsetFromBottom?: number;
+  /** Whether to draw the faint guide rail */
+  showRail?: boolean;
+};
+
+type SqueezeDotsState = {
+  /** Sorted, unique candle indices where squeeze is active */
+  squeezeIndices: readonly number[];
+  /** Indices where the squeeze has just released (squeeze→no-squeeze transition) */
+  releaseIndices: readonly number[];
+  options: Required<SqueezeDotsOptions>;
+};
+
+// ---- Defaults ----
+
+const DEFAULT_OPTIONS: Required<SqueezeDotsOptions> = {
+  squeezeColor: "239,83,80",
+  releaseColor: "38,166,154",
+  radius: 2.5,
+  offsetFromBottom: 10,
+  showRail: true,
+};
+
+// ---- Helpers ----
+
+function computeIndices(
+  signals: readonly SqueezeSignal[],
+  candles: readonly CandleRef[],
+): { squeezeIndices: number[]; releaseIndices: number[] } {
+  const timeToIdx = new Map<number, number>();
+  for (let i = 0; i < candles.length; i++) timeToIdx.set(candles[i].time, i);
+
+  const squeezeSet = new Set<number>();
+  for (const s of signals) {
+    const idx = timeToIdx.get(s.time);
+    if (idx != null) squeezeSet.add(idx);
+  }
+  const squeezeIndices = Array.from(squeezeSet).sort((a, b) => a - b);
+
+  // Release = the bar immediately after a squeeze bar that itself isn't a squeeze bar.
+  const releaseIndices: number[] = [];
+  for (const i of squeezeIndices) {
+    const next = i + 1;
+    if (next < candles.length && !squeezeSet.has(next)) releaseIndices.push(next);
+  }
+
+  return { squeezeIndices, releaseIndices };
+}
+
+// ---- Render ----
+
+function renderSqueezeDots(
+  { ctx, pane, timeScale }: PrimitiveRenderContext,
+  state: SqueezeDotsState,
+): void {
+  const { squeezeIndices, releaseIndices, options } = state;
+  if (squeezeIndices.length === 0 && releaseIndices.length === 0) return;
+
+  const start = timeScale.startIndex;
+  const end = timeScale.endIndex;
+  // The TTM ribbon sits as a thin colored bar row at the pane bottom. Bar
+  // width tracks bar spacing so it always reads as "this bar is in squeeze".
+  const ribbonHeight = options.radius * 2;
+  const ribbonY = pane.y + pane.height - options.offsetFromBottom - ribbonHeight / 2;
+  const barWidth = Math.max(2, timeScale.barSpacing * 0.9);
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(pane.x, pane.y, pane.width, pane.height);
+  ctx.clip();
+
+  // Faint guide rail spanning the visible range
+  if (options.showRail) {
+    ctx.save();
+    ctx.setLineDash([1, 3]);
+    ctx.strokeStyle = "rgba(120,123,134,0.25)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(pane.x, ribbonY + ribbonHeight / 2);
+    ctx.lineTo(pane.x + pane.width, ribbonY + ribbonHeight / 2);
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  const drawBar = (i: number, color: string) => {
+    if (i < start || i >= end) return;
+    const x = timeScale.indexToX(i);
+    ctx.fillStyle = color;
+    ctx.fillRect(x - barWidth / 2, ribbonY, barWidth, ribbonHeight);
+  };
+
+  for (const i of squeezeIndices) drawBar(i, `rgba(${options.squeezeColor},1)`);
+  for (const i of releaseIndices) drawBar(i, `rgba(${options.releaseColor},1)`);
+
+  ctx.restore();
+}
+
+// ---- Factory ----
+
+/**
+ * Create a PrimitivePlugin that renders TTM-style squeeze dots along the
+ * bottom of the price pane.
+ *
+ * @param signals - Output of `bollingerSqueeze()` (or any compatible shape)
+ * @param candles - Candle array used to map signal timestamps → bar indices
+ * @param options - Visual customization
+ */
+export function createSqueezeDots(
+  signals: readonly SqueezeSignal[],
+  candles: readonly CandleRef[],
+  options: SqueezeDotsOptions = {},
+): PrimitivePlugin<SqueezeDotsState> {
+  const merged = { ...DEFAULT_OPTIONS, ...options };
+  const { squeezeIndices, releaseIndices } = computeIndices(signals, candles);
+  return definePrimitive<SqueezeDotsState>({
+    name: "squeezeDots",
+    pane: "main",
+    zOrder: "above",
+    defaultState: { squeezeIndices, releaseIndices, options: merged },
+    render: renderSqueezeDots,
+  });
+}
+
+// ---- Convenience connector ----
+
+type SqueezeDotsHandle = {
+  /** Replace the squeeze data with a new computation */
+  update(signals: readonly SqueezeSignal[], candles: readonly CandleRef[]): void;
+  /** Remove the dots from the chart */
+  remove(): void;
+};
+
+/**
+ * Connect squeeze dots to a chart instance.
+ *
+ * @param chart - ChartInstance to attach to
+ * @param signals - Output of `bollingerSqueeze()`
+ * @param candles - Candle array used to map signal timestamps → bar indices
+ * @param options - Visual customization
+ */
+export function connectSqueezeDots(
+  chart: ChartInstance,
+  signals: readonly SqueezeSignal[],
+  candles: readonly CandleRef[],
+  options: SqueezeDotsOptions = {},
+): SqueezeDotsHandle {
+  chart.registerPrimitive(createSqueezeDots(signals, candles, options));
+
+  return {
+    update(newSignals, newCandles) {
+      chart.registerPrimitive(createSqueezeDots(newSignals, newCandles, options));
+    },
+    remove() {
+      chart.removePrimitive("squeezeDots");
+    },
+  };
+}

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -108,7 +108,14 @@ export class CanvasChart implements ChartInstance {
 
   // Auto-color cycling palette for indicators without explicit color
   private _colorIndex = 0;
-  private static readonly _COLOR_PALETTE = [
+  /**
+   * Per-palette counters so that a preset's palette (e.g. the `"number"`
+   * catch-all palette) rotates independently of the default palette and of
+   * other presets' palettes. Keyed by the palette array identity so the same
+   * array always resolves to the same counter.
+   */
+  private _paletteIndices = new WeakMap<readonly string[], number>();
+  private static readonly _COLOR_PALETTE: readonly string[] = [
     "#2196F3",
     "#FF9800",
     "#26a69a",
@@ -408,11 +415,22 @@ export class CanvasChart implements ChartInstance {
     // Introspect the series
     const result = introspect(series, config);
 
-    // Auto-assign color if not explicitly set (cycle through palette)
+    // Auto-assign color if not explicitly set (cycle through palette).
+    // Preset palettes are rotated per-palette (so multiple SMAs using the
+    // "number" palette pick blue/orange/teal/... in order); indicators with
+    // no preset palette fall back to the default palette with its own
+    // shared counter.
     if (!result.config.color && !result.config.channelColors) {
-      const palette = CanvasChart._COLOR_PALETTE;
-      result.config.color = palette[this._colorIndex % palette.length];
-      this._colorIndex++;
+      const presetPalette = result.config.colorPalette;
+      if (presetPalette && presetPalette.length > 0) {
+        const idx = this._paletteIndices.get(presetPalette) ?? 0;
+        result.config.color = presetPalette[idx % presetPalette.length];
+        this._paletteIndices.set(presetPalette, idx + 1);
+      } else {
+        const palette = CanvasChart._COLOR_PALETTE;
+        result.config.color = palette[this._colorIndex % palette.length];
+        this._colorIndex++;
+      }
     }
 
     // Resolve pane

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -402,6 +402,7 @@ export class CanvasChart implements ChartInstance {
       this._warn("addIndicator: expected an array", typeof series);
       return {
         id: "",
+        config: {},
         update: () => {},
         setData: () => {},
         setVisible: () => {},


### PR DESCRIPTION
## Summary

Adds a Signals panel and multi-instance indicator support to `indicator-showcase`, a new `connectSqueezeDots` chart plugin, and a handful of chart-side fixes that surfaced along the way.

### Showcase
- **Signals panel** alongside Plugins: MA Cross (5/25) triangles, RSI Divergence (mirrored dashed connectors on price pane + `rsi14` sub-pane), Bollinger Squeeze (TTM-style ribbon), Price Patterns (Double Top/Bottom + H&S drawn as zigzag + neckline + measured-move target).
- **Multi-instance indicators**: the "+" button on each preset row adds another instance with auto-bumped first numeric param so stacking SMA(20) + SMA(30) + SMA(45) just works. Each pill in the active bar has an inline-editable period — click the number to swap it into an input, Enter / blur to commit.
- Sidebar catalog, Plugins, and Signals panels now share one scroll viewport with the active bar pinned at the bottom.

### Chart (`@trendcraft/chart`)
- **New plugin**: `createSqueezeDots` / `connectSqueezeDots` — TTM-style ribbon of red (active-squeeze) / green (release) bars along the bottom of the price pane. Consumes `bollingerSqueeze()` output.
- **`IndicatorPreset.color`** now accepts `string | readonly string[]`; array values become a per-preset palette that rotates across instances via a dedicated `WeakMap` counter. The `"number"` catch-all preset now ships the 12-color palette, so scalar indicators (SMA, RSI, ...) no longer collapse into one color when stacked.
- **Parametric label regression fix**: `buildSeriesConfig` was passing the static `preset.meta.label` ("SMA") through to introspection and winning user-config precedence, erasing the parametric label ("SMA(20)") set by `withLabelParams`. It now leaves `label` undefined so introspect can read the tagged data's `__meta.label`.
- **`SeriesHandle.config`** — live getter onto the internal config so callers can read back the resolved color.
- **`IndicatorHandle.color`** — snapshotted color, used by the showcase to preserve an instance's color across the remove+add cycle triggered by param edits.
- Main bundle budget raised from 31 kB → 32 kB (brotli). Current size 30.59 kB. Dead-code trimming / plugin subpath split are candidates for a follow-up.

## Test plan
- [x] `pnpm test` in `packages/chart` (611 passing) and `packages/core` (4719 passing)
- [x] `pnpm build` in `packages/chart`
- [x] `pnpm size-check` passes against 32 kB Main limit (30.59 kB)
- [x] `npx tsc --noEmit` in `packages/chart/examples/indicator-showcase`
- [x] Manual: SMA(20) + SMA(30) + SMA(45) stacked with distinct colors, editing one pill's period preserves its color and leaves the others untouched, legend shows each instance's parametric label
- [x] Manual: Price Patterns, RSI Divergence (dual-pane), BB Squeeze ribbon, and MA Cross triangles all render on the daily sample
- [x] Manual: 1H timeframe — signals that produce no events flash "No events detected on the current dataset" instead of silently doing nothing