### PR TITLE
chore: allowlist esbuild + biome build scripts for pnpm 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@10.33.0",
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "packageManager": "pnpm@10.33.0",
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild"]
+    "onlyBuiltDependencies": ["@biomejs/biome", "esbuild"]
   }
 }

--- a/packages/chart/examples/indicator-showcase/package.json
+++ b/packages/chart/examples/indicator-showcase/package.json
@@ -15,5 +15,8 @@
   "devDependencies": {
     "typescript": "^5.7.2",
     "vite": "^6.0.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
   }
 }

--- a/packages/chart/examples/simple-chart/package.json
+++ b/packages/chart/examples/simple-chart/package.json
@@ -15,5 +15,8 @@
   "devDependencies": {
     "typescript": "^5.7.2",
     "vite": "^6.0.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
   }
 }

--- a/packages/chart/examples/simple-react-chart/package.json
+++ b/packages/chart/examples/simple-react-chart/package.json
@@ -20,5 +20,8 @@
     "@vitejs/plugin-react": "^4.3.4",
     "typescript": "^5.7.2",
     "vite": "^6.0.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
   }
 }

--- a/packages/chart/examples/simple-vue-chart/package.json
+++ b/packages/chart/examples/simple-vue-chart/package.json
@@ -17,5 +17,8 @@
     "@vitejs/plugin-vue": "^5.2.0",
     "typescript": "^5.7.2",
     "vite": "^6.0.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
   }
 }


### PR DESCRIPTION
## Summary

pnpm 10 (pulled in by `pnpm/action-setup@v6`) errors on ignored postinstall scripts in CI. The #57 bump attempt died with:

\`\`\`
ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: esbuild@0.25.12
##[error]Process completed with exit code 1.
\`\`\`

The failure lands in the **"Build chart examples"** step, which runs `pnpm install --ignore-workspace` inside each example. `--ignore-workspace` makes pnpm treat the example as a standalone project, so the root's `pnpm.onlyBuiltDependencies` doesn't cover it.

Fix in two places:

1. **Root `package.json`** — allowlist `@biomejs/biome` and `esbuild`. (On the current lockfile locally, biome is what trips the warning; esbuild was historically approved. Listing both future-proofs the workspace install.)
2. **Each example package.json** (`simple-chart`, `simple-react-chart`, `simple-vue-chart`, `indicator-showcase`) — allowlist `esbuild` so `pnpm install --ignore-workspace` doesn't re-trip the ignored-builds check.

Locally pnpm 10.33 emits these as a warning in an interactive shell, which is why my first pass "looked fine" — the same event becomes a hard error on CI.

## Test plan

- [x] `pnpm install --frozen-lockfile` at repo root: no ignored-scripts warning
- [x] Fresh `rm -rf node_modules && CI=true pnpm install --ignore-workspace` in `packages/chart/examples/simple-chart`: esbuild postinstall runs, no warning
- [x] Reproduced the pre-fix warning by temporarily removing `pnpm.onlyBuiltDependencies` — confirms the allowlist is doing the work
- [x] Green CI on this PR (both `ci (20)` and `ci (22)`, including the node-22-only "Build chart examples" step)

## Follow-up

- Once this lands, rebase #57 (pnpm/action-setup v5 → v6) onto main so CI picks up the allowlists.