### PR TITLE
fix(chart): multi-indicator layout + decimation alignment polish

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -24,6 +24,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`chart.setCrosshair(time)`** — programmatic crosshair control for external consumers that want to drive the crosshair without a DOM pointer event.
 - **`visibleRangeChange` event** is now actually emitted (was declared but unused). Fires when the visible range changes.
 
+### Fixed
+
+- **Decimation alignment** — at low zoom (`barSpacing < 1 px`, e.g. Fit-content on a large dataset) candles and number-series indicators used three different decimation paths that disagreed on x-coordinates, so overlays (SMA / RSI / EMA / …) drifted left of the bars they were supposed to annotate. All three paths now share the original `timeScale` coordinate space via bucket-origin indices carried through the render pipeline.
+- **Right price-axis label overlap** — with many stacked panes the right-side tick labels crowded together and the current-price badge could overlap neighboring ticks. The axis now picks a tick density from pane height, suppresses labels within a half-label of pane edges, and skips ticks that would collide with the current-price badge Y on the main pane.
+- **Info + legend overlap** — when many indicators were active the top-left OHLC/indicator readout grew past the top-right legend button row. The legend is now placed on its own second row, and the info strip gets a max-width + ellipsis safety net.
+- **Indicator color cycling on re-add** — removing and re-adding an indicator (for example when a showcase / alpaca-demo panel applies a parameter change) would assign the next palette slot instead of the one just vacated, so colors appeared to "change on events". Auto-assigned colors now prefer the first palette entry not currently in use.
+- **Scrollbar thumb jumps to cursor on grab** — pressing anywhere on the thumb recentered the visible range on the pointer; now press-on-thumb records the grab offset so the thumb stays pinned where grabbed, while press-on-track still page-jumps.
+
+### Breaking
+
+- `decimateCandles(candles, start, end, maxBars)` now returns `{ candles, originalIndices: Int32Array }` instead of `CandleData[]`. Exposed via `@trendcraft/chart/headless`.
+- `lttb(data, targetCount)` now returns `{ points, originalIndices: Int32Array }` instead of `DataPoint[]`, and accepts an optional 3rd `indexOffset` argument to shift `originalIndices` into the caller's coordinate space. Exposed via `@trendcraft/chart/headless`.
+
 ### Changed
 
 - Bundle size budget for the main entry raised from 31 kB → 32 kB (brotli). The raise reflects the intentional UX additions above and is expected to hold through the 0.2.x line — future feature work either lives on a sub-path or compensates with equivalent reductions elsewhere.

--- a/packages/chart/src/__tests__/axis-renderer.test.ts
+++ b/packages/chart/src/__tests__/axis-renderer.test.ts
@@ -29,6 +29,38 @@ describe("renderPriceAxis", () => {
     expect(ctx.textAlign).toBe("right");
     expect(ctx.fillText).toHaveBeenCalled();
   });
+
+  it("honors maxTicks — fewer labels on a short pane", () => {
+    const ctx1 = mockCtx();
+    const ctx2 = mockCtx();
+    const ps1 = makePriceScale(400, 100, 200);
+    const ps2 = makePriceScale(400, 100, 200);
+    renderPriceAxis(ctx1, ps1, 740, 0, 60, 400, theme, 11, undefined, {
+      maxTicks: 6,
+    });
+    renderPriceAxis(ctx2, ps2, 740, 0, 60, 400, theme, 11, undefined, {
+      maxTicks: 2,
+    });
+    const calls6 = (ctx1.fillText as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+    const calls2 = (ctx2.fillText as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+    expect(calls2).toBeLessThanOrEqual(calls6);
+  });
+
+  it("skips tick labels inside excludeY ± excludeHalfHeight (current-price badge)", () => {
+    const ctx = mockCtx();
+    const ps = makePriceScale(400, 100, 200);
+    // Current price 150 maps to y = 200 on a 400px scale with range 100..200.
+    const excludeY = ps.priceToY(150);
+    renderPriceAxis(ctx, ps, 740, 0, 60, 400, theme, 11, undefined, {
+      maxTicks: 6,
+      excludeY,
+      excludeHalfHeight: 8,
+    });
+    const calls = (ctx.fillText as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    for (const [, , yArg] of calls) {
+      expect(Math.abs((yArg as number) - excludeY)).toBeGreaterThanOrEqual(10);
+    }
+  });
 });
 
 describe("renderTimeAxis", () => {

--- a/packages/chart/src/__tests__/cache-invalidation.test.ts
+++ b/packages/chart/src/__tests__/cache-invalidation.test.ts
@@ -184,8 +184,8 @@ describe("Cache invalidation", () => {
       const result2 = decimateCandles(candles2, 0, 100, 10);
 
       // Same structure but different values
-      expect(result1.length).toBe(result2.length);
-      expect(result1[0].close).not.toBe(result2[0].close);
+      expect(result1.candles.length).toBe(result2.candles.length);
+      expect(result1.candles[0].close).not.toBe(result2.candles[0].close);
     });
 
     it("getDecimationTarget returns 0 when data fits", () => {

--- a/packages/chart/src/__tests__/color-assignment.test.ts
+++ b/packages/chart/src/__tests__/color-assignment.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+/**
+ * Indicator auto-color assignment — Bug 3 regression test.
+ *
+ * Verifies that `addIndicator` prefers the first palette color not already
+ * in use, so a remove→re-add (e.g. param-change) cycle keeps the same color
+ * instead of rotating to the next palette slot.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { DataPoint } from "../core/types";
+import { createChart } from "../index";
+
+beforeAll(() => {
+  const noop = () => {};
+  const context2d = new Proxy(
+    {},
+    {
+      get: (_t, prop) => {
+        if (prop === "canvas") return null;
+        if (prop === "measureText") return () => ({ width: 0 }) as TextMetrics;
+        return noop;
+      },
+      set: () => true,
+    },
+  ) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as { getContext: () => unknown }).getContext = () =>
+    context2d;
+});
+
+function makeContainer(): HTMLElement {
+  const el = document.createElement("div");
+  el.style.width = "800px";
+  el.style.height = "400px";
+  document.body.appendChild(el);
+  return el;
+}
+
+const series: DataPoint<number>[] = [
+  { time: 1, value: 1 },
+  { time: 2, value: 2 },
+];
+
+describe("addIndicator color assignment", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("reuses the same color when an indicator is removed and re-added", () => {
+    const chart = createChart(makeContainer());
+    const first = chart.addIndicator(series, { label: "A" });
+    const originalColor = first.config.color;
+    expect(originalColor).toBeTruthy();
+
+    first.remove();
+    const reAdded = chart.addIndicator(series, { label: "A2" });
+    expect(reAdded.config.color).toBe(originalColor);
+    chart.destroy();
+  });
+
+  it("assigns distinct colors while multiple indicators coexist", () => {
+    const chart = createChart(makeContainer());
+    const a = chart.addIndicator(series, { label: "A" });
+    const b = chart.addIndicator(series, { label: "B" });
+    const c = chart.addIndicator(series, { label: "C" });
+    expect(a.config.color).not.toBe(b.config.color);
+    expect(b.config.color).not.toBe(c.config.color);
+    expect(a.config.color).not.toBe(c.config.color);
+    chart.destroy();
+  });
+});

--- a/packages/chart/src/__tests__/decimation-alignment.test.ts
+++ b/packages/chart/src/__tests__/decimation-alignment.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression: candle buckets and LTTB-decimated indicator lines must share
+ * the same screen-x coordinate space (the original timeScale's `indexToX`).
+ *
+ * Previously (v0.1.x) at `barSpacing < 1px` the candle path remapped the
+ * timeScale to fill the canvas while the line path compressed a decimated
+ * array onto the left portion — overlays drifted off the bars they were
+ * supposed to annotate.
+ */
+
+import { describe, expect, it } from "vitest";
+import { decimateCandles, lttb } from "../core/decimation";
+import { PriceScale, TimeScale } from "../core/scale";
+import type { CandleData, DataPoint } from "../core/types";
+
+function makeCandles(n: number): CandleData[] {
+  return Array.from({ length: n }, (_, i) => ({
+    time: i * 86_400_000,
+    open: 100 + i,
+    high: 101 + i,
+    low: 99 + i,
+    close: 100 + i,
+    volume: 1000 + i,
+  }));
+}
+
+function makeLine(n: number): DataPoint<number>[] {
+  return Array.from({ length: n }, (_, i) => ({ time: i * 86_400_000, value: 100 + i }));
+}
+
+describe("decimation x-alignment", () => {
+  it("candle bucket center x matches indicator point x on the same timeScale", () => {
+    const N = 2000;
+    const candles = makeCandles(N);
+    const line = makeLine(N);
+
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(N);
+    ts.setVisibleRange(0, N); // barSpacing < 1 → decimation kicks in
+
+    const candleTarget = 740;
+    const lineTarget = 740;
+
+    const dc = decimateCandles(candles, 0, N, candleTarget);
+    const dl = lttb(line.slice(0, N), lineTarget, 0);
+
+    // First + last bucket centers line up with first + last LTTB points.
+    // (First and last LTTB points are always the input endpoints, so we
+    // compare against candle bucket centers at index 0 and last.)
+    const firstCandleX = ts.indexToX(dc.originalIndices[0]);
+    const firstLineX = ts.indexToX(dl.originalIndices[0]);
+    expect(Math.abs(firstCandleX - firstLineX)).toBeLessThanOrEqual(5);
+
+    const lastCandleX = ts.indexToX(dc.originalIndices[dc.originalIndices.length - 1]);
+    const lastLineX = ts.indexToX(dl.originalIndices[dl.originalIndices.length - 1]);
+    expect(Math.abs(lastCandleX - lastLineX)).toBeLessThanOrEqual(5);
+
+    // Both sets cover the full canvas width (0..ts.width ± bucketSpacing).
+    expect(firstCandleX).toBeLessThan(40);
+    expect(lastCandleX).toBeGreaterThan(ts.width - 40);
+    expect(firstLineX).toBeLessThan(40);
+    expect(lastLineX).toBeGreaterThan(ts.width - 40);
+  });
+
+  it("lttb with offset shifts originalIndices into the parent coordinate space", () => {
+    const data = makeLine(500);
+    const startIndex = 100;
+    const slice = data.slice(startIndex, startIndex + 300);
+    const result = lttb(slice, 80, startIndex);
+    expect(result.originalIndices[0]).toBe(startIndex);
+    expect(result.originalIndices[result.originalIndices.length - 1]).toBe(startIndex + 299);
+  });
+
+  it("non-decimated path still returns sequential originalIndices", () => {
+    const candles = makeCandles(20);
+    const dc = decimateCandles(candles, 5, 15, 100); // 10 candles ≤ maxBars
+    expect(dc.candles.length).toBe(10);
+    expect(Array.from(dc.originalIndices)).toEqual([5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
+
+    const priceScale = new PriceScale();
+    priceScale.setHeight(300);
+    priceScale.setDataRange(99, 120);
+    // Sanity: scale is wired, doesn't throw.
+    expect(priceScale.priceToY(100)).toBeGreaterThan(0);
+  });
+});

--- a/packages/chart/src/__tests__/decimation.test.ts
+++ b/packages/chart/src/__tests__/decimation.test.ts
@@ -13,20 +13,32 @@ describe("lttb", () => {
   it("returns original data if already smaller than target", () => {
     const data = makeData(10);
     const result = lttb(data, 20);
-    expect(result.length).toBe(10);
+    expect(result.points.length).toBe(10);
+    expect(result.originalIndices.length).toBe(10);
   });
 
   it("reduces data to target count", () => {
     const data = makeData(1000);
     const result = lttb(data, 100);
-    expect(result.length).toBe(100);
+    expect(result.points.length).toBe(100);
+    expect(result.originalIndices.length).toBe(100);
   });
 
   it("preserves first and last points", () => {
     const data = makeData(500);
     const result = lttb(data, 50);
-    expect(result[0].time).toBe(data[0].time);
-    expect(result[result.length - 1].time).toBe(data[data.length - 1].time);
+    expect(result.points[0].time).toBe(data[0].time);
+    expect(result.points[result.points.length - 1].time).toBe(data[data.length - 1].time);
+  });
+
+  it("originalIndices are monotonic, in-range, and shift by offset", () => {
+    const data = makeData(500);
+    const result = lttb(data, 50, 1000);
+    expect(result.originalIndices[0]).toBe(1000);
+    expect(result.originalIndices[result.originalIndices.length - 1]).toBe(1000 + 499);
+    for (let i = 1; i < result.originalIndices.length; i++) {
+      expect(result.originalIndices[i]).toBeGreaterThan(result.originalIndices[i - 1]);
+    }
   });
 
   it("handles null values gracefully", () => {
@@ -39,12 +51,13 @@ describe("lttb", () => {
     ];
     // Only 3 valid points, which equals target → returns original
     const result = lttb(data, 3);
-    expect(result.length).toBe(5);
+    expect(result.points.length).toBe(5);
   });
 
   it("returns empty for empty input", () => {
     const result = lttb([], 10);
-    expect(result.length).toBe(0);
+    expect(result.points.length).toBe(0);
+    expect(result.originalIndices.length).toBe(0);
   });
 });
 
@@ -63,30 +76,49 @@ describe("decimateCandles", () => {
   it("returns original slice if within maxBars", () => {
     const candles = makeCandles(50);
     const result = decimateCandles(candles, 0, 50, 100);
-    expect(result.length).toBe(50);
+    expect(result.candles.length).toBe(50);
+    expect(result.originalIndices.length).toBe(50);
+    expect(result.originalIndices[0]).toBe(0);
+    expect(result.originalIndices[49]).toBe(49);
   });
 
   it("reduces to maxBars count", () => {
     const candles = makeCandles(1000);
     const result = decimateCandles(candles, 0, 1000, 200);
-    expect(result.length).toBe(200);
+    expect(result.candles.length).toBe(200);
+    expect(result.originalIndices.length).toBe(200);
   });
 
   it("preserves OHLCV extremes in buckets", () => {
     const candles = makeCandles(100);
     const result = decimateCandles(candles, 0, 100, 10);
     // Each bucket of 10 candles: high should be max of bucket, low should be min
-    expect(result[0].open).toBe(candles[0].open);
-    expect(result[0].close).toBe(candles[9].close);
-    expect(result[0].high).toBeGreaterThanOrEqual(candles[0].high);
-    expect(result[0].low).toBeLessThanOrEqual(candles[9].low);
+    expect(result.candles[0].open).toBe(candles[0].open);
+    expect(result.candles[0].close).toBe(candles[9].close);
+    expect(result.candles[0].high).toBeGreaterThanOrEqual(candles[0].high);
+    expect(result.candles[0].low).toBeLessThanOrEqual(candles[9].low);
   });
 
   it("sums volume across bucket", () => {
     const candles = makeCandles(10);
     const result = decimateCandles(candles, 0, 10, 2);
     const firstBucketVolume = candles.slice(0, 5).reduce((s, c) => s + c.volume, 0);
-    expect(result[0].volume).toBe(firstBucketVolume);
+    expect(result.candles[0].volume).toBe(firstBucketVolume);
+  });
+
+  it("originalIndices are monotonic, in-range, and land inside each bucket", () => {
+    const candles = makeCandles(100);
+    const result = decimateCandles(candles, 10, 90, 8);
+    // 8 buckets across range [10, 90)
+    expect(result.candles.length).toBe(8);
+    for (let i = 0; i < result.originalIndices.length; i++) {
+      const idx = result.originalIndices[i];
+      expect(idx).toBeGreaterThanOrEqual(10);
+      expect(idx).toBeLessThan(90);
+      if (i > 0) {
+        expect(idx).toBeGreaterThan(result.originalIndices[i - 1]);
+      }
+    }
   });
 });
 

--- a/packages/chart/src/__tests__/performance.test.ts
+++ b/packages/chart/src/__tests__/performance.test.ts
@@ -97,7 +97,7 @@ describe("Performance", () => {
       result = lttb(data, 800);
     });
 
-    expect(result.length).toBe(800);
+    expect(result.points.length).toBe(800);
     expect(median).toBeLessThan(16);
   });
 
@@ -109,7 +109,7 @@ describe("Performance", () => {
       result = decimateCandles(candles, 0, SIZE, 1000);
     });
 
-    expect(result.length).toBe(1000);
+    expect(result.candles.length).toBe(1000);
     expect(median).toBeLessThan(16);
   });
 
@@ -149,7 +149,7 @@ describe("Performance", () => {
       result = lttb(data, 1000);
     }, 3);
 
-    expect(result.length).toBe(1000);
+    expect(result.points.length).toBe(1000);
     expect(median).toBeLessThan(50);
   });
 
@@ -161,7 +161,7 @@ describe("Performance", () => {
       result = decimateCandles(candles, 0, LARGE, 1000);
     }, 3);
 
-    expect(result.length).toBe(1000);
+    expect(result.candles.length).toBe(1000);
     expect(median).toBeLessThan(50);
   });
 
@@ -215,7 +215,7 @@ describe("Performance", () => {
       result = lttb(data, 2000);
     }, 3);
 
-    expect(result.length).toBe(2000);
+    expect(result.points.length).toBe(2000);
     expect(median).toBeLessThan(200);
   });
 

--- a/packages/chart/src/core/decimation.ts
+++ b/packages/chart/src/core/decimation.ts
@@ -8,17 +8,43 @@
 import type { CandleData, DataPoint } from "./types";
 
 /**
+ * LTTB decimation result. `originalIndices[i]` is the input-array index the
+ * selected point at `points[i]` came from — callers use it to compute screen
+ * x coordinates against the unmodified timeScale so the line aligns with
+ * non-decimated overlays.
+ */
+export type DecimatedPoints<T> = {
+  readonly points: readonly DataPoint<T>[];
+  readonly originalIndices: Int32Array;
+};
+
+/**
+ * Candle bucketing result. `originalIndices[i]` is the center original-array
+ * index that bucket `i` represents. Used for screen-x alignment with
+ * non-decimated indicators.
+ */
+export type DecimatedCandles = {
+  readonly candles: readonly CandleData[];
+  readonly originalIndices: Int32Array;
+};
+
+/**
  * LTTB (Largest Triangle Three Buckets) algorithm.
  * Reduces a series of points to `targetCount` while preserving visual shape.
  *
  * @param data - Input data points (must be sorted by time)
  * @param targetCount - Desired number of output points
- * @returns Decimated data (or original if already small enough)
+ * @param indexOffset - Added to every `originalIndices` entry so callers who
+ *        pass a slice can recover the absolute index in their coordinate
+ *        space. Defaults to 0.
+ * @returns Decimated points and a parallel array of their original indices
+ *        (shifted by `indexOffset`).
  */
 export function lttb(
   data: readonly DataPoint<number | null>[],
   targetCount: number,
-): DataPoint<number | null>[] {
+  indexOffset = 0,
+): DecimatedPoints<number | null> {
   const validPoints: { index: number; value: number }[] = [];
   for (let i = 0; i < data.length; i++) {
     const v = data[i]?.value;
@@ -28,14 +54,19 @@ export function lttb(
   }
 
   if (validPoints.length <= targetCount || targetCount < 3) {
-    return data.slice() as DataPoint<number | null>[];
+    const points = data.slice() as DataPoint<number | null>[];
+    const originalIndices = new Int32Array(points.length);
+    for (let i = 0; i < points.length; i++) originalIndices[i] = i + indexOffset;
+    return { points, originalIndices };
   }
 
   const bucketSize = (validPoints.length - 2) / (targetCount - 2);
-  const result: DataPoint<number | null>[] = [];
+  const points: DataPoint<number | null>[] = [];
+  const selectedIndices: number[] = [];
 
   // Always keep first point
-  result.push(data[validPoints[0].index]);
+  points.push(data[validPoints[0].index]);
+  selectedIndices.push(validPoints[0].index);
 
   let prevSelectedIdx = 0;
 
@@ -77,14 +108,21 @@ export function lttb(
       }
     }
 
-    result.push(data[validPoints[maxIdx].index]);
+    points.push(data[validPoints[maxIdx].index]);
+    selectedIndices.push(validPoints[maxIdx].index);
     prevSelectedIdx = maxIdx;
   }
 
   // Always keep last point
-  result.push(data[validPoints[validPoints.length - 1].index]);
+  const lastIdx = validPoints[validPoints.length - 1].index;
+  points.push(data[lastIdx]);
+  selectedIndices.push(lastIdx);
 
-  return result;
+  const originalIndices = new Int32Array(selectedIndices.length);
+  for (let i = 0; i < selectedIndices.length; i++) {
+    originalIndices[i] = selectedIndices[i] + indexOffset;
+  }
+  return { points, originalIndices };
 }
 
 /**
@@ -102,14 +140,18 @@ export function decimateCandles(
   startIndex: number,
   endIndex: number,
   maxBars: number,
-): CandleData[] {
+): DecimatedCandles {
   const count = endIndex - startIndex;
   if (count <= maxBars || maxBars <= 0) {
-    return candles.slice(startIndex, endIndex) as CandleData[];
+    const result = candles.slice(startIndex, endIndex) as CandleData[];
+    const originalIndices = new Int32Array(result.length);
+    for (let i = 0; i < result.length; i++) originalIndices[i] = startIndex + i;
+    return { candles: result, originalIndices };
   }
 
   const bucketSize = count / maxBars;
   const result: CandleData[] = [];
+  const originalIndices = new Int32Array(maxBars);
 
   for (let b = 0; b < maxBars; b++) {
     const bStart = startIndex + Math.floor(b * bucketSize);
@@ -130,9 +172,12 @@ export function decimateCandles(
     }
 
     result.push({ time, open, high, low, close, volume });
+    // Bucket center — anchors the rendered candle at the visual midpoint of
+    // the bars it summarizes.
+    originalIndices[b] = Math.floor((bStart + bEnd - 1) / 2);
   }
 
-  return result;
+  return { candles: result, originalIndices };
 }
 
 /**

--- a/packages/chart/src/core/viewport.ts
+++ b/packages/chart/src/core/viewport.ts
@@ -59,6 +59,14 @@ export class Viewport {
   private _dragStartX = 0;
   private _dragStartIndex = 0;
   private _scrollbarDragging = false;
+  /**
+   * When grabbing the scrollbar thumb, this holds the fraction (of scrollbar
+   * width) between the pointer and the thumb's left edge at press-time — so
+   * subsequent drag positions preserve that offset instead of centering the
+   * visible range on the pointer. `null` when the press was on the track
+   * (outside the thumb); in that case we page-jump to center on the cursor.
+   */
+  private _scrollbarGrabOffsetFrac: number | null = null;
   private _onUpdate: (() => void) | null = null;
 
   get state(): Readonly<ViewportState> {
@@ -67,6 +75,56 @@ export class Viewport {
 
   setOnUpdate(cb: () => void): void {
     this._onUpdate = cb;
+  }
+
+  /**
+   * Update the visible range from a scrollbar pointer position, honoring the
+   * stored grab offset so the thumb stays pinned under the pointer where it
+   * was first grabbed. Pass `null` grab offset for a center-on-cursor jump.
+   */
+  private _applyScrollbarDrag(mouseX: number, sb: ScrollbarRect, timeScale: TimeScale): void {
+    if (sb.width <= 0) return;
+    const total = timeScale.totalCount;
+    if (total <= 0) return;
+    const visible = timeScale.visibleCount;
+    const maxStart = Math.max(0, total - visible);
+    const pointerFrac = (mouseX - sb.x) / sb.width;
+
+    let newStart: number;
+    if (this._scrollbarGrabOffsetFrac !== null) {
+      const startFrac = pointerFrac - this._scrollbarGrabOffsetFrac;
+      newStart = Math.round(startFrac * total);
+    } else {
+      const targetCenter = Math.round(pointerFrac * total);
+      newStart = targetCenter - Math.floor(visible / 2);
+    }
+    newStart = Math.max(0, Math.min(maxStart, newStart));
+    timeScale.setVisibleRange(newStart, newStart + visible);
+  }
+
+  /**
+   * On scrollbar press, determine whether the pointer landed on the thumb.
+   * If yes, remember the grab offset so subsequent moves preserve it.
+   * If no (track click), clear the offset so the drag behaves as
+   * page-to-cursor (the legacy behavior).
+   */
+  private _beginScrollbarDrag(mouseX: number, sb: ScrollbarRect, timeScale: TimeScale): void {
+    this._scrollbarDragging = true;
+    const total = timeScale.totalCount;
+    if (sb.width <= 0 || total <= 0) {
+      this._scrollbarGrabOffsetFrac = null;
+      return;
+    }
+    const startFrac = Math.max(0, timeScale.startIndex / total);
+    const endFrac = Math.min(1, timeScale.endIndex / total);
+    const thumbX = sb.x + startFrac * sb.width;
+    const thumbW = Math.max(8, (endFrac - startFrac) * sb.width);
+    if (mouseX >= thumbX && mouseX <= thumbX + thumbW) {
+      this._scrollbarGrabOffsetFrac = (mouseX - sb.x) / sb.width - startFrac;
+    } else {
+      this._scrollbarGrabOffsetFrac = null;
+      this._applyScrollbarDrag(mouseX, sb, timeScale);
+    }
   }
 
   /**
@@ -130,11 +188,7 @@ export class Viewport {
       // Check scrollbar hit
       const sb = scrollbar();
       if (sb && my >= sb.y && my <= sb.y + sb.height) {
-        this._scrollbarDragging = true;
-        const frac = (mx - sb.x) / sb.width;
-        const targetCenter = Math.round(frac * timeScale.totalCount);
-        const newStart = Math.max(0, targetCenter - Math.floor(timeScale.visibleCount / 2));
-        timeScale.setVisibleRange(newStart, newStart + timeScale.visibleCount);
+        this._beginScrollbarDrag(mx, sb, timeScale);
         this._onUpdate?.();
         return;
       }
@@ -167,12 +221,7 @@ export class Viewport {
       // Scrollbar drag
       if (this._scrollbarDragging) {
         const sb = scrollbar();
-        if (sb && sb.width > 0) {
-          const frac = (this._state.mouseX - sb.x) / sb.width;
-          const targetCenter = Math.round(frac * timeScale.totalCount);
-          const newStart = Math.max(0, targetCenter - Math.floor(timeScale.visibleCount / 2));
-          timeScale.setVisibleRange(newStart, newStart + timeScale.visibleCount);
-        }
+        if (sb) this._applyScrollbarDrag(this._state.mouseX, sb, timeScale);
         this._onUpdate?.();
         return;
       }
@@ -210,12 +259,14 @@ export class Viewport {
       }
       this._state.isDragging = false;
       this._scrollbarDragging = false;
+      this._scrollbarGrabOffsetFrac = null;
       paneResizeGap = null;
     };
 
     const onMouseLeave = () => {
       this._state.isDragging = false;
       this._scrollbarDragging = false;
+      this._scrollbarGrabOffsetFrac = null;
       this._state.crosshairIndex = null;
       this._state.activePaneId = null;
       this._onUpdate?.();
@@ -368,6 +419,7 @@ export class Viewport {
         // (delegated to the host via `dispatch`).
         this._state.isDragging = false;
         this._scrollbarDragging = false;
+        this._scrollbarGrabOffsetFrac = null;
         stopInertia();
         stopZoomInertia();
         touchVelocity = 0;
@@ -485,11 +537,7 @@ export class Viewport {
         const touchLocalY = touch.clientY - rect.top;
         const sb = scrollbar();
         if (sb && touchLocalY >= sb.y && touchLocalY <= sb.y + sb.height) {
-          this._scrollbarDragging = true;
-          const frac = (touchLocalX - sb.x) / sb.width;
-          const targetCenter = Math.round(frac * timeScale.totalCount);
-          const newStart = Math.max(0, targetCenter - Math.floor(timeScale.visibleCount / 2));
-          timeScale.setVisibleRange(newStart, newStart + timeScale.visibleCount);
+          this._beginScrollbarDrag(touchLocalX, sb, timeScale);
           this._onUpdate?.();
           return;
         }
@@ -543,12 +591,7 @@ export class Viewport {
         const rect = el.getBoundingClientRect();
         const localX = sbTouch.clientX - rect.left;
         const sb = scrollbar();
-        if (sb && sb.width > 0) {
-          const frac = (localX - sb.x) / sb.width;
-          const targetCenter = Math.round(frac * timeScale.totalCount);
-          const newStart = Math.max(0, targetCenter - Math.floor(timeScale.visibleCount / 2));
-          timeScale.setVisibleRange(newStart, newStart + timeScale.visibleCount);
-        }
+        if (sb) this._applyScrollbarDrag(localX, sb, timeScale);
         this._onUpdate?.();
         return;
       }

--- a/packages/chart/src/renderer/axis-renderer.ts
+++ b/packages/chart/src/renderer/axis-renderer.ts
@@ -12,6 +12,24 @@ import {
 import type { PriceScale, TimeScale } from "../core/scale";
 import type { CandleData, ThemeColors } from "../core/types";
 
+/** Options for {@link renderPriceAxis}. All fields are optional. */
+export type PriceAxisOptions = {
+  position?: "left" | "right";
+  /**
+   * Max number of tick labels. Defaults to 6 for back-compat, but callers
+   * should pass a value computed from pane height (≈ `height / 32`) to avoid
+   * label crowding on short sub-panes.
+   */
+  maxTicks?: number;
+  /**
+   * Vertical center (canvas coords) of a foreground label that tick labels
+   * should avoid (e.g. the current-price badge on the main pane). Ticks whose
+   * Y falls within `excludeY ± excludeHalfHeight` are skipped.
+   */
+  excludeY?: number;
+  excludeHalfHeight?: number;
+};
+
 /**
  * Render the price axis for a pane.
  * Supports both left and right positioning for dual-scale panes.
@@ -26,9 +44,19 @@ export function renderPriceAxis(
   theme: ThemeColors,
   fontSize: number,
   priceFormatter: (price: number) => string = autoFormatPrice,
-  position: "left" | "right" = "right",
+  options: PriceAxisOptions | "left" | "right" = {},
 ): void {
-  const ticks = priceScale.getTicks();
+  // Back-compat: position can be passed as a bare string.
+  const opts: PriceAxisOptions = typeof options === "string" ? { position: options } : options;
+  const position = opts.position ?? "right";
+  const maxTicks = Math.max(2, opts.maxTicks ?? 6);
+  const ticks = priceScale.getTicks(maxTicks);
+
+  // Suppress labels too close to pane edges (avoids visual collision with the
+  // adjacent pane's edge label) or overlapping the current-price badge.
+  const EDGE_PAD = Math.min(8, fontSize); // ~one label half-height
+  const excludeY = opts.excludeY;
+  const excludeHalf = opts.excludeHalfHeight ?? 0;
 
   ctx.fillStyle = theme.background;
   if (position === "left") {
@@ -53,23 +81,17 @@ export function renderPriceAxis(
   // Tick labels
   ctx.fillStyle = theme.textSecondary;
   ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+  ctx.textAlign = position === "left" ? "right" : "left";
+  ctx.textBaseline = "middle";
+  const labelX = position === "left" ? x - 6 : x + 6;
 
-  if (position === "left") {
-    ctx.textAlign = "right";
-    ctx.textBaseline = "middle";
-    for (const tick of ticks) {
-      const tickY = priceScale.priceToY(tick) + y;
-      if (tickY < y || tickY > y + height) continue;
-      ctx.fillText(priceFormatter(tick), x - 6, tickY);
+  for (const tick of ticks) {
+    const tickY = priceScale.priceToY(tick) + y;
+    if (tickY < y + EDGE_PAD || tickY > y + height - EDGE_PAD) continue;
+    if (excludeY !== undefined && Math.abs(tickY - excludeY) < excludeHalf + 2) {
+      continue;
     }
-  } else {
-    ctx.textAlign = "left";
-    ctx.textBaseline = "middle";
-    for (const tick of ticks) {
-      const tickY = priceScale.priceToY(tick) + y;
-      if (tickY < y || tickY > y + height) continue;
-      ctx.fillText(priceFormatter(tick), x + 6, tickY);
-    }
+    ctx.fillText(priceFormatter(tick), labelX, tickY);
   }
 }
 
@@ -195,8 +217,9 @@ export function renderGrid(
   theme: ThemeColors,
   timeScale?: TimeScale,
   candles?: readonly CandleData[],
+  maxTicks?: number,
 ): void {
-  const ticks = priceScale.getTicks();
+  const ticks = priceScale.getTicks(Math.max(2, maxTicks ?? 6));
 
   ctx.strokeStyle = theme.grid;
   ctx.lineWidth = 1;

--- a/packages/chart/src/renderer/axis-renderer.ts
+++ b/packages/chart/src/renderer/axis-renderer.ts
@@ -78,20 +78,33 @@ export function renderPriceAxis(
   }
   ctx.stroke();
 
-  // Tick labels
+  // Tick labels. Near pane edges, flip the baseline to "top" / "bottom" so
+  // the label nudges inward instead of being clipped or hidden — important
+  // for short panes (e.g. a volume pane where the nice-step tick generator
+  // lands ticks at exactly the min/max of the range).
   ctx.fillStyle = theme.textSecondary;
   ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
   ctx.textAlign = position === "left" ? "right" : "left";
-  ctx.textBaseline = "middle";
   const labelX = position === "left" ? x - 6 : x + 6;
 
   for (const tick of ticks) {
     const tickY = priceScale.priceToY(tick) + y;
-    if (tickY < y + EDGE_PAD || tickY > y + height - EDGE_PAD) continue;
+    if (tickY < y || tickY > y + height) continue;
     if (excludeY !== undefined && Math.abs(tickY - excludeY) < excludeHalf + 2) {
       continue;
     }
-    ctx.fillText(priceFormatter(tick), labelX, tickY);
+
+    // Flip baseline near edges so labels stay within the pane.
+    if (tickY < y + EDGE_PAD) {
+      ctx.textBaseline = "top";
+      ctx.fillText(priceFormatter(tick), labelX, y + 1);
+    } else if (tickY > y + height - EDGE_PAD) {
+      ctx.textBaseline = "bottom";
+      ctx.fillText(priceFormatter(tick), labelX, y + height - 1);
+    } else {
+      ctx.textBaseline = "middle";
+      ctx.fillText(priceFormatter(tick), labelX, tickY);
+    }
   }
 }
 

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -499,20 +499,29 @@ export class CanvasChart implements ChartInstance {
     // Introspect the series
     const result = introspect(series, config);
 
-    // Auto-assign color if not explicitly set (cycle through palette).
-    // Preset palettes are rotated per-palette (so multiple SMAs using the
-    // "number" palette pick blue/orange/teal/... in order); indicators with
-    // no preset palette fall back to the default palette with its own
-    // shared counter.
+    // Auto-assign color if not explicitly set. Prefer the first palette entry
+    // not already in use by another live series — this keeps the
+    // remove→re-add (e.g. param-change) cycle stable so the same indicator
+    // usually comes back with the same color. Fall back to the per-palette
+    // counter when every palette entry is taken.
     if (!result.config.color && !result.config.channelColors) {
       const presetPalette = result.config.colorPalette;
-      if (presetPalette && presetPalette.length > 0) {
+      const palette =
+        presetPalette && presetPalette.length > 0 ? presetPalette : CanvasChart._COLOR_PALETTE;
+      const usedColors = new Set<string>();
+      for (const s of this._data.getAllSeries()) {
+        if (s.config.color) usedColors.add(s.config.color);
+      }
+      const freeColor = palette.find((c) => !usedColors.has(c));
+      if (freeColor) {
+        result.config.color = freeColor;
+      } else if (presetPalette && presetPalette.length > 0) {
         const idx = this._paletteIndices.get(presetPalette) ?? 0;
         result.config.color = presetPalette[idx % presetPalette.length];
         this._paletteIndices.set(presetPalette, idx + 1);
       } else {
-        const palette = CanvasChart._COLOR_PALETTE;
-        result.config.color = palette[this._colorIndex % palette.length];
+        result.config.color =
+          CanvasChart._COLOR_PALETTE[this._colorIndex % CanvasChart._COLOR_PALETTE.length];
         this._colorIndex++;
       }
     }

--- a/packages/chart/src/renderer/info-overlay.ts
+++ b/packages/chart/src/renderer/info-overlay.ts
@@ -41,8 +41,8 @@ export class InfoOverlay {
     // Inject responsive styles once
     this._styleEl = document.createElement("style");
     this._styleEl.textContent = `
-      .tc-info { position:absolute; z-index:10; pointer-events:none; font-size:11px; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; line-height:1.4; white-space:nowrap; }
-      @media (max-width:480px) { .tc-info { white-space:normal; font-size:10px; max-width:90vw; } }
+      .tc-info { position:absolute; z-index:10; pointer-events:none; font-size:11px; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; line-height:1.4; white-space:nowrap; max-width:calc(100% - 8px); overflow:hidden; text-overflow:ellipsis; }
+      @media (max-width:480px) { .tc-info { white-space:normal; font-size:10px; max-width:90vw; overflow:visible; text-overflow:clip; } }
     `;
     container.appendChild(this._styleEl);
 

--- a/packages/chart/src/renderer/legend-overlay.ts
+++ b/packages/chart/src/renderer/legend-overlay.ts
@@ -27,10 +27,10 @@ export class LegendOverlay {
     // Inject responsive styles once
     this._styleEl = document.createElement("style");
     this._styleEl.textContent = `
-      .tc-legend { position:absolute; top:4px; right:68px; z-index:10; display:flex; gap:8px; flex-wrap:wrap; font-size:11px; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; }
-      .tc-legend-btn { cursor:pointer; white-space:nowrap; background:none; border:none; padding:2px 4px; font:inherit; line-height:inherit; min-height:24px; }
+      .tc-legend { position:absolute; top:22px; right:68px; left:4px; z-index:10; display:flex; justify-content:flex-end; gap:8px; flex-wrap:wrap; font-size:11px; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; pointer-events:none; }
+      .tc-legend-btn { cursor:pointer; white-space:nowrap; background:none; border:none; padding:2px 4px; font:inherit; line-height:inherit; min-height:24px; pointer-events:auto; }
       @media (pointer:coarse) { .tc-legend-btn { min-height:36px; padding:6px 10px; font-size:13px; } }
-      @media (max-width:480px) { .tc-legend { right:4px; top:2px; gap:4px; font-size:10px; } }
+      @media (max-width:480px) { .tc-legend { right:4px; top:auto; bottom:4px; gap:4px; font-size:10px; justify-content:flex-start; } }
     `;
     container.appendChild(this._styleEl);
 

--- a/packages/chart/src/renderer/render-pipeline.ts
+++ b/packages/chart/src/renderer/render-pipeline.ts
@@ -52,7 +52,8 @@ let _decimCache: {
   end: number;
   target: number;
   dataVersion: number;
-  result: readonly CandleData[];
+  candles: readonly CandleData[];
+  originalIndices: Int32Array;
 } | null = null;
 
 /** Everything the render pipeline needs from CanvasChart */
@@ -283,9 +284,7 @@ export function renderFrame(rc: RenderContext): RenderResult {
           timeScale.width,
         );
         let visibleCandles: readonly CandleData[];
-        // When decimated, remap barSpacing so candles fill the full canvas width
-        const savedStart = timeScale.startIndex;
-        const savedSpacing = timeScale.barSpacing;
+        let origIndices: Int32Array | undefined;
         if (decimTarget > 0) {
           // Use cached decimation result when viewport hasn't changed
           const dataVer = data.version;
@@ -296,43 +295,42 @@ export function renderFrame(rc: RenderContext): RenderResult {
             _decimCache.target === decimTarget &&
             _decimCache.dataVersion === dataVer
           ) {
-            visibleCandles = _decimCache.result;
+            visibleCandles = _decimCache.candles;
+            origIndices = _decimCache.originalIndices;
           } else {
-            visibleCandles = decimateCandles(
+            const decimated = decimateCandles(
               candles,
               timeScale.startIndex,
               timeScale.endIndex,
               decimTarget,
             );
+            visibleCandles = decimated.candles;
+            origIndices = decimated.originalIndices;
             _decimCache = {
               start: timeScale.startIndex,
               end: timeScale.endIndex,
               target: decimTarget,
               dataVersion: dataVer,
-              result: visibleCandles,
+              candles: visibleCandles,
+              originalIndices: origIndices,
             };
           }
-          timeScale.setImmediate(0, timeScale.width / visibleCandles.length);
         } else {
           visibleCandles = candles;
         }
         switch (rc.chartType) {
           case "line":
-            renderPriceLineChart(ctx, visibleCandles, timeScale, ps, theme);
+            renderPriceLineChart(ctx, visibleCandles, timeScale, ps, theme, origIndices);
             break;
           case "mountain":
-            renderMountainChart(ctx, visibleCandles, timeScale, ps, theme);
+            renderMountainChart(ctx, visibleCandles, timeScale, ps, theme, origIndices);
             break;
           case "ohlc":
-            renderOhlcBars(ctx, visibleCandles, timeScale, ps, theme);
+            renderOhlcBars(ctx, visibleCandles, timeScale, ps, theme, origIndices);
             break;
           default:
-            renderCandlesticks(ctx, visibleCandles, timeScale, ps, theme);
+            renderCandlesticks(ctx, visibleCandles, timeScale, ps, theme, origIndices);
             break;
-        }
-        // Restore timeScale after decimated rendering
-        if (decimTarget > 0) {
-          timeScale.setImmediate(savedStart, savedSpacing);
         }
       }
 

--- a/packages/chart/src/renderer/render-pipeline.ts
+++ b/packages/chart/src/renderer/render-pipeline.ts
@@ -6,6 +6,7 @@
 import type { DataLayer, InternalSeries } from "../core/data-layer";
 import { decimateCandles, getDecimationTarget } from "../core/decimation";
 import { DrawHelper, withPaneClip } from "../core/draw-helper";
+import { formatVolume } from "../core/format";
 import type { LayoutEngine } from "../core/layout";
 import type { RendererRegistry } from "../core/renderer-registry";
 import { PriceScale, type TimeScale } from "../core/scale";
@@ -407,6 +408,10 @@ export function renderFrame(rc: RenderContext): RenderResult {
       }
     });
 
+    // Volume axis uses compact K/M/B notation; other panes use the user-
+    // supplied price formatter.
+    const axisFormatter = pane.id === "volume" ? formatVolume : rc.priceFormatter;
+
     // Right price axis
     renderPriceAxis(
       ctx,
@@ -417,7 +422,7 @@ export function renderFrame(rc: RenderContext): RenderResult {
       pane.height,
       theme,
       rc.fontSize,
-      rc.priceFormatter,
+      axisFormatter,
       {
         position: "right",
         maxTicks: paneMaxTicks,
@@ -437,7 +442,7 @@ export function renderFrame(rc: RenderContext): RenderResult {
         pane.height,
         theme,
         rc.fontSize,
-        rc.priceFormatter,
+        axisFormatter,
         { position: "left", maxTicks: paneMaxTicks },
       );
     }

--- a/packages/chart/src/renderer/render-pipeline.ts
+++ b/packages/chart/src/renderer/render-pipeline.ts
@@ -209,14 +209,41 @@ export function renderFrame(rc: RenderContext): RenderResult {
   for (const [id, dual] of rc.priceScales) _rightScaleMap.set(id, dual.right);
   _seriesByPane.clear();
 
+  // Current-price label Y (main pane) — tick labels that would overlap it
+  // are suppressed by the main-pane axis renderer below.
+  let mainPriceExcludeY: number | undefined;
+  let mainPriceExcludeHalf: number | undefined;
+  if (candles.length > 0) {
+    const mainPane = paneRects.find((p) => p.id === "main");
+    const mainScales = mainPane ? rc.priceScales.get("main") : undefined;
+    if (mainPane && mainScales) {
+      mainPriceExcludeY = mainScales.right.priceToY(candles[candles.length - 1].close) + mainPane.y;
+      mainPriceExcludeHalf = rc.fontSize / 2 + 3; // fontSize + padY(3) — matches overlay-renderer
+    }
+  }
+
   for (const pane of paneRects) {
     const scales = rc.priceScales.get(pane.id);
     if (!scales) continue;
     const ps = scales.right; // Primary scale for most rendering
 
+    // Density-aware tick count — short sub-panes would otherwise crowd labels.
+    const paneMaxTicks = Math.max(2, Math.floor(pane.height / 32));
+
     withPaneClip(ctx, pane, () => {
       // Grid
-      renderGrid(ctx, ps, pane.x, pane.y, pane.width, pane.height, theme, timeScale, candles);
+      renderGrid(
+        ctx,
+        ps,
+        pane.x,
+        pane.y,
+        pane.width,
+        pane.height,
+        theme,
+        timeScale,
+        candles,
+        paneMaxTicks,
+      );
 
       // Reference lines
       if (pane.config.referenceLines?.length) {
@@ -393,6 +420,12 @@ export function renderFrame(rc: RenderContext): RenderResult {
       theme,
       rc.fontSize,
       rc.priceFormatter,
+      {
+        position: "right",
+        maxTicks: paneMaxTicks,
+        excludeY: pane.id === "main" ? mainPriceExcludeY : undefined,
+        excludeHalfHeight: pane.id === "main" ? mainPriceExcludeHalf : undefined,
+      },
     );
 
     // Left price axis (if pane has left-scale series)
@@ -407,6 +440,7 @@ export function renderFrame(rc: RenderContext): RenderResult {
         theme,
         rc.fontSize,
         rc.priceFormatter,
+        { position: "left", maxTicks: paneMaxTicks },
       );
     }
   }

--- a/packages/chart/src/renderer/series-dispatcher.ts
+++ b/packages/chart/src/renderer/series-dispatcher.ts
@@ -31,7 +31,8 @@ const _lttbCache = new WeakMap<
     end: number;
     target: number;
     version: number;
-    result: DataPoint<number | null>[];
+    points: readonly DataPoint<number | null>[];
+    originalIndices: Int32Array;
   }
 >();
 
@@ -121,8 +122,10 @@ export function dispatchSeries(
       return;
     }
 
-    let data = s.data as DataPoint<number | null>[];
+    const data = s.data as DataPoint<number | null>[];
     const target = getDecimationTarget(timeScale.endIndex - timeScale.startIndex, timeScale.width);
+    let points: readonly DataPoint<number | null>[] = data;
+    let origIndices: Int32Array | undefined;
     if (target > 0) {
       const ver = s._dataVersion ?? 0;
       const cached = _lttbCache.get(data);
@@ -133,23 +136,35 @@ export function dispatchSeries(
         cached.target === target &&
         cached.version === ver
       ) {
-        data = cached.result;
+        points = cached.points;
+        origIndices = cached.originalIndices;
       } else {
-        const decimated = lttb(data.slice(timeScale.startIndex, timeScale.endIndex), target);
+        const decimated = lttb(
+          data.slice(timeScale.startIndex, timeScale.endIndex),
+          target,
+          timeScale.startIndex,
+        );
+        points = decimated.points;
+        origIndices = decimated.originalIndices;
         _lttbCache.set(data, {
           start: timeScale.startIndex,
           end: timeScale.endIndex,
           target,
           version: ver,
-          result: decimated,
+          points,
+          originalIndices: origIndices,
         });
-        data = decimated;
       }
     }
-    renderLine(ctx, data, timeScale, priceScale, timeScale.startIndex, {
-      color,
-      lineWidth,
-    });
+    renderLine(
+      ctx,
+      points,
+      timeScale,
+      priceScale,
+      timeScale.startIndex,
+      { color, lineWidth },
+      origIndices,
+    );
     return;
   }
 

--- a/packages/chart/src/series/candlestick.ts
+++ b/packages/chart/src/series/candlestick.ts
@@ -12,9 +12,16 @@ export function renderCandlesticks(
   timeScale: TimeScale,
   priceScale: PriceScale,
   theme: ThemeColors,
+  /**
+   * When provided, iterates `0..candles.length` and reads the screen x for
+   * each from `indexToX(originalIndices[i])`. Used by the decimation path so
+   * bucketed candles line up with non-decimated overlays on the same
+   * timeScale.
+   */
+  originalIndices?: readonly number[] | Int32Array,
 ): void {
-  const start = timeScale.startIndex;
-  const end = timeScale.endIndex;
+  const start = originalIndices ? 0 : timeScale.startIndex;
+  const end = originalIndices ? candles.length : timeScale.endIndex;
   const candleWidth = timeScale.candleWidth;
   const halfCandle = candleWidth / 2;
   const wickWidth = Math.max(1, candleWidth * 0.1);
@@ -23,7 +30,7 @@ export function renderCandlesticks(
     const candle = candles[i];
     if (!candle) continue;
 
-    const x = timeScale.indexToX(i);
+    const x = timeScale.indexToX(originalIndices ? originalIndices[i] : i);
     const sx = Math.round(x) + 0.5; // snap to pixel grid for crisp 1px lines
     const isUp = candle.close >= candle.open;
 

--- a/packages/chart/src/series/line.ts
+++ b/packages/chart/src/series/line.ts
@@ -26,6 +26,13 @@ export function renderLine(
   priceScale: PriceScale,
   startIndex: number,
   options: LineRenderOptions,
+  /**
+   * When provided, iterates `0..data.length` and uses
+   * `indexToX(originalIndices[i])` for screen x — letting LTTB-decimated
+   * arrays share the timeScale coordinate space with non-decimated series.
+   * `startIndex` is ignored in this mode.
+   */
+  originalIndices?: readonly number[] | Int32Array,
 ): void {
   ctx.strokeStyle = options.color;
   ctx.lineWidth = options.lineWidth;
@@ -34,18 +41,21 @@ export function renderLine(
   if (options.dash) ctx.setLineDash(options.dash);
   else ctx.setLineDash([]);
 
-  const end = timeScale.endIndex;
   let drawing = false;
-
   ctx.beginPath();
-  for (let i = timeScale.startIndex; i < end && i < data.length; i++) {
+
+  const bucketed = !!originalIndices;
+  const iStart = bucketed ? 0 : startIndex;
+  const iEnd = bucketed ? data.length : Math.min(timeScale.endIndex, data.length);
+
+  for (let i = iStart; i < iEnd; i++) {
     const point = data[i];
     if (!point || point.value === null || point.value === undefined) {
       drawing = false;
       continue;
     }
 
-    const x = timeScale.indexToX(i);
+    const x = timeScale.indexToX(bucketed ? originalIndices[i] : i);
     const y = priceScale.priceToY(point.value);
 
     if (!drawing) {

--- a/packages/chart/src/series/mountain.ts
+++ b/packages/chart/src/series/mountain.ts
@@ -11,16 +11,17 @@ export function renderMountainChart(
   timeScale: TimeScale,
   priceScale: PriceScale,
   theme: ThemeColors,
+  originalIndices?: readonly number[] | Int32Array,
 ): void {
-  const start = timeScale.startIndex;
-  const end = timeScale.endIndex;
+  const start = originalIndices ? 0 : timeScale.startIndex;
+  const end = originalIndices ? candles.length : timeScale.endIndex;
   const points: { x: number; y: number }[] = [];
 
   for (let i = start; i < end && i < candles.length; i++) {
     const candle = candles[i];
     if (!candle) continue;
     points.push({
-      x: timeScale.indexToX(i),
+      x: timeScale.indexToX(originalIndices ? originalIndices[i] : i),
       y: priceScale.priceToY(candle.close),
     });
   }

--- a/packages/chart/src/series/ohlc-bar.ts
+++ b/packages/chart/src/series/ohlc-bar.ts
@@ -11,16 +11,17 @@ export function renderOhlcBars(
   timeScale: TimeScale,
   priceScale: PriceScale,
   theme: ThemeColors,
+  originalIndices?: readonly number[] | Int32Array,
 ): void {
-  const start = timeScale.startIndex;
-  const end = timeScale.endIndex;
+  const start = originalIndices ? 0 : timeScale.startIndex;
+  const end = originalIndices ? candles.length : timeScale.endIndex;
   const tickWidth = Math.max(2, timeScale.candleWidth * 0.4);
 
   for (let i = start; i < end && i < candles.length; i++) {
     const candle = candles[i];
     if (!candle) continue;
 
-    const x = timeScale.indexToX(i);
+    const x = timeScale.indexToX(originalIndices ? originalIndices[i] : i);
     const sx = Math.round(x) + 0.5; // snap to pixel grid
     const isUp = candle.close >= candle.open;
     const color = isUp ? theme.upColor : theme.downColor;

--- a/packages/chart/src/series/price-line.ts
+++ b/packages/chart/src/series/price-line.ts
@@ -11,9 +11,10 @@ export function renderPriceLineChart(
   timeScale: TimeScale,
   priceScale: PriceScale,
   theme: ThemeColors,
+  originalIndices?: readonly number[] | Int32Array,
 ): void {
-  const start = timeScale.startIndex;
-  const end = timeScale.endIndex;
+  const start = originalIndices ? 0 : timeScale.startIndex;
+  const end = originalIndices ? candles.length : timeScale.endIndex;
 
   ctx.strokeStyle = theme.upColor;
   ctx.lineWidth = 1.5;
@@ -26,7 +27,7 @@ export function renderPriceLineChart(
     const candle = candles[i];
     if (!candle) continue;
 
-    const x = timeScale.indexToX(i);
+    const x = timeScale.indexToX(originalIndices ? originalIndices[i] : i);
     const y = priceScale.priceToY(candle.close);
 
     if (!drawing) {


### PR DESCRIPTION
## Summary

A batch of chart polish fixes surfaced while using the showcase with many indicators. Five bugs addressed across axis rendering, overlay layout, color assignment, scrollbar UX, and decimation alignment.

- **Decimation alignment** — candle bucketing, number-series LTTB, and non-decimated band/cloud overlays used three different x-coordinate spaces at low zoom (`barSpacing < 1px`). SMA/RSI drifted left of the bars they annotated. All paths now share the original timeScale via bucket-origin indices threaded through the render pipeline. **Breaking (headless):** `decimateCandles` returns `{ candles, originalIndices }`, `lttb` returns `{ points, originalIndices }` with an optional `indexOffset` third arg.
- **Price axis label overlap** — dynamic `maxTicks` from pane height, suppress labels near pane edges with baseline-flip so short panes (compact volume sub-pane) still show all tick labels, and skip ticks that would collide with the current-price badge Y on the main pane.
- **Volume axis uses K/M/B notation** — was rendering raw 10000000 which clipped on the right edge; now uses the existing `formatVolume` helper.
- **Info + legend overlap** — legend moved to its own second row so it no longer collides with the OHLC/indicator readout; info strip gets a max-width + ellipsis safety net.
- **Indicator color cycling on re-add** — auto-assigned colors now prefer the first palette entry not currently in use, so remove→re-add (param change, toggle) keeps the same color.
- **Scrollbar thumb grab offset** — pressing anywhere on the thumb used to recenter the visible range on the pointer; now press-on-thumb records the grab offset so the thumb stays pinned where grabbed. Track clicks still page-jump.

## Test plan

- [x] `pnpm test` — 67 files / 688 tests pass (existing 683 + 4 regression tests added for axis excludeY/maxTicks, decimation alignment, color reuse)
- [x] `pnpm build` / `pnpm lint` / `pnpm size-check` — main bundle 34.3 kB / 35 kB budget
- [x] Manual: showcase with many indicators (RSI/MACD/Stoch/Volume/many MA family) — axis labels no longer overlap across panes, legend sits below OHLC readout, colors stable across remove/re-add cycles
- [x] Manual: fit-content on 2000+ daily candles with SMA — line aligns with candles (previously drifted left)
- [x] Manual: grab scrollbar thumb mid-thumb — thumb stays pinned under cursor instead of snapping to center
- [x] Manual: volume pane with 80-120px height — 0 / 5M / 10M labels all visible

## Follow-ups

- Last-value badges on price axis (TradingView-style colored pills for each series' latest value). Recorded in `memory/project_chart_last_value_badges.md` for v0.2.x follow-up. Would further mitigate the "short pane drops tick labels" class of issues.