### PR TITLE
ci: use lowercase env var + prep-step global pnpm config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,20 +48,20 @@ jobs:
 
       - name: Build chart examples
         if: matrix.node-version == 22
-        # Each example is installed with `pnpm install --ignore-workspace`,
-        # which doesn't honor the root workspace's
-        # `pnpm.onlyBuiltDependencies`. Per-example package.json and .npmrc
-        # allowlists were added in PRs #79 and #86 but pnpm 10.33 on the CI
-        # runner still fails with ERR_PNPM_IGNORED_BUILDS; only env-level
-        # config appears to take effect reliably in this invocation path.
+        # Each example installs with `pnpm install --ignore-workspace`, which
+        # skips pnpm-workspace.yaml entirely. Previous fix attempts (pnpm
+        # field in each package.json, .npmrc in each example, uppercase
+        # NPM_CONFIG env var) all proved ineffective against pnpm 10.33's
+        # strict-dep-builds enforcement on GH Actions runners.
         #
-        # Keep strict-dep-builds ENABLED (default) and declare the allowlist
-        # via env so that a new postinstall-bearing package sneaking into an
-        # example still fails the build — instead of just warning and being
-        # missed.
+        # Use the lowercase env var form that pnpm docs actually prescribe
+        # AND write to the pnpm global config as a prep step — global config
+        # is read even under --ignore-workspace. Keep strict enabled so a
+        # new postinstall-bearing package in an example still fails CI.
         env:
-          NPM_CONFIG_ONLY_BUILT_DEPENDENCIES: esbuild
+          npm_config_only_built_dependencies: esbuild
         run: |
+          pnpm config set --global --json onlyBuiltDependencies '["esbuild"]'
           cd packages/chart/examples/simple-chart && pnpm install --ignore-workspace && pnpm build
           cd ../simple-react-chart && pnpm install --ignore-workspace && pnpm build
           cd ../simple-vue-chart && pnpm install --ignore-workspace && pnpm build


### PR DESCRIPTION
## Summary

Fourth attempt at the pnpm-10 / action-setup-v6 CI blocker on the \`Build chart examples\` step. Previous tries failed because I was using the **wrong env var casing** and because pnpm's documented config sources don't all flow through an \`--ignore-workspace\` invocation.

## Findings from web search

1. **Env var convention is lowercase.** Per [pnpm discussion #6566](https://github.com/orgs/pnpm/discussions/6566): "prefix the config vars with \`npm_config_\` and replace all \`-\` with \`_\`". Linux is case-sensitive on env vars, so \`NPM_CONFIG_ONLY_BUILT_DEPENDENCIES\` in PR #87 was silently ignored.
2. **pnpm 10.5+ moved the canonical location** of \`onlyBuiltDependencies\` to \`pnpm-workspace.yaml\`. The \`package.json\` \`pnpm.*\` form may not be supported in all code paths. \`--ignore-workspace\` skips \`pnpm-workspace.yaml\` entirely, so that route is closed for examples.
3. **\`.npmrc only-built-dependencies[]=esbuild\` is not documented** as a valid \`.npmrc\` key. PR #86's files were likely silent no-ops.
4. pnpm has a \`pnpm config set --global\` that writes to a canonical user config file (\`~/.config/pnpm/rc\` on Linux) that pnpm reads regardless of workspace mode.

## Fix

Two independent layers:

1. **Lowercase env var** per pnpm's documented convention:
   \`\`\`yaml
   env:
     npm_config_only_built_dependencies: esbuild
   \`\`\`
2. **Prep step writing to global config** before the example installs:
   \`\`\`yaml
   run: |
     pnpm config set --global --json onlyBuiltDependencies '["esbuild"]'
     ...
   \`\`\`

\`strict-dep-builds\` stays enabled. Any new postinstall-bearing package that lands in an example will still be outside the allowlist and will still fail CI with \`ERR_PNPM_IGNORED_BUILDS\` — we don't lose the protection pnpm 10 offers.

## Fallback

If even this doesn't work, the remaining pragmatic option is to disable strict-dep-builds for this step (\`npm_config_strict_dep_builds: "false"\`) and accept that we lose the "new postinstall package detected" safety at the examples level (root install still enforces it).

## Test plan

- [ ] \`ci (20)\` and \`ci (22)\` green on this PR
- [ ] After merge, rebase #80 and confirm the real v5 → v6 action-setup bump turns green