### PR TITLE
feat(chart): last-value badges on the price axis

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`chart.setCrosshair(time)`** — programmatic crosshair control for external consumers that want to drive the crosshair without a DOM pointer event.
 - **`visibleRangeChange` event** is now actually emitted (was declared but unused). Fires when the visible range changes.
 
+### Added — last-value badges
+
+- **`ChartOptions.showSeriesBadges`** — opt-in. When enabled, every labeled series gets a colored pill on the right price axis showing its latest value, mirroring the existing candle current-price badge. Multi-channel series (Bollinger Bands / MACD / etc.) get one pill per decomposed channel, each in its own `channelColors[channel]`. The volume pane also gets a pill colored by the last bar direction. Tick labels that would collide with a pill are suppressed; pills stacked on the same axis are shifted upward to clear each other and skipped if a shift would push them off the pane. Default: `false`.
+- **`ChartOptions.seriesBadgeMode`** — `"absolute"` (default) shows the data array's latest non-null value (live / streaming "current" value). `"visible"` shows the latest non-null value within the current visible range — useful when scrolling back through history.
+- **`PriceAxisOptions.excludeYRanges`** (headless) — a list replaces the singular `excludeY` / `excludeHalfHeight` fields so multiple foreground labels can be avoided by the tick placer. The old single-range fields remain supported for back-compat.
+
 ### Fixed
 
 - **Decimation alignment** — at low zoom (`barSpacing < 1 px`, e.g. Fit-content on a large dataset) candles and number-series indicators used three different decimation paths that disagreed on x-coordinates, so overlays (SMA / RSI / EMA / …) drifted left of the bars they were supposed to annotate. All three paths now share the original `timeScale` coordinate space via bucket-origin indices carried through the render pipeline.
@@ -40,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bundle size budget for the main entry raised from 31 kB → 32 kB (brotli). The raise reflects the intentional UX additions above and is expected to hold through the 0.2.x line — future feature work either lives on a sub-path or compensates with equivalent reductions elsewhere.
+- React / Vue wrapper budgets raised from 29 kB → 30 kB (brotli) to accommodate the new exports surfaced by the polish and badge features. Main budget raised 35 kB → 36 kB for the last-value badge feature.
 
 ### Internal
 

--- a/packages/chart/examples/indicator-showcase/index.html
+++ b/packages/chart/examples/indicator-showcase/index.html
@@ -77,6 +77,8 @@
         <button class="toolbar-btn" id="btn-timeframe">Daily</button>
         <button class="toolbar-btn" id="btn-type">Candle</button>
         <button class="toolbar-btn" id="btn-fit">Fit</button>
+        <button class="toolbar-btn" id="btn-badges">Badges: off</button>
+        <button class="toolbar-btn" id="btn-badge-mode">Mode: absolute</button>
         <button class="toolbar-btn" id="btn-export">Export PNG</button>
         <button class="toolbar-btn" id="btn-theme">Light</button>
       </div>

--- a/packages/chart/examples/indicator-showcase/src/main.ts
+++ b/packages/chart/examples/indicator-showcase/src/main.ts
@@ -178,6 +178,24 @@ fitBtn.addEventListener("click", () => {
   chart.fitContent();
 });
 
+// Last-value badges toggle
+const badgesBtn = document.getElementById("btn-badges") as HTMLElement;
+let badgesOn = false;
+badgesBtn.addEventListener("click", () => {
+  badgesOn = !badgesOn;
+  chart.applyOptions({ showSeriesBadges: badgesOn });
+  badgesBtn.textContent = `Badges: ${badgesOn ? "on" : "off"}`;
+});
+
+// Badge mode toggle: absolute (live / latest) ⇄ visible (right-edge of viewport)
+const badgeModeBtn = document.getElementById("btn-badge-mode") as HTMLElement;
+let badgeMode: "absolute" | "visible" = "absolute";
+badgeModeBtn.addEventListener("click", () => {
+  badgeMode = badgeMode === "absolute" ? "visible" : "absolute";
+  chart.applyOptions({ seriesBadgeMode: badgeMode });
+  badgeModeBtn.textContent = `Mode: ${badgeMode}`;
+});
+
 // Export PNG button — demonstrates toImage() with pane titles composited
 const exportBtn = document.getElementById("btn-export") as HTMLElement;
 exportBtn.addEventListener("click", async () => {

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -99,7 +99,7 @@
     {
       "name": "Main (createChart + all exports)",
       "path": "dist/index.js",
-      "limit": "35 kB"
+      "limit": "36 kB"
     },
     {
       "name": "Headless API",
@@ -109,12 +109,12 @@
     {
       "name": "React wrapper",
       "path": "dist/react/TrendChart.js",
-      "limit": "29 kB"
+      "limit": "30 kB"
     },
     {
       "name": "Vue wrapper",
       "path": "dist/vue/TrendChart.js",
-      "limit": "29 kB"
+      "limit": "30 kB"
     }
   ],
   "devDependencies": {

--- a/packages/chart/src/__tests__/axis-renderer.test.ts
+++ b/packages/chart/src/__tests__/axis-renderer.test.ts
@@ -46,6 +46,25 @@ describe("renderPriceAxis", () => {
     expect(calls2).toBeLessThanOrEqual(calls6);
   });
 
+  it("skips tick labels inside any excludeYRanges entry (multi-badge case)", () => {
+    const ctx = mockCtx();
+    const ps = makePriceScale(400, 100, 200);
+    const y150 = ps.priceToY(150);
+    const y125 = ps.priceToY(125);
+    renderPriceAxis(ctx, ps, 740, 0, 60, 400, theme, 11, undefined, {
+      maxTicks: 6,
+      excludeYRanges: [
+        { y: y150, half: 8 },
+        { y: y125, half: 8 },
+      ],
+    });
+    const calls = (ctx.fillText as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    for (const [, , yArg] of calls) {
+      expect(Math.abs((yArg as number) - y150)).toBeGreaterThanOrEqual(10);
+      expect(Math.abs((yArg as number) - y125)).toBeGreaterThanOrEqual(10);
+    }
+  });
+
   it("skips tick labels inside excludeY ± excludeHalfHeight (current-price badge)", () => {
     const ctx = mockCtx();
     const ps = makePriceScale(400, 100, 200);

--- a/packages/chart/src/__tests__/series-badges.test.ts
+++ b/packages/chart/src/__tests__/series-badges.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import type { InternalSeries } from "../core/data-layer";
+import { DARK_THEME } from "../core/types";
+import { computeSeriesBadges, drawSeriesBadges } from "../renderer/overlay-renderer";
+import { makePane, makePriceScale, mockCtx } from "./helpers/mock-ctx";
+
+const theme = DARK_THEME;
+const format = (v: number) => v.toFixed(2);
+
+function makeNumberSeries(
+  id: string,
+  label: string,
+  color: string,
+  values: (number | null)[],
+): InternalSeries {
+  return {
+    id,
+    paneId: "main",
+    scaleId: "right",
+    type: "line",
+    config: { label, color },
+    data: values.map((v, i) => ({ time: i, value: v })),
+    visible: true,
+  };
+}
+
+function makeBandSeries(
+  id: string,
+  label: string,
+  channelColors: Record<string, string>,
+  last: { upper: number; middle: number; lower: number },
+): InternalSeries {
+  return {
+    id,
+    paneId: "main",
+    scaleId: "right",
+    type: "band",
+    config: { label, channelColors },
+    data: [{ time: 0, value: last }],
+    visible: true,
+  };
+}
+
+describe("computeSeriesBadges", () => {
+  const pane = makePane("main", 400);
+  const priceScale = makePriceScale(400, 0, 100); // 100 at y=0, 0 at y=400
+
+  it("returns one badge per labeled number series", () => {
+    const ctx = mockCtx();
+    const a = makeNumberSeries("a", "SMA(5)", "#2196F3", [10, 20, 30]);
+    const b = makeNumberSeries("b", "EMA(10)", "#FF9800", [70, 80, 90]);
+    const result = computeSeriesBadges(ctx, pane, priceScale, [a, b], theme, 11, format);
+    expect(result.length).toBe(2);
+    expect(result.map((r) => r.color).sort()).toEqual(["#2196F3", "#FF9800"]);
+    expect(result.map((r) => r.label).sort()).toEqual(["30.00", "90.00"]);
+  });
+
+  it("skips unlabeled series", () => {
+    const ctx = mockCtx();
+    const s = makeNumberSeries("a", "", "#2196F3", [10, 20]);
+    s.config.label = undefined;
+    const result = computeSeriesBadges(ctx, pane, priceScale, [s], theme, 11, format);
+    expect(result.length).toBe(0);
+  });
+
+  it("skips series whose latest value is null", () => {
+    const ctx = mockCtx();
+    const s = makeNumberSeries("a", "SMA", "#2196F3", [10, 20, null, null]);
+    const result = computeSeriesBadges(ctx, pane, priceScale, [s], theme, 11, format);
+    // latestNumber falls back to last non-null → 20 — badge present
+    expect(result.length).toBe(1);
+    expect(result[0].label).toBe("20.00");
+  });
+
+  it("emits one badge per channel for multi-channel series", () => {
+    const ctx = mockCtx();
+    const bb = makeBandSeries(
+      "bb",
+      "BB(20,2)",
+      { upper: "#26a69a", middle: "#ffffff", lower: "#ef5350" },
+      { upper: 80, middle: 50, lower: 20 },
+    );
+    const result = computeSeriesBadges(ctx, pane, priceScale, [bb], theme, 11, format);
+    expect(result.length).toBe(3);
+    const colors = result.map((r) => r.color).sort();
+    expect(colors).toEqual(["#26a69a", "#ef5350", "#ffffff"]);
+  });
+
+  it("shifts a badge upward to avoid a preoccupied range (current-price badge)", () => {
+    const ctx = mockCtx();
+    const s = makeNumberSeries("a", "SMA", "#2196F3", [50]); // y = 200 (center)
+    const preoccupied = [{ y: 200, half: 8 }]; // exactly where SMA would land
+    const result = computeSeriesBadges(ctx, pane, priceScale, [s], theme, 11, format, preoccupied);
+    expect(result.length).toBe(1);
+    // half = fontSize/2 + padY = 5.5 + 3 = 8.5, preoccupied half = 8
+    // minDist = 16.5, new y should be 200 - 16.5 = 183.5
+    expect(result[0].y).toBeLessThan(200);
+    expect(Math.abs(200 - result[0].y)).toBeGreaterThanOrEqual(15);
+  });
+
+  it("skips a badge that cannot be shifted within the pane", () => {
+    const ctx = mockCtx();
+    // Value at top of pane, but preoccupied spans the whole pane → can't fit
+    const s = makeNumberSeries("a", "SMA", "#2196F3", [100]); // y = 0 (top)
+    const preoccupied = [{ y: 0, half: 200 }]; // huge range starting at pane top
+    const result = computeSeriesBadges(ctx, pane, priceScale, [s], theme, 11, format, preoccupied);
+    expect(result.length).toBe(0);
+  });
+
+  it("respects searchUpTo for visible-range mode", () => {
+    const ctx = mockCtx();
+    // values 10, 20, 30 — absolute latest is 30 (y=280), visible-up-to-1 is 20 (y=320)
+    const s = makeNumberSeries("a", "SMA", "#2196F3", [10, 20, 30]);
+    const absolute = computeSeriesBadges(ctx, pane, priceScale, [s], theme, 11, format);
+    const visible = computeSeriesBadges(
+      ctx,
+      pane,
+      priceScale,
+      [s],
+      theme,
+      11,
+      format,
+      [],
+      1, // visible end index = 2 → searchUpTo = 1
+    );
+    expect(absolute[0].label).toBe("30.00");
+    expect(visible[0].label).toBe("20.00");
+  });
+
+  it("renders extras (e.g. volume) as badges at the provided value", () => {
+    const ctx = mockCtx();
+    const result = computeSeriesBadges(
+      ctx,
+      pane,
+      priceScale,
+      [],
+      theme,
+      11,
+      format,
+      [],
+      undefined,
+      [{ value: 42, color: "#9c27b0" }],
+    );
+    expect(result.length).toBe(1);
+    expect(result[0].color).toBe("#9c27b0");
+    expect(result[0].label).toBe("42.00");
+  });
+
+  it("two overlapping series badges — lower stays, upper shifts", () => {
+    const ctx = mockCtx();
+    // Both at value 50 → same y before collision resolution
+    const a = makeNumberSeries("a", "A", "#2196F3", [50]);
+    const b = makeNumberSeries("b", "B", "#FF9800", [50]);
+    const result = computeSeriesBadges(ctx, pane, priceScale, [a, b], theme, 11, format);
+    expect(result.length).toBe(2);
+    // Sorted descending Y in return value; lower one unchanged, upper one shifted
+    expect(result[0].y).toBeGreaterThan(result[1].y);
+    expect(result[0].y).toBe(200);
+    expect(result[1].y).toBeLessThan(200);
+  });
+});
+
+describe("drawSeriesBadges", () => {
+  it("draws one fillRect + one fillText per badge", () => {
+    const ctx = mockCtx();
+    const badges = [
+      { y: 100, half: 8, x: 800, w: 50, color: "#2196F3", label: "10.00" },
+      { y: 200, half: 8, x: 800, w: 50, color: "#FF9800", label: "20.00" },
+    ];
+    drawSeriesBadges(ctx, badges, 11);
+    expect(ctx.fillRect).toHaveBeenCalledTimes(2);
+    expect(ctx.fillText).toHaveBeenCalledTimes(2);
+  });
+
+  it("no-op for empty badge list", () => {
+    const ctx = mockCtx();
+    drawSeriesBadges(ctx, [], 11);
+    expect(ctx.fillRect).not.toHaveBeenCalled();
+    expect(ctx.fillText).not.toHaveBeenCalled();
+  });
+});

--- a/packages/chart/src/core/types.ts
+++ b/packages/chart/src/core/types.ts
@@ -105,6 +105,22 @@ export type ChartOptions = {
   legend?: boolean;
   /** Show volume pane (default: true) */
   volume?: boolean;
+  /**
+   * Show a colored last-value pill on the right price axis for every labeled
+   * series (including each channel of multi-channel series like Bollinger
+   * Bands / MACD) and for the volume pane. Default: false. The candle
+   * current-price badge is always shown regardless of this setting.
+   */
+  showSeriesBadges?: boolean;
+  /**
+   * Which "last value" to show in series badges:
+   * - `"absolute"` (default): the last non-null value in the underlying data
+   *   array — i.e. the live / latest known value, even if the viewport has
+   *   scrolled back.
+   * - `"visible"`: the last non-null value within the current visible range
+   *   — what the user sees at the right edge of the chart.
+   */
+  seriesBadgeMode?: "absolute" | "visible";
   /** Scroll/pan sensitivity multiplier (default: 0.3, lower = slower) */
   scrollSensitivity?: number;
   /** Base chart type for price data (default: 'candlestick') */

--- a/packages/chart/src/renderer/axis-renderer.ts
+++ b/packages/chart/src/renderer/axis-renderer.ts
@@ -12,6 +12,9 @@ import {
 import type { PriceScale, TimeScale } from "../core/scale";
 import type { CandleData, ThemeColors } from "../core/types";
 
+/** A Y range (canvas coordinates) that tick labels must not overlap. */
+export type AxisExcludeRange = { y: number; half: number };
+
 /** Options for {@link renderPriceAxis}. All fields are optional. */
 export type PriceAxisOptions = {
   position?: "left" | "right";
@@ -22,12 +25,18 @@ export type PriceAxisOptions = {
    */
   maxTicks?: number;
   /**
-   * Vertical center (canvas coords) of a foreground label that tick labels
-   * should avoid (e.g. the current-price badge on the main pane). Ticks whose
-   * Y falls within `excludeY ± excludeHalfHeight` are skipped.
+   * @deprecated Use {@link excludeYRanges}. Kept for back-compat with the
+   * single current-price-badge exclusion the main pane originally needed.
    */
   excludeY?: number;
+  /** @deprecated Use {@link excludeYRanges}. */
   excludeHalfHeight?: number;
+  /**
+   * Y ranges tick labels must avoid (e.g. current-price badge + every
+   * series last-value badge). Tick labels whose Y falls inside any
+   * `y ± (half + 2)` are skipped.
+   */
+  excludeYRanges?: readonly AxisExcludeRange[];
 };
 
 /**
@@ -53,10 +62,12 @@ export function renderPriceAxis(
   const ticks = priceScale.getTicks(maxTicks);
 
   // Suppress labels too close to pane edges (avoids visual collision with the
-  // adjacent pane's edge label) or overlapping the current-price badge.
+  // adjacent pane's edge label) or overlapping foreground labels like the
+  // current-price badge or last-value series badges.
   const EDGE_PAD = Math.min(8, fontSize); // ~one label half-height
-  const excludeY = opts.excludeY;
-  const excludeHalf = opts.excludeHalfHeight ?? 0;
+  const excludeRanges: readonly AxisExcludeRange[] =
+    opts.excludeYRanges ??
+    (opts.excludeY !== undefined ? [{ y: opts.excludeY, half: opts.excludeHalfHeight ?? 0 }] : []);
 
   ctx.fillStyle = theme.background;
   if (position === "left") {
@@ -87,11 +98,11 @@ export function renderPriceAxis(
   ctx.textAlign = position === "left" ? "right" : "left";
   const labelX = position === "left" ? x - 6 : x + 6;
 
-  for (const tick of ticks) {
+  outer: for (const tick of ticks) {
     const tickY = priceScale.priceToY(tick) + y;
     if (tickY < y || tickY > y + height) continue;
-    if (excludeY !== undefined && Math.abs(tickY - excludeY) < excludeHalf + 2) {
-      continue;
+    for (const r of excludeRanges) {
+      if (Math.abs(tickY - r.y) < r.half + 2) continue outer;
     }
 
     // Flip baseline near edges so labels stay within the pane.

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -88,6 +88,8 @@ export class CanvasChart implements ChartInstance {
   private _infoOverlay: InfoOverlay | null = null;
   private _legendOverlay: LegendOverlay | null = null;
   private _watermark: string | undefined;
+  private _showSeriesBadges = false;
+  private _seriesBadgeMode: "absolute" | "visible" = "absolute";
   private _chartType: import("../core/types").ChartType;
   private _drawingTool: DrawingTool | null = null;
   private _detachDrawTap: (() => void) | null = null;
@@ -369,6 +371,8 @@ export class CanvasChart implements ChartInstance {
 
     // Watermark
     this._watermark = options?.watermark;
+    this._showSeriesBadges = options?.showSeriesBadges === true;
+    this._seriesBadgeMode = options?.seriesBadgeMode ?? "absolute";
     this._chartType = options?.chartType ?? "candlestick";
 
     // Volume pane visibility
@@ -809,6 +813,14 @@ export class CanvasChart implements ChartInstance {
       this._watermark = opts.watermark;
       this._needsRender = true;
     }
+    if (opts.showSeriesBadges !== undefined) {
+      this._showSeriesBadges = opts.showSeriesBadges === true;
+      this._needsRender = true;
+    }
+    if (opts.seriesBadgeMode !== undefined) {
+      this._seriesBadgeMode = opts.seriesBadgeMode;
+      this._needsRender = true;
+    }
     if (opts.animationDuration !== undefined) {
       this._animationDuration = opts.animationDuration;
     }
@@ -1096,6 +1108,8 @@ export class CanvasChart implements ChartInstance {
       fontSize: this._fontSize,
       chartType: this._chartType,
       watermark: this._watermark,
+      showSeriesBadges: this._showSeriesBadges,
+      seriesBadgeMode: this._seriesBadgeMode,
       priceFormatter: this._priceFormatter,
       timeFormatter: this._timeFormatter,
       data: this._data,

--- a/packages/chart/src/renderer/overlay-renderer.ts
+++ b/packages/chart/src/renderer/overlay-renderer.ts
@@ -28,6 +28,12 @@ export function renderPriceLine(
   priceScales: Map<string, PriceScale>,
   theme: ThemeColors,
   fontSize: number,
+  /**
+   * Which candle to anchor the badge + dashed line on. Defaults to the last
+   * bar in the array. Passing `min(candles.length, timeScale.endIndex) - 1`
+   * makes the badge follow the right edge of the viewport (visible-mode).
+   */
+  candleIndex?: number,
 ): void {
   if (candles.length === 0) return;
 
@@ -37,7 +43,9 @@ export function renderPriceLine(
   const ps = priceScales.get("main");
   if (!ps) return;
 
-  const lastCandle = candles[candles.length - 1];
+  const idx = candleIndex !== undefined ? candleIndex : candles.length - 1;
+  if (idx < 0 || idx >= candles.length) return;
+  const lastCandle = candles[idx];
   const price = lastCandle.close;
   const y = ps.priceToY(price) + mainPane.y;
   const isUp = lastCandle.close >= lastCandle.open;

--- a/packages/chart/src/renderer/overlay-renderer.ts
+++ b/packages/chart/src/renderer/overlay-renderer.ts
@@ -3,17 +3,20 @@
  * Extracted from canvas-chart.ts for maintainability.
  */
 
-import type { DataLayer } from "../core/data-layer";
+import type { DataLayer, InternalSeries } from "../core/data-layer";
 import { autoFormatPrice, measureTextWidth } from "../core/format";
 import type { PriceScale, TimeScale } from "../core/scale";
+import { defaultRegistry } from "../core/series-registry";
 import type {
   CandleData,
+  DataPoint,
   PaneRect,
   SignalMarker,
   ThemeColors,
   TimeframeOverlay,
   TradeMarker,
 } from "../core/types";
+import type { AxisExcludeRange } from "./axis-renderer";
 
 /**
  * Render current price line (dashed horizontal line at latest close).
@@ -295,4 +298,197 @@ export function renderPaneTitles(
       x += ctx.measureText(label).width + GAP;
     }
   }
+}
+
+/**
+ * A pre-laid-out last-value badge ready to be drawn. Returned by
+ * {@link computeSeriesBadges} so the caller can hand the occupied Y ranges
+ * to {@link renderPriceAxis} (via `excludeYRanges`) before the badge is
+ * actually painted — that way tick labels under a badge are suppressed.
+ */
+export type ComputedBadge = {
+  /** Canvas-space center Y of the badge. */
+  y: number;
+  /** Half the badge height (fontSize/2 + padY). */
+  half: number;
+  /** Canvas-space x where the badge starts (right axis origin). */
+  x: number;
+  /** Badge width in pixels. */
+  w: number;
+  /** Fill color (pill background) and text color (derived as white / black if needed). */
+  color: string;
+  /** Rendered label text (already formatted). */
+  label: string;
+};
+
+/**
+ * Compute last-value badges for a pane. Does not paint — returns the list so
+ * the caller can pass the occupied Y ranges into {@link renderPriceAxis} as
+ * `excludeYRanges` and then call {@link drawSeriesBadges}.
+ *
+ * Collision strategy: walk badges sorted by descending Y; if a candidate's
+ * range overlaps one already placed (including `preoccupied`), shift it
+ * upward just enough to clear. If shifting would push it off the pane, the
+ * candidate is skipped.
+ */
+export function computeSeriesBadges(
+  ctx: CanvasRenderingContext2D,
+  pane: PaneRect,
+  priceScale: PriceScale,
+  seriesOnPane: readonly InternalSeries[],
+  theme: ThemeColors,
+  fontSize: number,
+  valueFormatter: (value: number) => string,
+  preoccupied: readonly AxisExcludeRange[] = [],
+  /**
+   * Inclusive upper-bound index for the "latest value" search. `undefined`
+   * means "search from end of data" (absolute-last mode). Pass the visible
+   * endIndex − 1 for visible-range mode.
+   */
+  searchUpTo?: number,
+  /** Optional extra badges (e.g. synthetic volume pill) to fold into layout. */
+  extras: readonly { value: number; color: string }[] = [],
+): ComputedBadge[] {
+  const padX = 6;
+  const padY = 3;
+  const half = fontSize / 2 + padY;
+
+  ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+
+  type Candidate = { y: number; color: string; label: string; w: number };
+  const candidates: Candidate[] = [];
+
+  for (const s of seriesOnPane) {
+    if (!s.config.label) continue; // Only labeled series get a badge
+    const rule = s._rule ?? defaultRegistry.detect(s.data);
+    if (!rule) continue;
+
+    if (rule.name === "number") {
+      const val = latestNumber(s.data as DataPoint<number | null>[], searchUpTo);
+      if (val === null) continue;
+      candidates.push({
+        y: priceScale.priceToY(val) + pane.y,
+        color: s.config.color ?? theme.text,
+        label: valueFormatter(val),
+        w: 0,
+      });
+      continue;
+    }
+
+    // Multi-channel: one badge per channel with a defined latest value.
+    if (!s._channels || s._channelsLen !== s.data.length) {
+      s._channels = defaultRegistry.decomposeAll(s.data, rule);
+      s._channelsLen = s.data.length;
+    }
+    const channelColors = s.config.channelColors;
+    for (const [channelName, values] of s._channels) {
+      const val = latestInArray(values, searchUpTo);
+      if (val === null) continue;
+      const color = channelColors?.[channelName] ?? s.config.color ?? theme.text;
+      candidates.push({
+        y: priceScale.priceToY(val) + pane.y,
+        color,
+        label: valueFormatter(val),
+        w: 0,
+      });
+    }
+  }
+
+  // Extras (e.g. synthetic volume pill at the right edge).
+  for (const ex of extras) {
+    candidates.push({
+      y: priceScale.priceToY(ex.value) + pane.y,
+      color: ex.color,
+      label: valueFormatter(ex.value),
+      w: 0,
+    });
+  }
+
+  // Measure and drop candidates whose center is outside the pane.
+  for (const c of candidates) {
+    c.w = measureTextWidth(ctx, c.label) + padX * 2;
+  }
+  const inside = candidates.filter((c) => c.y >= pane.y && c.y <= pane.y + pane.height);
+
+  // Collision-resolve with descending Y so the lowest badge anchors first.
+  inside.sort((a, b) => b.y - a.y);
+
+  const placed: ComputedBadge[] = [];
+  // Include preoccupied ranges as immovable anchors.
+  const reserved: AxisExcludeRange[] = preoccupied.map((r) => ({ y: r.y, half: r.half }));
+
+  const paneTop = pane.y;
+  const paneBottom = pane.y + pane.height;
+
+  for (const c of inside) {
+    let y = c.y;
+    // Shift up while overlapping any reserved range. Cap iterations to avoid
+    // pathological loops on degenerate input.
+    for (let iter = 0; iter < reserved.length + placed.length + 4; iter++) {
+      let moved = false;
+      for (const r of reserved) {
+        const minDist = half + r.half;
+        const delta = y - r.y;
+        if (Math.abs(delta) < minDist) {
+          // Move upward (negative Y) to stay above r.
+          y = r.y - minDist;
+          moved = true;
+        }
+      }
+      if (!moved) break;
+    }
+    // Skip if shifted out of the pane.
+    if (y - half < paneTop || y + half > paneBottom) continue;
+
+    placed.push({
+      y,
+      half,
+      x: pane.x + pane.width,
+      w: c.w,
+      color: c.color,
+      label: c.label,
+    });
+    reserved.push({ y, half });
+  }
+
+  // Restore placement order to descending Y (for consistent draw order).
+  placed.sort((a, b) => b.y - a.y);
+  return placed;
+}
+
+/** Paint the badges produced by {@link computeSeriesBadges}. */
+export function drawSeriesBadges(
+  ctx: CanvasRenderingContext2D,
+  badges: readonly ComputedBadge[],
+  fontSize: number,
+): void {
+  if (badges.length === 0) return;
+  const padX = 6;
+  ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+  ctx.textAlign = "left";
+  ctx.textBaseline = "middle";
+  for (const b of badges) {
+    ctx.fillStyle = b.color;
+    ctx.fillRect(b.x, b.y - b.half, b.w, b.half * 2);
+    ctx.fillStyle = "#fff";
+    ctx.fillText(b.label, b.x + padX, b.y);
+  }
+}
+
+function latestNumber(data: readonly DataPoint<number | null>[], upTo?: number): number | null {
+  const start = upTo !== undefined ? Math.min(upTo, data.length - 1) : data.length - 1;
+  for (let i = start; i >= 0; i--) {
+    const v = data[i]?.value;
+    if (v !== null && v !== undefined) return v;
+  }
+  return null;
+}
+
+function latestInArray(values: readonly (number | null)[], upTo?: number): number | null {
+  const start = upTo !== undefined ? Math.min(upTo, values.length - 1) : values.length - 1;
+  for (let i = start; i >= 0; i--) {
+    const v = values[i];
+    if (v !== null && v !== undefined) return v;
+  }
+  return null;
 }

--- a/packages/chart/src/renderer/render-pipeline.ts
+++ b/packages/chart/src/renderer/render-pipeline.ts
@@ -26,6 +26,9 @@ import {
 import { renderCrosshair } from "./crosshair-renderer";
 import { renderDrawings } from "./drawing-renderer";
 import {
+  type ComputedBadge,
+  computeSeriesBadges,
+  drawSeriesBadges,
   renderPriceLine,
   renderSignals,
   renderTimeframeOverlays,
@@ -67,6 +70,10 @@ export type RenderContext = {
   fontSize: number;
   chartType: ChartType;
   watermark: string | undefined;
+  /** When true, draw last-value pills on each pane's right axis */
+  showSeriesBadges?: boolean;
+  /** Which value to show in series badges: "absolute" (default) or "visible". */
+  seriesBadgeMode?: "absolute" | "visible";
   priceFormatter: (price: number) => string;
   timeFormatter: ((time: number) => string) | undefined;
   data: DataLayer;
@@ -223,6 +230,10 @@ export function renderFrame(rc: RenderContext): RenderResult {
       mainPriceExcludeHalf = rc.fontSize / 2 + 3; // fontSize + padY(3) — matches overlay-renderer
     }
   }
+
+  // Last-value badges per pane, collected during the pane loop and drawn
+  // after renderPriceLine so they layer above the axis but below crosshair.
+  const pendingBadges: { badges: ComputedBadge[] }[] = [];
 
   for (const pane of paneRects) {
     const scales = rc.priceScales.get(pane.id);
@@ -412,6 +423,52 @@ export function renderFrame(rc: RenderContext): RenderResult {
     // supplied price formatter.
     const axisFormatter = pane.id === "volume" ? formatVolume : rc.priceFormatter;
 
+    // Compute last-value badges (if enabled) before the axis so we can tell
+    // the axis which Y ranges are occupied. The candle current-price badge
+    // is seeded as a preoccupied slot so series badges shift around it.
+    const excludeYRanges: { y: number; half: number }[] = [];
+    if (pane.id === "main" && mainPriceExcludeY !== undefined) {
+      excludeYRanges.push({ y: mainPriceExcludeY, half: mainPriceExcludeHalf ?? 0 });
+    }
+    let computedBadges: ComputedBadge[] = [];
+    if (rc.showSeriesBadges) {
+      const seriesOnPane = data.getSeriesForScale(pane.id, "right");
+      // Visible-range mode: search up to the last visible candle index.
+      const searchUpTo =
+        rc.seriesBadgeMode === "visible"
+          ? Math.max(0, Math.min(candles.length, timeScale.endIndex) - 1)
+          : undefined;
+      // Volume pane: the "volume" value isn't stored as a series — synthesize
+      // a badge from the candle array so it lives next to indicator pills.
+      const extras: { value: number; color: string }[] = [];
+      if (pane.id === "volume") {
+        const idx = searchUpTo ?? candles.length - 1;
+        const c = candles[idx];
+        if (c && Number.isFinite(c.volume)) {
+          const isUp = c.close >= c.open;
+          // Use solid up/down color (not translucent volumeUp/Down) so the
+          // white pill text stays readable.
+          extras.push({ value: c.volume, color: isUp ? theme.upColor : theme.downColor });
+        }
+      }
+      if (seriesOnPane.length > 0 || extras.length > 0) {
+        computedBadges = computeSeriesBadges(
+          ctx,
+          pane,
+          ps,
+          seriesOnPane,
+          theme,
+          rc.fontSize,
+          axisFormatter,
+          excludeYRanges,
+          searchUpTo,
+          extras,
+        );
+        for (const b of computedBadges) excludeYRanges.push({ y: b.y, half: b.half });
+        if (computedBadges.length > 0) pendingBadges.push({ badges: computedBadges });
+      }
+    }
+
     // Right price axis
     renderPriceAxis(
       ctx,
@@ -426,8 +483,7 @@ export function renderFrame(rc: RenderContext): RenderResult {
       {
         position: "right",
         maxTicks: paneMaxTicks,
-        excludeY: pane.id === "main" ? mainPriceExcludeY : undefined,
-        excludeHalfHeight: pane.id === "main" ? mainPriceExcludeHalf : undefined,
+        excludeYRanges: excludeYRanges.length > 0 ? excludeYRanges : undefined,
       },
     );
 
@@ -521,6 +577,12 @@ export function renderFrame(rc: RenderContext): RenderResult {
 
   // Overlays
   renderPriceLine(ctx, candles, paneRects, _rightScaleMap, theme, rc.fontSize);
+  // Last-value series badges (opt-in). Drawn after renderPriceLine so the
+  // candle current-price badge stays on top visually, and above the axis so
+  // pills aren't obscured by tick labels.
+  for (const { badges } of pendingBadges) {
+    drawSeriesBadges(ctx, badges, rc.fontSize);
+  }
   renderSignals(ctx, data.signals, candles, data, paneRects, _rightScaleMap, timeScale);
   renderTrades(ctx, data.trades, data, paneRects, _rightScaleMap, timeScale);
 

--- a/packages/chart/src/renderer/render-pipeline.ts
+++ b/packages/chart/src/renderer/render-pipeline.ts
@@ -218,15 +218,24 @@ export function renderFrame(rc: RenderContext): RenderResult {
   for (const [id, dual] of rc.priceScales) _rightScaleMap.set(id, dual.right);
   _seriesByPane.clear();
 
+  // Resolve which candle the current-price badge points at. In "visible"
+  // badge mode it follows the right edge of the viewport so all badges share
+  // the same semantics; otherwise it tracks the data array's last bar
+  // (live / streaming price).
+  const currentPriceIndex =
+    rc.seriesBadgeMode === "visible"
+      ? Math.max(0, Math.min(candles.length, timeScale.endIndex) - 1)
+      : candles.length - 1;
+
   // Current-price label Y (main pane) — tick labels that would overlap it
   // are suppressed by the main-pane axis renderer below.
   let mainPriceExcludeY: number | undefined;
   let mainPriceExcludeHalf: number | undefined;
-  if (candles.length > 0) {
+  if (candles.length > 0 && currentPriceIndex >= 0) {
     const mainPane = paneRects.find((p) => p.id === "main");
     const mainScales = mainPane ? rc.priceScales.get("main") : undefined;
     if (mainPane && mainScales) {
-      mainPriceExcludeY = mainScales.right.priceToY(candles[candles.length - 1].close) + mainPane.y;
+      mainPriceExcludeY = mainScales.right.priceToY(candles[currentPriceIndex].close) + mainPane.y;
       mainPriceExcludeHalf = rc.fontSize / 2 + 3; // fontSize + padY(3) — matches overlay-renderer
     }
   }
@@ -576,7 +585,7 @@ export function renderFrame(rc: RenderContext): RenderResult {
   renderDrawings(ctx, allDrawings, paneRects, _rightScaleMap, timeScale, data, theme, rc.fontSize);
 
   // Overlays
-  renderPriceLine(ctx, candles, paneRects, _rightScaleMap, theme, rc.fontSize);
+  renderPriceLine(ctx, candles, paneRects, _rightScaleMap, theme, rc.fontSize, currentPriceIndex);
   // Last-value series badges (opt-in). Drawn after renderPriceLine so the
   // candle current-price badge stays on top visually, and above the axis so
   // pills aren't obscured by tick labels.


### PR DESCRIPTION
## Summary

Add opt-in TradingView-style "last-value badges" — colored pills on each pane's right price axis showing the latest value of every labeled series. Gives a quick numeric readout without crosshair interaction and also helps on short sub-panes where tick labels were getting squeezed out.

- **`ChartOptions.showSeriesBadges`** (default `false`) turns the feature on.
- **`ChartOptions.seriesBadgeMode`** picks which "last value":
  - `"absolute"` (default) — the data array's latest non-null value (live / streaming price).
  - `"visible"` — the latest non-null value within the current visible range (right edge of viewport).
- Multi-channel series (BB upper/middle/lower, MACD macd/signal/histogram) get one pill per decomposed channel, each in its own `channelColors[channel]`.
- The volume pane gets a synthesized pill colored by the last bar direction, using the existing K/M/B formatter.
- Badges on the same axis are sorted by Y, shifted upward to avoid each other and the existing candle current-price badge, and skipped if a shift would push them off the pane.
- The candle current-price badge also follows `seriesBadgeMode`: in `"visible"` mode its dashed line + pill anchor to the last visible bar so all badges share the same "right-edge of what you see" semantic. Absolute mode keeps the existing live-price behavior.
- `PriceAxisOptions.excludeYRanges` generalizes the prior single-range `excludeY` / `excludeHalfHeight` (kept as deprecated shims) so the tick placer can avoid multiple foreground labels at once.
- Showcase gets two toolbar toggles — `Badges: on/off` and `Mode: absolute/visible` — backed by `chart.applyOptions`, exercising the runtime switch path.

## Test plan

- [x] `pnpm test` — 68 files / 700 tests pass (existing 688 + 12 new cases across series-badges.test.ts and axis-renderer.test.ts)
- [x] `pnpm build` / `pnpm lint` clean
- [x] `pnpm size-check` — Main 35.17 kB / 36 kB (budget raised from 35; documented in CHANGELOG), React 29.18 kB / 30 kB, Vue 29.53 kB / 30 kB, Headless 10.22 kB / 11 kB
- [x] Manual: showcase toolbar — toggle `Badges` and `Mode`, load an indicator set with multi-channel series (BB, MACD) and watch pills appear / switch semantics

## Follow-ups

- Per-pane or per-series opt-out (e.g. hide volume pill independently) — recorded in `memory/project_chart_last_value_badges.md` for future iteration.