### PR TITLE
ci: declare examples allowlist via env (keep strict-dep-builds on)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,18 @@ jobs:
 
       - name: Build chart examples
         if: matrix.node-version == 22
+        # Each example runs `pnpm install --ignore-workspace`, which does
+        # not honor the workspace root's pnpm.onlyBuiltDependencies. Both
+        # per-example package.json `pnpm.onlyBuiltDependencies` and
+        # per-example `.npmrc only-built-dependencies[]=esbuild` were tried
+        # and still produced ERR_PNPM_IGNORED_BUILDS on CI (pnpm 10.33 +
+        # pnpm/action-setup v6), while the same configuration emits only a
+        # warning locally. Disable strict-dep-builds for this step only so
+        # the install completes — we trust vite's transitive esbuild here
+        # because this step is a smoke test of example builds, not a
+        # security-sensitive path.
+        env:
+          NPM_CONFIG_STRICT_DEP_BUILDS: "false"
         run: |
           cd packages/chart/examples/simple-chart && pnpm install --ignore-workspace && pnpm build
           cd ../simple-react-chart && pnpm install --ignore-workspace && pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,18 +48,19 @@ jobs:
 
       - name: Build chart examples
         if: matrix.node-version == 22
-        # Each example runs `pnpm install --ignore-workspace`, which does
-        # not honor the workspace root's pnpm.onlyBuiltDependencies. Both
-        # per-example package.json `pnpm.onlyBuiltDependencies` and
-        # per-example `.npmrc only-built-dependencies[]=esbuild` were tried
-        # and still produced ERR_PNPM_IGNORED_BUILDS on CI (pnpm 10.33 +
-        # pnpm/action-setup v6), while the same configuration emits only a
-        # warning locally. Disable strict-dep-builds for this step only so
-        # the install completes — we trust vite's transitive esbuild here
-        # because this step is a smoke test of example builds, not a
-        # security-sensitive path.
+        # Each example is installed with `pnpm install --ignore-workspace`,
+        # which doesn't honor the root workspace's
+        # `pnpm.onlyBuiltDependencies`. Per-example package.json and .npmrc
+        # allowlists were added in PRs #79 and #86 but pnpm 10.33 on the CI
+        # runner still fails with ERR_PNPM_IGNORED_BUILDS; only env-level
+        # config appears to take effect reliably in this invocation path.
+        #
+        # Keep strict-dep-builds ENABLED (default) and declare the allowlist
+        # via env so that a new postinstall-bearing package sneaking into an
+        # example still fails the build — instead of just warning and being
+        # missed.
         env:
-          NPM_CONFIG_STRICT_DEP_BUILDS: "false"
+          NPM_CONFIG_ONLY_BUILT_DEPENDENCIES: esbuild
         run: |
           cd packages/chart/examples/simple-chart && pnpm install --ignore-workspace && pnpm build
           cd ../simple-react-chart && pnpm install --ignore-workspace && pnpm build


### PR DESCRIPTION
## Summary

Two prior attempts (#79 package.json + #86 .npmrc) tried to allowlist esbuild through config files. Neither took effect under \`pnpm/action-setup@v6\` + pnpm 10.33 on GH Actions; CI still erroring with \`ERR_PNPM_IGNORED_BUILDS\` on esbuild in the \`Build chart examples\` step.

Root cause is not fully pinned, but control experiments show:
- Same pnpm 10.33 binary + \`pnpm install --ignore-workspace\` emits only a warning locally, but errors on CI with no allowlist difference.
- \`pnpm.onlyBuiltDependencies\` in each example's \`package.json\` and \`only-built-dependencies[]=esbuild\` in each example's \`.npmrc\` are both ignored in this specific invocation path on CI.

## Fix

Declare the allowlist at **env level** on just the \`Build chart examples\` step:

\`\`\`yaml
env:
  NPM_CONFIG_ONLY_BUILT_DEPENDENCIES: esbuild
\`\`\`

- Env config is pnpm's highest-precedence source and appears to be the only layer the CI invocation reliably reads.
- \`strict-dep-builds\` stays enabled (the pnpm 10 default). If any *new* postinstall-bearing package slips into an example, it will still be outside the allowlist and CI will still fail with \`ERR_PNPM_IGNORED_BUILDS\` — future-safe.

## Why not just \`strict-dep-builds=false\`?

Strict=false would silently accept any new postinstall package with just a warning. That's a blind spot because the examples aren't workspace members (\`pnpm-workspace.yaml\` only lists \`packages/*\`), so their transitive deps don't flow through the root \`pnpm install --frozen-lockfile\` strictness check. Env-level allowlist keeps the safety net.

## Follow-ups

- Keep the \`.npmrc\` and \`pnpm.onlyBuiltDependencies\` entries in each example as documentation of intent; they'll start mattering again if pnpm fixes whatever is currently causing them to be ignored.
- After this lands, rebase #80 onto main and confirm green.

## Test plan

- [ ] \`ci (20)\` and \`ci (22)\` green on this PR
- [ ] Rebase #80; its \`ci (22)\` (which actually runs the strict-enabled v6 setup) turns green