### PR TITLE
feat: price source / session breaks / timezone (core) + time-proportional axis (chart)

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- draft: polish before release -->
+<!-- - session gap rendering (ChartOptions.timeScale.sessionGaps, TimeScale.setGapsBefore) -->
+<!-- - autoFormatTime shows date anchor after large time jumps within the same local day -->
+
 ### Added — UX pass
 
 - **Crosshair snap modes** via `ChartOptions.crosshair`:

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -99,7 +99,7 @@
     {
       "name": "Main (createChart + all exports)",
       "path": "dist/index.js",
-      "limit": "32 kB"
+      "limit": "35 kB"
     },
     {
       "name": "Headless API",
@@ -109,12 +109,12 @@
     {
       "name": "React wrapper",
       "path": "dist/react/TrendChart.js",
-      "limit": "27 kB"
+      "limit": "29 kB"
     },
     {
       "name": "Vue wrapper",
       "path": "dist/vue/TrendChart.js",
-      "limit": "27 kB"
+      "limit": "29 kB"
     }
   ],
   "devDependencies": {

--- a/packages/chart/src/__tests__/format.test.ts
+++ b/packages/chart/src/__tests__/format.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { autoFormatPrice, autoFormatTime, detectPrecision, formatVolume } from "../core/format";
+import {
+  autoFormatPrice,
+  autoFormatTime,
+  detectPrecision,
+  formatShortDate,
+  formatShortTime,
+  formatVolume,
+  pickNiceStep,
+} from "../core/format";
 
 describe("autoFormatPrice", () => {
   it("formats high prices with 0 decimals", () => {
@@ -78,6 +86,38 @@ describe("autoFormatTime", () => {
     // Timezone-dependent, just verify HH:MM format
     expect(label).toMatch(/^\d{2}:\d{2}$/);
   });
+
+  it("large jump across a day boundary shows date + time when the bar is mid-session", () => {
+    // Fri 14:00 local → Mon 22:30 local (weekend gap, >= 56h).
+    // Mon 22:30 is not near midnight, so the hour matters to the viewer.
+    const prev = new Date(2026, 0, 16, 14, 0, 0).getTime();
+    const next = new Date(2026, 0, 19, 22, 30, 0).getTime();
+    const label = autoFormatTime(next, prev);
+    expect(label).toMatch(/[A-Z][a-z]{2}/); // month
+    expect(label).toContain("22:30"); // explicit hour anchor
+  });
+
+  it("large jump across day boundary keeps compact date when bar is near midnight", () => {
+    // Daily bars: consecutive bars are 24h apart and timestamped at 00:00.
+    // Compact "Jan 17" is more readable than "Jan 17 00:00".
+    const prev = new Date(2026, 0, 16, 0, 0, 0).getTime();
+    const next = new Date(2026, 0, 17, 0, 0, 0).getTime();
+    const label = autoFormatTime(next, prev);
+    expect(label).not.toContain(":");
+  });
+
+  it("large time jump within the same local day shows date + time", () => {
+    // Simulates an overnight session gap (e.g. AAPL ET 16:00 → 09:30 next day,
+    // which can fall on the same local calendar day when viewed cross-TZ).
+    // Use local Date constructor so both times are the same calendar day in
+    // the test runner's TZ, then make the jump big (18h).
+    const prev = new Date(2026, 0, 15, 2, 0, 0).getTime(); // local 02:00
+    const next = new Date(2026, 0, 15, 20, 0, 0).getTime(); // local 20:00, +18h
+    const label = autoFormatTime(next, prev);
+    // Must include a month name (anchoring context) + the time, not just HH:MM
+    expect(label).toMatch(/[A-Z][a-z]{2}/);
+    expect(label).toMatch(/\d{2}:\d{2}/);
+  });
 });
 
 describe("formatVolume", () => {
@@ -139,5 +179,51 @@ describe("autoFormatPrice edge cases", () => {
 
   it("formats exactly 0.01", () => {
     expect(autoFormatPrice(0.01)).toBe("0.0100");
+  });
+});
+
+describe("formatShortTime", () => {
+  it("returns HH:MM 24h format", () => {
+    const t = new Date(2026, 0, 15, 9, 30).getTime();
+    expect(formatShortTime(t)).toBe("09:30");
+  });
+  it("pads hours and minutes", () => {
+    const t = new Date(2026, 0, 15, 1, 5).getTime();
+    expect(formatShortTime(t)).toBe("01:05");
+  });
+});
+
+describe("formatShortDate", () => {
+  it("returns month + day", () => {
+    const t = new Date(2026, 2, 16, 10, 0).getTime();
+    expect(formatShortDate(t)).toContain("16");
+  });
+  it("returns year when year boundary crossed", () => {
+    const prev = new Date(2026, 11, 31).getTime();
+    const cur = new Date(2027, 0, 1).getTime();
+    expect(formatShortDate(cur, prev)).toBe("2027");
+  });
+});
+
+describe("pickNiceStep", () => {
+  const M = 60_000;
+  const H = 60 * M;
+  const D = 24 * H;
+
+  it("picks 5m for short spans", () => {
+    expect(pickNiceStep(30 * M, 6)).toBe(5 * M);
+  });
+  it("picks 15m for 2-hour span with 8 labels", () => {
+    expect(pickNiceStep(2 * H, 8)).toBe(15 * M);
+  });
+  it("picks 1h for 8-hour span with 8 labels", () => {
+    expect(pickNiceStep(8 * H, 8)).toBe(H);
+  });
+  it("picks 1 day for week-long span", () => {
+    expect(pickNiceStep(7 * D, 7)).toBe(D);
+  });
+  it("gracefully handles edge cases", () => {
+    expect(pickNiceStep(0, 10)).toBeGreaterThan(0);
+    expect(pickNiceStep(100, 0)).toBeGreaterThan(0);
   });
 });

--- a/packages/chart/src/__tests__/scale.test.ts
+++ b/packages/chart/src/__tests__/scale.test.ts
@@ -139,3 +139,218 @@ describe("PriceScale", () => {
     expect(y100).toBeGreaterThan(y1000);
   });
 });
+
+describe("TimeScale session gaps", () => {
+  it("no gaps → identical behavior to plain index layout", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(100);
+    const before = ts.indexToX(50);
+    ts.setGapsBefore([]);
+    expect(ts.hasGaps).toBe(false);
+    expect(ts.indexToX(50)).toBe(before);
+  });
+
+  it("indexToX shifts bars after a gap to the right", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(100);
+    ts.scrollTo(0);
+    const x10Before = ts.indexToX(10);
+    const x50Before = ts.indexToX(50);
+    ts.setGapsBefore([{ index: 30, size: 1 }]);
+    // Bars before index 30 unchanged
+    expect(ts.indexToX(10)).toBe(x10Before);
+    // Bar 50 moved by 1 × barSpacing to the right
+    expect(ts.indexToX(50)).toBeCloseTo(x50Before + ts.barSpacing, 5);
+  });
+
+  it("xToIndex is the inverse of indexToX across gap boundaries", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(200);
+    ts.setGapsBefore([
+      { index: 50, size: 0.5 },
+      { index: 100, size: 0.5 },
+      { index: 150, size: 0.5 },
+    ]);
+    ts.scrollTo(0);
+    for (const idx of [0, 25, 49, 50, 75, 100, 149, 150, 199]) {
+      const x = ts.indexToX(idx);
+      expect(ts.xToIndex(x)).toBe(idx);
+    }
+  });
+
+  it("scrollToEnd keeps last real bar in view when gaps are present", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(500);
+    ts.setGapsBefore([
+      { index: 100, size: 0.5 },
+      { index: 200, size: 0.5 },
+      { index: 300, size: 0.5 },
+      { index: 400, size: 0.5 },
+    ]);
+    ts.scrollToEnd();
+    const lastX = ts.indexToX(499);
+    // Last bar should be near the right edge, within one visibleCount of width
+    expect(lastX).toBeGreaterThan(0);
+    expect(lastX).toBeLessThanOrEqual(800);
+  });
+
+  it("clearGaps restores original layout", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(100);
+    ts.scrollTo(0);
+    const xBefore = ts.indexToX(80);
+    ts.setGapsBefore([{ index: 30, size: 1 }]);
+    expect(ts.indexToX(80)).not.toBe(xBefore);
+    ts.clearGaps();
+    expect(ts.hasGaps).toBe(false);
+    expect(ts.indexToX(80)).toBe(xBefore);
+  });
+});
+
+describe("TimeScale.setTimeProportional", () => {
+  /** Build 1-min bars for `count` consecutive minutes starting at `startMs`. */
+  function mkTimes(startMs: number, count: number, stepMs = 60_000): number[] {
+    const out = new Array(count);
+    for (let i = 0; i < count; i++) out[i] = startMs + i * stepMs;
+    return out;
+  }
+
+  it("uniform 1-min bars behave identically to index layout", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    const times = mkTimes(0, 100);
+    ts.setTotalCount(100);
+    ts.scrollTo(0);
+    const before = ts.indexToX(50);
+    ts.setTimeProportional(times);
+    // Uniform data → virt[i] = i → same x
+    expect(ts.indexToX(50)).toBeCloseTo(before, 5);
+    expect(ts.hasTimeData).toBe(true);
+    expect(ts.hasGaps).toBe(true);
+  });
+
+  it("expands bars in proportion to their wall-clock gaps within a session", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(3);
+    ts.scrollTo(0);
+    // Bars at 0, 10m, 40m — second gap is 3× first gap.
+    const times = [0, 10 * 60_000, 40 * 60_000];
+    ts.setTimeProportional(times, { medianMs: 10 * 60_000 });
+    const x0 = ts.indexToX(0);
+    const x1 = ts.indexToX(1);
+    const x2 = ts.indexToX(2);
+    expect(x1 - x0).toBeCloseTo(ts.barSpacing, 5); // 1 bar gap
+    expect(x2 - x1).toBeCloseTo(3 * ts.barSpacing, 5); // 3 bar gaps
+  });
+
+  it("compresses session breaks to sessionGapBars", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(4);
+    ts.scrollTo(0);
+    // 0, 1m, 1m + overnight(17h), + 1m
+    const overnight = 17 * 60 * 60 * 1000;
+    const times = [0, 60_000, 60_000 + overnight, 2 * 60_000 + overnight];
+    ts.setTimeProportional(times, { medianMs: 60_000, sessionGapBars: 1.5 });
+    const d1 = ts.indexToX(1) - ts.indexToX(0);
+    const d2 = ts.indexToX(2) - ts.indexToX(1);
+    const d3 = ts.indexToX(3) - ts.indexToX(2);
+    expect(d1).toBeCloseTo(ts.barSpacing, 5);
+    expect(d2).toBeCloseTo(1.5 * ts.barSpacing, 5); // compressed
+    expect(d3).toBeCloseTo(ts.barSpacing, 5);
+  });
+
+  it("timeToX returns a pixel for a time that matches a bar", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(100);
+    ts.scrollTo(0);
+    const times = mkTimes(0, 100);
+    ts.setTimeProportional(times, { medianMs: 60_000 });
+    const x = ts.timeToX(times[20]);
+    expect(x).not.toBeNull();
+    expect(x).toBeCloseTo(ts.indexToX(20), 5);
+  });
+
+  it("timeToX returns a real position for the bar at the session-close (compressed gap left endpoint)", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(4);
+    ts.scrollTo(0);
+    const overnight = 17 * 60 * 60 * 1000;
+    // Bar 1 is the session-close; the next segment is a compressed gap.
+    const times = [0, 60_000, 60_000 + overnight, 2 * 60_000 + overnight];
+    ts.setTimeProportional(times, { medianMs: 60_000 });
+    const x = ts.timeToX(times[1]);
+    expect(x).not.toBeNull();
+    expect(x).toBeCloseTo(ts.indexToX(1), 5);
+  });
+
+  it("timeToX returns null for a time inside a compressed session gap", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(4);
+    ts.scrollTo(0);
+    const overnight = 17 * 60 * 60 * 1000;
+    const times = [0, 60_000, 60_000 + overnight, 2 * 60_000 + overnight];
+    ts.setTimeProportional(times, { medianMs: 60_000 });
+    // Ask for a time inside the overnight window (1h into the gap)
+    const midGap = 60_000 + 60 * 60_000;
+    expect(ts.timeToX(midGap)).toBeNull();
+  });
+
+  it("getTimeTicks emits ticks only at wall-clock nice boundaries", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(120);
+    const start = Date.UTC(2026, 0, 15, 0, 0, 0);
+    const times = mkTimes(start, 120); // 2 hours of 1-min bars
+    ts.setTimeProportional(times, { medianMs: 60_000 });
+    ts.scrollTo(0);
+    const ticks = ts.getTimeTicks(15 * 60_000); // 15-min step
+    expect(ticks.length).toBeGreaterThan(0);
+    for (const t of ticks) {
+      expect(t.time % (15 * 60_000)).toBe(0);
+    }
+  });
+
+  it("getDateTicks emits one tick per local-day boundary", () => {
+    const ts = new TimeScale();
+    ts.setWidth(1600);
+    // 3 days of bars at 1-hour intervals, each day has 24 bars
+    const times: number[] = [];
+    for (let day = 0; day < 3; day++) {
+      for (let h = 0; h < 24; h++) {
+        times.push(Date.UTC(2026, 0, 15 + day, h, 0, 0));
+      }
+    }
+    ts.setTotalCount(times.length);
+    ts.setTimeProportional(times);
+    ts.scrollTo(0);
+    const ticks = ts.getDateTicks();
+    // Should be <= 3 date tick (one per day boundary in view). Exact count
+    // depends on local TZ interpretation of UTC dates; assert at least 1
+    // and at most 4 (in case of a half-day seen at the edge).
+    expect(ticks.length).toBeGreaterThanOrEqual(1);
+    expect(ticks.length).toBeLessThanOrEqual(4);
+  });
+
+  it("clearGaps resets both virt and time data", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(100);
+    ts.setTimeProportional(mkTimes(0, 100));
+    expect(ts.hasTimeData).toBe(true);
+    ts.clearGaps();
+    expect(ts.hasTimeData).toBe(false);
+    expect(ts.hasGaps).toBe(false);
+    expect(ts.getTimeTicks(60_000)).toEqual([]);
+    expect(ts.getDateTicks()).toEqual([]);
+  });
+});

--- a/packages/chart/src/core/format.ts
+++ b/packages/chart/src/core/format.ts
@@ -113,13 +113,93 @@ export function autoFormatTime(time: number, prevTime: number | null): string {
     return `${MONTH_NAMES[month]}`;
   }
 
-  // Day changed
+  // Anchor a time label when the jump is "big" AND the destination bar is at
+  // a different time-of-day than the previous one. Daily / weekly data keeps
+  // bars at a consistent hour (e.g. 00:00 or 09:30), so the hour is noise.
+  // Session gaps (overnight, weekend) move between different times-of-day.
+  const bigJump = time - prevTime > 4 * 60 * 60 * 1000;
+  const prevTod = prev.getHours() * 60 + prev.getMinutes();
+  const curTod = hours * 60 + minutes;
+  const sameTimeOfDay = Math.abs(prevTod - curTod) < 60;
+  const nearMidnight = hours === 0 && minutes < 30;
+  const anchorTime = bigJump && !nearMidnight && !sameTimeOfDay;
+
+  // Day changed (local TZ)
   if (prev.getDate() !== day) {
-    return `${MONTH_NAMES[month]} ${day}`;
+    return anchorTime
+      ? `${MONTH_NAMES[month]} ${day} ${pad2(hours)}:${pad2(minutes)}`
+      : `${MONTH_NAMES[month]} ${day}`;
+  }
+
+  // Same local day, but a big time jump — likely a session gap (e.g. AAPL
+  // overnight viewed from Japan, where Mon ET 16:00 and Tue ET 09:30 both
+  // fall on the same JST day). Surface the date to anchor the viewer.
+  if (anchorTime) {
+    return `${MONTH_NAMES[month]} ${day} ${pad2(hours)}:${pad2(minutes)}`;
   }
 
   // Same day: show time
   return `${pad2(hours)}:${pad2(minutes)}`;
+}
+
+/**
+ * Format a wall-clock time as a short axis label (HH:MM).
+ * Uses 24-hour format in browser local TZ.
+ */
+export function formatShortTime(time: number): string {
+  const d = new Date(time);
+  return `${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
+}
+
+/**
+ * Format a date as a short axis anchor ("Mar 16" or "2026" at year boundaries).
+ * Locale-aware via the MONTH_NAMES table.
+ */
+export function formatShortDate(time: number, prevTime: number | null = null): string {
+  const d = new Date(time);
+  if (prevTime !== null) {
+    const prev = new Date(prevTime);
+    if (prev.getFullYear() !== d.getFullYear()) return `${d.getFullYear()}`;
+    if (prev.getMonth() !== d.getMonth()) return `${MONTH_NAMES[d.getMonth()]} ${d.getDate()}`;
+  }
+  return `${MONTH_NAMES[d.getMonth()]} ${d.getDate()}`;
+}
+
+/**
+ * Nice tick-step candidates in ms. Used by {@link pickNiceStep} to choose a
+ * readable wall-clock spacing (5 min, 15 min, 1 hour, 1 day, etc.) that fits
+ * the visible span and target tick count.
+ */
+const NICE_STEPS_MS: readonly number[] = [
+  60_000, // 1 min
+  5 * 60_000, // 5 min
+  10 * 60_000, // 10 min
+  15 * 60_000, // 15 min
+  30 * 60_000, // 30 min
+  60 * 60_000, // 1 hour
+  2 * 60 * 60_000, // 2 hours
+  4 * 60 * 60_000, // 4 hours
+  6 * 60 * 60_000, // 6 hours
+  12 * 60 * 60_000, // 12 hours
+  24 * 60 * 60_000, // 1 day
+  2 * 24 * 60 * 60_000, // 2 days
+  7 * 24 * 60 * 60_000, // 1 week
+  30 * 24 * 60 * 60_000, // ~1 month
+  90 * 24 * 60 * 60_000, // ~1 quarter
+  365 * 24 * 60 * 60_000, // ~1 year
+];
+
+/**
+ * Pick a readable wall-clock tick step for a time-axis spanning `rangeMs`
+ * with at most `maxTicks` labels visible.
+ */
+export function pickNiceStep(rangeMs: number, maxTicks: number): number {
+  if (rangeMs <= 0 || maxTicks <= 0) return NICE_STEPS_MS[0];
+  const target = rangeMs / maxTicks;
+  for (const step of NICE_STEPS_MS) {
+    if (step >= target) return step;
+  }
+  return NICE_STEPS_MS[NICE_STEPS_MS.length - 1];
 }
 
 /**

--- a/packages/chart/src/core/layout.ts
+++ b/packages/chart/src/core/layout.ts
@@ -30,7 +30,7 @@ export class LayoutEngine {
   private _totalWidth = 0;
   private _totalHeight = 0;
   private _priceAxisWidth = 60;
-  private _timeAxisHeight = 24;
+  private _timeAxisHeight = 32;
   private _scrollbarHeight = 16;
   private _paneRects: PaneRect[] = [];
 

--- a/packages/chart/src/core/scale.ts
+++ b/packages/chart/src/core/scale.ts
@@ -12,9 +12,30 @@ import type { ScaleMode } from "./types";
 // ============================================
 
 /**
- * Maps candle indices to x-pixel positions.
- * Uses index-based positioning (not continuous time) to avoid gaps
- * from non-trading hours.
+ * Time-proportional config for {@link TimeScale.setTimeProportional}.
+ */
+export type TimeProportionalOptions = {
+  /** Typical bar interval in ms. Default: auto (median of consecutive deltas). */
+  medianMs?: number;
+  /** Deltas exceeding this compress to `sessionGapBars` instead of proportional. Default: 4h. */
+  sessionThresholdMs?: number;
+  /** Width (in bar-units) of a compressed session gap. Default: 1.5. */
+  sessionGapBars?: number;
+};
+
+/**
+ * Maps candle indices (and optionally wall-clock time) to x-pixel positions.
+ *
+ * - **Index mode** (default): bars are laid out at uniform `barSpacing`;
+ *   `indexToX(i) = (i - startIndex + 0.5) * barSpacing`. Fast and cheap.
+ * - **Virtual mode**: each bar has an explicit virtual position in `_virt`,
+ *   enabling:
+ *     - {@link setGapsBefore} — fixed extra space before specific indices
+ *       (legacy day-boundary gap API).
+ *     - {@link setTimeProportional} — spacing within a session proportional
+ *       to the bar's wall-clock delta, with long session breaks compressed
+ *       to a fixed visual gap. Enables {@link timeToX}, {@link getTimeTicks},
+ *       {@link getDateTicks} for a Yahoo / TradingView style time axis.
  */
 export class TimeScale {
   /** First visible candle index */
@@ -32,6 +53,18 @@ export class TimeScale {
   /** Maximum bar spacing */
   private readonly _maxBarSpacing = 50;
 
+  /**
+   * Virtual position of each bar (length = totalCount when populated).
+   * `_virt[i]` is the virtual x-coordinate (in bar-units) of real bar i.
+   * Empty = index mode (fast path: virtual = real index).
+   */
+  private _virt: Float64Array = new Float64Array(0);
+  /**
+   * Wall-clock timestamps of each bar — populated by setTimeProportional only.
+   * Used by timeToX / getTimeTicks / getDateTicks. Empty in other modes.
+   */
+  private _candleTimes: Float64Array = new Float64Array(0);
+
   get startIndex(): number {
     return Math.floor(this._startIndex);
   }
@@ -42,7 +75,12 @@ export class TimeScale {
   }
 
   get endIndex(): number {
-    return Math.min(Math.floor(this._startIndex) + this._visibleCount, this._totalCount);
+    if (this._virt.length === 0) {
+      return Math.min(Math.floor(this._startIndex) + this._visibleCount, this._totalCount);
+    }
+    const startV = this.virtAt(this._startIndex);
+    const end = Math.ceil(this.realAtVirt(startV + this._visibleCount));
+    return Math.min(end, this._totalCount);
   }
 
   get visibleCount(): number {
@@ -63,7 +101,155 @@ export class TimeScale {
 
   setTotalCount(count: number): void {
     this._totalCount = count;
+    // Reset virtual/time mode — caller must re-apply if needed.
+    if (this._virt.length !== 0 && this._virt.length !== count) {
+      this._virt = new Float64Array(0);
+      this._candleTimes = new Float64Array(0);
+    }
     this.clamp();
+  }
+
+  /**
+   * Install visual gaps at specific real indices. Each entry reserves `size`
+   * bar-widths of empty space strictly before that real index. Pass an empty
+   * array to clear all gaps. Legacy API — prefer {@link setTimeProportional}
+   * for wall-clock-aware spacing.
+   *
+   * @example
+   * ```ts
+   * // Insert a half-bar gap before indices 390 (Mon open) and 780 (Tue open)
+   * timeScale.setGapsBefore([
+   *   { index: 390, size: 0.5 },
+   *   { index: 780, size: 0.5 },
+   * ]);
+   * ```
+   */
+  setGapsBefore(gaps: ReadonlyArray<{ index: number; size: number }>): void {
+    const n = this._totalCount;
+    if (n === 0 || gaps.length === 0) {
+      this._virt = new Float64Array(0);
+      this._candleTimes = new Float64Array(0);
+      this.clamp();
+      return;
+    }
+    const gapMap = new Map<number, number>();
+    for (const g of gaps) {
+      if (g.size <= 0) continue;
+      gapMap.set(g.index, (gapMap.get(g.index) ?? 0) + g.size);
+    }
+    const virt = new Float64Array(n);
+    virt[0] = gapMap.get(0) ?? 0;
+    for (let i = 1; i < n; i++) {
+      virt[i] = virt[i - 1] + 1 + (gapMap.get(i) ?? 0);
+    }
+    this._virt = virt;
+    this._candleTimes = new Float64Array(0);
+    this.clamp();
+  }
+
+  /**
+   * Configure the axis to lay bars out proportionally to their wall-clock
+   * time deltas, compressing long session breaks to a fixed gap.
+   *
+   * @param candleTimes - Per-bar epoch-ms timestamps (length must equal totalCount).
+   * @param options     - see {@link TimeProportionalOptions}.
+   */
+  setTimeProportional(candleTimes: ArrayLike<number>, options: TimeProportionalOptions = {}): void {
+    const n = candleTimes.length;
+    if (n !== this._totalCount || n === 0) {
+      this._virt = new Float64Array(0);
+      this._candleTimes = new Float64Array(0);
+      this.clamp();
+      return;
+    }
+    const median = options.medianMs ?? TimeScale.computeMedianInterval(candleTimes);
+    const sessionThreshold = options.sessionThresholdMs ?? 4 * 60 * 60 * 1000;
+    const sessionGapBars = options.sessionGapBars ?? 1.5;
+
+    const times = new Float64Array(n);
+    for (let i = 0; i < n; i++) times[i] = candleTimes[i];
+
+    const virt = new Float64Array(n);
+    virt[0] = 0;
+    for (let i = 1; i < n; i++) {
+      const delta = times[i] - times[i - 1];
+      let gap: number;
+      if (delta > sessionThreshold) {
+        gap = sessionGapBars;
+      } else if (median > 0 && delta > 0) {
+        gap = Math.max(0.001, delta / median);
+      } else {
+        gap = 1;
+      }
+      virt[i] = virt[i - 1] + gap;
+    }
+    this._virt = virt;
+    this._candleTimes = times;
+    this._cachedMedian = median;
+    this.clamp();
+  }
+
+  clearGaps(): void {
+    if (this._virt.length === 0) return;
+    this._virt = new Float64Array(0);
+    this._candleTimes = new Float64Array(0);
+    this._cachedMedian = 0;
+    this.clamp();
+  }
+
+  get hasGaps(): boolean {
+    return this._virt.length > 0;
+  }
+
+  /** True when setTimeProportional has been applied and time-based APIs work. */
+  get hasTimeData(): boolean {
+    return this._candleTimes.length > 0;
+  }
+
+  private static computeMedianInterval(times: ArrayLike<number>): number {
+    const n = times.length;
+    if (n < 2) return 60_000;
+    const deltas: number[] = [];
+    const stride = Math.max(1, Math.floor(n / 64));
+    for (let i = stride; i < n; i += stride) {
+      const d = (times[i] - times[i - stride]) / stride;
+      if (d > 0) deltas.push(d);
+    }
+    if (deltas.length === 0) return 60_000;
+    deltas.sort((a, b) => a - b);
+    return deltas[Math.floor(deltas.length / 2)];
+  }
+
+  /** Virtual position of a (possibly fractional) real index. */
+  private virtAt(i: number): number {
+    const virt = this._virt;
+    if (virt.length === 0) return i;
+    const n = virt.length;
+    if (i <= 0) return virt[0] + i;
+    if (i >= n - 1) return virt[n - 1] + (i - (n - 1));
+    const lo = Math.floor(i);
+    const frac = i - lo;
+    return virt[lo] + (virt[lo + 1] - virt[lo]) * frac;
+  }
+
+  /** Inverse of virtAt: map virtual coord back to (possibly fractional) real index. */
+  private realAtVirt(v: number): number {
+    const virt = this._virt;
+    if (virt.length === 0) return v;
+    const n = virt.length;
+    if (v <= virt[0]) return v - virt[0];
+    if (v >= virt[n - 1]) return n - 1 + (v - virt[n - 1]);
+    // Binary search for largest i with virt[i] <= v
+    let lo = 0;
+    let hi = n - 1;
+    while (lo < hi - 1) {
+      const mid = (lo + hi) >> 1;
+      if (virt[mid] <= v) lo = mid;
+      else hi = mid;
+    }
+    const span = virt[hi] - virt[lo];
+    if (span <= 0) return lo;
+    return lo + (v - virt[lo]) / span;
   }
 
   setWidth(width: number): void {
@@ -73,12 +259,79 @@ export class TimeScale {
 
   /** Index to center-x pixel position within data area */
   indexToX(index: number): number {
-    return (index - this._startIndex + 0.5) * this._barSpacing;
+    if (this._virt.length === 0) {
+      return (index - this._startIndex + 0.5) * this._barSpacing;
+    }
+    const vi = this.virtAt(index);
+    const vs = this.virtAt(this._startIndex);
+    return (vi - vs + 0.5) * this._barSpacing;
   }
 
   /** X pixel to candle index at that position */
   xToIndex(x: number): number {
-    return Math.floor(x / this._barSpacing + this._startIndex);
+    if (this._virt.length === 0) {
+      return Math.floor(x / this._barSpacing + this._startIndex);
+    }
+    const vs = this.virtAt(this._startIndex);
+    const vTarget = vs + x / this._barSpacing;
+    return Math.floor(this.realAtVirt(vTarget));
+  }
+
+  /**
+   * Convert a wall-clock time (epoch ms) to an x pixel position.
+   * Returns `null` if the time falls inside a compressed session gap
+   * (no bar to position against).
+   * Only usable after {@link setTimeProportional} has been called.
+   */
+  timeToX(time: number): number | null {
+    const times = this._candleTimes;
+    const n = times.length;
+    if (n === 0) return null;
+    if (time <= times[0]) return this.indexToX(0) + (time - times[0]) * this.pxPerMsAt(0);
+    if (time >= times[n - 1])
+      return this.indexToX(n - 1) + (time - times[n - 1]) * this.pxPerMsAt(n - 2);
+
+    // Binary search: largest i with times[i] <= time
+    let lo = 0;
+    let hi = n - 1;
+    while (lo < hi - 1) {
+      const mid = (lo + hi) >> 1;
+      if (times[mid] <= time) lo = mid;
+      else hi = mid;
+    }
+    // Exact bar match — always place at the bar's index position,
+    // even if the following segment is a compressed session gap.
+    if (times[lo] === time) return this.indexToX(lo);
+    if (times[lo + 1] === time) return this.indexToX(lo + 1);
+
+    const dt = times[lo + 1] - times[lo];
+    if (dt <= 0) return this.indexToX(lo);
+    // Detect compressed gap: much larger spacing than virtual spacing suggests.
+    const virtSpan = this._virt[lo + 1] - this._virt[lo];
+    if (virtSpan < dt / this.medianMsHeuristic() / 2) {
+      return null; // inside a compressed session gap
+    }
+    const frac = (time - times[lo]) / dt;
+    const virtI = this._virt[lo] + frac * virtSpan;
+    const vs = this.virtAt(this._startIndex);
+    return (virtI - vs + 0.5) * this._barSpacing;
+  }
+
+  private pxPerMsAt(segmentStart: number): number {
+    const times = this._candleTimes;
+    const virt = this._virt;
+    if (segmentStart < 0 || segmentStart >= times.length - 1) return 0;
+    const dt = times[segmentStart + 1] - times[segmentStart];
+    if (dt <= 0) return 0;
+    const dv = virt[segmentStart + 1] - virt[segmentStart];
+    return (dv / dt) * this._barSpacing;
+  }
+
+  private _cachedMedian = 0;
+  private medianMsHeuristic(): number {
+    if (this._cachedMedian > 0) return this._cachedMedian;
+    this._cachedMedian = TimeScale.computeMedianInterval(this._candleTimes);
+    return this._cachedMedian;
   }
 
   /** Scroll by delta candles (positive = scroll right) */
@@ -95,7 +348,13 @@ export class TimeScale {
 
   /** Scroll to show last candles */
   scrollToEnd(): void {
-    this._startIndex = Math.max(0, this._totalCount - this._visibleCount);
+    if (this._virt.length === 0) {
+      this._startIndex = Math.max(0, this._totalCount - this._visibleCount);
+      return;
+    }
+    const virtEnd = this._virt[this._virt.length - 1] + 1; // last bar + 1 slot for padding
+    const targetVirt = Math.max(0, virtEnd - this._visibleCount);
+    this._startIndex = Math.max(0, this.realAtVirt(targetVirt));
   }
 
   /** Zoom around a pixel position (Google Maps style — anchor stays under cursor) */
@@ -203,9 +462,75 @@ export class TimeScale {
 
   /** Maximum allowed startIndex, or null if all data fits in view */
   private get maxStartIndex(): number | null {
-    if (this._totalCount <= 0 || this._visibleCount >= this._totalCount) return null;
+    if (this._totalCount <= 0) return null;
+    const virtTotal =
+      this._virt.length > 0 ? this._virt[this._virt.length - 1] + 1 : this._totalCount;
+    if (this._visibleCount >= virtTotal) return null;
     const rightPad = Math.ceil(this._visibleCount * 0.2);
-    return Math.max(0, this._totalCount + rightPad - this._visibleCount);
+    const maxStartVirt = Math.max(0, virtTotal + rightPad - this._visibleCount);
+    if (this._virt.length === 0) return maxStartVirt;
+    return this.realAtVirt(maxStartVirt);
+  }
+
+  /**
+   * Get visible time range [t0, t1] if time data is available.
+   */
+  getVisibleTimeRange(): readonly [number, number] | null {
+    if (this._candleTimes.length === 0) return null;
+    const n = this._candleTimes.length;
+    const start = Math.max(0, Math.min(n - 1, this.startIndex));
+    const end = Math.max(0, Math.min(n - 1, this.endIndex - 1));
+    if (end < start) return null;
+    return [this._candleTimes[start], this._candleTimes[end]];
+  }
+
+  /**
+   * Generate time ticks at wall-clock regular intervals. Requires prior
+   * {@link setTimeProportional}. Tick times falling inside compressed session
+   * gaps are skipped. Returns empty array when no time data is available.
+   */
+  getTimeTicks(stepMs: number): Array<{ time: number; x: number }> {
+    if (this._candleTimes.length === 0 || stepMs <= 0) return [];
+    const range = this.getVisibleTimeRange();
+    if (!range) return [];
+    const [t0, t1] = range;
+    const out: Array<{ time: number; x: number }> = [];
+    const first = Math.ceil(t0 / stepMs) * stepMs;
+    for (let t = first; t <= t1; t += stepMs) {
+      const x = this.timeToX(t);
+      if (x !== null && x >= 0 && x <= this._width) {
+        out.push({ time: t, x });
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Generate date ticks at local-TZ calendar-day boundaries within the
+   * visible range. Requires prior {@link setTimeProportional}.
+   */
+  getDateTicks(): Array<{ time: number; x: number }> {
+    if (this._candleTimes.length === 0) return [];
+    const times = this._candleTimes;
+    const start = Math.max(0, this.startIndex);
+    const end = Math.min(times.length - 1, this.endIndex - 1);
+    if (end < start) return [];
+    const out: Array<{ time: number; x: number }> = [];
+    let prevKey = start > 0 ? localDayKey(times[start - 1]) : -1;
+    for (let i = start; i <= end; i++) {
+      const key = localDayKey(times[i]);
+      if (key !== prevKey) {
+        out.push({ time: times[i], x: this.indexToX(i) });
+        prevKey = key;
+      }
+    }
+    return out;
+  }
+
+  /** Median bar interval in ms (0 if time data not available). */
+  get medianBarIntervalMs(): number {
+    if (this._candleTimes.length === 0) return 0;
+    return this.medianMsHeuristic();
   }
 
   private clamp(): void {
@@ -220,6 +545,12 @@ export class TimeScale {
     const maxStart = this.maxStartIndex ?? 0;
     this._startIndex = Math.max(0, Math.min(maxStart, this._startIndex));
   }
+}
+
+/** Local-TZ calendar day key (year*10000 + month*100 + date) */
+function localDayKey(time: number): number {
+  const d = new Date(time);
+  return d.getFullYear() * 10000 + d.getMonth() * 100 + d.getDate();
 }
 
 // ============================================

--- a/packages/chart/src/core/types.ts
+++ b/packages/chart/src/core/types.ts
@@ -123,6 +123,47 @@ export type ChartOptions = {
   hotkeys?: Partial<Record<string, HotkeyAction>> | false;
   /** Interaction behavior */
   interaction?: InteractionOptions;
+  /** Time scale behavior (session gaps, etc.) */
+  timeScale?: TimeScaleOptions;
+};
+
+/**
+ * Options for the time scale. Currently controls whether visual gaps are
+ * inserted between trading sessions when the data is intraday.
+ */
+export type TimeScaleOptions = {
+  /**
+   * Insert visual gaps between trading sessions (e.g. overnight breaks in
+   * intraday data) so the x-axis shows empty space rather than compressing
+   * non-trading hours to a zero-width seam.
+   *
+   * - `false` / omitted (default): index-based layout with no gaps (legacy).
+   * - `true`: auto-detect intraday (median bar interval < 6h) and insert a
+   *   gap wherever consecutive bars have a time delta significantly larger
+   *   than the median (e.g. overnight, weekends). TZ-agnostic.
+   * - object form: fine-grained control.
+   */
+  sessionGaps?: boolean | SessionGapsOptions;
+};
+
+export type SessionGapsOptions = {
+  /**
+   * Detection mode:
+   * - `"timeGap"` (default): insert a gap whenever the time delta between
+   *   consecutive bars exceeds `gapThresholdMs` (or 2 × median when unset).
+   *   Works correctly regardless of data timezone.
+   * - `"dayBoundary"`: insert a gap whenever the UTC calendar day changes
+   *   between consecutive bars. Useful for 24×7 data (crypto / FX) where
+   *   time deltas are uniform but you still want a daily divider.
+   * - `"off"`: disabled.
+   */
+  mode?: "timeGap" | "dayBoundary" | "off";
+  /** Gap size in bar-widths (default: 1.0). */
+  sizeBars?: number;
+  /** Only enable if median bar interval ≤ this many ms (default: 6h). */
+  intradayThresholdMs?: number;
+  /** For `"timeGap"` mode: the minimum delta to count as a session gap (default: 2 × median). */
+  gapThresholdMs?: number;
 };
 
 /**

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -89,6 +89,8 @@ export type {
   CrosshairOptions,
   InteractionOptions,
   HotkeyAction,
+  TimeScaleOptions,
+  SessionGapsOptions,
 } from "./core/types";
 
 export { DEFAULT_HOTKEYS, type HotkeyMap } from "./core/hotkeys";

--- a/packages/chart/src/renderer/axis-renderer.ts
+++ b/packages/chart/src/renderer/axis-renderer.ts
@@ -2,7 +2,13 @@
  * Axis Renderer — Draws price (Y) and time (X) axes.
  */
 
-import { autoFormatPrice, autoFormatTime } from "../core/format";
+import {
+  autoFormatPrice,
+  autoFormatTime,
+  formatShortDate,
+  formatShortTime,
+  pickNiceStep,
+} from "../core/format";
 import type { PriceScale, TimeScale } from "../core/scale";
 import type { CandleData, ThemeColors } from "../core/types";
 
@@ -93,15 +99,26 @@ export function renderTimeAxis(
   ctx.lineTo(x + width, y);
   ctx.stroke();
 
-  // Compute label interval
-  const minLabelSpacing = 80;
-  const barSpacing = timeScale.barSpacing;
-  const labelInterval = Math.max(1, Math.ceil(minLabelSpacing / barSpacing));
-
   ctx.fillStyle = theme.textSecondary;
   ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
   ctx.textAlign = "center";
   ctx.textBaseline = "top";
+
+  // --- Two-row mode: wall-clock time ticks + date anchors (requires time data) ---
+  const intradayThresholdMs = 6 * 60 * 60 * 1000;
+  const medianMs = timeScale.medianBarIntervalMs;
+  const twoRow =
+    !timeFormatter && timeScale.hasTimeData && medianMs > 0 && medianMs <= intradayThresholdMs;
+
+  if (twoRow && height >= 28) {
+    renderTwoRowAxis(ctx, timeScale, x, y, width, height);
+    return;
+  }
+
+  // --- Legacy single-row mode: labels at fixed pixel spacing ---
+  const minLabelSpacing = 80;
+  const barSpacing = timeScale.barSpacing;
+  const labelInterval = Math.max(1, Math.ceil(minLabelSpacing / barSpacing));
 
   const start = timeScale.startIndex;
   const end = timeScale.endIndex;
@@ -119,6 +136,48 @@ export function renderTimeAxis(
     prevLabelTime = candle.time;
 
     ctx.fillText(label, labelX, y + 6);
+  }
+}
+
+/**
+ * Render a two-row time axis: upper = wall-clock HH:MM ticks at regular
+ * intervals, lower = date anchors at local-TZ day boundaries.
+ */
+function renderTwoRowAxis(
+  ctx: CanvasRenderingContext2D,
+  timeScale: TimeScale,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): void {
+  // Pick tick step based on visible time span and target label density.
+  const range = timeScale.getVisibleTimeRange();
+  if (!range) return;
+  const [t0, t1] = range;
+  const minLabelPx = 70;
+  const maxTicks = Math.max(2, Math.floor(width / minLabelPx));
+  const step = pickNiceStep(t1 - t0, maxTicks);
+
+  const timeTicks = timeScale.getTimeTicks(step);
+  const dateTicks = timeScale.getDateTicks();
+
+  // Upper row: HH:MM at time ticks. Show date when HH:MM is 00:00 to avoid a
+  // confusing "naked 00:00" that in 24h format might look like a tick near
+  // midnight but without date context (the date row will anchor it below).
+  const topY = y + 4;
+  for (const t of timeTicks) {
+    ctx.fillText(formatShortTime(t.time), x + t.x, topY);
+  }
+
+  // Lower row: date at day boundaries. Skip the first tick if it would collide
+  // with the very-left edge (likely a partial view).
+  const bottomY = y + Math.max(18, height / 2);
+  let prevDateTime: number | null = null;
+  for (const d of dateTicks) {
+    const label = formatShortDate(d.time, prevDateTime);
+    ctx.fillText(label, x + d.x, bottomY);
+    prevDateTime = d.time;
   }
 }
 

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -28,6 +28,7 @@ import type {
   PaneRect,
   SeriesConfig,
   SeriesHandle,
+  SessionGapsOptions,
   SignalMarker,
   ThemeColors,
   TimeValue,
@@ -54,7 +55,7 @@ const DEFAULT_OPTIONS: Required<
 > = {
   height: 400,
   priceAxisWidth: 60,
-  timeAxisHeight: 24,
+  timeAxisHeight: 32,
   fontSize: 11,
 };
 
@@ -106,6 +107,7 @@ export class CanvasChart implements ChartInstance {
   private _animationDuration: number;
   private _locale: ChartLocale;
   private _crosshairOpts: import("../core/types").CrosshairOptions;
+  private _sessionGapsOpts: ResolvedSessionGapsOptions;
   private _overlaysHidden = false;
   private _overlaySavedVisibility: Map<string, boolean> | null = null;
   // Cached visible range for change-detection in the render loop — the public
@@ -218,6 +220,7 @@ export class CanvasChart implements ChartInstance {
       snapThreshold: options?.crosshair?.snapThreshold ?? 12,
       lockOnLongPress: options?.crosshair?.lockOnLongPress ?? true,
     };
+    this._sessionGapsOpts = resolveSessionGapsOptions(options?.timeScale?.sessionGaps);
     this._locale = mergeLocale(options?.locale);
     setMonthNames(this._locale.months);
     this._pixelRatio =
@@ -414,6 +417,7 @@ export class CanvasChart implements ChartInstance {
     const removed = candles.length - valid.length;
     this._data.setCandles(valid);
     this._timeScale.setTotalCount(this._data.candleCount);
+    this._applySessionGaps();
     this._timeScale.scrollToEnd();
     this._needsRender = true;
     if (removed > 0) {
@@ -437,9 +441,18 @@ export class CanvasChart implements ChartInstance {
     }
     // Auto-follow: if last candle is visible before update, keep following
     const wasAtEnd = this._timeScale.endIndex >= this._data.candleCount - 1;
+    const prevCount = this._data.candleCount;
 
     this._data.updateCandle(candle);
-    this._timeScale.setTotalCount(this._data.candleCount);
+    const newCount = this._data.candleCount;
+    this._timeScale.setTotalCount(newCount);
+
+    // If a new bar was appended (count grew) and we had a virtual/time layout,
+    // `setTotalCount` cleared it to avoid stale arrays. Re-apply so streaming
+    // charts keep their session-gap layout and two-row time axis.
+    if (newCount !== prevCount && this._sessionGapsOpts.mode !== "off") {
+      this._applySessionGaps();
+    }
 
     if (wasAtEnd) {
       if (this._batching) {
@@ -811,6 +824,12 @@ export class CanvasChart implements ChartInstance {
       this._needsRender = true;
     }
 
+    if (opts.timeScale !== undefined && opts.timeScale.sessionGaps !== undefined) {
+      this._sessionGapsOpts = resolveSessionGapsOptions(opts.timeScale.sessionGaps);
+      this._applySessionGaps();
+      this._needsRender = true;
+    }
+
     // Legend overlay — create/destroy
     if (opts.legend !== undefined) {
       if (opts.legend === false && this._legendOverlay) {
@@ -1125,4 +1144,120 @@ export class CanvasChart implements ChartInstance {
       this._data.getAllSeries().length,
     );
   }
+
+  /**
+   * Recompute and apply the time-scale layout (virtual coords + session gaps)
+   * based on the currently-loaded candles and the resolved `sessionGaps`
+   * options. Called automatically after `setCandles`.
+   *
+   * - `mode: "timeGap"` (default): time-proportional layout via
+   *   `setTimeProportional` — bars sit at their wall-clock positions within a
+   *   session and session breaks compress to `sizeBars` bar-widths.
+   * - `mode: "dayBoundary"`: legacy fixed gap at each UTC day change via
+   *   `setGapsBefore` (no time-proportional within-session spacing).
+   * - `mode: "off"`: disable virtual coords (index-based layout).
+   */
+  private _applySessionGaps(): void {
+    const opts = this._sessionGapsOpts;
+    if (opts.mode === "off") {
+      this._timeScale.clearGaps();
+      return;
+    }
+    const candles = this._data.candles;
+    if (candles.length < 3) {
+      this._timeScale.clearGaps();
+      return;
+    }
+    const median = medianBarInterval(candles);
+    if (median > opts.intradayThresholdMs) {
+      this._timeScale.clearGaps();
+      return;
+    }
+    if (opts.mode === "timeGap") {
+      // Time-proportional layout. Threshold for compressing a large delta:
+      // explicit gapThresholdMs wins; otherwise 4h (well above any intra-session
+      // gap like a 1h lunch break, well below overnight).
+      const threshold = opts.gapThresholdMs > 0 ? opts.gapThresholdMs : 4 * 60 * 60 * 1000;
+      const times: number[] = new Array(candles.length);
+      for (let i = 0; i < candles.length; i++) times[i] = candles[i].time;
+      this._timeScale.setTimeProportional(times, {
+        medianMs: median,
+        sessionThresholdMs: threshold,
+        sessionGapBars: opts.sizeBars,
+      });
+      return;
+    }
+    // Legacy dayBoundary path.
+    const gaps = computeSessionGaps(candles, median, opts);
+    this._timeScale.setGapsBefore(gaps);
+  }
+}
+
+// ============================================
+// Session gap helpers
+// ============================================
+
+type ResolvedSessionGapsOptions = Required<SessionGapsOptions>;
+
+function resolveSessionGapsOptions(
+  input: boolean | SessionGapsOptions | undefined,
+): ResolvedSessionGapsOptions {
+  if (!input) {
+    return {
+      mode: "off",
+      sizeBars: 1,
+      intradayThresholdMs: 6 * 60 * 60 * 1000,
+      gapThresholdMs: 0,
+    };
+  }
+  const opts: SessionGapsOptions = input === true ? {} : input;
+  return {
+    mode: opts.mode ?? "timeGap",
+    sizeBars: opts.sizeBars ?? 1,
+    intradayThresholdMs: opts.intradayThresholdMs ?? 6 * 60 * 60 * 1000,
+    gapThresholdMs: opts.gapThresholdMs ?? 0,
+  };
+}
+
+function medianBarInterval(candles: readonly CandleData[]): number {
+  const deltas: number[] = [];
+  const stride = Math.max(1, Math.floor(candles.length / 64));
+  for (let i = stride; i < candles.length; i += stride) {
+    const d = candles[i].time - candles[i - stride].time;
+    if (d > 0) deltas.push(d / stride);
+  }
+  if (deltas.length === 0) return Number.POSITIVE_INFINITY;
+  deltas.sort((a, b) => a - b);
+  return deltas[Math.floor(deltas.length / 2)];
+}
+
+function computeSessionGaps(
+  candles: readonly CandleData[],
+  medianMs: number,
+  opts: ResolvedSessionGapsOptions,
+): Array<{ index: number; size: number }> {
+  const gaps: Array<{ index: number; size: number }> = [];
+  if (opts.mode === "timeGap") {
+    const threshold = opts.gapThresholdMs > 0 ? opts.gapThresholdMs : medianMs * 2;
+    for (let i = 1; i < candles.length; i++) {
+      const delta = candles[i].time - candles[i - 1].time;
+      if (delta > threshold) {
+        gaps.push({ index: i, size: opts.sizeBars });
+      }
+    }
+  } else if (opts.mode === "dayBoundary") {
+    // Compare UTC calendar day between consecutive bars so cross-timezone
+    // data (e.g. US stocks viewed from Asia) still gets sensible boundaries
+    // — US/Asian/EU sessions all fit within a single UTC day.
+    let prevDay = -1;
+    for (let i = 0; i < candles.length; i++) {
+      const d = new Date(candles[i].time);
+      const day = d.getUTCFullYear() * 10000 + d.getUTCMonth() * 100 + d.getUTCDate();
+      if (prevDay >= 0 && day !== prevDay) {
+        gaps.push({ index: i, size: opts.sizeBars });
+      }
+      prevDay = day;
+    }
+  }
+  return gaps;
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Unreleased
+
+### Added — Price Source Coverage
+
+- `RsiOptions.source`, `MacdOptions.source`, `CciOptions.source` — `rsi()` / `macd()` / `cci()` and their incremental counterparts (`createRsi` / `createMacd` / `createCci`) now accept a `PriceSource` (`"close" | "hl2" | "hlc3" | "ohlc4" | ...`). Defaults preserve current behavior (`"close"` for RSI/MACD, `"hlc3"` for CCI), so existing call sites are unaffected.
+  ```typescript
+  // Use typical price (HLC3) as RSI input
+  const rsiTypical = rsi(candles, { period: 14, source: "hlc3" });
+  ```
+
+### Added — Session: Lunch Breaks & Timezone Awareness
+
+- `SessionDefinition.breaks?: SessionBreak[]` — sessions can now define one or more intra-session breaks (e.g. JPX/HKEX lunch). Bars inside a break report `inSession: false`, the session anchor (name, open, high, low) is preserved, and `barIndex` does not advance. `sessionStats` and `sessionBreakout` skip break bars but still treat the surrounding session as a single occurrence.
+- `SessionDefinition.timezone?: string` — interpret session and break times in any IANA timezone (e.g. `"America/New_York"`, `"Asia/Tokyo"`). DST transitions are handled automatically via the runtime's built-in `Intl.DateTimeFormat` (zero new dependencies). `KillZoneDefinition` accepts the same field.
+  ```typescript
+  // Define NYSE in ET — DST follows automatically
+  const nyse = [{ name: "NYSE", startHour: 9, startMinute: 30, endHour: 16, endMinute: 0,
+                  timezone: "America/New_York" }];
+  ```
+- New session presets and helpers: `getJpxSessions()`, `getHkexSessions()`, `isInSessionWindow()`, `isInAnyBreak()`, `getTzHourMinute()`. New exported types: `SessionBreak`.
+
+### Notes
+
+- All additions are optional; omitting `source`, `breaks`, and `timezone` produces byte-identical results to v0.2.0.
+
 ## v0.2.0 (2026-04-20)
 
 Minor bump introducing live-streaming, indicator-registry, and series-metadata APIs, plus parameterized indicator labels.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -268,11 +268,16 @@ export {
   // Session / Kill Zones
   defineSession,
   getIctSessions,
+  getJpxSessions,
+  getHkexSessions,
   detectSessions,
   sessionStats,
   killZones,
   getIctKillZones,
   sessionBreakout,
+  isInSessionWindow,
+  isInAnyBreak,
+  getTzHourMinute,
   // Filter (Ehlers)
   superSmoother,
   roofingFilter,

--- a/packages/core/src/indicators/__tests__/price-source.test.ts
+++ b/packages/core/src/indicators/__tests__/price-source.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Verifies that `source` option on RSI/MACD/CCI is wired up correctly.
+ * Default behavior must stay unchanged; non-default sources must alter results.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { Candle } from "../../types";
+import { cci } from "../momentum/cci";
+import { macd } from "../momentum/macd";
+import { rsi } from "../momentum/rsi";
+
+function makeCandles(count: number): Candle[] {
+  const out: Candle[] = [];
+  for (let i = 0; i < count; i++) {
+    const close = 100 + Math.sin(i / 3) * 5 + i * 0.1;
+    // Non-constant high/low spread so hl2/hlc3 differ from close by varying amounts
+    const highSpread = 1 + Math.abs(Math.cos(i / 2)) * 2;
+    const lowSpread = 0.5 + Math.abs(Math.sin(i / 4)) * 1.5;
+    out.push({
+      time: 1_700_000_000_000 + i * 60_000,
+      open: close - 0.5,
+      high: close + highSpread,
+      low: close - lowSpread,
+      close,
+      volume: 1000 + i,
+    });
+  }
+  return out;
+}
+
+describe("RSI source option", () => {
+  const candles = makeCandles(60);
+
+  it("defaults to close (backward compatible)", () => {
+    const a = rsi(candles, { period: 14 });
+    const b = rsi(candles, { period: 14, source: "close" });
+    expect(a.map((p) => p.value)).toEqual(b.map((p) => p.value));
+  });
+
+  it("produces different series for hl2 vs close", () => {
+    const a = rsi(candles, { period: 14, source: "close" });
+    const b = rsi(candles, { period: 14, source: "hl2" });
+    const aLast = a.at(-1)?.value;
+    const bLast = b.at(-1)?.value;
+    expect(aLast).not.toBeNull();
+    expect(bLast).not.toBeNull();
+    expect(aLast).not.toBeCloseTo(bLast as number, 6);
+  });
+});
+
+describe("MACD source option", () => {
+  const candles = makeCandles(80);
+
+  it("defaults to close", () => {
+    const a = macd(candles);
+    const b = macd(candles, { source: "close" });
+    expect(a.map((p) => p.value.macd)).toEqual(b.map((p) => p.value.macd));
+  });
+
+  it("produces different MACD line for hlc3 vs close", () => {
+    const a = macd(candles, { source: "close" });
+    const b = macd(candles, { source: "hlc3" });
+    const aLast = a.at(-1)?.value.macd;
+    const bLast = b.at(-1)?.value.macd;
+    expect(aLast).not.toBeNull();
+    expect(bLast).not.toBeNull();
+    expect(aLast).not.toBeCloseTo(bLast as number, 6);
+  });
+});
+
+describe("CCI source option", () => {
+  const candles = makeCandles(60);
+
+  it("defaults to hlc3 (typical price, backward compatible)", () => {
+    const a = cci(candles, { period: 20 });
+    const b = cci(candles, { period: 20, source: "hlc3" });
+    expect(a.map((p) => p.value)).toEqual(b.map((p) => p.value));
+  });
+
+  it("produces different series for close vs hlc3", () => {
+    const a = cci(candles, { period: 20, source: "hlc3" });
+    const b = cci(candles, { period: 20, source: "close" });
+    const aLast = a.at(-1)?.value;
+    const bLast = b.at(-1)?.value;
+    expect(aLast).not.toBeNull();
+    expect(bLast).not.toBeNull();
+    expect(aLast).not.toBeCloseTo(bLast as number, 4);
+  });
+});

--- a/packages/core/src/indicators/incremental/momentum/cci.ts
+++ b/packages/core/src/indicators/incremental/momentum/cci.ts
@@ -7,9 +7,10 @@
  * Uses CircularBuffer for the lookback window of typical prices.
  */
 
-import type { NormalizedCandle } from "../../../types";
+import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { getSourcePrice } from "../utils";
 
 /**
  * State for incremental CCI
@@ -35,11 +36,12 @@ export type CciState = {
  * ```
  */
 export function createCci(
-  options: { period: number; constant?: number },
+  options: { period: number; constant?: number; source?: PriceSource },
   warmUpOptions?: WarmUpOptions<CciState>,
 ): IncrementalIndicator<number | null, CciState> {
   const period = options.period;
   const constant = options.constant ?? 0.015;
+  const source = options.source ?? "hlc3";
 
   let buffer: CircularBuffer<number>;
   let sum: number;
@@ -73,7 +75,7 @@ export function createCci(
 
   const indicator: IncrementalIndicator<number | null, CciState> = {
     next(candle: NormalizedCandle) {
-      const tp = (candle.high + candle.low + candle.close) / 3;
+      const tp = getSourcePrice(candle, source);
 
       if (buffer.isFull) {
         sum = sum - buffer.oldest() + tp;
@@ -88,7 +90,7 @@ export function createCci(
     },
 
     peek(candle: NormalizedCandle) {
-      const tp = (candle.high + candle.low + candle.close) / 3;
+      const tp = getSourcePrice(candle, source);
 
       let newSum: number;
       if (buffer.isFull) {

--- a/packages/core/src/indicators/incremental/momentum/macd.ts
+++ b/packages/core/src/indicators/incremental/momentum/macd.ts
@@ -4,8 +4,9 @@
  * Composite indicator using three EMA layers: fast, slow, signal.
  */
 
-import type { MacdValue, NormalizedCandle } from "../../../types";
+import type { MacdValue, NormalizedCandle, PriceSource } from "../../../types";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { getSourcePrice } from "../utils";
 
 export type MacdState = {
   fastPeriod: number;
@@ -37,12 +38,18 @@ export type MacdState = {
  * ```
  */
 export function createMacd(
-  options: { fastPeriod?: number; slowPeriod?: number; signalPeriod?: number } = {},
+  options: {
+    fastPeriod?: number;
+    slowPeriod?: number;
+    signalPeriod?: number;
+    source?: PriceSource;
+  } = {},
   warmUpOptions?: WarmUpOptions<MacdState>,
 ): IncrementalIndicator<MacdValue, MacdState> {
   const fastPeriod = options.fastPeriod ?? 12;
   const slowPeriod = options.slowPeriod ?? 26;
   const signalPeriod = options.signalPeriod ?? 9;
+  const source = options.source ?? "close";
   const fastMult = 2 / (fastPeriod + 1);
   const slowMult = 2 / (slowPeriod + 1);
   const signalMult = 2 / (signalPeriod + 1);
@@ -100,7 +107,7 @@ export function createMacd(
   const indicator: IncrementalIndicator<MacdValue, MacdState> = {
     next(candle: NormalizedCandle) {
       count++;
-      const price = candle.close;
+      const price = getSourcePrice(candle, source);
 
       // Update fast EMA
       const fastResult = updateEma(price, fastEma, fastSum, fastPeriod, fastMult, count);
@@ -145,7 +152,7 @@ export function createMacd(
     },
 
     peek(candle: NormalizedCandle) {
-      const price = candle.close;
+      const price = getSourcePrice(candle, source);
       const peekCount = count + 1;
 
       // Preview fast EMA

--- a/packages/core/src/indicators/incremental/momentum/rsi.ts
+++ b/packages/core/src/indicators/incremental/momentum/rsi.ts
@@ -4,8 +4,9 @@
  * Uses Wilder's smoothing method for consistency with batch implementation.
  */
 
-import type { NormalizedCandle } from "../../../types";
+import type { NormalizedCandle, PriceSource } from "../../../types";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { getSourcePrice } from "../utils";
 
 export type RsiState = {
   period: number;
@@ -30,10 +31,11 @@ export type RsiState = {
  * ```
  */
 export function createRsi(
-  options: { period?: number } = {},
+  options: { period?: number; source?: PriceSource } = {},
   warmUpOptions?: WarmUpOptions<RsiState>,
 ): IncrementalIndicator<number | null, RsiState> {
   const period = options.period ?? 14;
+  const source = options.source ?? "close";
 
   let prevClose: number | null;
   let avgGain: number;
@@ -69,18 +71,19 @@ export function createRsi(
   const indicator: IncrementalIndicator<number | null, RsiState> = {
     next(candle: NormalizedCandle) {
       count++;
+      const price = getSourcePrice(candle, source);
 
       if (prevClose === null) {
         // First candle: no change to compute
-        prevClose = candle.close;
+        prevClose = price;
         return { time: candle.time, value: null };
       }
 
-      const change = candle.close - prevClose;
+      const change = price - prevClose;
       const gain = change > 0 ? change : 0;
       const loss = change < 0 ? -change : 0;
 
-      prevClose = candle.close;
+      prevClose = price;
 
       // count includes current candle. We need period+1 candles to produce first RSI.
       // Candle 1: no change (null), candles 2..period: collect gains/losses, candle period+1: first RSI
@@ -120,7 +123,8 @@ export function createRsi(
         return { time: candle.time, value: null };
       }
 
-      const change = candle.close - prevClose;
+      const price = getSourcePrice(candle, source);
+      const change = price - prevClose;
       const gain = change > 0 ? change : 0;
       const loss = change < 0 ? -change : 0;
 

--- a/packages/core/src/indicators/index.ts
+++ b/packages/core/src/indicators/index.ts
@@ -322,14 +322,20 @@ export type {
 export {
   defineSession,
   getIctSessions,
+  getJpxSessions,
+  getHkexSessions,
   detectSessions,
   sessionStats,
   killZones,
   getIctKillZones,
   sessionBreakout,
+  isInSessionWindow,
+  isInAnyBreak,
+  getTzHourMinute,
 } from "./session";
 export type {
   SessionDefinition,
+  SessionBreak,
   SessionInfo,
   SessionStatsOptions,
   SessionStatsValue,

--- a/packages/core/src/indicators/momentum/cci.ts
+++ b/packages/core/src/indicators/momentum/cci.ts
@@ -5,9 +5,9 @@
  * over a given period. Used to identify overbought/oversold conditions.
  */
 
-import { isNormalized, normalizeCandles } from "../../core/normalize";
+import { getPriceSeries, isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
-import type { Candle, NormalizedCandle, Series } from "../../types";
+import type { Candle, NormalizedCandle, PriceSource, Series } from "../../types";
 import { CCI_META } from "../indicator-meta";
 
 /**
@@ -18,6 +18,8 @@ export type CciOptions = {
   period?: number;
   /** Constant multiplier (default: 0.015) */
   constant?: number;
+  /** Price source (default: 'hlc3' — typical price) */
+  source?: PriceSource;
 };
 
 /**
@@ -49,7 +51,7 @@ export function cci(
   candles: Candle[] | NormalizedCandle[],
   options: CciOptions = {},
 ): Series<number | null> {
-  const { period = 20, constant = 0.015 } = options;
+  const { period = 20, constant = 0.015, source = "hlc3" } = options;
 
   if (period < 1) {
     throw new Error("CCI period must be at least 1");
@@ -60,8 +62,8 @@ export function cci(
 
   const result: Series<number | null> = [];
 
-  // Calculate typical prices
-  const typicalPrices: number[] = normalized.map((c) => (c.high + c.low + c.close) / 3);
+  // Calculate source prices (default: typical price hlc3)
+  const typicalPrices: number[] = getPriceSeries(normalized, source);
 
   for (let i = 0; i < normalized.length; i++) {
     if (i < period - 1) {

--- a/packages/core/src/indicators/momentum/macd.ts
+++ b/packages/core/src/indicators/momentum/macd.ts
@@ -29,7 +29,7 @@ export function macd(
   candles: Candle[] | NormalizedCandle[],
   options: MacdOptions = {},
 ): Series<MacdValue> {
-  const { fastPeriod = 12, slowPeriod = 26, signalPeriod = 9 } = options;
+  const { fastPeriod = 12, slowPeriod = 26, signalPeriod = 9, source = "close" } = options;
 
   if (fastPeriod < 1 || slowPeriod < 1 || signalPeriod < 1) {
     throw new Error("MACD periods must be at least 1");
@@ -47,8 +47,8 @@ export function macd(
   }
 
   // Calculate fast and slow EMAs
-  const fastEma = ema(normalized, { period: fastPeriod });
-  const slowEma = ema(normalized, { period: slowPeriod });
+  const fastEma = ema(normalized, { period: fastPeriod, source });
+  const slowEma = ema(normalized, { period: slowPeriod, source });
 
   // Calculate MACD line
   const macdLine: (number | null)[] = [];

--- a/packages/core/src/indicators/momentum/rsi.ts
+++ b/packages/core/src/indicators/momentum/rsi.ts
@@ -3,7 +3,7 @@
  * Uses Wilder's smoothing method
  */
 
-import { isNormalized, normalizeCandles } from "../../core/normalize";
+import { getPriceSeries, isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, RsiOptions, Series } from "../../types";
 import { RSI_META } from "../indicator-meta";
@@ -32,7 +32,7 @@ export function rsi(
   candles: Candle[] | NormalizedCandle[],
   options: RsiOptions = {},
 ): Series<number | null> {
-  const { period = 14 } = options;
+  const { period = 14, source = "close" } = options;
 
   if (period < 1) {
     throw new Error("RSI period must be at least 1");
@@ -40,6 +40,7 @@ export function rsi(
 
   // Normalize if needed
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
+  const prices = getPriceSeries(normalized, source);
 
   const result: Series<number | null> = [];
 
@@ -51,7 +52,7 @@ export function rsi(
   // Calculate price changes
   const changes: number[] = [];
   for (let i = 1; i < normalized.length; i++) {
-    changes.push(normalized[i].close - normalized[i - 1].close);
+    changes.push(prices[i] - prices[i - 1]);
   }
 
   // First candle has no RSI (no previous price)

--- a/packages/core/src/indicators/session/__tests__/lunch-break.test.ts
+++ b/packages/core/src/indicators/session/__tests__/lunch-break.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for SessionDefinition.breaks (intra-session lunch break).
+ */
+
+import { describe, expect, it } from "vitest";
+import type { Candle } from "../../../types";
+import { sessionBreakout } from "../session-breakout";
+import { detectSessions, getJpxSessions } from "../session-definition";
+import { sessionStats } from "../session-stats";
+
+/**
+ * Build 1-minute bars from 00:00 UTC for the given count of bars.
+ * Start time is 2026-01-05 (Mon) 00:00:00 UTC.
+ */
+function makeMinuteBars(count: number, startEpoch = Date.UTC(2026, 0, 5, 0, 0, 0)): Candle[] {
+  const out: Candle[] = [];
+  for (let i = 0; i < count; i++) {
+    const price = 1000 + i;
+    out.push({
+      time: startEpoch + i * 60_000,
+      open: price,
+      high: price + 2,
+      low: price - 2,
+      close: price + 1,
+      volume: 100,
+    });
+  }
+  return out;
+}
+
+describe("SessionDefinition breaks — JPX lunch", () => {
+  const sessions = getJpxSessions();
+
+  it("detectSessions marks break bars as inSession=false but keeps session name", () => {
+    // 9h of bars = 540 minute-bars starting at 00:00 UTC
+    const candles = makeMinuteBars(9 * 60);
+    const info = detectSessions(candles, sessions);
+
+    // 00:00 UTC → inside JPX morning (09:00 JST)
+    expect(info[0].value.session).toBe("JPX");
+    expect(info[0].value.inSession).toBe(true);
+
+    // 02:30 UTC (= 11:30 JST) → break begins
+    const breakStart = info[2 * 60 + 30];
+    expect(breakStart.value.session).toBe("JPX");
+    expect(breakStart.value.inSession).toBe(false);
+
+    // 03:00 UTC (= 12:00 JST) → still in break
+    const midBreak = info[3 * 60];
+    expect(midBreak.value.inSession).toBe(false);
+
+    // 03:30 UTC (= 12:30 JST) → break ends, afternoon session
+    const afterBreak = info[3 * 60 + 30];
+    expect(afterBreak.value.session).toBe("JPX");
+    expect(afterBreak.value.inSession).toBe(true);
+
+    // 06:00 UTC (= 15:00 JST) → still in session (closes at 15:30)
+    const beforeClose = info[6 * 60];
+    expect(beforeClose.value.session).toBe("JPX");
+    expect(beforeClose.value.inSession).toBe(true);
+
+    // 06:30 UTC (= 15:30 JST) → session ends
+    const sessionEnd = info[6 * 60 + 30];
+    expect(sessionEnd.value.session).toBeNull();
+    expect(sessionEnd.value.inSession).toBe(false);
+  });
+
+  it("detectSessions preserves sessionOpen across the break", () => {
+    const candles = makeMinuteBars(9 * 60);
+    const info = detectSessions(candles, sessions);
+
+    const openAt1Hour = info[60].value.sessionOpen;
+    const openAfterBreak = info[3 * 60 + 30].value.sessionOpen;
+    expect(openAfterBreak).toBe(openAt1Hour);
+    expect(openAfterBreak).not.toBeNull();
+  });
+
+  it("detectSessions does not advance barIndex during break", () => {
+    const candles = makeMinuteBars(9 * 60);
+    const info = detectSessions(candles, sessions);
+
+    // barIndex at 02:29 UTC (last bar before break) vs at 03:30 UTC (first bar after break)
+    const lastBeforeBreak = info[2 * 60 + 29].value.barIndex;
+    const firstAfterBreak = info[3 * 60 + 30].value.barIndex;
+    // Break is 60 minutes; firstAfterBreak should be lastBeforeBreak + 1
+    expect(firstAfterBreak).toBe(lastBeforeBreak + 1);
+  });
+
+  it("sessionStats treats JPX as one occurrence with break bars excluded", () => {
+    const candles = makeMinuteBars(9 * 60);
+    const stats = sessionStats(candles, { sessions, lookback: 10 });
+    expect(stats).toHaveLength(1);
+    const jpx = stats[0];
+    expect(jpx.session).toBe("JPX");
+    // 6.5h window = 390 bars. Break 60 bars. Expect 330 bars counted.
+    expect(jpx.barCount).toBe(330);
+  });
+
+  it("sessionBreakout uses full-session range (excluding break) as reference", () => {
+    // Extend to multi-day so a completed session exists before a breakout can fire.
+    const twoDays = makeMinuteBars(24 * 60 * 2);
+    const bo = sessionBreakout(twoDays, { sessions });
+    // After session end (06:30 UTC on day 1), fromSession should be "JPX".
+    const atDay1End = bo[6 * 60 + 31];
+    expect(atDay1End.value.fromSession).toBe("JPX");
+    expect(atDay1End.value.rangeHigh).not.toBeNull();
+    expect(atDay1End.value.rangeLow).not.toBeNull();
+  });
+});
+
+describe("SessionDefinition breaks — backward compatibility", () => {
+  it("sessions without breaks behave exactly as before", () => {
+    const candles = makeMinuteBars(24 * 60);
+    const sessionsNoBreak = [
+      {
+        name: "Custom",
+        startHour: 9,
+        startMinute: 0,
+        endHour: 15,
+        endMinute: 0,
+      },
+    ];
+    const info = detectSessions(candles, sessionsNoBreak);
+    const stats = sessionStats(candles, { sessions: sessionsNoBreak, lookback: 10 });
+    // 09:00–15:00 = 6h = 360 bars
+    expect(stats[0].barCount).toBe(360);
+    // All in-window bars should report inSession=true
+    const inWindowBars = info.filter((p) => p.value.session === "Custom");
+    expect(inWindowBars.every((p) => p.value.inSession)).toBe(true);
+  });
+});

--- a/packages/core/src/indicators/session/__tests__/tz-utils.test.ts
+++ b/packages/core/src/indicators/session/__tests__/tz-utils.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for tz-utils and timezone-aware SessionDefinition.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { Candle } from "../../../types";
+import { detectSessions } from "../session-definition";
+import { getTzHourMinute } from "../tz-utils";
+
+describe("getTzHourMinute", () => {
+  it("returns UTC hour/minute when timezone is omitted or 'UTC'", () => {
+    const t = Date.UTC(2026, 0, 15, 13, 45, 0);
+    expect(getTzHourMinute(t)).toEqual({ hour: 13, minute: 45 });
+    expect(getTzHourMinute(t, "UTC")).toEqual({ hour: 13, minute: 45 });
+  });
+
+  it("converts UTC to America/New_York with EST offset (winter, no DST)", () => {
+    // 2026-01-15 14:30 UTC = 09:30 EST
+    const t = Date.UTC(2026, 0, 15, 14, 30, 0);
+    expect(getTzHourMinute(t, "America/New_York")).toEqual({ hour: 9, minute: 30 });
+  });
+
+  it("converts UTC to America/New_York with EDT offset (summer, after DST)", () => {
+    // 2026-06-15 13:30 UTC = 09:30 EDT (-4h)
+    const t = Date.UTC(2026, 5, 15, 13, 30, 0);
+    expect(getTzHourMinute(t, "America/New_York")).toEqual({ hour: 9, minute: 30 });
+  });
+
+  it("DST transition: NY 2026-03-08 02:00 → 03:00 local skips an hour", () => {
+    // Just before DST: 2026-03-08 06:30 UTC = 01:30 EST
+    expect(getTzHourMinute(Date.UTC(2026, 2, 8, 6, 30, 0), "America/New_York")).toEqual({
+      hour: 1,
+      minute: 30,
+    });
+    // Just after DST: 2026-03-08 07:30 UTC = 03:30 EDT (skipped 02:xx)
+    expect(getTzHourMinute(Date.UTC(2026, 2, 8, 7, 30, 0), "America/New_York")).toEqual({
+      hour: 3,
+      minute: 30,
+    });
+  });
+
+  it("Asia/Tokyo is always UTC+9 (no DST)", () => {
+    // 2026-01-15 00:00 UTC = 09:00 JST
+    expect(getTzHourMinute(Date.UTC(2026, 0, 15, 0, 0, 0), "Asia/Tokyo")).toEqual({
+      hour: 9,
+      minute: 0,
+    });
+    // 2026-07-15 00:00 UTC = 09:00 JST (no DST shift)
+    expect(getTzHourMinute(Date.UTC(2026, 6, 15, 0, 0, 0), "Asia/Tokyo")).toEqual({
+      hour: 9,
+      minute: 0,
+    });
+  });
+});
+
+describe("SessionDefinition with timezone (DST awareness)", () => {
+  const nyOpen = [
+    {
+      name: "NY Stock Market",
+      // 09:30 - 16:00 ET (DST-aware)
+      startHour: 9,
+      startMinute: 30,
+      endHour: 16,
+      endMinute: 0,
+      timezone: "America/New_York",
+    },
+  ];
+
+  function bar(time: number): Candle {
+    return { time, open: 100, high: 101, low: 99, close: 100, volume: 100 };
+  }
+
+  it("EST (winter): 14:30 UTC = 09:30 ET → in session", () => {
+    const candles = [bar(Date.UTC(2026, 0, 15, 14, 30, 0))]; // 09:30 EST
+    const info = detectSessions(candles, nyOpen);
+    expect(info[0].value.session).toBe("NY Stock Market");
+    expect(info[0].value.inSession).toBe(true);
+  });
+
+  it("EST (winter): 14:00 UTC = 09:00 ET → out of session (before open)", () => {
+    const candles = [bar(Date.UTC(2026, 0, 15, 14, 0, 0))]; // 09:00 EST
+    const info = detectSessions(candles, nyOpen);
+    expect(info[0].value.session).toBeNull();
+  });
+
+  it("EDT (summer): 13:30 UTC = 09:30 EDT → in session (DST-shifted)", () => {
+    const candles = [bar(Date.UTC(2026, 5, 15, 13, 30, 0))]; // 09:30 EDT
+    const info = detectSessions(candles, nyOpen);
+    expect(info[0].value.session).toBe("NY Stock Market");
+    expect(info[0].value.inSession).toBe(true);
+  });
+
+  it("EDT (summer): 14:30 UTC = 10:30 EDT → in session", () => {
+    const candles = [bar(Date.UTC(2026, 5, 15, 14, 30, 0))]; // 10:30 EDT
+    const info = detectSessions(candles, nyOpen);
+    expect(info[0].value.inSession).toBe(true);
+  });
+});

--- a/packages/core/src/indicators/session/index.ts
+++ b/packages/core/src/indicators/session/index.ts
@@ -1,11 +1,15 @@
 // Session Definition & Detection
 export {
   getIctSessions,
+  getJpxSessions,
+  getHkexSessions,
   defineSession,
   detectSessions,
   isInSession,
+  isInSessionWindow,
+  isInAnyBreak,
 } from "./session-definition";
-export type { SessionDefinition, SessionInfo } from "./session-definition";
+export type { SessionBreak, SessionDefinition, SessionInfo } from "./session-definition";
 
 // Session Statistics
 export { sessionStats } from "./session-stats";
@@ -21,3 +25,6 @@ export type {
   SessionBreakoutOptions,
   SessionBreakoutValue,
 } from "./session-breakout";
+
+// Timezone utilities
+export { getTzHourMinute } from "./tz-utils";

--- a/packages/core/src/indicators/session/kill-zones.ts
+++ b/packages/core/src/indicators/session/kill-zones.ts
@@ -13,6 +13,7 @@
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import type { Candle, NormalizedCandle, Series } from "../../types";
 import { isInSession } from "./session-definition";
+import { getTzHourMinute } from "./tz-utils";
 
 /**
  * Definition of a kill zone with expected behavior
@@ -30,6 +31,8 @@ export type KillZoneDefinition = {
   endMinute: number;
   /** Expected behavior in this zone */
   characteristic: string;
+  /** Optional IANA timezone (default: "UTC") */
+  timezone?: string;
 };
 
 /**
@@ -133,12 +136,9 @@ export function killZones(
   const result: Series<KillZoneValue> = [];
 
   for (const candle of normalized) {
-    const date = new Date(candle.time);
-    const hour = date.getUTCHours();
-    const minute = date.getUTCMinutes();
-
     let matched: KillZoneDefinition | null = null;
     for (const zone of zoneDefs) {
+      const { hour, minute } = getTzHourMinute(candle.time, zone.timezone);
       if (isInSession(hour, minute, zone)) {
         matched = zone;
         break;

--- a/packages/core/src/indicators/session/session-breakout.ts
+++ b/packages/core/src/indicators/session/session-breakout.ts
@@ -9,7 +9,13 @@
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, Series } from "../../types";
-import { type SessionDefinition, getIctSessions, isInSession } from "./session-definition";
+import {
+  type SessionDefinition,
+  getIctSessions,
+  isInAnyBreak,
+  isInSessionWindow,
+} from "./session-definition";
+import { getTzHourMinute } from "./tz-utils";
 
 /**
  * Options for sessionBreakout
@@ -80,21 +86,29 @@ export function sessionBreakout(
   let rangeLow: number | null = null;
 
   for (const candle of normalized) {
-    const date = new Date(candle.time);
-    const hour = date.getUTCHours();
-    const minute = date.getUTCMinutes();
-
-    // Find which session this candle belongs to
-    let matchedSession: string | null = null;
+    // Determine session using the outer window; bars inside a break remain
+    // attached to the session but do not update its range. Each session's
+    // own timezone is honored.
+    let matchedSession: SessionDefinition | null = null;
+    let matchedHour = 0;
+    let matchedMinute = 0;
     for (const session of sessionDefs) {
-      if (isInSession(hour, minute, session)) {
-        matchedSession = session.name;
+      const { hour, minute } = getTzHourMinute(candle.time, session.timezone);
+      if (isInSessionWindow(hour, minute, session)) {
+        matchedSession = session;
+        matchedHour = hour;
+        matchedMinute = minute;
         break;
       }
     }
+    const matchedName = matchedSession?.name ?? null;
+    const inBreak =
+      matchedSession !== null &&
+      matchedSession.breaks !== undefined &&
+      isInAnyBreak(matchedHour, matchedMinute, matchedSession.breaks);
 
     // Handle session transitions
-    if (matchedSession !== activeSessionName) {
+    if (matchedName !== activeSessionName) {
       // If we had an active session and it just ended, save its range
       if (activeSessionName !== null && activeHigh !== Number.NEGATIVE_INFINITY) {
         completedSessionName = activeSessionName;
@@ -103,17 +117,22 @@ export function sessionBreakout(
       }
 
       // Start tracking new session
-      if (matchedSession !== null) {
-        activeSessionName = matchedSession;
-        activeHigh = candle.high;
-        activeLow = candle.low;
+      if (matchedName !== null) {
+        activeSessionName = matchedName;
+        if (inBreak) {
+          activeHigh = Number.NEGATIVE_INFINITY;
+          activeLow = Number.POSITIVE_INFINITY;
+        } else {
+          activeHigh = candle.high;
+          activeLow = candle.low;
+        }
       } else {
         activeSessionName = null;
         activeHigh = Number.NEGATIVE_INFINITY;
         activeLow = Number.POSITIVE_INFINITY;
       }
-    } else if (matchedSession !== null) {
-      // Continue tracking current session
+    } else if (matchedName !== null && !inBreak) {
+      // Continue tracking current session — skip break bars.
       activeHigh = Math.max(activeHigh, candle.high);
       activeLow = Math.min(activeLow, candle.low);
     }

--- a/packages/core/src/indicators/session/session-definition.ts
+++ b/packages/core/src/indicators/session/session-definition.ts
@@ -10,6 +10,18 @@
 
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import type { Candle, NormalizedCandle, Series } from "../../types";
+import { getTzHourMinute } from "./tz-utils";
+
+/**
+ * An intra-session break (e.g. lunch break on JPX/HKEX).
+ * Start/end times are interpreted in the same timezone as the parent session.
+ */
+export type SessionBreak = {
+  startHour: number;
+  startMinute: number;
+  endHour: number;
+  endMinute: number;
+};
 
 /**
  * Definition of a trading session with start/end times in UTC
@@ -24,6 +36,18 @@ export type SessionDefinition = {
   endHour: number;
   /** End minute (0-59) */
   endMinute: number;
+  /**
+   * Optional intra-session breaks (e.g. JPX lunch 11:30-12:30).
+   * Bars falling inside a break are considered out-of-session:
+   * `inSession=false`, `barIndex` does not advance, and session O/H/L are preserved.
+   */
+  breaks?: SessionBreak[];
+  /**
+   * Optional IANA timezone for interpreting startHour/startMinute/endHour/endMinute
+   * and any breaks (e.g. "America/New_York", "Asia/Tokyo"). Defaults to "UTC".
+   * When set, DST is handled automatically by the runtime's tzdata.
+   */
+  timezone?: string;
 };
 
 /**
@@ -90,6 +114,54 @@ export function getIctSessions(): SessionDefinition[] {
 }
 
 /**
+ * Returns the JPX (Tokyo Stock Exchange) session in UTC with a lunch break.
+ *
+ * JPX regular hours (effective 2024-11-05): 09:00–11:30 / 12:30–15:30 JST
+ * (UTC+9, no DST). In UTC: 00:00–06:30 with a break at 02:30–03:30.
+ *
+ * Note: Real JPX market data has no bars during the lunch break; the `breaks`
+ * field is for 24×7 data sources (crypto / FX) or synthetic bars that cross
+ * the lunch hour and need to be excluded from session statistics.
+ *
+ * @example
+ * ```ts
+ * const sessions = getJpxSessions();
+ * const info = detectSessions(candles, sessions);
+ * ```
+ */
+export function getJpxSessions(): SessionDefinition[] {
+  return [
+    {
+      name: "JPX",
+      startHour: 0,
+      startMinute: 0,
+      endHour: 6,
+      endMinute: 30,
+      breaks: [{ startHour: 2, startMinute: 30, endHour: 3, endMinute: 30 }],
+    },
+  ];
+}
+
+/**
+ * Returns the HKEX (Hong Kong) session in UTC with a lunch break.
+ *
+ * HKEX regular hours: 09:30-12:00 / 13:00-16:00 HKT (UTC+8, no DST).
+ * In UTC: 01:30-08:00 with a break at 04:00-05:00.
+ */
+export function getHkexSessions(): SessionDefinition[] {
+  return [
+    {
+      name: "HKEX",
+      startHour: 1,
+      startMinute: 30,
+      endHour: 8,
+      endMinute: 0,
+      breaks: [{ startHour: 4, startMinute: 0, endHour: 5, endMinute: 0 }],
+    },
+  ];
+}
+
+/**
  * Factory function to create a custom session definition.
  *
  * @param name - Session name
@@ -119,15 +191,71 @@ export function defineSession(
  * Handles both normal sessions (start < end) and midnight-crossing sessions.
  */
 export function isInSession(hour: number, minute: number, session: SessionDefinition): boolean {
+  if (
+    !isInTimeWindow(
+      hour,
+      minute,
+      session.startHour,
+      session.startMinute,
+      session.endHour,
+      session.endMinute,
+    )
+  ) {
+    return false;
+  }
+  if (session.breaks && isInAnyBreak(hour, minute, session.breaks)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Check if (hour, minute) matches the session's start/end window, ignoring breaks.
+ * Used to keep the "anchor" session state through breaks.
+ */
+export function isInSessionWindow(
+  hour: number,
+  minute: number,
+  session: SessionDefinition,
+): boolean {
+  return isInTimeWindow(
+    hour,
+    minute,
+    session.startHour,
+    session.startMinute,
+    session.endHour,
+    session.endMinute,
+  );
+}
+
+/**
+ * Check if (hour, minute) falls inside any of the given breaks.
+ */
+export function isInAnyBreak(hour: number, minute: number, breaks: SessionBreak[]): boolean {
+  for (const br of breaks) {
+    if (isInTimeWindow(hour, minute, br.startHour, br.startMinute, br.endHour, br.endMinute)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isInTimeWindow(
+  hour: number,
+  minute: number,
+  startHour: number,
+  startMinute: number,
+  endHour: number,
+  endMinute: number,
+): boolean {
   const timeMinutes = hour * 60 + minute;
-  const startMinutes = session.startHour * 60 + session.startMinute;
-  const endMinutes = session.endHour * 60 + session.endMinute;
+  const startMinutes = startHour * 60 + startMinute;
+  const endMinutes = endHour * 60 + endMinute;
 
   if (startMinutes <= endMinutes) {
-    // Normal session (no midnight crossing)
     return timeMinutes >= startMinutes && timeMinutes < endMinutes;
   }
-  // Session crosses midnight (e.g., 22:00 - 05:00)
+  // Window crosses midnight (e.g., 22:00 - 05:00)
   return timeMinutes >= startMinutes || timeMinutes < endMinutes;
 }
 
@@ -172,25 +300,37 @@ export function detectSessions(
   let sessionLow: number | null = null;
 
   for (const candle of normalized) {
-    // candle.time is in milliseconds after normalization
-    const date = new Date(candle.time);
-    const hour = date.getUTCHours();
-    const minute = date.getUTCMinutes();
-
-    // Find which session this candle belongs to
-    let matchedSession: string | null = null;
+    // Find the session whose outer window contains this candle (break-agnostic),
+    // evaluating each session in its own configured timezone.
+    let anchorSession: SessionDefinition | null = null;
+    let anchorHour = 0;
+    let anchorMinute = 0;
     for (const session of sessionDefs) {
-      if (isInSession(hour, minute, session)) {
-        matchedSession = session.name;
+      const { hour, minute } = getTzHourMinute(candle.time, session.timezone);
+      if (isInSessionWindow(hour, minute, session)) {
+        anchorSession = session;
+        anchorHour = hour;
+        anchorMinute = minute;
         break;
       }
     }
+    const inBreak =
+      anchorSession !== null &&
+      anchorSession.breaks !== undefined &&
+      isInAnyBreak(anchorHour, anchorMinute, anchorSession.breaks);
+    const anchorName = anchorSession?.name ?? null;
 
-    // Check if session changed
-    if (matchedSession !== currentSessionName) {
-      currentSessionName = matchedSession;
+    // Session anchor changed (new session entered, or fell outside everything)
+    if (anchorName !== currentSessionName) {
+      currentSessionName = anchorName;
       barIndex = 0;
-      if (matchedSession !== null) {
+      if (anchorName !== null && !inBreak) {
+        sessionOpen = candle.open;
+        sessionHigh = candle.high;
+        sessionLow = candle.low;
+      } else if (anchorName !== null && inBreak) {
+        // Entered a session for the first time during its own break (unusual but handle gracefully).
+        // Treat as session started, but this bar does not advance the session.
         sessionOpen = candle.open;
         sessionHigh = candle.high;
         sessionLow = candle.low;
@@ -199,17 +339,18 @@ export function detectSessions(
         sessionHigh = null;
         sessionLow = null;
       }
-    } else if (matchedSession !== null) {
+    } else if (anchorName !== null && !inBreak) {
       barIndex++;
       sessionHigh = Math.max(sessionHigh ?? candle.high, candle.high);
       sessionLow = Math.min(sessionLow ?? candle.low, candle.low);
     }
+    // if anchorName !== null && inBreak: preserve everything, don't advance barIndex.
 
     result.push({
       time: candle.time,
       value: {
-        session: matchedSession,
-        inSession: matchedSession !== null,
+        session: anchorName,
+        inSession: anchorName !== null && !inBreak,
         barIndex,
         sessionOpen,
         sessionHigh,

--- a/packages/core/src/indicators/session/session-stats.ts
+++ b/packages/core/src/indicators/session/session-stats.ts
@@ -7,7 +7,13 @@
 
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import type { Candle, NormalizedCandle } from "../../types";
-import { type SessionDefinition, getIctSessions, isInSession } from "./session-definition";
+import {
+  type SessionDefinition,
+  getIctSessions,
+  isInAnyBreak,
+  isInSessionWindow,
+} from "./session-definition";
+import { getTzHourMinute } from "./tz-utils";
 
 /**
  * Options for sessionStats
@@ -93,27 +99,36 @@ export function sessionStats(
   }
 
   for (const candle of normalized) {
-    const date = new Date(candle.time);
-    const hour = date.getUTCHours();
-    const minute = date.getUTCMinutes();
-
     for (const session of sessionDefs) {
-      const inSess = isInSession(hour, minute, session);
-      const wasInSess = prevSession.get(session.name) ?? false;
+      const { hour, minute } = getTzHourMinute(candle.time, session.timezone);
+      // Use the outer window for occurrence boundary detection, so a lunch break
+      // does not split one session into two occurrences.
+      const inWindow = isInSessionWindow(hour, minute, session);
+      const inBreak =
+        inWindow && session.breaks !== undefined && isInAnyBreak(hour, minute, session.breaks);
+      const wasInWindow = prevSession.get(session.name) ?? false;
 
-      if (inSess) {
-        if (!wasInSess) {
-          // New session occurrence
-          const occ: SessionOccurrence = {
-            high: candle.high,
-            low: candle.low,
-            totalVolume: candle.volume,
-            bullishBars: candle.close > candle.open ? 1 : 0,
-            totalBars: 1,
-          };
+      if (inWindow) {
+        if (!wasInWindow) {
+          // New session occurrence starts. Seed with this bar unless it is in a break.
+          const occ: SessionOccurrence = inBreak
+            ? {
+                high: Number.NEGATIVE_INFINITY,
+                low: Number.POSITIVE_INFINITY,
+                totalVolume: 0,
+                bullishBars: 0,
+                totalBars: 0,
+              }
+            : {
+                high: candle.high,
+                low: candle.low,
+                totalVolume: candle.volume,
+                bullishBars: candle.close > candle.open ? 1 : 0,
+                totalBars: 1,
+              };
           currentOcc.set(session.name, occ);
-        } else {
-          // Continue current occurrence
+        } else if (!inBreak) {
+          // Continue current occurrence — skip break bars entirely.
           const occ = currentOcc.get(session.name);
           if (!occ) continue;
           occ.high = Math.max(occ.high, candle.high);
@@ -122,23 +137,24 @@ export function sessionStats(
           if (candle.close > candle.open) occ.bullishBars++;
           occ.totalBars++;
         }
-      } else if (wasInSess) {
-        // Session just ended — finalize occurrence
+        // if inBreak && wasInWindow: do nothing (preserve occurrence through break)
+      } else if (wasInWindow) {
+        // Session window just ended — finalize occurrence if any real bars collected.
         const occ = currentOcc.get(session.name);
-        if (occ) {
+        if (occ && occ.totalBars > 0) {
           occurrences.get(session.name)?.push(occ);
-          currentOcc.set(session.name, null);
         }
+        currentOcc.set(session.name, null);
       }
 
-      prevSession.set(session.name, inSess);
+      prevSession.set(session.name, inWindow);
     }
   }
 
   // Finalize any still-open sessions
   for (const session of sessionDefs) {
     const occ = currentOcc.get(session.name);
-    if (occ) {
+    if (occ && occ.totalBars > 0) {
       occurrences.get(session.name)?.push(occ);
     }
   }

--- a/packages/core/src/indicators/session/tz-utils.ts
+++ b/packages/core/src/indicators/session/tz-utils.ts
@@ -1,0 +1,68 @@
+/**
+ * Timezone utilities for session detection.
+ *
+ * Uses the runtime's built-in `Intl.DateTimeFormat` (zero external deps)
+ * to convert a UTC epoch ms into local hour/minute for any IANA timezone.
+ * DST is handled automatically by the runtime's tzdata.
+ */
+
+/**
+ * Returns the local { hour, minute } for the given UTC epoch milliseconds
+ * in the specified IANA timezone (e.g. "America/New_York", "Asia/Tokyo").
+ *
+ * - For "UTC" (or empty / undefined input), uses native getUTCHours/Minutes
+ *   to avoid the Intl.DateTimeFormat allocation cost.
+ * - For other zones, uses Intl.DateTimeFormat.formatToParts to extract
+ *   the hour and minute fields with DST applied automatically.
+ *
+ * @param epochMs - Time in UTC epoch milliseconds
+ * @param timezone - IANA timezone identifier (default "UTC")
+ *
+ * @example
+ * ```ts
+ * // 2026-03-08 14:00 UTC = 09:00 New York EST (winter)
+ * getTzHourMinute(Date.UTC(2026, 2, 8, 14, 0), "America/New_York");
+ * // => { hour: 9, minute: 0 }
+ *
+ * // 2026-03-15 14:00 UTC = 10:00 New York EDT (after DST)
+ * getTzHourMinute(Date.UTC(2026, 2, 15, 14, 0), "America/New_York");
+ * // => { hour: 10, minute: 0 }
+ * ```
+ */
+export function getTzHourMinute(
+  epochMs: number,
+  timezone = "UTC",
+): { hour: number; minute: number } {
+  if (!timezone || timezone === "UTC") {
+    const d = new Date(epochMs);
+    return { hour: d.getUTCHours(), minute: d.getUTCMinutes() };
+  }
+
+  const fmt = getCachedFormatter(timezone);
+  const parts = fmt.formatToParts(epochMs);
+  let hour = 0;
+  let minute = 0;
+  for (const p of parts) {
+    if (p.type === "hour") hour = Number(p.value);
+    else if (p.type === "minute") minute = Number(p.value);
+  }
+  // Some locales render midnight as "24" — normalize to 0.
+  if (hour === 24) hour = 0;
+  return { hour, minute };
+}
+
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getCachedFormatter(timezone: string): Intl.DateTimeFormat {
+  let fmt = formatterCache.get(timezone);
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+    formatterCache.set(timezone, fmt);
+  }
+  return fmt;
+}

--- a/packages/core/src/types/candle.ts
+++ b/packages/core/src/types/candle.ts
@@ -194,6 +194,7 @@ export type EmaOptions = {
  */
 export type RsiOptions = {
   period?: number;
+  source?: PriceSource;
 };
 
 /**
@@ -203,6 +204,7 @@ export type MacdOptions = {
   fastPeriod?: number;
   slowPeriod?: number;
   signalPeriod?: number;
+  source?: PriceSource;
 };
 
 /**


### PR DESCRIPTION
## Summary

Two coupled v0.x additions spanning both packages.

### `trendcraft` (core) — add price source, session breaks, timezone support

- `RSI` / `MACD` / `CCI` (batch + incremental) now accept `source?: PriceSource` so typical / hl2 / ohlc4 can drive momentum indicators without pre-transforming candles. Defaults preserve current behavior.
- `SessionDefinition.breaks` lets a session carry intra-session breaks (e.g. JPX lunch 11:30–12:30 JST). `detectSessions`, `sessionStats`, and `sessionBreakout` treat break bars as out-of-session without losing the surrounding session anchor.
- `SessionDefinition.timezone` / `KillZoneDefinition.timezone` accept any IANA tz via the runtime's `Intl.DateTimeFormat` (zero new deps, DST handled automatically).
- New presets: `getJpxSessions()` (09:00–15:30 JST with lunch break, post 2024-11-05 schedule), `getHkexSessions()`.
- New helpers: `isInSessionWindow`, `isInAnyBreak`, `getTzHourMinute`, `SessionBreak` type.
- All additions are optional; existing tests stay green.

### `@trendcraft/chart` — time-proportional intraday axis with two-row labels

Intraday data with real overnight / weekend gaps previously rendered with every bar at uniform `barSpacing`, so a 16-hour overnight collapsed to zero visual width and the axis jumped from 04:17 straight to 22:34 with no indication the date had changed. The axis now:

- Positions bars proportionally to their wall-clock time within a session (so sparse trading shows as visible empty space) and compresses long session breaks to a fixed `sessionGapBars` width.
- Renders a two-row time axis: upper row = wall-clock HH:MM ticks at "nice" intervals (5m / 15m / 30m / 1h / 4h / 1d), lower row = date anchors at local-TZ day boundaries. Daily+ data falls back to the single-row layout.

Public API additions:

- `TimeScale.setTimeProportional(candleTimes, opts)`, `timeToX(time)`, `getTimeTicks(stepMs)`, `getDateTicks()`, `hasTimeData`, `medianBarIntervalMs`.
- `ChartOptions.timeScale.sessionGaps` now routes `mode: "timeGap"` (default when truthy) through `setTimeProportional`; `"dayBoundary"` keeps the legacy fixed-gap path; `"off"` keeps pure index layout. Runtime-togglable via `applyOptions`.
- `format.ts`: new `formatShortTime`, `formatShortDate`, `pickNiceStep`. `autoFormatTime` suppresses redundant HH:MM on daily+ data by comparing time-of-day stability.
- `layout.ts`: default `timeAxisHeight` 24 → 32 to accommodate two rows; explicit user overrides still win.

Bug fixes surfaced during the rework:

- `updateCandle` re-applies the session-gap layout after an append, so live streaming charts keep the two-row axis instead of silently reverting to index layout on the first tick.
- `timeToX(exactBarTime)` at a session-close bar (left endpoint of a compressed gap) now returns the bar's real position instead of `null`.

Size budget: main 33.79 kB (limit raised 32 → 35 kB), headless 9.97 kB, React 27.74 kB, Vue 28 kB.

## Test plan

- [x] `pnpm test` in `packages/core` — 4740 tests pass, incl. new `price-source` / `lunch-break` / `tz-utils` suites (DST transitions verified).
- [x] `pnpm test` in `packages/chart` — 679 tests pass, incl. new `setTimeProportional` / `timeToX` / `getTimeTicks` / `getDateTicks` cases plus regression for the compressed-gap endpoint bug.
- [x] `pnpm lint` — clean across the workspace.
- [x] `pnpm build` — both packages build.
- [x] `pnpm size-check` — all four bundles within the updated limits.
- [x] Visual check via `packages/chart/examples/_ux-playground`: AAPL 1-min real data shows time-proportional bars, overnight compressed to a narrow gap, date row anchors days; daily data falls back to single-row labels.
- [x] Codex review — P1 (live-update gap preservation) and P2 (`timeToX` at compressed-gap endpoints) resolved with regression tests.