### PR TITLE
refactor(chart): consolidate canvas helpers and price-range loops

### DIFF
--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -99,7 +99,7 @@
     {
       "name": "Main (createChart + all exports)",
       "path": "dist/index.js",
-      "limit": "32 kB"
+      "limit": "31 kB"
     },
     {
       "name": "Headless API",

--- a/packages/chart/src/__tests__/draw-helper.test.ts
+++ b/packages/chart/src/__tests__/draw-helper.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { DrawHelper } from "../core/draw-helper";
+import { DrawHelper, strokeNullableLine, withPaneClip } from "../core/draw-helper";
 import { PriceScale, TimeScale } from "../core/scale";
 
 /** Create a minimal mock CanvasRenderingContext2D */
@@ -11,6 +11,8 @@ function mockCtx(): CanvasRenderingContext2D {
     stroke: vi.fn(),
     fill: vi.fn(),
     arc: vi.fn(),
+    rect: vi.fn(),
+    clip: vi.fn(),
     closePath: vi.fn(),
     fillRect: vi.fn(),
     strokeRect: vi.fn(),
@@ -223,8 +225,86 @@ describe("DrawHelper.scope()", () => {
       }),
     ).toThrow("test");
 
-    // save was called but restore may not be — let's verify scope handles this
-    // Actually our current implementation doesn't try/catch. Let's accept this behavior.
     expect(ctx.save).toHaveBeenCalledOnce();
+    expect(ctx.restore).toHaveBeenCalledOnce();
+  });
+});
+
+describe("withPaneClip()", () => {
+  const pane = { x: 10, y: 20, width: 800, height: 400 };
+
+  it("establishes a clip rect and restores after the callback", () => {
+    const ctx = mockCtx();
+    const order: string[] = [];
+    (ctx.save as ReturnType<typeof vi.fn>).mockImplementation(() => order.push("save"));
+    (ctx.beginPath as ReturnType<typeof vi.fn>).mockImplementation(() => order.push("beginPath"));
+    (ctx.rect as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => order.push("rect"));
+    (ctx.clip as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => order.push("clip"));
+    (ctx.restore as ReturnType<typeof vi.fn>).mockImplementation(() => order.push("restore"));
+
+    withPaneClip(ctx, pane, () => order.push("inner"));
+
+    expect(order).toEqual(["save", "beginPath", "rect", "clip", "inner", "restore"]);
+    expect(ctx.rect).toHaveBeenCalledWith(10, 20, 800, 400);
+  });
+
+  it("restores even if the callback throws", () => {
+    const ctx = mockCtx();
+
+    expect(() =>
+      withPaneClip(ctx, pane, () => {
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+
+    expect(ctx.save).toHaveBeenCalledOnce();
+    expect(ctx.restore).toHaveBeenCalledOnce();
+  });
+});
+
+describe("strokeNullableLine()", () => {
+  it("breaks the path at null gaps (moveTo after each gap)", () => {
+    const { ctx, ts, ps } = makeHelper();
+    const start = ts.startIndex;
+    const values: (number | null)[] = new Array(100).fill(null);
+    values[start] = 100;
+    values[start + 1] = 110;
+    // gap at start + 2
+    values[start + 3] = 120;
+    values[start + 4] = 130;
+
+    strokeNullableLine(ctx, values, ts, ps, { color: "#0f0", lineWidth: 2 });
+
+    expect(ctx.strokeStyle).toBe("#0f0");
+    expect(ctx.lineWidth).toBe(2);
+    // 2 segments → 2 moveTo calls, plus 2 lineTo (one per continuation)
+    expect(ctx.moveTo).toHaveBeenCalledTimes(2);
+    expect(ctx.lineTo).toHaveBeenCalledTimes(2);
+    expect(ctx.stroke).toHaveBeenCalledOnce();
+  });
+
+  it("clears the line-dash it set on exit", () => {
+    const { ctx, ts, ps } = makeHelper();
+    const start = ts.startIndex;
+    const values: (number | null)[] = new Array(100).fill(null);
+    values[start] = 100;
+    values[start + 1] = 110;
+
+    strokeNullableLine(ctx, values, ts, ps, { color: "#f00", dash: [4, 2] });
+
+    const calls = (ctx.setLineDash as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0][0]).toEqual([4, 2]);
+    expect(calls[calls.length - 1][0]).toEqual([]);
+  });
+
+  it("is a no-op on an all-null array (beginPath+stroke only, no path commands)", () => {
+    const { ctx, ts, ps } = makeHelper();
+    const values: (number | null)[] = new Array(100).fill(null);
+
+    strokeNullableLine(ctx, values, ts, ps, { color: "#000" });
+
+    expect(ctx.moveTo).not.toHaveBeenCalled();
+    expect(ctx.lineTo).not.toHaveBeenCalled();
+    expect(ctx.stroke).toHaveBeenCalledOnce();
   });
 });

--- a/packages/chart/src/__tests__/value-range.test.ts
+++ b/packages/chart/src/__tests__/value-range.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { emptyRange, reduceRange } from "../core/value-range";
+
+describe("reduceRange()", () => {
+  it("returns min/max over the index window", () => {
+    const [min, max] = reduceRange([10, 20, 30, 40, 50], 1, 4);
+    expect(min).toBe(20);
+    expect(max).toBe(40);
+  });
+
+  it("skips null/undefined values", () => {
+    const [min, max] = reduceRange([5, null, 10, undefined, 15], 0, 5);
+    expect(min).toBe(5);
+    expect(max).toBe(15);
+  });
+
+  it("returns empty range for all-null input", () => {
+    const [min, max] = reduceRange([null, null, null], 0, 3);
+    expect(min).toBe(Number.POSITIVE_INFINITY);
+    expect(max).toBe(Number.NEGATIVE_INFINITY);
+  });
+
+  it("clamps endIndex to values.length", () => {
+    const [min, max] = reduceRange([1, 2, 3], 0, 100);
+    expect(min).toBe(1);
+    expect(max).toBe(3);
+  });
+
+  it("accumulates across multiple sources", () => {
+    const first = reduceRange([10, 20], 0, 2);
+    const merged = reduceRange([5, 25], 0, 2, first);
+    expect(merged).toEqual([5, 25]);
+  });
+
+  it("never mutates the accumulator tuple it was passed", () => {
+    const acc: [number, number] = [100, 100];
+    const result = reduceRange([50, 150], 0, 2, acc);
+    expect(acc).toEqual([100, 100]);
+    expect(result).toEqual([50, 150]);
+  });
+});
+
+describe("emptyRange()", () => {
+  it("returns a fresh tuple each call (no shared state)", () => {
+    const a = emptyRange();
+    const b = emptyRange();
+    expect(a).not.toBe(b);
+    a[0] = 42;
+    expect(b[0]).toBe(Number.POSITIVE_INFINITY);
+  });
+});

--- a/packages/chart/src/core/draw-helper.ts
+++ b/packages/chart/src/core/draw-helper.ts
@@ -77,35 +77,7 @@ export class DrawHelper {
    * Values are indexed by candle index (values[startIndex..endIndex]).
    */
   line(values: readonly (number | null)[], style: StrokeStyle): void {
-    const { ctx, timeScale, priceScale } = this;
-    const start = timeScale.startIndex;
-    const end = timeScale.endIndex;
-
-    ctx.strokeStyle = style.color;
-    ctx.lineWidth = style.lineWidth ?? 1.5;
-    ctx.lineJoin = "round";
-    ctx.lineCap = "round";
-    ctx.setLineDash(style.dash ?? []);
-
-    let drawing = false;
-    ctx.beginPath();
-    for (let i = start; i < end && i < values.length; i++) {
-      const val = values[i];
-      if (val === null || val === undefined) {
-        drawing = false;
-        continue;
-      }
-      const px = timeScale.indexToX(i);
-      const py = priceScale.priceToY(val);
-      if (!drawing) {
-        ctx.moveTo(px, py);
-        drawing = true;
-      } else {
-        ctx.lineTo(px, py);
-      }
-    }
-    ctx.stroke();
-    ctx.setLineDash([]);
+    strokeNullableLine(this.ctx, values, this.timeScale, this.priceScale, style);
   }
 
   /**
@@ -258,4 +230,66 @@ export class DrawHelper {
     fn(this.ctx);
     this.ctx.restore();
   }
+}
+
+/**
+ * Stroke a polyline over the currently-visible bar range, breaking the path
+ * at any null/undefined sample (so indicators with warm-up gaps render as
+ * disconnected segments rather than a line back to the origin).
+ *
+ * Shared by {@link DrawHelper.line} and the series renderers (band, line,
+ * cloud) so the null-gap rule lives in exactly one place.
+ */
+export function strokeNullableLine(
+  ctx: CanvasRenderingContext2D,
+  values: readonly (number | null | undefined)[],
+  timeScale: { startIndex: number; endIndex: number; indexToX: (i: number) => number },
+  priceScale: { priceToY: (p: number) => number },
+  style: StrokeStyle,
+): void {
+  const start = timeScale.startIndex;
+  const end = Math.min(timeScale.endIndex, values.length);
+
+  ctx.strokeStyle = style.color;
+  ctx.lineWidth = style.lineWidth ?? 1.5;
+  ctx.lineJoin = "round";
+  ctx.lineCap = "round";
+  ctx.setLineDash(style.dash ?? []);
+
+  let drawing = false;
+  ctx.beginPath();
+  for (let i = start; i < end; i++) {
+    const val = values[i];
+    if (val === null || val === undefined) {
+      drawing = false;
+      continue;
+    }
+    const px = timeScale.indexToX(i);
+    const py = priceScale.priceToY(val);
+    if (!drawing) {
+      ctx.moveTo(px, py);
+      drawing = true;
+    } else {
+      ctx.lineTo(px, py);
+    }
+  }
+  ctx.stroke();
+  ctx.setLineDash([]);
+}
+
+/**
+ * Clip the given canvas to a pane rect for the duration of `fn`.
+ * Always pairs save/restore, even if `fn` throws.
+ */
+export function withPaneClip(
+  ctx: CanvasRenderingContext2D,
+  pane: { x: number; y: number; width: number; height: number },
+  fn: () => void,
+): void {
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(pane.x, pane.y, pane.width, pane.height);
+  ctx.clip();
+  fn();
+  ctx.restore();
 }

--- a/packages/chart/src/core/draw-helper.ts
+++ b/packages/chart/src/core/draw-helper.ts
@@ -223,12 +223,16 @@ export class DrawHelper {
 
   /**
    * Scoped block with automatic save/restore.
-   * Ensures all canvas state changes (lineDash, transforms, etc.) are cleaned up.
+   * Ensures all canvas state changes (lineDash, transforms, etc.) are cleaned
+   * up even if `fn` throws.
    */
   scope(fn: (ctx: CanvasRenderingContext2D) => void): void {
     this.ctx.save();
-    fn(this.ctx);
-    this.ctx.restore();
+    try {
+      fn(this.ctx);
+    } finally {
+      this.ctx.restore();
+    }
   }
 }
 
@@ -290,6 +294,9 @@ export function withPaneClip(
   ctx.beginPath();
   ctx.rect(pane.x, pane.y, pane.width, pane.height);
   ctx.clip();
-  fn();
-  ctx.restore();
+  try {
+    fn();
+  } finally {
+    ctx.restore();
+  }
 }

--- a/packages/chart/src/core/value-range.ts
+++ b/packages/chart/src/core/value-range.ts
@@ -7,8 +7,10 @@
 /** Running min/max accumulator. Pass between calls to accumulate across sources. */
 export type MinMax = [min: number, max: number];
 
-/** Identity element for {@link MinMax}. */
-export const EMPTY_RANGE: MinMax = [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY];
+/** Fresh identity accumulator — always allocate, never share (tuples are mutable). */
+export function emptyRange(): MinMax {
+  return [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY];
+}
 
 /**
  * Reduce a numeric array (with null/undefined gaps) into its min/max over
@@ -18,7 +20,7 @@ export function reduceRange(
   values: readonly (number | null | undefined)[],
   startIndex: number,
   endIndex: number,
-  acc: MinMax = [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY],
+  acc: MinMax = emptyRange(),
 ): MinMax {
   let [min, max] = acc;
   const lim = Math.min(endIndex, values.length);

--- a/packages/chart/src/core/value-range.ts
+++ b/packages/chart/src/core/value-range.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared min/max helpers for series price-range computation.
+ * Each `*PriceRange` in src/series/ delegates to these to avoid
+ * duplicating the same null-safe reduction loop in every renderer.
+ */
+
+/** Running min/max accumulator. Pass between calls to accumulate across sources. */
+export type MinMax = [min: number, max: number];
+
+/** Identity element for {@link MinMax}. */
+export const EMPTY_RANGE: MinMax = [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY];
+
+/**
+ * Reduce a numeric array (with null/undefined gaps) into its min/max over
+ * [startIndex, endIndex). Accepts an accumulator for multi-source ranges.
+ */
+export function reduceRange(
+  values: readonly (number | null | undefined)[],
+  startIndex: number,
+  endIndex: number,
+  acc: MinMax = [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY],
+): MinMax {
+  let [min, max] = acc;
+  const lim = Math.min(endIndex, values.length);
+  for (let i = startIndex; i < lim; i++) {
+    const v = values[i];
+    if (v === null || v === undefined) continue;
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  return [min, max];
+}

--- a/packages/chart/src/plugins/andrews-pitchfork.ts
+++ b/packages/chart/src/plugins/andrews-pitchfork.ts
@@ -29,6 +29,7 @@
  * ```
  */
 
+import { withPaneClip } from "../core/draw-helper";
 import { definePrimitive } from "../core/plugin-types";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import type { ChartInstance } from "../core/types";
@@ -99,63 +100,58 @@ function renderAndrewsPitchfork(
   const lowerEndX = rightEdgeX;
   const lowerEndY = lowerAnchorY + (dyMed / dxMed) * (rightEdgeX - lowerAnchorX);
 
-  ctx.save();
-  ctx.beginPath();
-  ctx.rect(pane.x, pane.y, pane.width, pane.height);
-  ctx.clip();
+  withPaneClip(ctx, pane, () => {
+    const stroke = state.color ?? "rgba(100,149,237,0.9)";
+    const fill = state.fillColor ?? "rgba(100,149,237,0.08)";
 
-  const stroke = state.color ?? "rgba(100,149,237,0.9)";
-  const fill = state.fillColor ?? "rgba(100,149,237,0.08)";
-
-  // Fill the region between upper and lower handles (from their anchor points forward).
-  ctx.fillStyle = fill;
-  ctx.beginPath();
-  ctx.moveTo(upperAnchorX, upperAnchorY);
-  ctx.lineTo(upperEndX, upperEndY);
-  ctx.lineTo(lowerEndX, lowerEndY);
-  ctx.lineTo(lowerAnchorX, lowerAnchorY);
-  ctx.closePath();
-  ctx.fill();
-
-  // Handle connector (P1 ↔ P2 short dashed segment)
-  ctx.strokeStyle = stroke;
-  ctx.lineWidth = 1;
-  ctx.setLineDash([3, 3]);
-  ctx.beginPath();
-  ctx.moveTo(x1, y1);
-  ctx.lineTo(x2, y2);
-  ctx.stroke();
-  ctx.setLineDash([]);
-
-  // Median line (solid)
-  ctx.lineWidth = 1.5;
-  ctx.beginPath();
-  ctx.moveTo(x0, y0);
-  ctx.lineTo(medianEndX, medianEndY);
-  ctx.stroke();
-
-  // Upper + lower handle lines (solid, thinner)
-  ctx.lineWidth = 1;
-  ctx.beginPath();
-  ctx.moveTo(upperAnchorX, upperAnchorY);
-  ctx.lineTo(upperEndX, upperEndY);
-  ctx.moveTo(lowerAnchorX, lowerAnchorY);
-  ctx.lineTo(lowerEndX, lowerEndY);
-  ctx.stroke();
-
-  // Small anchor dots
-  ctx.fillStyle = stroke;
-  for (const [ax, ay] of [
-    [x0, y0],
-    [x1, y1],
-    [x2, y2],
-  ]) {
+    // Fill the region between upper and lower handles (from their anchor points forward).
+    ctx.fillStyle = fill;
     ctx.beginPath();
-    ctx.arc(ax, ay, 2.5, 0, Math.PI * 2);
+    ctx.moveTo(upperAnchorX, upperAnchorY);
+    ctx.lineTo(upperEndX, upperEndY);
+    ctx.lineTo(lowerEndX, lowerEndY);
+    ctx.lineTo(lowerAnchorX, lowerAnchorY);
+    ctx.closePath();
     ctx.fill();
-  }
 
-  ctx.restore();
+    // Handle connector (P1 ↔ P2 short dashed segment)
+    ctx.strokeStyle = stroke;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([3, 3]);
+    ctx.beginPath();
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Median line (solid)
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(x0, y0);
+    ctx.lineTo(medianEndX, medianEndY);
+    ctx.stroke();
+
+    // Upper + lower handle lines (solid, thinner)
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(upperAnchorX, upperAnchorY);
+    ctx.lineTo(upperEndX, upperEndY);
+    ctx.moveTo(lowerAnchorX, lowerAnchorY);
+    ctx.lineTo(lowerEndX, lowerEndY);
+    ctx.stroke();
+
+    // Small anchor dots
+    ctx.fillStyle = stroke;
+    for (const [ax, ay] of [
+      [x0, y0],
+      [x1, y1],
+      [x2, y2],
+    ]) {
+      ctx.beginPath();
+      ctx.arc(ax, ay, 2.5, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  });
 }
 
 // ---- Factory ----

--- a/packages/chart/src/plugins/market-profile.ts
+++ b/packages/chart/src/plugins/market-profile.ts
@@ -20,6 +20,7 @@
  * ```
  */
 
+import { withPaneClip } from "../core/draw-helper";
 import { definePrimitive } from "../core/plugin-types";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import type { ChartInstance } from "../core/types";
@@ -102,71 +103,66 @@ function renderMarketProfile(
   const barLeft = pane.x + 8;
   const profileRight = barLeft + reservedWidth;
 
-  ctx.save();
-  ctx.beginPath();
-  ctx.rect(pane.x, pane.y, pane.width, pane.height);
-  ctx.clip();
+  withPaneClip(ctx, pane, () => {
+    const prices = [...profile.keys()].sort((a, b) => a - b);
+    const tickSize = prices.length > 1 ? prices[1] - prices[0] : 1;
+    const barH = Math.max(2, Math.abs(priceScale.priceToY(0) - priceScale.priceToY(tickSize)) - 1);
 
-  const prices = [...profile.keys()].sort((a, b) => a - b);
-  const tickSize = prices.length > 1 ? prices[1] - prices[0] : 1;
-  const barH = Math.max(2, Math.abs(priceScale.priceToY(0) - priceScale.priceToY(tickSize)) - 1);
+    for (const [price, count] of profile) {
+      const y = priceScale.priceToY(price);
+      const barW = (count / maxCount) * reservedWidth;
+      const isPoc = price === poc;
+      const inVA =
+        valueAreaLow != null &&
+        valueAreaHigh != null &&
+        price >= valueAreaLow &&
+        price <= valueAreaHigh;
 
-  for (const [price, count] of profile) {
-    const y = priceScale.priceToY(price);
-    const barW = (count / maxCount) * reservedWidth;
-    const isPoc = price === poc;
-    const inVA =
-      valueAreaLow != null &&
-      valueAreaHigh != null &&
-      price >= valueAreaLow &&
-      price <= valueAreaHigh;
+      ctx.fillStyle = isPoc ? options.pocColor : inVA ? options.valueAreaColor : options.barColor;
+      ctx.fillRect(barLeft, y - barH / 2, barW, barH);
 
-    ctx.fillStyle = isPoc ? options.pocColor : inVA ? options.valueAreaColor : options.barColor;
-    ctx.fillRect(barLeft, y - barH / 2, barW, barH);
-
-    if (isPoc) {
-      ctx.strokeStyle = options.pocColor;
-      ctx.lineWidth = 1;
-      ctx.strokeRect(barLeft, y - barH / 2, barW, barH);
+      if (isPoc) {
+        ctx.strokeStyle = options.pocColor;
+        ctx.lineWidth = 1;
+        ctx.strokeRect(barLeft, y - barH / 2, barW, barH);
+      }
     }
-  }
 
-  // VAH / VAL dashed lines + labels
-  ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
-  ctx.textBaseline = "bottom";
-  for (const [label, price] of [
-    ["VAH", valueAreaHigh],
-    ["VAL", valueAreaLow],
-  ] as const) {
-    if (price == null) continue;
-    const y = Math.round(priceScale.priceToY(price)) + 0.5;
-    ctx.strokeStyle = options.vaEdgeColor;
-    ctx.lineWidth = 1;
-    ctx.setLineDash([4, 3]);
-    ctx.beginPath();
-    ctx.moveTo(barLeft, y);
-    ctx.lineTo(profileRight + 20, y);
-    ctx.stroke();
-    ctx.setLineDash([]);
-    ctx.fillStyle = options.vaEdgeColor;
-    ctx.fillText(label, profileRight + 4, y - 2);
-  }
+    // VAH / VAL dashed lines + labels
+    ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
+    ctx.textBaseline = "bottom";
+    for (const [label, price] of [
+      ["VAH", valueAreaHigh],
+      ["VAL", valueAreaLow],
+    ] as const) {
+      if (price == null) continue;
+      const y = Math.round(priceScale.priceToY(price)) + 0.5;
+      ctx.strokeStyle = options.vaEdgeColor;
+      ctx.lineWidth = 1;
+      ctx.setLineDash([4, 3]);
+      ctx.beginPath();
+      ctx.moveTo(barLeft, y);
+      ctx.lineTo(profileRight + 20, y);
+      ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.fillStyle = options.vaEdgeColor;
+      ctx.fillText(label, profileRight + 4, y - 2);
+    }
 
-  // POC solid line + label
-  if (poc != null) {
-    const y = Math.round(priceScale.priceToY(poc)) + 0.5;
-    ctx.strokeStyle = options.pocColor;
-    ctx.lineWidth = 1.5;
-    ctx.beginPath();
-    ctx.moveTo(barLeft, y);
-    ctx.lineTo(profileRight + 20, y);
-    ctx.stroke();
-    ctx.fillStyle = options.pocColor;
-    ctx.font = "bold 10px -apple-system, BlinkMacSystemFont, sans-serif";
-    ctx.fillText("POC", profileRight + 4, y - 2);
-  }
-
-  ctx.restore();
+    // POC solid line + label
+    if (poc != null) {
+      const y = Math.round(priceScale.priceToY(poc)) + 0.5;
+      ctx.strokeStyle = options.pocColor;
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.moveTo(barLeft, y);
+      ctx.lineTo(profileRight + 20, y);
+      ctx.stroke();
+      ctx.fillStyle = options.pocColor;
+      ctx.font = "bold 10px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.fillText("POC", profileRight + 4, y - 2);
+    }
+  });
 }
 
 // ---- Factory ----

--- a/packages/chart/src/plugins/regime-heatmap.ts
+++ b/packages/chart/src/plugins/regime-heatmap.ts
@@ -21,6 +21,7 @@
  * ```
  */
 
+import { withPaneClip } from "../core/draw-helper";
 import { definePrimitive } from "../core/plugin-types";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import type { ChartInstance, DataPoint } from "../core/types";
@@ -66,25 +67,20 @@ function renderRegimeHeatmap(
   const end = timeScale.endIndex;
   const barWidth = Math.max(1, timeScale.barSpacing);
 
-  ctx.save();
-  ctx.beginPath();
-  ctx.rect(pane.x, pane.y, pane.width, pane.height);
-  ctx.clip();
+  withPaneClip(ctx, pane, () => {
+    for (let i = start; i < end && i < data.length; i++) {
+      const point = data[i];
+      if (!point?.value) continue;
 
-  for (let i = start; i < end && i < data.length; i++) {
-    const point = data[i];
-    if (!point?.value) continue;
+      const { regime, label, confidence } = point.value;
+      const rgb = regimeToRgb(regime, label);
+      const alpha = 0.15 + (confidence ?? 0.5) * 0.25;
+      const x = timeScale.indexToX(i);
 
-    const { regime, label, confidence } = point.value;
-    const rgb = regimeToRgb(regime, label);
-    const alpha = 0.15 + (confidence ?? 0.5) * 0.25;
-    const x = timeScale.indexToX(i);
-
-    ctx.fillStyle = `rgba(${rgb},${alpha.toFixed(3)})`;
-    ctx.fillRect(x - barWidth / 2, pane.y, barWidth, pane.height);
-  }
-
-  ctx.restore();
+      ctx.fillStyle = `rgba(${rgb},${alpha.toFixed(3)})`;
+      ctx.fillRect(x - barWidth / 2, pane.y, barWidth, pane.height);
+    }
+  });
 }
 
 // ---- Factory ----

--- a/packages/chart/src/plugins/session-zones.ts
+++ b/packages/chart/src/plugins/session-zones.ts
@@ -19,6 +19,7 @@
  * ```
  */
 
+import { withPaneClip } from "../core/draw-helper";
 import { definePrimitive } from "../core/plugin-types";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import type { ChartInstance, DataPoint } from "../core/types";
@@ -82,52 +83,47 @@ function renderSessionZones(
   const end = timeScale.endIndex;
   const barWidth = Math.max(1, timeScale.barSpacing);
 
-  ctx.save();
-  ctx.beginPath();
-  ctx.rect(pane.x, pane.y, pane.width, pane.height);
-  ctx.clip();
+  withPaneClip(ctx, pane, () => {
+    // Collect spans first, then render labels with collision avoidance so
+    // dense intraday ranges don't produce an unreadable wall of text.
+    type Span = { zone: string; startIndex: number; endIndex: number };
+    const spans: Span[] = [];
+    let spanStart = -1;
+    let spanZone = "";
 
-  // Collect spans first, then render labels with collision avoidance so
-  // dense intraday ranges don't produce an unreadable wall of text.
-  type Span = { zone: string; startIndex: number; endIndex: number };
-  const spans: Span[] = [];
-  let spanStart = -1;
-  let spanZone = "";
+    for (let i = start; i < end && i < data.length; i++) {
+      const point = data[i];
+      if (!point?.value) continue;
 
-  for (let i = start; i < end && i < data.length; i++) {
-    const point = data[i];
-    if (!point?.value) continue;
+      const { zone, inKillZone } = point.value;
 
-    const { zone, inKillZone } = point.value;
+      if (inKillZone && zone) {
+        const rgb = zoneToRgb(zone);
+        const x = timeScale.indexToX(i);
 
-    if (inKillZone && zone) {
-      const rgb = zoneToRgb(zone);
-      const x = timeScale.indexToX(i);
+        ctx.fillStyle = `rgba(${rgb},0.18)`;
+        ctx.fillRect(x - barWidth / 2, pane.y, barWidth, pane.height);
 
-      ctx.fillStyle = `rgba(${rgb},0.18)`;
-      ctx.fillRect(x - barWidth / 2, pane.y, barWidth, pane.height);
-
-      if (zone !== spanZone) {
-        if (spanStart >= 0 && spanZone) {
-          spans.push({ zone: spanZone, startIndex: spanStart, endIndex: i - 1 });
+        if (zone !== spanZone) {
+          if (spanStart >= 0 && spanZone) {
+            spans.push({ zone: spanZone, startIndex: spanStart, endIndex: i - 1 });
+          }
+          spanStart = i;
+          spanZone = zone;
         }
-        spanStart = i;
-        spanZone = zone;
+      } else if (spanStart >= 0 && spanZone) {
+        spans.push({ zone: spanZone, startIndex: spanStart, endIndex: i - 1 });
+        spanStart = -1;
+        spanZone = "";
       }
-    } else if (spanStart >= 0 && spanZone) {
-      spans.push({ zone: spanZone, startIndex: spanStart, endIndex: i - 1 });
-      spanStart = -1;
-      spanZone = "";
     }
-  }
-  if (spanStart >= 0 && spanZone) {
-    const lastIdx = Math.min(end - 1, data.length - 1);
-    spans.push({ zone: spanZone, startIndex: spanStart, endIndex: lastIdx });
-  }
+    if (spanStart >= 0 && spanZone) {
+      const lastIdx = Math.min(end - 1, data.length - 1);
+      spans.push({ zone: spanZone, startIndex: spanStart, endIndex: lastIdx });
+    }
 
-  renderZoneLabels(ctx, spans, timeScale, pane.y);
-
-  ctx.restore();
+    renderZoneLabels(ctx, spans, timeScale, pane.y);
+  });
 }
 
 function renderZoneLabels(

--- a/packages/chart/src/plugins/smc-layer.ts
+++ b/packages/chart/src/plugins/smc-layer.ts
@@ -22,6 +22,7 @@
  * ```
  */
 
+import { withPaneClip } from "../core/draw-helper";
 import { definePrimitive } from "../core/plugin-types";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import type { ChartInstance, DataPoint } from "../core/types";
@@ -221,32 +222,27 @@ function renderBosLevels(
 function renderSmcLayer(context: PrimitiveRenderContext, state: SmcState): void {
   const { ctx, pane, timeScale, priceScale, theme } = context;
 
-  ctx.save();
-  ctx.beginPath();
-  ctx.rect(pane.x, pane.y, pane.width, pane.height);
-  ctx.clip();
+  withPaneClip(ctx, pane, () => {
+    // Order blocks (lowest visual priority)
+    if (state.orderBlocks.length > 0) {
+      renderOrderBlocks(ctx, state.orderBlocks, timeScale, priceScale);
+    }
 
-  // Order blocks (lowest visual priority)
-  if (state.orderBlocks.length > 0) {
-    renderOrderBlocks(ctx, state.orderBlocks, timeScale, priceScale);
-  }
+    // FVG zones
+    if (state.fvgZones.length > 0) {
+      renderFvgZones(ctx, state.fvgZones, timeScale, priceScale);
+    }
 
-  // FVG zones
-  if (state.fvgZones.length > 0) {
-    renderFvgZones(ctx, state.fvgZones, timeScale, priceScale);
-  }
+    // BOS levels
+    if (state.bosLevels.length > 0) {
+      renderBosLevels(ctx, state.bosLevels, timeScale, priceScale, theme);
+    }
 
-  // BOS levels
-  if (state.bosLevels.length > 0) {
-    renderBosLevels(ctx, state.bosLevels, timeScale, priceScale, theme);
-  }
-
-  // Sweep markers (highest visual priority)
-  if (state.sweepMarkers.length > 0) {
-    renderSweepMarkers(ctx, state.sweepMarkers, timeScale, priceScale);
-  }
-
-  ctx.restore();
+    // Sweep markers (highest visual priority)
+    if (state.sweepMarkers.length > 0) {
+      renderSweepMarkers(ctx, state.sweepMarkers, timeScale, priceScale);
+    }
+  });
 }
 
 // ---- Factory ----

--- a/packages/chart/src/plugins/squeeze-dots.ts
+++ b/packages/chart/src/plugins/squeeze-dots.ts
@@ -21,6 +21,7 @@
  * ```
  */
 
+import { withPaneClip } from "../core/draw-helper";
 import { definePrimitive } from "../core/plugin-types";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import type { ChartInstance } from "../core/types";
@@ -110,35 +111,30 @@ function renderSqueezeDots(
   const ribbonY = pane.y + pane.height - options.offsetFromBottom - ribbonHeight / 2;
   const barWidth = Math.max(2, timeScale.barSpacing * 0.9);
 
-  ctx.save();
-  ctx.beginPath();
-  ctx.rect(pane.x, pane.y, pane.width, pane.height);
-  ctx.clip();
+  withPaneClip(ctx, pane, () => {
+    // Faint guide rail spanning the visible range
+    if (options.showRail) {
+      ctx.save();
+      ctx.setLineDash([1, 3]);
+      ctx.strokeStyle = "rgba(120,123,134,0.25)";
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(pane.x, ribbonY + ribbonHeight / 2);
+      ctx.lineTo(pane.x + pane.width, ribbonY + ribbonHeight / 2);
+      ctx.stroke();
+      ctx.restore();
+    }
 
-  // Faint guide rail spanning the visible range
-  if (options.showRail) {
-    ctx.save();
-    ctx.setLineDash([1, 3]);
-    ctx.strokeStyle = "rgba(120,123,134,0.25)";
-    ctx.lineWidth = 1;
-    ctx.beginPath();
-    ctx.moveTo(pane.x, ribbonY + ribbonHeight / 2);
-    ctx.lineTo(pane.x + pane.width, ribbonY + ribbonHeight / 2);
-    ctx.stroke();
-    ctx.restore();
-  }
+    const drawBar = (i: number, color: string) => {
+      if (i < start || i >= end) return;
+      const x = timeScale.indexToX(i);
+      ctx.fillStyle = color;
+      ctx.fillRect(x - barWidth / 2, ribbonY, barWidth, ribbonHeight);
+    };
 
-  const drawBar = (i: number, color: string) => {
-    if (i < start || i >= end) return;
-    const x = timeScale.indexToX(i);
-    ctx.fillStyle = color;
-    ctx.fillRect(x - barWidth / 2, ribbonY, barWidth, ribbonHeight);
-  };
-
-  for (const i of squeezeIndices) drawBar(i, `rgba(${options.squeezeColor},1)`);
-  for (const i of releaseIndices) drawBar(i, `rgba(${options.releaseColor},1)`);
-
-  ctx.restore();
+    for (const i of squeezeIndices) drawBar(i, `rgba(${options.squeezeColor},1)`);
+    for (const i of releaseIndices) drawBar(i, `rgba(${options.releaseColor},1)`);
+  });
 }
 
 // ---- Factory ----

--- a/packages/chart/src/plugins/sr-confluence.ts
+++ b/packages/chart/src/plugins/sr-confluence.ts
@@ -17,6 +17,7 @@
  * ```
  */
 
+import { withPaneClip } from "../core/draw-helper";
 import { definePrimitive } from "../core/plugin-types";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import type { ChartInstance } from "../core/types";
@@ -64,11 +65,6 @@ function renderSrConfluence(
   const { zones } = state;
   if (zones.length === 0) return;
 
-  ctx.save();
-  ctx.beginPath();
-  ctx.rect(pane.x, pane.y, pane.width, pane.height);
-  ctx.clip();
-
   // Bands fill the entire pane horizontally and labels pin to the right
   // edge of the pane — both are independent of the visible index range so
   // they don't flicker as the user pans/zooms.
@@ -76,36 +72,36 @@ function renderSrConfluence(
   const right = pane.x + pane.width;
   const width = pane.width;
 
-  for (const zone of zones) {
-    const topY = priceScale.priceToY(zone.high);
-    const bottomY = priceScale.priceToY(zone.low);
-    const h = bottomY - topY;
-    if (h <= 0) continue;
+  withPaneClip(ctx, pane, () => {
+    for (const zone of zones) {
+      const topY = priceScale.priceToY(zone.high);
+      const bottomY = priceScale.priceToY(zone.low);
+      const h = bottomY - topY;
+      if (h <= 0) continue;
 
-    const rgb = strengthToRgb(zone.strength);
-    const alpha = 0.06 + (zone.strength / 100) * 0.12;
+      const rgb = strengthToRgb(zone.strength);
+      const alpha = 0.06 + (zone.strength / 100) * 0.12;
 
-    ctx.fillStyle = `rgba(${rgb},${alpha.toFixed(3)})`;
-    ctx.fillRect(left, topY, width, h);
+      ctx.fillStyle = `rgba(${rgb},${alpha.toFixed(3)})`;
+      ctx.fillRect(left, topY, width, h);
 
-    ctx.strokeStyle = `rgba(${rgb},${(alpha * 2.5).toFixed(3)})`;
-    ctx.lineWidth = 0.5;
-    ctx.beginPath();
-    ctx.moveTo(left, topY);
-    ctx.lineTo(right, topY);
-    ctx.moveTo(left, bottomY);
-    ctx.lineTo(right, bottomY);
-    ctx.stroke();
+      ctx.strokeStyle = `rgba(${rgb},${(alpha * 2.5).toFixed(3)})`;
+      ctx.lineWidth = 0.5;
+      ctx.beginPath();
+      ctx.moveTo(left, topY);
+      ctx.lineTo(right, topY);
+      ctx.moveTo(left, bottomY);
+      ctx.lineTo(right, bottomY);
+      ctx.stroke();
 
-    const centerY = (topY + bottomY) / 2;
-    ctx.fillStyle = `rgba(${rgb},0.7)`;
-    ctx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
-    ctx.textAlign = "right";
-    ctx.textBaseline = "middle";
-    ctx.fillText(`S${zone.strength.toFixed(0)}`, right - 4, centerY);
-  }
-
-  ctx.restore();
+      const centerY = (topY + bottomY) / 2;
+      ctx.fillStyle = `rgba(${rgb},0.7)`;
+      ctx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.textAlign = "right";
+      ctx.textBaseline = "middle";
+      ctx.fillText(`S${zone.strength.toFixed(0)}`, right - 4, centerY);
+    }
+  });
 }
 
 // ---- Factory ----

--- a/packages/chart/src/plugins/trade-analysis.ts
+++ b/packages/chart/src/plugins/trade-analysis.ts
@@ -18,6 +18,7 @@
  * ```
  */
 
+import { withPaneClip } from "../core/draw-helper";
 import { definePrimitive } from "../core/plugin-types";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import type { ChartInstance } from "../core/types";
@@ -100,85 +101,80 @@ function renderTradeAnalysis(
   const { trades, candles } = state;
   if (trades.length === 0 || candles.length === 0) return;
 
-  ctx.save();
-  ctx.beginPath();
-  ctx.rect(pane.x, pane.y, pane.width, pane.height);
-  ctx.clip();
+  withPaneClip(ctx, pane, () => {
+    for (const trade of trades) {
+      const entryIdx = findIndex(candles, trade.entryTime);
+      const exitIdx = findIndex(candles, trade.exitTime);
+      if (entryIdx >= candles.length || exitIdx >= candles.length) continue;
 
-  for (const trade of trades) {
-    const entryIdx = findIndex(candles, trade.entryTime);
-    const exitIdx = findIndex(candles, trade.exitTime);
-    if (entryIdx >= candles.length || exitIdx >= candles.length) continue;
+      const direction = trade.direction ?? (trade.returnPercent >= 0 ? "long" : "short");
+      const entryX = timeScale.indexToX(entryIdx);
+      const exitX = timeScale.indexToX(exitIdx);
+      const entryY = priceScale.priceToY(trade.entryPrice);
+      const exitY = priceScale.priceToY(trade.exitPrice);
 
-    const direction = trade.direction ?? (trade.returnPercent >= 0 ? "long" : "short");
-    const entryX = timeScale.indexToX(entryIdx);
-    const exitX = timeScale.indexToX(exitIdx);
-    const entryY = priceScale.priceToY(trade.entryPrice);
-    const exitY = priceScale.priceToY(trade.exitPrice);
+      // Compute MFE/MAE price levels from candles
+      const { mfePrice, maePrice } = computeMfeMaePrice(
+        candles,
+        entryIdx,
+        exitIdx,
+        trade.entryPrice,
+        direction,
+      );
 
-    // Compute MFE/MAE price levels from candles
-    const { mfePrice, maePrice } = computeMfeMaePrice(
-      candles,
-      entryIdx,
-      exitIdx,
-      trade.entryPrice,
-      direction,
-    );
+      const mfeY = priceScale.priceToY(mfePrice);
+      const maeY = priceScale.priceToY(maePrice);
 
-    const mfeY = priceScale.priceToY(mfePrice);
-    const maeY = priceScale.priceToY(maePrice);
+      // MFE dashed line
+      ctx.save();
+      ctx.setLineDash([3, 2]);
+      ctx.strokeStyle = `rgba(${MFE_COLOR},0.5)`;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(entryX, mfeY);
+      ctx.lineTo(exitX, mfeY);
+      ctx.stroke();
+      ctx.restore();
 
-    // MFE dashed line
-    ctx.save();
-    ctx.setLineDash([3, 2]);
-    ctx.strokeStyle = `rgba(${MFE_COLOR},0.5)`;
-    ctx.lineWidth = 1;
-    ctx.beginPath();
-    ctx.moveTo(entryX, mfeY);
-    ctx.lineTo(exitX, mfeY);
-    ctx.stroke();
-    ctx.restore();
+      // MAE dashed line
+      ctx.save();
+      ctx.setLineDash([3, 2]);
+      ctx.strokeStyle = `rgba(${MAE_COLOR},0.5)`;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(entryX, maeY);
+      ctx.lineTo(exitX, maeY);
+      ctx.stroke();
+      ctx.restore();
 
-    // MAE dashed line
-    ctx.save();
-    ctx.setLineDash([3, 2]);
-    ctx.strokeStyle = `rgba(${MAE_COLOR},0.5)`;
-    ctx.lineWidth = 1;
-    ctx.beginPath();
-    ctx.moveTo(entryX, maeY);
-    ctx.lineTo(exitX, maeY);
-    ctx.stroke();
-    ctx.restore();
+      // Shaded area between MFE and MAE
+      const topY = Math.min(mfeY, maeY);
+      const bottomY = Math.max(mfeY, maeY);
+      ctx.fillStyle = "rgba(120,123,134,0.03)";
+      ctx.fillRect(entryX, topY, exitX - entryX, bottomY - topY);
 
-    // Shaded area between MFE and MAE
-    const topY = Math.min(mfeY, maeY);
-    const bottomY = Math.max(mfeY, maeY);
-    ctx.fillStyle = "rgba(120,123,134,0.03)";
-    ctx.fillRect(entryX, topY, exitX - entryX, bottomY - topY);
+      // Trade line (entry → exit)
+      const isWin = trade.returnPercent >= 0;
+      ctx.strokeStyle = `rgba(${isWin ? TRADE_WIN_COLOR : TRADE_LOSS_COLOR},0.6)`;
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.moveTo(entryX, entryY);
+      ctx.lineTo(exitX, exitY);
+      ctx.stroke();
 
-    // Trade line (entry → exit)
-    const isWin = trade.returnPercent >= 0;
-    ctx.strokeStyle = `rgba(${isWin ? TRADE_WIN_COLOR : TRADE_LOSS_COLOR},0.6)`;
-    ctx.lineWidth = 1.5;
-    ctx.beginPath();
-    ctx.moveTo(entryX, entryY);
-    ctx.lineTo(exitX, exitY);
-    ctx.stroke();
+      // Entry dot
+      ctx.fillStyle = "rgba(33,150,243,0.8)";
+      ctx.beginPath();
+      ctx.arc(entryX, entryY, 3, 0, Math.PI * 2);
+      ctx.fill();
 
-    // Entry dot
-    ctx.fillStyle = "rgba(33,150,243,0.8)";
-    ctx.beginPath();
-    ctx.arc(entryX, entryY, 3, 0, Math.PI * 2);
-    ctx.fill();
-
-    // Exit dot
-    ctx.fillStyle = `rgba(${isWin ? TRADE_WIN_COLOR : TRADE_LOSS_COLOR},0.8)`;
-    ctx.beginPath();
-    ctx.arc(exitX, exitY, 3, 0, Math.PI * 2);
-    ctx.fill();
-  }
-
-  ctx.restore();
+      // Exit dot
+      ctx.fillStyle = `rgba(${isWin ? TRADE_WIN_COLOR : TRADE_LOSS_COLOR},0.8)`;
+      ctx.beginPath();
+      ctx.arc(exitX, exitY, 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  });
 }
 
 // ---- Factory ----

--- a/packages/chart/src/plugins/volume-profile.ts
+++ b/packages/chart/src/plugins/volume-profile.ts
@@ -21,6 +21,7 @@
  * ```
  */
 
+import { withPaneClip } from "../core/draw-helper";
 import { definePrimitive } from "../core/plugin-types";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import type { ChartInstance } from "../core/types";
@@ -106,55 +107,50 @@ function renderVolumeProfile(
   const rightEdge = pane.x + pane.width;
   const stripLeft = rightEdge - reservedWidth;
 
-  ctx.save();
-  ctx.beginPath();
-  ctx.rect(pane.x, pane.y, pane.width, pane.height);
-  ctx.clip();
+  withPaneClip(ctx, pane, () => {
+    for (const level of profile.levels) {
+      const topY = priceScale.priceToY(level.priceHigh);
+      const bottomY = priceScale.priceToY(level.priceLow);
+      const barHeight = Math.max(1, bottomY - topY);
 
-  for (const level of profile.levels) {
-    const topY = priceScale.priceToY(level.priceHigh);
-    const bottomY = priceScale.priceToY(level.priceLow);
-    const barHeight = Math.max(1, bottomY - topY);
+      const barLen = (level.volumePercent / maxPercent) * reservedWidth;
+      if (barLen <= 0) continue;
 
-    const barLen = (level.volumePercent / maxPercent) * reservedWidth;
-    if (barLen <= 0) continue;
+      const inValueArea = level.priceMid >= profile.val && level.priceMid <= profile.vah;
+      ctx.fillStyle = highlightValueArea && inValueArea ? valueAreaColor : barColor;
 
-    const inValueArea = level.priceMid >= profile.val && level.priceMid <= profile.vah;
-    ctx.fillStyle = highlightValueArea && inValueArea ? valueAreaColor : barColor;
+      // Bar extends leftward from the right edge.
+      ctx.fillRect(rightEdge - barLen, topY, barLen, barHeight);
+    }
 
-    // Bar extends leftward from the right edge.
-    ctx.fillRect(rightEdge - barLen, topY, barLen, barHeight);
-  }
+    // POC line — thin horizontal line across the entire pane width.
+    if (showPoc) {
+      const pocY = priceScale.priceToY(profile.poc);
+      ctx.strokeStyle = pocColor;
+      ctx.lineWidth = 1;
+      ctx.setLineDash([4, 3]);
+      ctx.beginPath();
+      ctx.moveTo(pane.x, pocY);
+      ctx.lineTo(rightEdge, pocY);
+      ctx.stroke();
+      ctx.setLineDash([]);
 
-  // POC line — thin horizontal line across the entire pane width.
-  if (showPoc) {
-    const pocY = priceScale.priceToY(profile.poc);
-    ctx.strokeStyle = pocColor;
-    ctx.lineWidth = 1;
-    ctx.setLineDash([4, 3]);
+      // POC label
+      ctx.fillStyle = pocColor;
+      ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.textAlign = "right";
+      ctx.textBaseline = "bottom";
+      ctx.fillText("POC", rightEdge - 4, pocY - 2);
+    }
+
+    // Subtle divider between chart and histogram strip.
+    ctx.strokeStyle = "rgba(128,128,128,0.2)";
+    ctx.lineWidth = 0.5;
     ctx.beginPath();
-    ctx.moveTo(pane.x, pocY);
-    ctx.lineTo(rightEdge, pocY);
+    ctx.moveTo(stripLeft, pane.y);
+    ctx.lineTo(stripLeft, pane.y + pane.height);
     ctx.stroke();
-    ctx.setLineDash([]);
-
-    // POC label
-    ctx.fillStyle = pocColor;
-    ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
-    ctx.textAlign = "right";
-    ctx.textBaseline = "bottom";
-    ctx.fillText("POC", rightEdge - 4, pocY - 2);
-  }
-
-  // Subtle divider between chart and histogram strip.
-  ctx.strokeStyle = "rgba(128,128,128,0.2)";
-  ctx.lineWidth = 0.5;
-  ctx.beginPath();
-  ctx.moveTo(stripLeft, pane.y);
-  ctx.lineTo(stripLeft, pane.y + pane.height);
-  ctx.stroke();
-
-  ctx.restore();
+  });
 }
 
 // ---- Factory ----

--- a/packages/chart/src/plugins/wyckoff-phase.ts
+++ b/packages/chart/src/plugins/wyckoff-phase.ts
@@ -27,6 +27,7 @@
  * ```
  */
 
+import { withPaneClip } from "../core/draw-helper";
 import { definePrimitive } from "../core/plugin-types";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import type { ChartInstance, DataPoint } from "../core/types";
@@ -210,143 +211,138 @@ function renderWyckoffPhase(
   const barWidth = Math.max(1, timeScale.barSpacing);
   const last = phases[phases.length - 1]?.value;
 
-  ctx.save();
-  ctx.beginPath();
-  ctx.rect(pane.x, pane.y, pane.width, pane.height);
-  ctx.clip();
+  withPaneClip(ctx, pane, () => {
+    // ----- 1. Range boxes -----
+    if (options.showRangeBox) {
+      const spans = collectPhaseSpans(phases);
+      for (const span of spans) {
+        if (span.endIndex < start || span.startIndex >= end) continue;
+        const rgb = PHASE_COLORS[span.phase] ?? PHASE_COLORS.unknown;
+        const x1 = timeScale.indexToX(span.startIndex);
+        const x2 = timeScale.indexToX(span.endIndex);
+        const y1 = priceScale.priceToY(span.rangeHigh);
+        const y2 = priceScale.priceToY(span.rangeLow);
+        const w = x2 - x1;
+        const h = y2 - y1;
+        if (w <= 0 || h <= 0) continue;
 
-  // ----- 1. Range boxes -----
-  if (options.showRangeBox) {
-    const spans = collectPhaseSpans(phases);
-    for (const span of spans) {
-      if (span.endIndex < start || span.startIndex >= end) continue;
-      const rgb = PHASE_COLORS[span.phase] ?? PHASE_COLORS.unknown;
-      const x1 = timeScale.indexToX(span.startIndex);
-      const x2 = timeScale.indexToX(span.endIndex);
-      const y1 = priceScale.priceToY(span.rangeHigh);
-      const y2 = priceScale.priceToY(span.rangeLow);
-      const w = x2 - x1;
-      const h = y2 - y1;
-      if (w <= 0 || h <= 0) continue;
+        ctx.fillStyle = `rgba(${rgb},0.08)`;
+        ctx.fillRect(x1, y1, w, h);
 
-      ctx.fillStyle = `rgba(${rgb},0.08)`;
-      ctx.fillRect(x1, y1, w, h);
-
-      ctx.strokeStyle = `rgba(${rgb},0.55)`;
-      ctx.lineWidth = 1;
-      ctx.setLineDash([4, 3]);
-      ctx.strokeRect(x1, y1, w, h);
-      ctx.setLineDash([]);
-    }
-  }
-
-  // ----- 2. Event labels -----
-  if (options.showEventLabels) {
-    ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
-    ctx.textAlign = "center";
-    for (let i = start; i < end && i < phases.length; i++) {
-      const point = phases[i];
-      const event = point?.value?.event;
-      if (!event) continue;
-
-      const placement = EVENT_PLACEMENT[event] ?? "above";
-      const x = timeScale.indexToX(i);
-
-      // Prefer candle high/low for precise placement; fall back to the
-      // phase's range boundaries when candles weren't provided.
-      const candle = candles[i];
-      const rangeHigh = point.value?.rangeHigh ?? null;
-      const rangeLow = point.value?.rangeLow ?? null;
-      const anchorPrice =
-        placement === "above"
-          ? (candle?.high ?? rangeHigh ?? rangeLow)
-          : (candle?.low ?? rangeLow ?? rangeHigh);
-      if (anchorPrice == null) continue;
-
-      const anchorY = priceScale.priceToY(anchorPrice);
-      const y = placement === "above" ? anchorY - 4 : anchorY + 12;
-
-      const phaseKey =
-        point.value?.phase && PHASE_COLORS[point.value.phase] ? point.value.phase : "unknown";
-      const rgb = PHASE_COLORS[phaseKey];
-
-      // Small dot at the anchor price
-      ctx.fillStyle = `rgba(${rgb},0.9)`;
-      ctx.beginPath();
-      ctx.arc(x, anchorY, 2, 0, Math.PI * 2);
-      ctx.fill();
-
-      // Text label
-      ctx.fillStyle = `rgba(${rgb},0.95)`;
-      ctx.textBaseline = placement === "above" ? "bottom" : "top";
-      ctx.fillText(event, x, y);
-    }
-  }
-
-  // ----- 3. Bottom timeline bar -----
-  if (options.showTimelineBar) {
-    const barY = pane.y + pane.height - PHASE_BAR_HEIGHT;
-    for (let i = start; i < end && i < phases.length; i++) {
-      const point = phases[i];
-      if (!point?.value) continue;
-      const { phase, confidence } = point.value;
-      const rgb = PHASE_COLORS[phase] ?? PHASE_COLORS.unknown;
-      const alpha = 0.4 + ((confidence ?? 50) / 100) * 0.5;
-      const x = timeScale.indexToX(i);
-      ctx.fillStyle = `rgba(${rgb},${alpha.toFixed(3)})`;
-      ctx.fillRect(x - barWidth / 2, barY, barWidth, PHASE_BAR_HEIGHT);
-    }
-
-    // VSA event dots just above the timeline bar
-    if (vsa.length > 0) {
-      const markerY = barY - 4;
-      for (let i = start; i < end && i < vsa.length; i++) {
-        const point = vsa[i];
-        if (!point?.value) continue;
-        const { barType } = point.value;
-        if (barType === "normal") continue;
-        const rgb = VSA_MARKER_COLORS[barType];
-        if (!rgb) continue;
-        const x = timeScale.indexToX(i);
-        ctx.fillStyle = `rgba(${rgb},0.8)`;
-        ctx.beginPath();
-        ctx.arc(x, markerY, 2, 0, Math.PI * 2);
-        ctx.fill();
+        ctx.strokeStyle = `rgba(${rgb},0.55)`;
+        ctx.lineWidth = 1;
+        ctx.setLineDash([4, 3]);
+        ctx.strokeRect(x1, y1, w, h);
+        ctx.setLineDash([]);
       }
     }
-  }
 
-  // ----- 4. Corner badge (top-left) -----
-  if (options.showPhaseBadge && last) {
-    const label = PHASE_LABELS[last.phase] ?? last.phase;
-    const conf = last.confidence ?? 0;
-    const subPhase = last.subPhase ? ` · ${last.subPhase}` : "";
-    const text = `Wyckoff: ${label} (${conf.toFixed(0)})${subPhase}`;
-    const rgb = PHASE_COLORS[last.phase] ?? PHASE_COLORS.unknown;
+    // ----- 2. Event labels -----
+    if (options.showEventLabels) {
+      ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.textAlign = "center";
+      for (let i = start; i < end && i < phases.length; i++) {
+        const point = phases[i];
+        const event = point?.value?.event;
+        if (!event) continue;
 
-    ctx.font = "bold 11px -apple-system, BlinkMacSystemFont, sans-serif";
-    ctx.textAlign = "left";
-    ctx.textBaseline = "top";
-    const textWidth = ctx.measureText(text).width;
-    const padX = 8;
-    const padY = 4;
-    const boxW = textWidth + padX * 2;
-    const boxH = 18;
-    // Offset below the chart's OHLC legend row (typically ~22 px from top).
-    const boxX = pane.x + 8;
-    const boxY = pane.y + 32;
+        const placement = EVENT_PLACEMENT[event] ?? "above";
+        const x = timeScale.indexToX(i);
 
-    ctx.fillStyle = "rgba(22,26,37,0.85)";
-    ctx.fillRect(boxX, boxY, boxW, boxH);
-    ctx.strokeStyle = `rgba(${rgb},0.7)`;
-    ctx.lineWidth = 1;
-    ctx.strokeRect(boxX, boxY, boxW, boxH);
+        // Prefer candle high/low for precise placement; fall back to the
+        // phase's range boundaries when candles weren't provided.
+        const candle = candles[i];
+        const rangeHigh = point.value?.rangeHigh ?? null;
+        const rangeLow = point.value?.rangeLow ?? null;
+        const anchorPrice =
+          placement === "above"
+            ? (candle?.high ?? rangeHigh ?? rangeLow)
+            : (candle?.low ?? rangeLow ?? rangeHigh);
+        if (anchorPrice == null) continue;
 
-    ctx.fillStyle = `rgba(${rgb},0.95)`;
-    ctx.fillText(text, boxX + padX, boxY + padY);
-  }
+        const anchorY = priceScale.priceToY(anchorPrice);
+        const y = placement === "above" ? anchorY - 4 : anchorY + 12;
 
-  ctx.restore();
+        const phaseKey =
+          point.value?.phase && PHASE_COLORS[point.value.phase] ? point.value.phase : "unknown";
+        const rgb = PHASE_COLORS[phaseKey];
+
+        // Small dot at the anchor price
+        ctx.fillStyle = `rgba(${rgb},0.9)`;
+        ctx.beginPath();
+        ctx.arc(x, anchorY, 2, 0, Math.PI * 2);
+        ctx.fill();
+
+        // Text label
+        ctx.fillStyle = `rgba(${rgb},0.95)`;
+        ctx.textBaseline = placement === "above" ? "bottom" : "top";
+        ctx.fillText(event, x, y);
+      }
+    }
+
+    // ----- 3. Bottom timeline bar -----
+    if (options.showTimelineBar) {
+      const barY = pane.y + pane.height - PHASE_BAR_HEIGHT;
+      for (let i = start; i < end && i < phases.length; i++) {
+        const point = phases[i];
+        if (!point?.value) continue;
+        const { phase, confidence } = point.value;
+        const rgb = PHASE_COLORS[phase] ?? PHASE_COLORS.unknown;
+        const alpha = 0.4 + ((confidence ?? 50) / 100) * 0.5;
+        const x = timeScale.indexToX(i);
+        ctx.fillStyle = `rgba(${rgb},${alpha.toFixed(3)})`;
+        ctx.fillRect(x - barWidth / 2, barY, barWidth, PHASE_BAR_HEIGHT);
+      }
+
+      // VSA event dots just above the timeline bar
+      if (vsa.length > 0) {
+        const markerY = barY - 4;
+        for (let i = start; i < end && i < vsa.length; i++) {
+          const point = vsa[i];
+          if (!point?.value) continue;
+          const { barType } = point.value;
+          if (barType === "normal") continue;
+          const rgb = VSA_MARKER_COLORS[barType];
+          if (!rgb) continue;
+          const x = timeScale.indexToX(i);
+          ctx.fillStyle = `rgba(${rgb},0.8)`;
+          ctx.beginPath();
+          ctx.arc(x, markerY, 2, 0, Math.PI * 2);
+          ctx.fill();
+        }
+      }
+    }
+
+    // ----- 4. Corner badge (top-left) -----
+    if (options.showPhaseBadge && last) {
+      const label = PHASE_LABELS[last.phase] ?? last.phase;
+      const conf = last.confidence ?? 0;
+      const subPhase = last.subPhase ? ` · ${last.subPhase}` : "";
+      const text = `Wyckoff: ${label} (${conf.toFixed(0)})${subPhase}`;
+      const rgb = PHASE_COLORS[last.phase] ?? PHASE_COLORS.unknown;
+
+      ctx.font = "bold 11px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.textAlign = "left";
+      ctx.textBaseline = "top";
+      const textWidth = ctx.measureText(text).width;
+      const padX = 8;
+      const padY = 4;
+      const boxW = textWidth + padX * 2;
+      const boxH = 18;
+      // Offset below the chart's OHLC legend row (typically ~22 px from top).
+      const boxX = pane.x + 8;
+      const boxY = pane.y + 32;
+
+      ctx.fillStyle = "rgba(22,26,37,0.85)";
+      ctx.fillRect(boxX, boxY, boxW, boxH);
+      ctx.strokeStyle = `rgba(${rgb},0.7)`;
+      ctx.lineWidth = 1;
+      ctx.strokeRect(boxX, boxY, boxW, boxH);
+
+      ctx.fillStyle = `rgba(${rgb},0.95)`;
+      ctx.fillText(text, boxX + padX, boxY + padY);
+    }
+  });
 }
 
 // ---- Factory ----

--- a/packages/chart/src/renderer/range-calculator.ts
+++ b/packages/chart/src/renderer/range-calculator.ts
@@ -7,11 +7,12 @@ import type { InternalSeries } from "../core/data-layer";
 import type { RendererRegistry } from "../core/renderer-registry";
 import { defaultRegistry } from "../core/series-registry";
 import type { CandleData, DataPoint, PaneRect } from "../core/types";
+import { type MinMax, emptyRange, reduceRange } from "../core/value-range";
 import { bandPriceRange } from "../series/band";
 import { candlePriceRange } from "../series/candlestick";
 import { cloudPriceRange } from "../series/cloud";
 import { volumeRange } from "../series/histogram";
-import { channelPriceRange, linePriceRange } from "../series/line";
+import { linePriceRange } from "../series/line";
 
 /**
  * Compute the price range for a pane based on candles and assigned series.
@@ -98,12 +99,9 @@ export function computeSeriesRange(
 
   // Generic: decompose and find range across all channels
   const channels = defaultRegistry.decomposeAll(s.data, rule);
-  let min = Number.POSITIVE_INFINITY;
-  let max = Number.NEGATIVE_INFINITY;
+  let acc: MinMax = emptyRange();
   for (const [, vals] of channels) {
-    const [cMin, cMax] = channelPriceRange(vals, start, end);
-    if (cMin < min) min = cMin;
-    if (cMax > max) max = cMax;
+    acc = reduceRange(vals, start, end, acc);
   }
-  return [min, max];
+  return acc;
 }

--- a/packages/chart/src/renderer/render-pipeline.ts
+++ b/packages/chart/src/renderer/render-pipeline.ts
@@ -5,7 +5,7 @@
 
 import type { DataLayer, InternalSeries } from "../core/data-layer";
 import { decimateCandles, getDecimationTarget } from "../core/decimation";
-import { DrawHelper } from "../core/draw-helper";
+import { DrawHelper, withPaneClip } from "../core/draw-helper";
 import type { LayoutEngine } from "../core/layout";
 import type { RendererRegistry } from "../core/renderer-registry";
 import { PriceScale, type TimeScale } from "../core/scale";
@@ -212,178 +212,173 @@ export function renderFrame(rc: RenderContext): RenderResult {
     if (!scales) continue;
     const ps = scales.right; // Primary scale for most rendering
 
-    ctx.save();
-    ctx.beginPath();
-    ctx.rect(pane.x, pane.y, pane.width, pane.height);
-    ctx.clip();
+    withPaneClip(ctx, pane, () => {
+      // Grid
+      renderGrid(ctx, ps, pane.x, pane.y, pane.width, pane.height, theme, timeScale, candles);
 
-    // Grid
-    renderGrid(ctx, ps, pane.x, pane.y, pane.width, pane.height, theme, timeScale, candles);
-
-    // Reference lines
-    if (pane.config.referenceLines?.length) {
-      renderReferenceLines(
-        ctx,
-        pane.config.referenceLines,
-        ps,
-        pane.x,
-        pane.y,
-        pane.width,
-        pane.config.referenceLineColor ?? theme.textSecondary,
-      );
-    }
-    if (pane.config.leftScale?.referenceLines?.length) {
-      renderReferenceLines(
-        ctx,
-        pane.config.leftScale.referenceLines,
-        scales.left,
-        pane.x,
-        pane.y,
-        pane.width,
-        pane.config.leftScale.referenceLineColor ?? theme.textSecondary,
-      );
-    }
-
-    ctx.translate(0, pane.y);
-
-    // Score heatmap
-    if (pane.id === "main" && data.scores.length > 0) {
-      renderScoreHeatmap(ctx, data.scores, timeScale, { ...pane, y: 0 });
-    }
-
-    // Price data
-    if (pane.id === "main") {
-      const decimTarget = getDecimationTarget(
-        timeScale.endIndex - timeScale.startIndex,
-        timeScale.width,
-      );
-      let visibleCandles: readonly CandleData[];
-      // When decimated, remap barSpacing so candles fill the full canvas width
-      const savedStart = timeScale.startIndex;
-      const savedSpacing = timeScale.barSpacing;
-      if (decimTarget > 0) {
-        // Use cached decimation result when viewport hasn't changed
-        const dataVer = data.version;
-        if (
-          _decimCache &&
-          _decimCache.start === timeScale.startIndex &&
-          _decimCache.end === timeScale.endIndex &&
-          _decimCache.target === decimTarget &&
-          _decimCache.dataVersion === dataVer
-        ) {
-          visibleCandles = _decimCache.result;
-        } else {
-          visibleCandles = decimateCandles(
-            candles,
-            timeScale.startIndex,
-            timeScale.endIndex,
-            decimTarget,
-          );
-          _decimCache = {
-            start: timeScale.startIndex,
-            end: timeScale.endIndex,
-            target: decimTarget,
-            dataVersion: dataVer,
-            result: visibleCandles,
-          };
-        }
-        timeScale.setImmediate(0, timeScale.width / visibleCandles.length);
-      } else {
-        visibleCandles = candles;
-      }
-      switch (rc.chartType) {
-        case "line":
-          renderPriceLineChart(ctx, visibleCandles, timeScale, ps, theme);
-          break;
-        case "mountain":
-          renderMountainChart(ctx, visibleCandles, timeScale, ps, theme);
-          break;
-        case "ohlc":
-          renderOhlcBars(ctx, visibleCandles, timeScale, ps, theme);
-          break;
-        default:
-          renderCandlesticks(ctx, visibleCandles, timeScale, ps, theme);
-          break;
-      }
-      // Restore timeScale after decimated rendering
-      if (decimTarget > 0) {
-        timeScale.setImmediate(savedStart, savedSpacing);
-      }
-    }
-
-    if (pane.id === "volume") {
-      renderVolume(ctx, candles, timeScale, ps, theme);
-    }
-
-    // Pre-compute translated pane object once (avoids spread per primitive)
-    const translatedPane = { ...pane, y: 0 };
-
-    // 'below' primitives
-    for (const prim of rc.rendererRegistry.getPrimitives(pane.id, "below")) {
-      try {
-        if (!drawHelper) drawHelper = new DrawHelper(ctx, timeScale, ps);
-        else drawHelper.reset(ctx, timeScale, ps);
-        prim.plugin.render(
-          {
-            ctx,
-            pane: translatedPane,
-            timeScale,
-            priceScale: ps,
-            dataLayer: data,
-            theme,
-            draw: drawHelper,
-          },
-          prim.state,
-        );
-      } catch (err) {
-        rc.emit("error", { source: `primitive:${prim.plugin.name}`, error: err });
-      }
-    }
-
-    // Series — dispatch to correct scale (cache for later info overlay use)
-    const paneSeriesForRender = data.getSeriesForPane(pane.id);
-    _seriesByPane.set(pane.id, paneSeriesForRender);
-    for (const s of paneSeriesForRender) {
-      try {
-        const seriesScale = s.scaleId === "left" ? scales.left : ps;
-        dispatchSeries(
+      // Reference lines
+      if (pane.config.referenceLines?.length) {
+        renderReferenceLines(
           ctx,
-          s,
-          timeScale,
-          seriesScale,
-          data,
+          pane.config.referenceLines,
+          ps,
+          pane.x,
+          pane.y,
           pane.width,
-          theme,
-          rc.rendererRegistry,
+          pane.config.referenceLineColor ?? theme.textSecondary,
         );
-      } catch (err) {
-        rc.emit("error", { source: `series:${s.id}`, error: err });
       }
-    }
+      if (pane.config.leftScale?.referenceLines?.length) {
+        renderReferenceLines(
+          ctx,
+          pane.config.leftScale.referenceLines,
+          scales.left,
+          pane.x,
+          pane.y,
+          pane.width,
+          pane.config.leftScale.referenceLineColor ?? theme.textSecondary,
+        );
+      }
 
-    // 'above' primitives
-    for (const prim of rc.rendererRegistry.getPrimitives(pane.id, "above")) {
-      try {
-        if (!drawHelper) drawHelper = new DrawHelper(ctx, timeScale, ps);
-        else drawHelper.reset(ctx, timeScale, ps);
-        prim.plugin.render(
-          {
+      ctx.translate(0, pane.y);
+
+      // Score heatmap
+      if (pane.id === "main" && data.scores.length > 0) {
+        renderScoreHeatmap(ctx, data.scores, timeScale, { ...pane, y: 0 });
+      }
+
+      // Price data
+      if (pane.id === "main") {
+        const decimTarget = getDecimationTarget(
+          timeScale.endIndex - timeScale.startIndex,
+          timeScale.width,
+        );
+        let visibleCandles: readonly CandleData[];
+        // When decimated, remap barSpacing so candles fill the full canvas width
+        const savedStart = timeScale.startIndex;
+        const savedSpacing = timeScale.barSpacing;
+        if (decimTarget > 0) {
+          // Use cached decimation result when viewport hasn't changed
+          const dataVer = data.version;
+          if (
+            _decimCache &&
+            _decimCache.start === timeScale.startIndex &&
+            _decimCache.end === timeScale.endIndex &&
+            _decimCache.target === decimTarget &&
+            _decimCache.dataVersion === dataVer
+          ) {
+            visibleCandles = _decimCache.result;
+          } else {
+            visibleCandles = decimateCandles(
+              candles,
+              timeScale.startIndex,
+              timeScale.endIndex,
+              decimTarget,
+            );
+            _decimCache = {
+              start: timeScale.startIndex,
+              end: timeScale.endIndex,
+              target: decimTarget,
+              dataVersion: dataVer,
+              result: visibleCandles,
+            };
+          }
+          timeScale.setImmediate(0, timeScale.width / visibleCandles.length);
+        } else {
+          visibleCandles = candles;
+        }
+        switch (rc.chartType) {
+          case "line":
+            renderPriceLineChart(ctx, visibleCandles, timeScale, ps, theme);
+            break;
+          case "mountain":
+            renderMountainChart(ctx, visibleCandles, timeScale, ps, theme);
+            break;
+          case "ohlc":
+            renderOhlcBars(ctx, visibleCandles, timeScale, ps, theme);
+            break;
+          default:
+            renderCandlesticks(ctx, visibleCandles, timeScale, ps, theme);
+            break;
+        }
+        // Restore timeScale after decimated rendering
+        if (decimTarget > 0) {
+          timeScale.setImmediate(savedStart, savedSpacing);
+        }
+      }
+
+      if (pane.id === "volume") {
+        renderVolume(ctx, candles, timeScale, ps, theme);
+      }
+
+      // Pre-compute translated pane object once (avoids spread per primitive)
+      const translatedPane = { ...pane, y: 0 };
+
+      // 'below' primitives
+      for (const prim of rc.rendererRegistry.getPrimitives(pane.id, "below")) {
+        try {
+          if (!drawHelper) drawHelper = new DrawHelper(ctx, timeScale, ps);
+          else drawHelper.reset(ctx, timeScale, ps);
+          prim.plugin.render(
+            {
+              ctx,
+              pane: translatedPane,
+              timeScale,
+              priceScale: ps,
+              dataLayer: data,
+              theme,
+              draw: drawHelper,
+            },
+            prim.state,
+          );
+        } catch (err) {
+          rc.emit("error", { source: `primitive:${prim.plugin.name}`, error: err });
+        }
+      }
+
+      // Series — dispatch to correct scale (cache for later info overlay use)
+      const paneSeriesForRender = data.getSeriesForPane(pane.id);
+      _seriesByPane.set(pane.id, paneSeriesForRender);
+      for (const s of paneSeriesForRender) {
+        try {
+          const seriesScale = s.scaleId === "left" ? scales.left : ps;
+          dispatchSeries(
             ctx,
-            pane: translatedPane,
+            s,
             timeScale,
-            priceScale: ps,
-            dataLayer: data,
+            seriesScale,
+            data,
+            pane.width,
             theme,
-            draw: drawHelper,
-          },
-          prim.state,
-        );
-      } catch (err) {
-        rc.emit("error", { source: `primitive:${prim.plugin.name}`, error: err });
+            rc.rendererRegistry,
+          );
+        } catch (err) {
+          rc.emit("error", { source: `series:${s.id}`, error: err });
+        }
       }
-    }
 
-    ctx.restore();
+      // 'above' primitives
+      for (const prim of rc.rendererRegistry.getPrimitives(pane.id, "above")) {
+        try {
+          if (!drawHelper) drawHelper = new DrawHelper(ctx, timeScale, ps);
+          else drawHelper.reset(ctx, timeScale, ps);
+          prim.plugin.render(
+            {
+              ctx,
+              pane: translatedPane,
+              timeScale,
+              priceScale: ps,
+              dataLayer: data,
+              theme,
+              draw: drawHelper,
+            },
+            prim.state,
+          );
+        } catch (err) {
+          rc.emit("error", { source: `primitive:${prim.plugin.name}`, error: err });
+        }
+      }
+    });
 
     // Right price axis
     renderPriceAxis(

--- a/packages/chart/src/series/band.ts
+++ b/packages/chart/src/series/band.ts
@@ -3,7 +3,9 @@
  * Renders upper/middle/lower bands with filled area (BB, KC, Donchian).
  */
 
+import { strokeNullableLine } from "../core/draw-helper";
 import type { PriceScale, TimeScale } from "../core/scale";
+import { reduceRange } from "../core/value-range";
 
 export type BandRenderOptions = {
   upperColor: string;
@@ -41,44 +43,13 @@ export function renderBand(
   renderFillBetween(ctx, upper, lower, start, end, timeScale, priceScale, opts.fillColor);
 
   // Lines
-  renderBandLine(ctx, upper, start, end, timeScale, priceScale, opts.upperColor, opts.lineWidth);
-  renderBandLine(ctx, middle, start, end, timeScale, priceScale, opts.middleColor, opts.lineWidth);
-  renderBandLine(ctx, lower, start, end, timeScale, priceScale, opts.lowerColor, opts.lineWidth);
-}
-
-function renderBandLine(
-  ctx: CanvasRenderingContext2D,
-  values: readonly (number | null)[],
-  start: number,
-  end: number,
-  timeScale: TimeScale,
-  priceScale: PriceScale,
-  color: string,
-  lineWidth: number,
-): void {
-  ctx.strokeStyle = color;
-  ctx.lineWidth = lineWidth;
-  ctx.lineJoin = "round";
-  ctx.setLineDash([]);
-
-  let drawing = false;
-  ctx.beginPath();
-  for (let i = start; i < end && i < values.length; i++) {
-    const val = values[i];
-    if (val === null || val === undefined) {
-      drawing = false;
-      continue;
-    }
-    const x = timeScale.indexToX(i);
-    const y = priceScale.priceToY(val);
-    if (!drawing) {
-      ctx.moveTo(x, y);
-      drawing = true;
-    } else {
-      ctx.lineTo(x, y);
-    }
-  }
-  ctx.stroke();
+  const lw = opts.lineWidth;
+  strokeNullableLine(ctx, upper, timeScale, priceScale, { color: opts.upperColor, lineWidth: lw });
+  strokeNullableLine(ctx, middle, timeScale, priceScale, {
+    color: opts.middleColor,
+    lineWidth: lw,
+  });
+  strokeNullableLine(ctx, lower, timeScale, priceScale, { color: opts.lowerColor, lineWidth: lw });
 }
 
 function renderFillBetween(
@@ -147,19 +118,5 @@ export function bandPriceRange(
   startIndex: number,
   endIndex: number,
 ): [number, number] {
-  let min = Number.POSITIVE_INFINITY;
-  let max = Number.NEGATIVE_INFINITY;
-  for (let i = startIndex; i < endIndex; i++) {
-    const u = i < upper.length ? upper[i] : null;
-    const l = i < lower.length ? lower[i] : null;
-    if (u !== null && u !== undefined) {
-      if (u > max) max = u;
-      if (u < min) min = u;
-    }
-    if (l !== null && l !== undefined) {
-      if (l > max) max = l;
-      if (l < min) min = l;
-    }
-  }
-  return [min, max];
+  return reduceRange(lower, startIndex, endIndex, reduceRange(upper, startIndex, endIndex));
 }

--- a/packages/chart/src/series/cloud.ts
+++ b/packages/chart/src/series/cloud.ts
@@ -3,7 +3,9 @@
  * Renders Ichimoku-style cloud (filled area between two lines) + additional lines.
  */
 
+import { strokeNullableLine } from "../core/draw-helper";
 import type { PriceScale, TimeScale } from "../core/scale";
+import { type MinMax, reduceRange } from "../core/value-range";
 
 export type CloudRenderOptions = {
   lineColors: Record<string, string>;
@@ -49,7 +51,7 @@ export function renderCloud(
   for (const [key, color] of Object.entries(opts.lineColors)) {
     const values = channels.get(key);
     if (!values) continue;
-    renderCloudLine(ctx, values, start, end, timeScale, priceScale, color, opts.lineWidth);
+    strokeNullableLine(ctx, values, timeScale, priceScale, { color, lineWidth: opts.lineWidth });
   }
 }
 
@@ -108,56 +110,15 @@ function drawCloudSegment(
   }
 }
 
-function renderCloudLine(
-  ctx: CanvasRenderingContext2D,
-  values: readonly (number | null)[],
-  start: number,
-  end: number,
-  timeScale: TimeScale,
-  priceScale: PriceScale,
-  color: string,
-  lineWidth: number,
-): void {
-  ctx.strokeStyle = color;
-  ctx.lineWidth = lineWidth;
-  ctx.lineJoin = "round";
-  ctx.setLineDash([]);
-
-  let drawing = false;
-  ctx.beginPath();
-  for (let i = start; i < end && i < values.length; i++) {
-    const val = values[i];
-    if (val === null || val === undefined) {
-      drawing = false;
-      continue;
-    }
-    const x = timeScale.indexToX(i);
-    const y = priceScale.priceToY(val);
-    if (!drawing) {
-      ctx.moveTo(x, y);
-      drawing = true;
-    } else {
-      ctx.lineTo(x, y);
-    }
-  }
-  ctx.stroke();
-}
-
 /** Compute price range across all cloud channels */
 export function cloudPriceRange(
   channels: Map<string, (number | null)[]>,
   startIndex: number,
   endIndex: number,
 ): [number, number] {
-  let min = Number.POSITIVE_INFINITY;
-  let max = Number.NEGATIVE_INFINITY;
+  let acc: MinMax = [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY];
   for (const [, vals] of channels) {
-    for (let i = startIndex; i < endIndex && i < vals.length; i++) {
-      const v = vals[i];
-      if (v === null || v === undefined) continue;
-      if (v < min) min = v;
-      if (v > max) max = v;
-    }
+    acc = reduceRange(vals, startIndex, endIndex, acc);
   }
-  return [min, max];
+  return acc;
 }

--- a/packages/chart/src/series/cloud.ts
+++ b/packages/chart/src/series/cloud.ts
@@ -5,7 +5,7 @@
 
 import { strokeNullableLine } from "../core/draw-helper";
 import type { PriceScale, TimeScale } from "../core/scale";
-import { type MinMax, reduceRange } from "../core/value-range";
+import { type MinMax, emptyRange, reduceRange } from "../core/value-range";
 
 export type CloudRenderOptions = {
   lineColors: Record<string, string>;
@@ -116,7 +116,7 @@ export function cloudPriceRange(
   startIndex: number,
   endIndex: number,
 ): [number, number] {
-  let acc: MinMax = [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY];
+  let acc: MinMax = emptyRange();
   for (const [, vals] of channels) {
     acc = reduceRange(vals, startIndex, endIndex, acc);
   }

--- a/packages/chart/src/series/line.ts
+++ b/packages/chart/src/series/line.ts
@@ -3,8 +3,10 @@
  * Renders a continuous line from Series<number> or decomposed channels.
  */
 
+import { strokeNullableLine } from "../core/draw-helper";
 import type { PriceScale, TimeScale } from "../core/scale";
 import type { DataPoint } from "../core/types";
+import { reduceRange } from "../core/value-range";
 
 export type LineRenderOptions = {
   color: string;
@@ -68,37 +70,11 @@ export function renderChannelLine(
   priceScale: PriceScale,
   options: LineRenderOptions,
 ): void {
-  ctx.strokeStyle = options.color;
-  ctx.lineWidth = options.lineWidth;
-  ctx.lineJoin = "round";
-  ctx.lineCap = "round";
-  if (options.dash) ctx.setLineDash(options.dash);
-  else ctx.setLineDash([]);
-
-  const start = timeScale.startIndex;
-  const end = timeScale.endIndex;
-  let drawing = false;
-
-  ctx.beginPath();
-  for (let i = start; i < end && i < values.length; i++) {
-    const val = values[i];
-    if (val === null || val === undefined) {
-      drawing = false;
-      continue;
-    }
-
-    const x = timeScale.indexToX(i);
-    const y = priceScale.priceToY(val);
-
-    if (!drawing) {
-      ctx.moveTo(x, y);
-      drawing = true;
-    } else {
-      ctx.lineTo(x, y);
-    }
-  }
-  ctx.stroke();
-  ctx.setLineDash([]);
+  strokeNullableLine(ctx, values, timeScale, priceScale, {
+    color: options.color,
+    lineWidth: options.lineWidth,
+    dash: options.dash,
+  });
 }
 
 /** Compute min/max of visible data for auto-ranging */
@@ -109,7 +85,8 @@ export function linePriceRange(
 ): [number, number] {
   let min = Number.POSITIVE_INFINITY;
   let max = Number.NEGATIVE_INFINITY;
-  for (let i = startIndex; i < endIndex && i < data.length; i++) {
+  const lim = Math.min(endIndex, data.length);
+  for (let i = startIndex; i < lim; i++) {
     const val = data[i]?.value;
     if (val === null || val === undefined) continue;
     if (val < min) min = val;
@@ -124,13 +101,5 @@ export function channelPriceRange(
   startIndex: number,
   endIndex: number,
 ): [number, number] {
-  let min = Number.POSITIVE_INFINITY;
-  let max = Number.NEGATIVE_INFINITY;
-  for (let i = startIndex; i < endIndex && i < values.length; i++) {
-    const val = values[i];
-    if (val === null || val === undefined) continue;
-    if (val < min) min = val;
-    if (val > max) max = val;
-  }
-  return [min, max];
+  return reduceRange(values, startIndex, endIndex);
 }


### PR DESCRIPTION
## Summary

Two-commit refactor extracting shared canvas/range helpers across the chart package. No behaviour change; 623 tests pass (+12 new direct tests); bundle is 30.60 kB brotli against the 31 kB limit (restored from the accidental 32 kB bump on the previous branch).

### Commit 1 — `915febc` extract shared helpers
- `withPaneClip(ctx, pane, fn)` in `core/draw-helper.ts` replaces 10 copies of the `save/beginPath/rect/clip/…/restore` block across every plugin.
- `strokeNullableLine()` collapses three identical null-gap polyline loops in `series/{band,line,cloud}.ts`; `DrawHelper.line()` now delegates to it so the gap-handling rule lives in exactly one place.
- `core/value-range.ts` adds `reduceRange()` + `MinMax`; `{line,channel,band,cloud}PriceRange` thin out to wrappers.
- Size limit restored from 32 kB → 31 kB.

### Commit 2 — `764fbcf` finish the consolidation
- `withPaneClip()` and `DrawHelper.scope()` now wrap the callback in `try/finally`, so `ctx.restore()` pairs correctly even when the callback throws. The `scope()` test was quietly asserting the old (buggy) behaviour and is now updated.
- `render-pipeline.ts` swaps its own hand-rolled per-pane `save/clip/restore` for `withPaneClip()`. The clip contract is now in one place rather than two.
- `computeSeriesRange()`'s generic channel reducer delegates to `reduceRange()`; the unused `EMPTY_RANGE` export is replaced with an `emptyRange()` factory (shared mutable tuples were a footgun).
- Direct tests added for `strokeNullableLine`, `withPaneClip`, `reduceRange`, `emptyRange`, including the throw-then-restore path.

### What we deliberately didn't consolidate
`candlePriceRange` reads `.high`/`.low` fields; `volumeRange` and `histogramRange` force a zero baseline. Bending them into the generic reducer would hide the special semantics rather than remove duplication, so they keep their own loops.

### Context on the size-limit bump
The previous branch bumped `size-limit` 31 → 32 kB when `connectSqueezeDots` was added. Investigation showed brotli already compresses the repeated patterns well — dedup alone doesn't move bundle size meaningfully. The right framing was maintainability, not bytes: helpers exist so a future change lives in one spot. The size limit is back to 31 kB with headroom (30.60 kB current).

## Test plan
- [x] `pnpm --filter @trendcraft/chart test` — 623/623 pass
- [x] `pnpm --filter @trendcraft/chart lint`
- [x] `pnpm --filter @trendcraft/chart build`
- [x] `pnpm --filter @trendcraft/chart size-check` — main 30.60 kB / 31 kB
- [ ] Manual sanity check of indicator-showcase (plugins render inside pane bounds, band/cloud/line null gaps still render as breaks)