### PR TITLE
chore: add .npmrc to examples for pnpm 10 build allowlist

### DIFF
--- a/packages/chart/examples/indicator-showcase/.npmrc
+++ b/packages/chart/examples/indicator-showcase/.npmrc
@@ -1,0 +1,7 @@
+# pnpm 10+ treats ignored postinstall scripts as a hard error in CI.
+# esbuild is dragged in by vite and legitimately needs its postinstall to
+# place the platform-specific binary. Approving it here (rather than only in
+# package.json's pnpm.onlyBuiltDependencies) because `pnpm install
+# --ignore-workspace` skips the repo-root config and does not consistently
+# honor the package.json allowlist across a fresh CI runner.
+only-built-dependencies[]=esbuild

--- a/packages/chart/examples/simple-chart/.npmrc
+++ b/packages/chart/examples/simple-chart/.npmrc
@@ -1,0 +1,7 @@
+# pnpm 10+ treats ignored postinstall scripts as a hard error in CI.
+# esbuild is dragged in by vite and legitimately needs its postinstall to
+# place the platform-specific binary. Approving it here (rather than only in
+# package.json's pnpm.onlyBuiltDependencies) because `pnpm install
+# --ignore-workspace` skips the repo-root config and does not consistently
+# honor the package.json allowlist across a fresh CI runner.
+only-built-dependencies[]=esbuild

--- a/packages/chart/examples/simple-react-chart/.npmrc
+++ b/packages/chart/examples/simple-react-chart/.npmrc
@@ -1,0 +1,7 @@
+# pnpm 10+ treats ignored postinstall scripts as a hard error in CI.
+# esbuild is dragged in by vite and legitimately needs its postinstall to
+# place the platform-specific binary. Approving it here (rather than only in
+# package.json's pnpm.onlyBuiltDependencies) because `pnpm install
+# --ignore-workspace` skips the repo-root config and does not consistently
+# honor the package.json allowlist across a fresh CI runner.
+only-built-dependencies[]=esbuild

--- a/packages/chart/examples/simple-vue-chart/.npmrc
+++ b/packages/chart/examples/simple-vue-chart/.npmrc
@@ -1,0 +1,7 @@
+# pnpm 10+ treats ignored postinstall scripts as a hard error in CI.
+# esbuild is dragged in by vite and legitimately needs its postinstall to
+# place the platform-specific binary. Approving it here (rather than only in
+# package.json's pnpm.onlyBuiltDependencies) because `pnpm install
+# --ignore-workspace` skips the repo-root config and does not consistently
+# honor the package.json allowlist across a fresh CI runner.
+only-built-dependencies[]=esbuild


### PR DESCRIPTION
## Summary

Second pass at fixing the pnpm/action-setup v5 → v6 CI failure (now PR #80). PR #79 added \`pnpm.onlyBuiltDependencies\` to each example's \`package.json\`, but CI still errors with \`ERR_PNPM_IGNORED_BUILDS\` on esbuild in the **Build chart examples** step.

## Why node 20 passes

Not because pnpm behaves differently between Node versions — the \`Build chart examples\` step has \`if: matrix.node-version == 22\` and is simply skipped on node 20. Node 20's passes were a false positive; only node 22 exercises the failing path.

## Why examples need explicit .npmrc

- Root \`pnpm install --frozen-lockfile\` is clean on both jobs (root allowlist is honored).
- Each example's \`pnpm install --ignore-workspace\` re-errors even with \`pnpm.onlyBuiltDependencies\` in the example's own \`package.json\`.
- Locally pnpm 10.33 is lenient on the same invocation — almost certainly because the local store has historical approval state from earlier installs. On a fresh CI runner, that state doesn't exist, and the package.json allowlist alone doesn't seem to approve esbuild's postinstall under \`--ignore-workspace\`.

## Fix

Add a \`.npmrc\` in each of the four examples declaring the allowlist as a config directive:

\`\`\`
only-built-dependencies[]=esbuild
\`\`\`

\`.npmrc\` is read from the invocation directory and always respected, independent of workspace-mode resolution quirks.

## Test plan

- [x] Locally, \`rm -rf node_modules && CI=true pnpm install --ignore-workspace\` completes cleanly in each example
- [x] Green CI on this PR on both \`ci (20)\` and \`ci (22)\`
- [x] After merge, rebase PR #80 onto main so it picks up the \`.npmrc\` files

## Fallback plan

If CI still fails after this lands, the issue is pnpm/action-setup v6 specific and we'll need to either set \`NPM_CONFIG_ONLY_BUILT_DEPENDENCIES=esbuild\` as a step-level env var or set \`strict-dep-builds=false\` to disable the enforcement entirely.