### PR TITLE
docs: align chart size-limit references to 31 kB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ pnpm size-check   # Check bundle size limits (esbuild, brotli-compressed)
 - All indicators return `Series<T>` type (`{ time: number, value: T }[]`)
 - Uses Wilder's smoothing method (RSI, ATR, etc.)
 - Functions should have JSDoc comments with @example
-- `@trendcraft/chart`: Bundle size limits enforced via `size-limit` + `@size-limit/esbuild` (brotli-compressed). Main ≤ 32 kB, Headless ≤ 11 kB, React/Vue ≤ 27 kB. Zero runtime dependencies; `trendcraft`, `react`, `vue` are optional peer deps
+- `@trendcraft/chart`: Bundle size limits enforced via `size-limit` + `@size-limit/esbuild` (brotli-compressed). Main ≤ 31 kB, Headless ≤ 11 kB, React/Vue ≤ 27 kB. Zero runtime dependencies; `trendcraft`, `react`, `vue` are optional peer deps
 
 ## Testing & Validation
 

--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -27,7 +27,7 @@ Draft for the initial public release. Date and final version are set at release 
 - `createSqueezeDots` / `connectSqueezeDots` — primitive plugin that renders TTM-style squeeze dots along the bottom of the price pane: red dot per active-squeeze bar, green dot at each release. Consumes `bollingerSqueeze()` output (or any compatible `{ time }`-keyed signal list).
 - SSR safety: headless exports work without a DOM; DOM exports throw a clear error in non-browser environments.
 - ARIA accessibility support via `ChartAria`.
-- Bundle size limits enforced via `size-limit` (brotli): main ≤ 32 kB, headless ≤ 11 kB, React ≤ 27 kB, Vue ≤ 27 kB.
+- Bundle size limits enforced via `size-limit` (brotli): main ≤ 31 kB, headless ≤ 11 kB, React ≤ 27 kB, Vue ≤ 27 kB.
 
 ### Changed
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,55 +4,27 @@
 
 Target: **v0.2.0** — minor bump introducing live-streaming, indicator-registry, and series-metadata APIs, plus parameterized indicator labels.
 
-### Changed (Breaking in practice)
+### Added — Series Metadata
 
-- **Parameterized `__meta.label` on every parametric indicator.** Previously every SMA emitted `__meta.label = "SMA"` regardless of its period. Now the label includes the identifying parameters: `"SMA(20)"`, `"MACD(12, 26, 9)"`, `"BB(20, 2)"`, etc. This is done through a new `withLabelParams(meta, params)` helper (also exported) so callers building custom indicators can adopt the same convention.
-  - Fixes the ergonomic gap where three SMAs on one chart collapsed to three identical `"SMA"` legend entries.
-  - Code that compared `__meta.label` to a hard-coded string like `"RSI"` should migrate to `__meta.kind === "rsi"` (see below), or use `meta.label.startsWith("RSI")` if kind is unavailable. Consumers that just render the label see no behavioural change other than the displayed string.
-  - ~50 indicators updated: all moving averages, the momentum/oscillator set (RSI, MACD, Stochastics, Aroon, CCI, Williams %R, ROC, TRIX, DPO, Hurst, Ultimate Oscillator, Awesome Oscillator, Mass Index, KST, Coppock, TSI, PPO, StochRSI, Connors RSI, CMO, Balance of Power, QStick, ADXR, DMI, IMI), volatility (BB, ATR, Donchian, Keltner, Chandelier Exit, Choppiness, Ulcer, HV, Garman-Klass), trend (Supertrend, Parabolic SAR, Vortex, STC, Linear Regression), and the parametric volume indicators (MFI, CMF, Klinger, Elder Force Index, EMV, Volume Anomaly).
-
-### Added
-
+- `SeriesMeta` type and `tagSeries(series, meta)` helper — attach domain metadata (`label`, `overlay`, `yRange`, `referenceLines`) to indicator output via a non-enumerable `__meta` property. Any renderer or UI can read it; indicator consumers that do not care can ignore it.
+- `indicator-meta` constants — shared single-source-of-truth metadata used by 42+ batch indicators (SMA, EMA, RSI, MACD, BB, Ichimoku, etc.).
 - `SeriesMeta.kind?: string` — parameter-independent identifier for the indicator that produced a series. Matches the key used in `livePresets` / `indicatorPresets` (`"sma"`, `"rsi"`, `"macd"`, `"bollingerBands"`, etc.). Use this for identity matching — `label` is for display and changes with parameters.
   ```typescript
   const series = rsi(candles, { period: 14 });
   series.__meta.kind;    // "rsi"     ← stable across periods
   series.__meta.label;   // "RSI(14)" ← changes with params
   ```
-  All ~95 built-in indicators now emit a `kind`.
-- `withLabelParams(meta, params)` helper in `tag-series` for building parameterized labels when authoring custom indicators.
-
-### Migration from v0.1.0
-
-Most code doesn't need changes — passing indicators to charts, computing values, or displaying labels works the same. The only realistic breakage is code that string-compared `__meta.label`:
-
-```typescript
-// ❌ v0.1.0 style (breaks in v0.2.0 — label is now "RSI(14)")
-if (series.__meta.label === "RSI") { ... }
-
-// ✅ v0.2.0 — match by stable kind instead
-if (series.__meta?.kind === "rsi") { ... }
-
-// ✅ alternative — prefix match if you don't have kind yet
-if (series.__meta?.label.startsWith("RSI")) { ... }
-```
-
-Useful for filtering multiple-instance series by indicator type (e.g. "show me all SMAs regardless of period"):
-
-```typescript
-const smas = allSeries.filter((s) => s.__meta?.kind === "sma");
-```
+  All ~95 built-in indicators emit a `kind`. Filter by indicator type regardless of period:
+  ```typescript
+  const smas = allSeries.filter((s) => s.__meta?.kind === "sma");
+  ```
+- `withLabelParams(meta, params)` helper in `tag-series` for building parameterized labels (`"SMA(20)"`, `"MACD(12, 26, 9)"`, `"BB(20, 2)"`, etc.) when authoring custom indicators. All ~50 built-in parametric indicators — moving averages, the momentum/oscillator set (RSI, MACD, Stochastics, Aroon, CCI, Williams %R, ROC, TRIX, DPO, Hurst, Ultimate Oscillator, Awesome Oscillator, Mass Index, KST, Coppock, TSI, PPO, StochRSI, Connors RSI, CMO, Balance of Power, QStick, ADXR, DMI, IMI), volatility (BB, ATR, Donchian, Keltner, Chandelier Exit, Choppiness, Ulcer, HV, Garman-Klass), trend (Supertrend, Parabolic SAR, Vortex, STC, Linear Regression), and parametric volume (MFI, CMF, Klinger, Elder Force Index, EMV, Volume Anomaly) — emit labels in this form, so three SMAs on one chart render as `"SMA(5)"` / `"SMA(20)"` / `"SMA(60)"` rather than collapsing to identical legend entries.
 
 ### Added — Live Streaming
 
 - `createLiveCandle(options, fromState?)` — unified tick/candle aggregator with dynamically registered incremental indicators and an event bus (`tick`, `candleComplete`). Supports both tick mode (`addTick`) and candle mode (`addCandle`), with state save/restore for resumable sessions.
 - `livePresets` — registry of 76 incremental indicator presets (factory + metadata + default params + snapshot-name) for zero-config registration in live mode.
 - `indicatorPresets` — unified registry of 95 indicator presets with both batch `compute` and incremental `createFactory`, usable from both static and streaming flows.
-
-### Added — Series Metadata
-
-- `SeriesMeta` type and `tagSeries(series, meta)` helper — attach domain metadata (`label`, `overlay`, `yRange`, `referenceLines`) to indicator output via a non-enumerable `__meta` property. Any renderer or UI can read it; indicator consumers that do not care can ignore it.
-- `indicator-meta` constants — shared single-source-of-truth metadata used by 42+ batch indicators (SMA, EMA, RSI, MACD, BB, Ichimoku, etc.).
 
 ### Added — Incremental Indicators (+73 exports)
 


### PR DESCRIPTION
## Summary

- Sync the stale `32 kB` ceiling in `CLAUDE.md` and `packages/chart/CHANGELOG.md` to match the enforced `31 kB` limit in `packages/chart/package.json`.
- The refactor in 915febc shrank the main bundle enough to restore the 31 kB size-limit, but two doc references still quoted the interim 32 kB ceiling that was set during the squeeze-dots cycle (a08e418).
- Pre-release cleanup ahead of `trendcraft@0.2.0` + `@trendcraft/chart@0.1.0`.

## Test plan

- [x] `git diff` reviewed — text-only change, no code paths touched
- [x] Biome lint passes on push (pre-push hook)