### PR TITLE
core 0.3.0: incremental indicators, generics refactor, trading calendar

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+### Added — Trading Calendar (market-specific annualization)
+
+- New `src/calendar/` module exposes a minimal `TradingCalendar` interface plus five presets:
+  `US_EQUITY_CALENDAR` (252), `JPX_CALENDAR` (245), `HKEX_CALENDAR` (247),
+  `CRYPTO_CALENDAR` (365), `FX_CALENDAR` (260). The presets carry only
+  `name` + `tradingDaysPerYear`; they do **not** ship holiday tables. Users
+  who need bar-level holiday gap detection can attach their own
+  `isTradingDay(date)` predicate.
+- `annualizationFactor({ calendar?, periodsPerYear? })` helper — single source
+  of truth for annualization across risk / volatility / runtime-metrics.
+- Wired into existing sites (all additive, defaults unchanged):
+  - `calculateMetricsFromReturns`, `stressTest`, `runAllStressTests` now accept
+    an `AnnualizationOptions` bag — Sharpe scales by `sqrt(periodsPerYear)`.
+  - `ulcerPerformanceIndex` accepts `AnnualizationOptions` — the annualized
+    return exponent `(1 + r) ** (N / n)` uses the configured `N`.
+  - `garch` / `ewmaVolatility` option types extend `AnnualizationOptions` —
+    the annualized volatility forecast uses `sqrt(N)` from the calendar.
+  - `volatilityRegime` accepts `calendar` / `periodsPerYear` through
+    `VolatilityRegimeOptions` — historical volatility annualization follows.
+  - `calculateRuntimeMetrics` gains a `calendar` field on `RuntimeMetricsOptions`;
+    it takes precedence over the legacy numeric `annualizationFactor`.
+  ```typescript
+  import { stressTest, PRESET_SCENARIOS, JPX_CALENDAR } from "trendcraft";
+  // Sharpe on a Japanese-equity strategy uses 245 bars/year, not 252
+  const result = stressTest(dailyReturns, PRESET_SCENARIOS.covidCrash2020, 100_000, {
+    calendar: JPX_CALENDAR,
+  });
+  ```
+
 ### Added — Price Source Coverage
 
 - `RsiOptions.source`, `MacdOptions.source`, `CciOptions.source` — `rsi()` / `macd()` / `cci()` and their incremental counterparts (`createRsi` / `createMacd` / `createCci`) now accept a `PriceSource` (`"close" | "hl2" | "hlc3" | "ohlc4" | ...`). Defaults preserve current behavior (`"close"` for RSI/MACD, `"hlc3"` for CCI), so existing call sites are unaffected.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -52,6 +52,17 @@ default + custom params, multiple price sources, snapshot resume, and
   });
   ```
 
+### Documented — Price Source Helpers
+
+- The pure helpers `getPrice(candle, source)` and `getPriceSeries(candles, source)`
+  (already exported since v0.1.0) are now covered in `docs/API.md` /
+  `docs/API.ja.md` under a new **Price Source Helpers** subsection. The
+  streaming equivalent `incremental.getSourcePrice` is cross-referenced.
+- `PriceSource` type listing in the API docs corrected to include the
+  `"volume"` variant that has always been part of the implementation.
+- `llms.txt` Data Utilities section enumerates `getPrice`,
+  `getPriceSeries`, and `incremental.getSourcePrice`.
+
 ### Added — Price Source Coverage
 
 - `RsiOptions.source`, `MacdOptions.source`, `CciOptions.source` — `rsi()` / `macd()` / `cci()` and their incremental counterparts (`createRsi` / `createMacd` / `createCci`) now accept a `PriceSource` (`"close" | "hl2" | "hlc3" | "ohlc4" | ...`). Defaults preserve current behavior (`"close"` for RSI/MACD, `"hlc3"` for CCI), so existing call sites are unaffected.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -16,6 +16,13 @@
   const crsi = connorsRsi(candles, { rsiPeriod: 3, streakPeriod: 2, rocPeriod: 100, source: "hlc3" });
   ```
 
+### Added — Incremental Price Indicators
+
+- `createHeikinAshi()` — incremental Heikin-Ashi. Emits the same `{open, high, low, close, trend}` shape as `heikinAshi()` and supports `getState()` / `fromState` snapshot resumption for live sessions. Exposed via `incremental.createHeikinAshi`.
+- `createReturns()` — incremental simple or log returns of close prices. `{ period?: number; type?: "simple" | "log" }`; emits `null` until `period + 1` candles have been seen. Exposed via `incremental.createReturns`.
+
+Parity with the batch versions is covered by `src/indicators/incremental/__tests__/heikin-ashi-returns.test.ts`.
+
 ### Added — Session: Lunch Breaks & Timezone Awareness
 
 - `SessionDefinition.breaks?: SessionBreak[]` — sessions can now define one or more intra-session breaks (e.g. JPX/HKEX lunch). Bars inside a break report `inSession: false`, the session anchor (name, open, high, low) is preserved, and `barIndex` does not advance. `sessionStats` and `sessionBreakout` skip break bars but still treat the surrounding session as a single occurrence.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -20,8 +20,11 @@
 
 - `createHeikinAshi()` — incremental Heikin-Ashi. Emits the same `{open, high, low, close, trend}` shape as `heikinAshi()` and supports `getState()` / `fromState` snapshot resumption for live sessions. Exposed via `incremental.createHeikinAshi`.
 - `createReturns()` — incremental simple or log returns of close prices. `{ period?: number; type?: "simple" | "log" }`; emits `null` until `period + 1` candles have been seen. Exposed via `incremental.createReturns`.
+- `createSwingPoints()` — incremental Swing Points (leftBars/rightBars window). Confirmation lags by `rightBars` bars; the emitted `time` is the swing candidate bar's original time. The set of confirmed swing-high / swing-low bar times matches batch `swingPoints()` exactly on the same input.
+- `createZigzag()` — incremental Zigzag with percent-deviation or ATR-based thresholds. Pivots are emitted at the pivot bar's original time as reversals confirm; the collapsed-by-time pivot sequence matches batch `zigzag()` on the same input. Uses `createAtr` internally for ATR mode (state snapshot includes the nested ATR state).
+- `createBreakOfStructure()` / `createChangeOfCharacter()` — incremental BOS and CHoCH. Each emits per-candle `BosValue` at the current candle's time and matches batch `breakOfStructure()` / `changeOfCharacter()` value-by-value, including the running `trend` and the trailing `swingHighLevel` / `swingLowLevel`.
 
-Parity with the batch versions is covered by `src/indicators/incremental/__tests__/heikin-ashi-returns.test.ts`.
+Parity with batch is covered by `heikin-ashi-returns.test.ts`, `swing-points.test.ts`, `zigzag.test.ts`, and `break-of-structure.test.ts` under `src/indicators/incremental/__tests__/`.
 
 ### Added — Session: Lunch Breaks & Timezone Awareness
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -9,6 +9,12 @@
   // Use typical price (HLC3) as RSI input
   const rsiTypical = rsi(candles, { period: 14, source: "hlc3" });
   ```
+- `StochRsiOptions.source`, `ConnorsRsiOptions.source` — derived RSI indicators now thread the price source through every internal component. `stochRsi()` / `createStochRsi()` pass `source` to the inner RSI. `connorsRsi()` / `createConnorsRsi()` use the same `source` for the price RSI, the streak comparison, and the 1-period ROC used by `rocPercentile`. Defaults remain `"close"`.
+  ```typescript
+  // Compute StochRSI / Connors RSI on the typical price
+  const srsi = stochRsi(candles, { rsiPeriod: 14, stochPeriod: 14, source: "hlc3" });
+  const crsi = connorsRsi(candles, { rsiPeriod: 3, streakPeriod: 2, rocPeriod: 100, source: "hlc3" });
+  ```
 
 ### Added — Session: Lunch Breaks & Timezone Awareness
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added — More Incremental Indicators
 
+- `createLinearRegression()` — incremental rolling least-squares linear
+  regression. Maintains O(1)-updateable running sums (`sumY` / `sumY²` /
+  `sumXY`) plus a `period`-sized CircularBuffer; the four-field output
+  (`value`, `slope`, `intercept`, `rSquared`) matches batch
+  `linearRegression()` to 6 decimal places. R² is computed via the
+  Pearson form (`(n·sumXY − sumX·sumY)² / ((n·sumXX − sumX²)·(n·sumYY − sumY²))`)
+  rather than iterating ssRes / ssTot. Exposed via
+  `incremental.createLinearRegression`.
 - `createStandardDeviation()` — incremental rolling population standard
   deviation. Maintains `sum` / `sumSq` running totals plus a `period`-sized
   CircularBuffer for O(1) per-bar updates. Matches batch `standardDeviation()`

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+### Added — More Incremental Indicators
+
+- `createStandardDeviation()` — incremental rolling population standard
+  deviation. Maintains `sum` / `sumSq` running totals plus a `period`-sized
+  CircularBuffer for O(1) per-bar updates. Matches batch `standardDeviation()`
+  to 8 decimal places. Exposed via `incremental.createStandardDeviation`.
+- `createSuperSmoother()` — incremental Ehlers 2-pole Super Smoother filter.
+  State carries `prevPrice` and the last two outputs; first 2 bars emit
+  `null` (matches the batch IIR seeding). Exposed via
+  `incremental.createSuperSmoother`.
+- `createRoofingFilter()` — incremental Ehlers Roofing Filter (2-pole
+  high-pass cascaded into a Super Smoother). State carries the last two
+  inputs, last two high-pass outputs, and last two filter outputs. Matches
+  batch `roofingFilter()` to 10 decimal places. Exposed via
+  `incremental.createRoofingFilter`.
+
+Parity with the batch versions is covered by 18 new tests in
+`src/indicators/incremental/__tests__/stddev-ehlers.test.ts`, including
+default + custom params, multiple price sources, snapshot resume, and
+`peek` non-mutation.
+
 ### Added — Trading Calendar (market-specific annualization)
 
 - New `src/calendar/` module exposes a minimal `TradingCalendar` interface plus five presets:

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -24,6 +24,7 @@
   - [条件の組み合わせ](#条件の組み合わせ)
 - [ユーティリティ](#ユーティリティ)
   - [データ正規化](#データ正規化)
+  - [価格ソースヘルパー](#価格ソースヘルパー)
   - [リサンプリング](#リサンプリング)
 - [シグナルスコアリング](#シグナルスコアリング)
   - [ScoreBuilder](#scorebuilder)
@@ -2882,6 +2883,46 @@ const normalized = normalizeCandles(candles);
 
 ---
 
+### 価格ソースヘルパー
+
+正規化済みローソク足から特定の価格フィールドを取り出す純関数。`source?: PriceSource` オプションを持つインジケーターは内部でこれらを呼んでいるため、自前のリターン計算・回帰・フィルタなど **`source` を受け付けない処理に価格列を渡すとき** にだけ直接使う。
+
+#### `getPrice(candle, source)`
+
+1本の正規化済みローソク足から1つの価格値を取り出す。
+
+```typescript
+import { normalizeCandle, getPrice } from 'trendcraft';
+
+const c = normalizeCandle({ time: '2024-01-01', open: 99, high: 102, low: 98, close: 101, volume: 1000 });
+getPrice(c, 'close');  // 101
+getPrice(c, 'hl2');    // 100        ((102 + 98) / 2)
+getPrice(c, 'hlc3');   // 100.333... ((102 + 98 + 101) / 3)
+getPrice(c, 'ohlc4');  // 100        ((99 + 102 + 98 + 101) / 4)
+getPrice(c, 'volume'); // 1000
+```
+
+#### `getPriceSeries(candles, source)`
+
+正規化済みローソク足配列から価格系列(`number[]`)を取り出す。実装は `candles.map((c) => getPrice(c, source))` と同等。
+
+```typescript
+import { normalizeCandles, getPriceSeries } from 'trendcraft';
+
+const normalized = normalizeCandles(candles);
+const closes = getPriceSeries(normalized, 'close');
+const typical = getPriceSeries(normalized, 'hlc3');
+```
+
+**`source` オプションとの使い分け:**
+- `source` オプションを持つインジケーター → 直接 `source: 'hlc3'` を渡す。事前抽出は不要
+- 価格に対する自前計算（リターン、回帰、独自フィルタ等）→ `getPriceSeries` で `number[]` を取得
+- コールバック内で1点だけ価格を取り出したい → `getPrice`
+
+ストリーミング(incremental)側では `incremental.getSourcePrice(candle, source)` が同等の役割を果たす。`createSma` / `createRsi` などの `source` オプションが内部で呼んでいる。
+
+---
+
 ### リサンプリング
 
 #### `resample(candles, timeframe)`
@@ -5725,7 +5766,7 @@ interface IndicatorValue<T> {
 
 type Series<T> = IndicatorValue<T>[];
 
-type PriceSource = 'open' | 'high' | 'low' | 'close' | 'hl2' | 'hlc3' | 'ohlc4';
+type PriceSource = 'open' | 'high' | 'low' | 'close' | 'hl2' | 'hlc3' | 'ohlc4' | 'volume';
 ```
 
 ### シグナル型

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -28,6 +28,7 @@
   - [Combining Conditions](#combining-conditions)
 - [Utilities](#utilities)
   - [Data Normalization](#data-normalization)
+  - [Price Source Helpers](#price-source-helpers)
   - [Resampling](#resampling)
 - [Signal Scoring](#signal-scoring)
   - [ScoreBuilder](#scorebuilder)
@@ -3312,6 +3313,46 @@ const normalized = normalizeCandles(candles);
 
 ---
 
+### Price Source Helpers
+
+Pure helpers for extracting a specific price field from a normalized candle. Most indicators that accept a `source?: PriceSource` option call these internally; you only need them when feeding price data into a non-`source`-aware function (e.g. computing returns, plotting a derived series, or composing indicators yourself).
+
+#### `getPrice(candle, source)`
+
+Extract a single price value from one normalized candle.
+
+```typescript
+import { normalizeCandle, getPrice } from 'trendcraft';
+
+const c = normalizeCandle({ time: '2024-01-01', open: 99, high: 102, low: 98, close: 101, volume: 1000 });
+getPrice(c, 'close');  // 101
+getPrice(c, 'hl2');    // 100        ((102 + 98) / 2)
+getPrice(c, 'hlc3');   // 100.333... ((102 + 98 + 101) / 3)
+getPrice(c, 'ohlc4');  // 100        ((99 + 102 + 98 + 101) / 4)
+getPrice(c, 'volume'); // 1000
+```
+
+#### `getPriceSeries(candles, source)`
+
+Extract a price series (`number[]`) from an array of normalized candles. Equivalent to `candles.map((c) => getPrice(c, source))`.
+
+```typescript
+import { normalizeCandles, getPriceSeries } from 'trendcraft';
+
+const normalized = normalizeCandles(candles);
+const closes = getPriceSeries(normalized, 'close');
+const typical = getPriceSeries(normalized, 'hlc3');
+```
+
+**When to reach for these vs. `source` options:**
+- Indicator with a `source` option → pass `source: 'hlc3'` directly. No need to pre-extract.
+- Custom math on prices (returns, regressions, your own filters) → use `getPriceSeries` to get a clean `number[]`.
+- One-off price extraction inside a callback → use `getPrice`.
+
+For the streaming/incremental side, the equivalent helper is `incremental.getSourcePrice(candle, source)`, which is what `createSma`, `createRsi`, etc. call internally when their `source` option is set.
+
+---
+
 ### Resampling
 
 #### `resample(candles, timeframe)`
@@ -6301,7 +6342,7 @@ interface IndicatorValue<T> {
 
 type Series<T> = IndicatorValue<T>[];
 
-type PriceSource = 'open' | 'high' | 'low' | 'close' | 'hl2' | 'hlc3' | 'ohlc4';
+type PriceSource = 'open' | 'high' | 'low' | 'close' | 'hl2' | 'hlc3' | 'ohlc4' | 'volume';
 ```
 
 ### Signal Types

--- a/packages/core/llms.txt
+++ b/packages/core/llms.txt
@@ -361,6 +361,9 @@ Presets: `"momentum"`, `"meanReversion"`, `"trendFollowing"`, `"balanced"`, `"ag
 
 ### Normalization and Resampling
 - `normalizeCandles(candles)` — Normalize various date formats to Unix timestamps
+- `getPrice(candle, source)` — Extract one price field (`'close' | 'hl2' | 'hlc3' | 'ohlc4' | 'open' | 'high' | 'low' | 'volume'`) from a normalized candle
+- `getPriceSeries(candles, source)` — `number[]` of the chosen price field across all candles; pre-extract for math that doesn't take a `source` option
+- `incremental.getSourcePrice(candle, source)` — same helper for streaming pipelines (used internally by `createSma` / `createRsi` etc. when a `source` option is set)
 - `resample(candles, 'weekly' | 'monthly')` — Timeframe resampling
 - `parseCsv(csvString)` — Parse CSV data to candles
 

--- a/packages/core/src/analysis/runtime-metrics.ts
+++ b/packages/core/src/analysis/runtime-metrics.ts
@@ -59,6 +59,8 @@ export type RuntimeMetricsOptions = {
   riskFreeRate?: number;
   /** Number of trading periods per year (default: 252 for daily) */
   annualizationFactor?: number;
+  /** Calendar preset supplying tradingDaysPerYear. Overrides annualizationFactor when provided. */
+  calendar?: import("../calendar").TradingCalendar;
 };
 
 /**
@@ -87,7 +89,10 @@ export function calculateRuntimeMetrics(
   trades: Trade[],
   options: RuntimeMetricsOptions = {},
 ): RuntimeMetrics {
-  const { initialCapital = 100_000, riskFreeRate = 0, annualizationFactor = 252 } = options;
+  const { initialCapital = 100_000, riskFreeRate = 0 } = options;
+  // Calendar takes precedence over the legacy annualizationFactor number
+  const annualizationFactor =
+    options.calendar?.tradingDaysPerYear ?? options.annualizationFactor ?? 252;
 
   const stats = calculateTradeStats(trades);
 

--- a/packages/core/src/calendar/__tests__/annualize.test.ts
+++ b/packages/core/src/calendar/__tests__/annualize.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  CRYPTO_CALENDAR,
+  FX_CALENDAR,
+  HKEX_CALENDAR,
+  JPX_CALENDAR,
+  US_EQUITY_CALENDAR,
+  annualizationFactor,
+} from "../index";
+
+describe("annualizationFactor", () => {
+  it("defaults to 252 when no options are supplied", () => {
+    expect(annualizationFactor()).toBe(252);
+    expect(annualizationFactor({})).toBe(252);
+  });
+
+  it("honors periodsPerYear override", () => {
+    expect(annualizationFactor({ periodsPerYear: 365 })).toBe(365);
+    expect(annualizationFactor({ periodsPerYear: 52 })).toBe(52);
+  });
+
+  it("prefers calendar over periodsPerYear when both are provided", () => {
+    expect(annualizationFactor({ calendar: JPX_CALENDAR, periodsPerYear: 999 })).toBe(
+      JPX_CALENDAR.tradingDaysPerYear,
+    );
+  });
+
+  it("resolves each preset to its documented value", () => {
+    expect(annualizationFactor({ calendar: US_EQUITY_CALENDAR })).toBe(252);
+    expect(annualizationFactor({ calendar: JPX_CALENDAR })).toBe(245);
+    expect(annualizationFactor({ calendar: HKEX_CALENDAR })).toBe(247);
+    expect(annualizationFactor({ calendar: CRYPTO_CALENDAR })).toBe(365);
+    expect(annualizationFactor({ calendar: FX_CALENDAR })).toBe(260);
+  });
+});
+
+describe("TradingCalendar preset shapes", () => {
+  it("all presets are well-formed", () => {
+    for (const cal of [
+      US_EQUITY_CALENDAR,
+      JPX_CALENDAR,
+      HKEX_CALENDAR,
+      CRYPTO_CALENDAR,
+      FX_CALENDAR,
+    ]) {
+      expect(typeof cal.name).toBe("string");
+      expect(cal.name.length).toBeGreaterThan(0);
+      expect(cal.tradingDaysPerYear).toBeGreaterThan(0);
+      expect(cal.tradingDaysPerYear).toBeLessThanOrEqual(365);
+    }
+  });
+
+  it("does not ship holiday predicates by default (users supply their own)", () => {
+    for (const cal of [US_EQUITY_CALENDAR, JPX_CALENDAR, CRYPTO_CALENDAR]) {
+      expect(cal.isTradingDay).toBeUndefined();
+    }
+  });
+});

--- a/packages/core/src/calendar/__tests__/integration.test.ts
+++ b/packages/core/src/calendar/__tests__/integration.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Integration tests: verify annualization wiring actually changes downstream
+ * metrics (Sharpe, GARCH forecast, Ulcer Performance Index, etc.) when the
+ * calendar is swapped.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ewmaVolatility, garch } from "../../indicators/volatility/garch";
+import { ulcerPerformanceIndex } from "../../risk/drawdown-analysis";
+import { calculateMetricsFromReturns } from "../../risk/stress-test";
+import { CRYPTO_CALENDAR, JPX_CALENDAR, US_EQUITY_CALENDAR } from "../index";
+
+function syntheticReturns(n = 200, seed = 1): number[] {
+  let s = seed;
+  const r = () => {
+    s = (s * 16807) % 2147483647;
+    return s / 2147483647;
+  };
+  return Array.from({ length: n }, () => (r() - 0.48) * 0.02);
+}
+
+describe("calendar integration: stress-test metrics", () => {
+  const returns = syntheticReturns(250, 11);
+
+  it("defaults to US (252) when no calendar is provided", () => {
+    const us = calculateMetricsFromReturns(returns, { calendar: US_EQUITY_CALENDAR });
+    const def = calculateMetricsFromReturns(returns);
+    expect(def.sharpe).toBeCloseTo(us.sharpe, 12);
+  });
+
+  it("crypto (365) produces a larger-magnitude Sharpe than US (252)", () => {
+    const us = calculateMetricsFromReturns(returns, { calendar: US_EQUITY_CALENDAR });
+    const crypto = calculateMetricsFromReturns(returns, { calendar: CRYPTO_CALENDAR });
+    // Sharpe scales with sqrt(N); sqrt(365)/sqrt(252) ~ 1.203
+    expect(Math.abs(crypto.sharpe)).toBeGreaterThan(Math.abs(us.sharpe));
+    expect(Math.abs(crypto.sharpe) / Math.abs(us.sharpe)).toBeCloseTo(Math.sqrt(365 / 252), 2);
+  });
+
+  it("totalReturn / maxDrawdown do not depend on the calendar", () => {
+    const us = calculateMetricsFromReturns(returns, { calendar: US_EQUITY_CALENDAR });
+    const jpx = calculateMetricsFromReturns(returns, { calendar: JPX_CALENDAR });
+    expect(us.totalReturn).toBe(jpx.totalReturn);
+    expect(us.maxDrawdown).toBe(jpx.maxDrawdown);
+  });
+});
+
+describe("calendar integration: GARCH / EWMA forecasts", () => {
+  const returns = syntheticReturns(300, 42);
+
+  it("GARCH forecast scales by sqrt(periodsPerYear)", () => {
+    const us = garch(returns, { calendar: US_EQUITY_CALENDAR });
+    const crypto = garch(returns, { calendar: CRYPTO_CALENDAR });
+    // Forecast is sqrt(variance) * sqrt(N) * 100 — ratio should match sqrt factor
+    expect(crypto.volatilityForecast / us.volatilityForecast).toBeCloseTo(Math.sqrt(365 / 252), 4);
+  });
+
+  it("EWMA volatility scales by sqrt(periodsPerYear)", () => {
+    const us = ewmaVolatility(returns, { calendar: US_EQUITY_CALENDAR });
+    const crypto = ewmaVolatility(returns, { calendar: CRYPTO_CALENDAR });
+    for (let i = 10; i < us.length; i += 20) {
+      if (us[i].value > 0) {
+        expect(crypto[i].value / us[i].value).toBeCloseTo(Math.sqrt(365 / 252), 4);
+      }
+    }
+  });
+
+  it("default (no calendar) equals US explicit", () => {
+    const def = garch(returns);
+    const us = garch(returns, { calendar: US_EQUITY_CALENDAR });
+    expect(def.volatilityForecast).toBeCloseTo(us.volatilityForecast, 8);
+  });
+});
+
+describe("calendar integration: Ulcer Performance Index", () => {
+  const equity = Array.from({ length: 120 }, (_, i) => {
+    // Drifting upward curve with some pullbacks
+    const base = 100 * (1 + 0.001 * i);
+    const pullback = Math.max(0, Math.sin(i / 4)) * 2;
+    return base - pullback;
+  });
+
+  it("JPX (245) produces a slightly smaller UPI than US (252) on the same curve", () => {
+    const us = ulcerPerformanceIndex(equity, 0, { calendar: US_EQUITY_CALENDAR });
+    const jpx = ulcerPerformanceIndex(equity, 0, { calendar: JPX_CALENDAR });
+    // UPI's annualized return uses (1+r)^(N/n); higher N → larger exponent → larger UPI for positive r
+    expect(us).toBeGreaterThan(jpx);
+  });
+});

--- a/packages/core/src/calendar/annualize.ts
+++ b/packages/core/src/calendar/annualize.ts
@@ -1,0 +1,34 @@
+/**
+ * Annualization helpers.
+ *
+ * Single source of truth for "how many periods per year" across risk,
+ * volatility, and runtime-metrics modules. Each consuming function accepts
+ * an `AnnualizationOptions` bag and resolves it here, so the fallback
+ * default (`252`) only lives in one place.
+ */
+
+import type { TradingCalendar } from "./types";
+
+/**
+ * Options for controlling how a scalar metric is annualized.
+ *
+ * Resolution order when both are supplied: `calendar` wins. Omitting both
+ * yields the US-equity convention (`252`).
+ */
+export type AnnualizationOptions = {
+  /** Calendar preset supplying `tradingDaysPerYear`. */
+  calendar?: TradingCalendar;
+  /** Raw override (bars per year). Useful for non-daily bar frequencies. */
+  periodsPerYear?: number;
+};
+
+/**
+ * Resolve a concrete periods-per-year factor from the options bag.
+ *
+ * @returns `calendar.tradingDaysPerYear` if provided, otherwise
+ *          `periodsPerYear`, otherwise `252`.
+ */
+export function annualizationFactor(opts: AnnualizationOptions = {}): number {
+  if (opts.calendar) return opts.calendar.tradingDaysPerYear;
+  return opts.periodsPerYear ?? 252;
+}

--- a/packages/core/src/calendar/index.ts
+++ b/packages/core/src/calendar/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Trading calendar module.
+ *
+ * Lightweight API for market-specific annualization factors. Presets cover
+ * the most common markets (US equities, JPX, HKEX, crypto, FX); users who
+ * need bar-level holiday gap detection can build their own `TradingCalendar`
+ * with a custom `isTradingDay` predicate.
+ */
+
+export type { TradingCalendar } from "./types";
+export type { AnnualizationOptions } from "./annualize";
+export { annualizationFactor } from "./annualize";
+export {
+  CRYPTO_CALENDAR,
+  FX_CALENDAR,
+  HKEX_CALENDAR,
+  JPX_CALENDAR,
+  US_EQUITY_CALENDAR,
+} from "./presets";

--- a/packages/core/src/calendar/presets.ts
+++ b/packages/core/src/calendar/presets.ts
@@ -1,0 +1,39 @@
+/**
+ * Preset trading calendars for common markets.
+ *
+ * Values are conventional periods-per-year used in industry for Sharpe /
+ * volatility annualization. They do not carry holiday tables — core
+ * intentionally avoids year-by-year data that would go stale.
+ */
+
+import type { TradingCalendar } from "./types";
+
+/** US equities (NYSE / Nasdaq): ~252 trading days per year. */
+export const US_EQUITY_CALENDAR: TradingCalendar = {
+  name: "US Equity",
+  tradingDaysPerYear: 252,
+};
+
+/** Japan Exchange Group (JPX): ~245 trading days per year (more holidays than US). */
+export const JPX_CALENDAR: TradingCalendar = {
+  name: "JPX",
+  tradingDaysPerYear: 245,
+};
+
+/** Hong Kong Exchange (HKEX): ~247 trading days per year. */
+export const HKEX_CALENDAR: TradingCalendar = {
+  name: "HKEX",
+  tradingDaysPerYear: 247,
+};
+
+/** Crypto (24/7 continuous): 365 periods per year for daily bars. */
+export const CRYPTO_CALENDAR: TradingCalendar = {
+  name: "Crypto",
+  tradingDaysPerYear: 365,
+};
+
+/** Spot FX (24/5 Mon-Fri): ~260 trading days per year. */
+export const FX_CALENDAR: TradingCalendar = {
+  name: "FX",
+  tradingDaysPerYear: 260,
+};

--- a/packages/core/src/calendar/types.ts
+++ b/packages/core/src/calendar/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Trading calendar types.
+ *
+ * The calendar module is intentionally tiny: it only provides the
+ * "periods per year" factor used for annualizing volatility / Sharpe /
+ * return metrics. Holiday tables are not shipped in core — users can
+ * supply their own `isTradingDay` predicate when they need gap-aware
+ * analysis.
+ */
+
+/**
+ * A market-specific annualization calendar.
+ *
+ * @example
+ * ```ts
+ * import { JPX_CALENDAR, calculateVaR } from "trendcraft";
+ *
+ * // Use ~245 days/year for a Japanese-market strategy instead of US 252
+ * const result = calculateVaR(returns, { confidence: 0.95, calendar: JPX_CALENDAR });
+ * ```
+ */
+export interface TradingCalendar {
+  /** Human-readable name, surfaced in logs / reports. */
+  name: string;
+  /**
+   * Number of trading periods per year used for annualization:
+   * - Sharpe/Sortino: `mean/sd * sqrt(tradingDaysPerYear)`
+   * - Annualized return: `(1 + total) ** (tradingDaysPerYear / n) - 1`
+   * - Historical volatility: `stdDev * sqrt(tradingDaysPerYear)`
+   */
+  tradingDaysPerYear: number;
+  /**
+   * Optional holiday predicate. When omitted, every day is considered a
+   * trading day — sufficient for pure annualization math. Provide a custom
+   * predicate only when the consumer needs bar-level gap detection.
+   */
+  isTradingDay?(date: Date): boolean;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1426,3 +1426,14 @@ export type {
   CandleFormerValue,
   PredictionDirection,
 } from "./ml";
+
+// Trading calendar (market-specific annualization)
+export {
+  annualizationFactor,
+  CRYPTO_CALENDAR,
+  FX_CALENDAR,
+  HKEX_CALENDAR,
+  JPX_CALENDAR,
+  US_EQUITY_CALENDAR,
+} from "./calendar";
+export type { AnnualizationOptions, TradingCalendar } from "./calendar";

--- a/packages/core/src/indicators/__tests__/connors-rsi.test.ts
+++ b/packages/core/src/indicators/__tests__/connors-rsi.test.ts
@@ -87,4 +87,50 @@ describe("connorsRsi", () => {
     const nonNullValues = result.filter((r) => r.value.crsi !== null);
     expect(nonNullValues.length).toBeGreaterThan(0);
   });
+
+  it("should thread source through to all components", () => {
+    // Varying wicks per bar — a constant offset would leave RSI/ROC unchanged,
+    // so we make both wicks depend on i.
+    const base: NormalizedCandle[] = [];
+    for (let i = 0; i < 120; i++) {
+      const close = 100 + Math.sin(i * 0.3) * 20 + i * 0.1;
+      const upperWick = 1 + Math.abs(Math.cos(i * 0.7)) * 4;
+      const lowerWick = 0.5 + Math.abs(Math.sin(i * 0.9)) * 2;
+      base.push({
+        time: 1700000000000 + i * 86400000,
+        open: close - 0.5,
+        high: close + upperWick,
+        low: close - lowerWick,
+        close,
+        volume: 1000,
+      });
+    }
+    const asClose = connorsRsi(base, { rsiPeriod: 3, streakPeriod: 2, rocPeriod: 100 });
+    const asHlc3 = connorsRsi(base, {
+      rsiPeriod: 3,
+      streakPeriod: 2,
+      rocPeriod: 100,
+      source: "hlc3",
+    });
+
+    // Pick a point where both are non-null and check they differ
+    const i = asClose.findIndex(
+      (r, idx) => r.value.crsi !== null && asHlc3[idx].value.crsi !== null,
+    );
+    expect(i).toBeGreaterThan(-1);
+    expect(asClose[i].value.crsi).not.toBeCloseTo(asHlc3[i].value.crsi!, 4);
+  });
+
+  it("should match previous behavior when source is omitted (close)", () => {
+    const closes: number[] = [];
+    for (let i = 0; i < 120; i++) closes.push(100 + Math.sin(i * 0.3) * 20);
+    const candles = makeCandles(closes);
+
+    const withoutOpt = connorsRsi(candles);
+    const withClose = connorsRsi(candles, { source: "close" });
+
+    for (let i = 0; i < withoutOpt.length; i++) {
+      expect(withoutOpt[i].value.crsi).toEqual(withClose[i].value.crsi);
+    }
+  });
 });

--- a/packages/core/src/indicators/__tests__/stoch-rsi.test.ts
+++ b/packages/core/src/indicators/__tests__/stoch-rsi.test.ts
@@ -157,4 +157,43 @@ describe("stochRsi", () => {
     expect(result[0].time).toBe(candles[0].time);
     expect(result[4].time).toBe(candles[4].time);
   });
+
+  it("should accept a price source and pass it through to the underlying RSI", () => {
+    // Wicks that vary per bar, so hlc3 != close + constant offset.
+    // This ensures the first-differences (which drive RSI) actually differ.
+    const base: NormalizedCandle[] = [];
+    for (let i = 0; i < 60; i++) {
+      const close = 100 + Math.sin(i * 0.4) * 10;
+      const upperWick = 1 + Math.abs(Math.cos(i * 0.7)) * 4;
+      const lowerWick = 0.5 + Math.abs(Math.sin(i * 0.9)) * 2;
+      base.push({
+        time: 1700000000000 + i * 86400000,
+        open: close - 0.5,
+        high: close + upperWick,
+        low: close - lowerWick,
+        close,
+        volume: 1000,
+      });
+    }
+    const defaulted = stochRsi(base, { rsiPeriod: 14, stochPeriod: 14 });
+    const explicitClose = stochRsi(base, {
+      rsiPeriod: 14,
+      stochPeriod: 14,
+      source: "close",
+    });
+    const viaHlc3 = stochRsi(base, { rsiPeriod: 14, stochPeriod: 14, source: "hlc3" });
+
+    // Default === close
+    for (let i = 0; i < defaulted.length; i++) {
+      expect(defaulted[i].value.stochRsi).toEqual(explicitClose[i].value.stochRsi);
+    }
+
+    // hlc3 must differ at least once
+    const diverged = defaulted.some((r, i) => {
+      const a = r.value.stochRsi;
+      const b = viaHlc3[i].value.stochRsi;
+      return a !== null && b !== null && Math.abs(a - b) > 1e-6;
+    });
+    expect(diverged).toBe(true);
+  });
 });

--- a/packages/core/src/indicators/incremental/__tests__/break-of-structure.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/break-of-structure.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Parity tests for incremental BOS / CHoCH vs batch.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../../types";
+import { breakOfStructure, changeOfCharacter } from "../../price/break-of-structure";
+import { createBreakOfStructure, createChangeOfCharacter } from "../price/break-of-structure";
+
+function generateCandles(count: number): NormalizedCandle[] {
+  const candles: NormalizedCandle[] = [];
+  const MS = 86400000;
+  const base = new Date("2020-01-01").getTime();
+  let price = 100;
+  let s = 31;
+  const r = () => {
+    s = (s * 16807) % 2147483647;
+    return s / 2147483647;
+  };
+  for (let i = 0; i < count; i++) {
+    const change = (r() - 0.5) * 5;
+    const open = price;
+    const close = price * (1 + change / 100);
+    const high = Math.max(open, close) * (1 + r() * 0.015);
+    const low = Math.min(open, close) * (1 - r() * 0.015);
+    candles.push({ time: base + i * MS, open, high, low, close, volume: 1000 });
+    price = close;
+  }
+  return candles;
+}
+
+describe("createBreakOfStructure", () => {
+  const candles = generateCandles(250);
+  const period = 3;
+
+  it("matches batch BOS value-by-value", () => {
+    const batch = breakOfStructure(candles, { swingPeriod: period });
+    const live = createBreakOfStructure({ swingPeriod: period });
+    for (let i = 0; i < candles.length; i++) {
+      const l = live.next(candles[i]).value;
+      const b = batch[i].value;
+      expect(l.bullishBos).toBe(b.bullishBos);
+      expect(l.bearishBos).toBe(b.bearishBos);
+      expect(l.trend).toBe(b.trend);
+      expect(l.brokenLevel).toBe(b.brokenLevel);
+      expect(l.swingHighLevel).toBe(b.swingHighLevel);
+      expect(l.swingLowLevel).toBe(b.swingLowLevel);
+    }
+  });
+
+  it("fires at least one bullish or bearish BOS on random data", () => {
+    const live = createBreakOfStructure({ swingPeriod: period });
+    let fired = false;
+    for (const c of candles) {
+      const { value } = live.next(c);
+      if (value.bullishBos || value.bearishBos) fired = true;
+    }
+    expect(fired).toBe(true);
+  });
+
+  it("restores from snapshot without drift", () => {
+    const a = createBreakOfStructure({ swingPeriod: period });
+    for (let i = 0; i < 100; i++) a.next(candles[i]);
+    const b = createBreakOfStructure({ swingPeriod: period }, { fromState: a.getState() });
+    for (let i = 100; i < candles.length; i++) {
+      const va = a.next(candles[i]).value;
+      const vb = b.next(candles[i]).value;
+      expect(vb).toEqual(va);
+    }
+  });
+
+  it("peek does not mutate state", () => {
+    const bos = createBreakOfStructure({ swingPeriod: period });
+    for (let i = 0; i < 50; i++) bos.next(candles[i]);
+    const before = JSON.stringify(bos.getState());
+    bos.peek(candles[50]);
+    expect(JSON.stringify(bos.getState())).toBe(before);
+  });
+
+  it("throws on invalid swingPeriod", () => {
+    expect(() => createBreakOfStructure({ swingPeriod: 0 })).toThrow();
+  });
+});
+
+describe("createChangeOfCharacter", () => {
+  const candles = generateCandles(250);
+  const period = 3;
+
+  it("matches batch CHoCH value-by-value", () => {
+    const batch = changeOfCharacter(candles, { swingPeriod: period });
+    const live = createChangeOfCharacter({ swingPeriod: period });
+    for (let i = 0; i < candles.length; i++) {
+      const l = live.next(candles[i]).value;
+      const b = batch[i].value;
+      expect(l.bullishBos).toBe(b.bullishBos);
+      expect(l.bearishBos).toBe(b.bearishBos);
+      expect(l.trend).toBe(b.trend);
+      expect(l.brokenLevel).toBe(b.brokenLevel);
+    }
+  });
+
+  it("snapshot resume is stable", () => {
+    const a = createChangeOfCharacter({ swingPeriod: period });
+    for (let i = 0; i < 120; i++) a.next(candles[i]);
+    const b = createChangeOfCharacter({ swingPeriod: period }, { fromState: a.getState() });
+    for (let i = 120; i < candles.length; i++) {
+      const va = a.next(candles[i]).value;
+      const vb = b.next(candles[i]).value;
+      expect(vb.bullishBos).toBe(va.bullishBos);
+      expect(vb.bearishBos).toBe(va.bearishBos);
+      expect(vb.trend).toBe(va.trend);
+    }
+  });
+});

--- a/packages/core/src/indicators/incremental/__tests__/heikin-ashi-returns.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/heikin-ashi-returns.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Parity tests for the newly incremental-ized price indicators:
+ * Heikin-Ashi and Returns.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../../types";
+import { heikinAshi } from "../../price/heikin-ashi";
+import { returns as returnsBatch } from "../../price/returns";
+import { processAll } from "../bridge";
+import { createHeikinAshi } from "../price/heikin-ashi";
+import { createReturns } from "../price/returns";
+
+function generateCandles(count: number): NormalizedCandle[] {
+  const candles: NormalizedCandle[] = [];
+  const MS_PER_DAY = 86400000;
+  const baseTime = new Date("2020-01-01").getTime();
+  let price = 100;
+  let seed = 42;
+  const random = () => {
+    seed = (seed * 16807) % 2147483647;
+    return seed / 2147483647;
+  };
+  for (let i = 0; i < count; i++) {
+    const change = (random() - 0.5) * 4;
+    const open = price;
+    const close = price * (1 + change / 100);
+    const high = Math.max(open, close) * (1 + random() * 0.01);
+    const low = Math.min(open, close) * (1 - random() * 0.01);
+    candles.push({
+      time: baseTime + i * MS_PER_DAY,
+      open,
+      high,
+      low,
+      close,
+      volume: Math.floor(100000 + random() * 900000),
+    });
+    price = close;
+  }
+  return candles;
+}
+
+describe("createHeikinAshi", () => {
+  const candles = generateCandles(100);
+
+  it("matches batch heikinAshi value-by-value", () => {
+    const batch = heikinAshi(candles);
+    const incr = processAll(createHeikinAshi(), candles);
+    expect(incr.length).toBe(batch.length);
+    for (let i = 0; i < batch.length; i++) {
+      expect(incr[i].time).toBe(batch[i].time);
+      expect(incr[i].value.open).toBeCloseTo(batch[i].value.open, 10);
+      expect(incr[i].value.high).toBeCloseTo(batch[i].value.high, 10);
+      expect(incr[i].value.low).toBeCloseTo(batch[i].value.low, 10);
+      expect(incr[i].value.close).toBeCloseTo(batch[i].value.close, 10);
+      expect(incr[i].value.trend).toBe(batch[i].value.trend);
+    }
+  });
+
+  it("restores from snapshot without drift", () => {
+    const ha = createHeikinAshi();
+    for (let i = 0; i < 50; i++) ha.next(candles[i]);
+    const snap = ha.getState();
+    const resumed = createHeikinAshi({}, { fromState: snap });
+    const batch = heikinAshi(candles);
+    for (let i = 50; i < candles.length; i++) {
+      const { value } = resumed.next(candles[i]);
+      expect(value.close).toBeCloseTo(batch[i].value.close, 10);
+      expect(value.open).toBeCloseTo(batch[i].value.open, 10);
+    }
+  });
+
+  it("peek does not advance state", () => {
+    const ha = createHeikinAshi();
+    for (let i = 0; i < 20; i++) ha.next(candles[i]);
+    const before = ha.getState();
+    const peeked = ha.peek(candles[20]);
+    const after = ha.getState();
+    expect(after).toEqual(before);
+    const advanced = ha.next(candles[20]);
+    expect(peeked.value.close).toBeCloseTo(advanced.value.close, 10);
+  });
+});
+
+describe("createReturns", () => {
+  const candles = generateCandles(80);
+
+  for (const type of ["simple", "log"] as const) {
+    for (const period of [1, 5]) {
+      it(`matches batch returns (${type}, period=${period})`, () => {
+        const batch = returnsBatch(candles, { period, type });
+        const incr = processAll(createReturns({ period, type }), candles);
+        expect(incr.length).toBe(batch.length);
+        for (let i = 0; i < batch.length; i++) {
+          expect(incr[i].time).toBe(batch[i].time);
+          if (batch[i].value === null) {
+            expect(incr[i].value).toBeNull();
+          } else {
+            expect(incr[i].value).not.toBeNull();
+            expect(incr[i].value as number).toBeCloseTo(batch[i].value as number, 10);
+          }
+        }
+      });
+    }
+  }
+
+  it("throws on invalid period", () => {
+    expect(() => createReturns({ period: 0 })).toThrow();
+  });
+
+  it("emits null on a zero reference price without crashing", () => {
+    // Build a candle where the reference (period=1 -> previous) close is 0
+    const flat: NormalizedCandle[] = [
+      { time: 0, open: 0, high: 0, low: 0, close: 0, volume: 0 },
+      { time: 1, open: 1, high: 1, low: 1, close: 1, volume: 0 },
+    ];
+    const incr = processAll(createReturns({ period: 1 }), flat);
+    expect(incr[0].value).toBeNull();
+    expect(incr[1].value).toBeNull();
+  });
+
+  it("restores from snapshot and continues correctly", () => {
+    const batch = returnsBatch(candles, { period: 3, type: "simple" });
+    const r = createReturns({ period: 3, type: "simple" });
+    for (let i = 0; i < 40; i++) r.next(candles[i]);
+    const snap = r.getState();
+    const resumed = createReturns({}, { fromState: snap });
+    for (let i = 40; i < candles.length; i++) {
+      const { value } = resumed.next(candles[i]);
+      if (batch[i].value === null) {
+        expect(value).toBeNull();
+      } else {
+        expect(value as number).toBeCloseTo(batch[i].value as number, 10);
+      }
+    }
+  });
+});

--- a/packages/core/src/indicators/incremental/__tests__/linear-regression.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/linear-regression.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Parity tests for incremental Linear Regression vs the batch
+ * `linearRegression()` implementation.
+ *
+ * The incremental version maintains running sumY / sumY² / sumXY using a
+ * sliding-window update rule, so we want to ensure the resulting four
+ * outputs (value, slope, intercept, rSquared) match the batch ones bar
+ * for bar across multiple periods and price sources.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../../types";
+import { linearRegression } from "../../trend/linear-regression";
+import { processAll } from "../bridge";
+import { createLinearRegression } from "../trend/linear-regression";
+
+function generateCandles(count: number, seed = 91): NormalizedCandle[] {
+  const candles: NormalizedCandle[] = [];
+  const MS = 86400000;
+  const base = new Date("2020-01-01").getTime();
+  let price = 100;
+  let s = seed;
+  const r = () => {
+    s = (s * 16807) % 2147483647;
+    return s / 2147483647;
+  };
+  for (let i = 0; i < count; i++) {
+    const change = (r() - 0.5) * 4;
+    const open = price;
+    const close = price * (1 + change / 100);
+    const high = Math.max(open, close) * (1 + r() * 0.015);
+    const low = Math.min(open, close) * (1 - r() * 0.015);
+    candles.push({ time: base + i * MS, open, high, low, close, volume: 1000 });
+    price = close;
+  }
+  return candles;
+}
+
+function expectSeriesMatch(
+  incr: ReturnType<typeof processAll<ReturnType<typeof linearRegression>[number]["value"]>>,
+  batch: ReturnType<typeof linearRegression>,
+  digits = 6,
+) {
+  expect(incr.length).toBe(batch.length);
+  for (let i = 0; i < batch.length; i++) {
+    const a = incr[i].value;
+    const b = batch[i].value;
+    if (a === null || b === null) {
+      expect(a).toBeNull();
+      expect(b).toBeNull();
+      continue;
+    }
+    expect(a.value).toBeCloseTo(b.value, digits);
+    expect(a.slope).toBeCloseTo(b.slope, digits);
+    expect(a.intercept).toBeCloseTo(b.intercept, digits);
+    expect(a.rSquared).toBeCloseTo(b.rSquared, digits);
+  }
+}
+
+describe("createLinearRegression", () => {
+  const candles = generateCandles(200);
+
+  for (const period of [5, 14, 50]) {
+    it(`matches batch linearRegression (period=${period})`, () => {
+      const batch = linearRegression(candles, { period });
+      const incr = processAll(createLinearRegression({ period }), candles);
+      expectSeriesMatch(incr, batch, 6);
+    });
+  }
+
+  it("source=hlc3 matches batch", () => {
+    const batch = linearRegression(candles, { period: 20, source: "hlc3" });
+    const incr = processAll(createLinearRegression({ period: 20, source: "hlc3" }), candles);
+    expectSeriesMatch(incr, batch, 6);
+  });
+
+  it("snapshot resume continues with no drift", () => {
+    const a = createLinearRegression({ period: 14 });
+    for (let i = 0; i < 80; i++) a.next(candles[i]);
+    const b = createLinearRegression({ period: 14 }, { fromState: a.getState() });
+    const batch = linearRegression(candles, { period: 14 });
+    for (let i = 80; i < candles.length; i++) {
+      const v = b.next(candles[i]).value;
+      const ref = batch[i].value;
+      if (ref === null) {
+        expect(v).toBeNull();
+      } else {
+        expect(v?.slope).toBeCloseTo(ref.slope, 6);
+        expect(v?.value).toBeCloseTo(ref.value, 6);
+        expect(v?.rSquared).toBeCloseTo(ref.rSquared, 6);
+      }
+    }
+  });
+
+  it("peek does not mutate state", () => {
+    const lr = createLinearRegression({ period: 14 });
+    for (let i = 0; i < 50; i++) lr.next(candles[i]);
+    const before = JSON.stringify(lr.getState());
+    lr.peek(candles[50]);
+    expect(JSON.stringify(lr.getState())).toBe(before);
+  });
+
+  it("peek result equals next result", () => {
+    const lr = createLinearRegression({ period: 10 });
+    for (let i = 0; i < 30; i++) lr.next(candles[i]);
+    const peeked = lr.peek(candles[30]).value;
+    const advanced = lr.next(candles[30]).value;
+    expect(peeked).not.toBeNull();
+    expect(advanced).not.toBeNull();
+    expect(peeked?.slope).toBeCloseTo(advanced?.slope as number, 10);
+    expect(peeked?.value).toBeCloseTo(advanced?.value as number, 10);
+    expect(peeked?.rSquared).toBeCloseTo(advanced?.rSquared as number, 10);
+  });
+
+  it("isWarmedUp aligns with the first non-null output", () => {
+    const lr = createLinearRegression({ period: 5 });
+    expect(lr.isWarmedUp).toBe(false);
+    // First period-1 calls return null
+    for (let i = 0; i < 4; i++) {
+      const { value } = lr.next(candles[i]);
+      expect(value).toBeNull();
+      expect(lr.isWarmedUp).toBe(false);
+    }
+    const first = lr.next(candles[4]);
+    expect(first.value).not.toBeNull();
+    expect(lr.isWarmedUp).toBe(true);
+  });
+
+  it("rSquared is 1 on a perfectly linear series", () => {
+    // y = 10 + 2x exactly
+    const linearCandles: NormalizedCandle[] = [];
+    for (let i = 0; i < 30; i++) {
+      const c = 10 + 2 * i;
+      linearCandles.push({
+        time: 1700000000000 + i * 86400000,
+        open: c,
+        high: c,
+        low: c,
+        close: c,
+        volume: 1000,
+      });
+    }
+    const lr = createLinearRegression({ period: 10 });
+    let last: ReturnType<typeof lr.next> | null = null;
+    for (const c of linearCandles) last = lr.next(c);
+    expect(last?.value).not.toBeNull();
+    expect(last?.value?.slope).toBeCloseTo(2, 8);
+    expect(last?.value?.rSquared).toBeCloseTo(1, 8);
+  });
+
+  it("throws on invalid period", () => {
+    expect(() => createLinearRegression({ period: 1 })).toThrow();
+    expect(() => createLinearRegression({ period: 0 })).toThrow();
+  });
+
+  it("restoring from snapshot uses saved period/source even if options omit them", () => {
+    // Build a state under non-default config (period=20, source=hlc3)
+    const a = createLinearRegression({ period: 20, source: "hlc3" });
+    for (let i = 0; i < 80; i++) a.next(candles[i]);
+    const snap = a.getState();
+
+    // Restore WITHOUT specifying options (would otherwise default to period=14, close)
+    const b = createLinearRegression({}, { fromState: snap });
+    const batch = linearRegression(candles, { period: 20, source: "hlc3" });
+    for (let i = 80; i < candles.length; i++) {
+      const v = b.next(candles[i]).value;
+      const ref = batch[i].value;
+      if (ref === null) {
+        expect(v).toBeNull();
+      } else {
+        expect(v?.slope).toBeCloseTo(ref.slope, 6);
+        expect(v?.value).toBeCloseTo(ref.value, 6);
+        expect(v?.rSquared).toBeCloseTo(ref.rSquared, 6);
+      }
+    }
+  });
+});

--- a/packages/core/src/indicators/incremental/__tests__/stddev-ehlers.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/stddev-ehlers.test.ts
@@ -94,6 +94,17 @@ describe("createStandardDeviation", () => {
   it("throws on invalid period", () => {
     expect(() => createStandardDeviation({ period: 0 })).toThrow();
   });
+
+  it("restoring from snapshot uses saved period/source even if options omit them", () => {
+    const a = createStandardDeviation({ period: 30, source: "hlc3" });
+    for (let i = 0; i < 80; i++) a.next(candles[i]);
+    const b = createStandardDeviation({}, { fromState: a.getState() });
+    const batch = standardDeviation(candles, { period: 30, source: "hlc3" });
+    for (let i = 80; i < candles.length; i++) {
+      const v = b.next(candles[i]).value;
+      expect(v as number).toBeCloseTo(batch[i].value as number, 8);
+    }
+  });
 });
 
 describe("createSuperSmoother", () => {
@@ -149,6 +160,17 @@ describe("createSuperSmoother", () => {
     const c = ss.next(candles[2]); // first real value
     expect(c.value).not.toBeNull();
     expect(ss.isWarmedUp).toBe(true);
+  });
+
+  it("restoring from snapshot uses saved period/source even if options omit them", () => {
+    const a = createSuperSmoother({ period: 25, source: "hlc3" });
+    for (let i = 0; i < 60; i++) a.next(candles[i]);
+    const b = createSuperSmoother({}, { fromState: a.getState() });
+    const batch = superSmoother(candles, { period: 25, source: "hlc3" });
+    for (let i = 60; i < candles.length; i++) {
+      const v = b.next(candles[i]).value;
+      expect(v as number).toBeCloseTo(batch[i].value as number, 10);
+    }
   });
 });
 
@@ -208,5 +230,17 @@ describe("createRoofingFilter", () => {
     const c = rf.next(candles[2]); // first real value
     expect(c.value).not.toBeNull();
     expect(rf.isWarmedUp).toBe(true);
+  });
+
+  it("restoring from snapshot uses saved highPass/lowPass/source even if options omit them", () => {
+    const opts = { highPassPeriod: 30, lowPassPeriod: 8, source: "hlc3" as const };
+    const a = createRoofingFilter(opts);
+    for (let i = 0; i < 70; i++) a.next(candles[i]);
+    const b = createRoofingFilter({}, { fromState: a.getState() });
+    const batch = roofingFilter(candles, opts);
+    for (let i = 70; i < candles.length; i++) {
+      const v = b.next(candles[i]).value;
+      expect(v as number).toBeCloseTo(batch[i].value as number, 10);
+    }
   });
 });

--- a/packages/core/src/indicators/incremental/__tests__/stddev-ehlers.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/stddev-ehlers.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Parity tests for the new statistical / filter incremental indicators:
+ * Standard Deviation, Super Smoother, Roofing Filter.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../../types";
+import { roofingFilter } from "../../filter/roofing-filter";
+import { superSmoother } from "../../filter/super-smoother";
+import { standardDeviation } from "../../volatility/standard-deviation";
+import { processAll } from "../bridge";
+import { createRoofingFilter } from "../filter/roofing-filter";
+import { createSuperSmoother } from "../filter/super-smoother";
+import { createStandardDeviation } from "../volatility/standard-deviation";
+
+function generateCandles(count: number, seed = 17): NormalizedCandle[] {
+  const candles: NormalizedCandle[] = [];
+  const MS = 86400000;
+  const base = new Date("2020-01-01").getTime();
+  let price = 100;
+  let s = seed;
+  const r = () => {
+    s = (s * 16807) % 2147483647;
+    return s / 2147483647;
+  };
+  for (let i = 0; i < count; i++) {
+    const change = (r() - 0.5) * 4;
+    const open = price;
+    const close = price * (1 + change / 100);
+    const high = Math.max(open, close) * (1 + r() * 0.015);
+    const low = Math.min(open, close) * (1 - r() * 0.015);
+    candles.push({ time: base + i * MS, open, high, low, close, volume: 1000 });
+    price = close;
+  }
+  return candles;
+}
+
+describe("createStandardDeviation", () => {
+  const candles = generateCandles(200);
+
+  for (const period of [5, 20, 50]) {
+    it(`matches batch standardDeviation (period=${period})`, () => {
+      const batch = standardDeviation(candles, { period });
+      const incr = processAll(createStandardDeviation({ period }), candles);
+      for (let i = 0; i < batch.length; i++) {
+        if (batch[i].value === null) {
+          expect(incr[i].value).toBeNull();
+        } else {
+          expect(incr[i].value as number).toBeCloseTo(batch[i].value as number, 8);
+        }
+      }
+    });
+  }
+
+  it("source=hl2 matches batch", () => {
+    const batch = standardDeviation(candles, { period: 20, source: "hl2" });
+    const incr = processAll(createStandardDeviation({ period: 20, source: "hl2" }), candles);
+    for (let i = 0; i < batch.length; i++) {
+      if (batch[i].value === null) {
+        expect(incr[i].value).toBeNull();
+      } else {
+        expect(incr[i].value as number).toBeCloseTo(batch[i].value as number, 8);
+      }
+    }
+  });
+
+  it("snapshot resume", () => {
+    const a = createStandardDeviation({ period: 20 });
+    for (let i = 0; i < 80; i++) a.next(candles[i]);
+    const b = createStandardDeviation({ period: 20 }, { fromState: a.getState() });
+    const batch = standardDeviation(candles, { period: 20 });
+    for (let i = 80; i < candles.length; i++) {
+      const v = b.next(candles[i]).value;
+      expect(v as number).toBeCloseTo(batch[i].value as number, 8);
+    }
+  });
+
+  it("peek does not mutate state", () => {
+    const sd = createStandardDeviation({ period: 20 });
+    for (let i = 0; i < 50; i++) sd.next(candles[i]);
+    const before = JSON.stringify(sd.getState());
+    sd.peek(candles[50]);
+    expect(JSON.stringify(sd.getState())).toBe(before);
+  });
+
+  it("peek result equals next result", () => {
+    const sd = createStandardDeviation({ period: 10 });
+    for (let i = 0; i < 30; i++) sd.next(candles[i]);
+    const peeked = sd.peek(candles[30]).value;
+    const advanced = sd.next(candles[30]).value;
+    expect(peeked as number).toBeCloseTo(advanced as number, 12);
+  });
+
+  it("throws on invalid period", () => {
+    expect(() => createStandardDeviation({ period: 0 })).toThrow();
+  });
+});
+
+describe("createSuperSmoother", () => {
+  const candles = generateCandles(120);
+
+  for (const period of [5, 10, 25]) {
+    it(`matches batch superSmoother (period=${period})`, () => {
+      const batch = superSmoother(candles, { period });
+      const incr = processAll(createSuperSmoother({ period }), candles);
+      for (let i = 0; i < batch.length; i++) {
+        if (batch[i].value === null) {
+          expect(incr[i].value).toBeNull();
+        } else {
+          expect(incr[i].value as number).toBeCloseTo(batch[i].value as number, 10);
+        }
+      }
+    });
+  }
+
+  it("source=hlc3 matches batch", () => {
+    const batch = superSmoother(candles, { period: 10, source: "hlc3" });
+    const incr = processAll(createSuperSmoother({ period: 10, source: "hlc3" }), candles);
+    for (let i = 0; i < batch.length; i++) {
+      if (batch[i].value === null) continue;
+      expect(incr[i].value as number).toBeCloseTo(batch[i].value as number, 10);
+    }
+  });
+
+  it("snapshot resume", () => {
+    const a = createSuperSmoother({ period: 10 });
+    for (let i = 0; i < 60; i++) a.next(candles[i]);
+    const b = createSuperSmoother({ period: 10 }, { fromState: a.getState() });
+    const batch = superSmoother(candles, { period: 10 });
+    for (let i = 60; i < candles.length; i++) {
+      const v = b.next(candles[i]).value;
+      expect(v as number).toBeCloseTo(batch[i].value as number, 10);
+    }
+  });
+
+  it("throws on invalid period", () => {
+    expect(() => createSuperSmoother({ period: 0 })).toThrow();
+  });
+
+  it("isWarmedUp aligns with the first non-null output", () => {
+    const ss = createSuperSmoother({ period: 10 });
+    expect(ss.isWarmedUp).toBe(false);
+    const a = ss.next(candles[0]); // null
+    expect(a.value).toBeNull();
+    expect(ss.isWarmedUp).toBe(false);
+    const b = ss.next(candles[1]); // null (still warming up)
+    expect(b.value).toBeNull();
+    expect(ss.isWarmedUp).toBe(false);
+    const c = ss.next(candles[2]); // first real value
+    expect(c.value).not.toBeNull();
+    expect(ss.isWarmedUp).toBe(true);
+  });
+});
+
+describe("createRoofingFilter", () => {
+  const candles = generateCandles(150);
+
+  it("matches batch roofingFilter (default params)", () => {
+    const batch = roofingFilter(candles);
+    const incr = processAll(createRoofingFilter(), candles);
+    for (let i = 0; i < batch.length; i++) {
+      if (batch[i].value === null) {
+        expect(incr[i].value).toBeNull();
+      } else {
+        expect(incr[i].value as number).toBeCloseTo(batch[i].value as number, 10);
+      }
+    }
+  });
+
+  it("matches batch roofingFilter (custom params)", () => {
+    const opts = { highPassPeriod: 30, lowPassPeriod: 8, source: "hlc3" as const };
+    const batch = roofingFilter(candles, opts);
+    const incr = processAll(createRoofingFilter(opts), candles);
+    for (let i = 0; i < batch.length; i++) {
+      if (batch[i].value === null) continue;
+      expect(incr[i].value as number).toBeCloseTo(batch[i].value as number, 10);
+    }
+  });
+
+  it("snapshot resume preserves filter memory", () => {
+    const a = createRoofingFilter({ highPassPeriod: 48, lowPassPeriod: 10 });
+    for (let i = 0; i < 70; i++) a.next(candles[i]);
+    const b = createRoofingFilter(
+      { highPassPeriod: 48, lowPassPeriod: 10 },
+      { fromState: a.getState() },
+    );
+    const batch = roofingFilter(candles);
+    for (let i = 70; i < candles.length; i++) {
+      const v = b.next(candles[i]).value;
+      expect(v as number).toBeCloseTo(batch[i].value as number, 10);
+    }
+  });
+
+  it("throws on invalid params", () => {
+    expect(() => createRoofingFilter({ highPassPeriod: 0 })).toThrow();
+    expect(() => createRoofingFilter({ lowPassPeriod: 0 })).toThrow();
+  });
+
+  it("isWarmedUp aligns with the first non-null output", () => {
+    const rf = createRoofingFilter();
+    expect(rf.isWarmedUp).toBe(false);
+    const a = rf.next(candles[0]); // null
+    expect(a.value).toBeNull();
+    expect(rf.isWarmedUp).toBe(false);
+    const b = rf.next(candles[1]); // null
+    expect(b.value).toBeNull();
+    expect(rf.isWarmedUp).toBe(false);
+    const c = rf.next(candles[2]); // first real value
+    expect(c.value).not.toBeNull();
+    expect(rf.isWarmedUp).toBe(true);
+  });
+});

--- a/packages/core/src/indicators/incremental/__tests__/swing-points.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/swing-points.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Parity tests for incremental Swing Points vs the batch swingPoints().
+ *
+ * Batch emits one entry per candle at candle.time; incremental emits at
+ * mid-bar time with `rightBars` delay. We reconcile by grouping emissions
+ * by time and comparing the set of confirmed swing highs/lows.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../../types";
+import { swingPoints } from "../../price/swing-points";
+import { createSwingPoints } from "../price/swing-points";
+
+function generateCandles(count: number): NormalizedCandle[] {
+  const candles: NormalizedCandle[] = [];
+  const MS_PER_DAY = 86400000;
+  const baseTime = new Date("2020-01-01").getTime();
+  let price = 100;
+  let seed = 123;
+  const random = () => {
+    seed = (seed * 16807) % 2147483647;
+    return seed / 2147483647;
+  };
+  for (let i = 0; i < count; i++) {
+    const change = (random() - 0.5) * 6;
+    const open = price;
+    const close = price * (1 + change / 100);
+    const high = Math.max(open, close) * (1 + random() * 0.02);
+    const low = Math.min(open, close) * (1 - random() * 0.02);
+    candles.push({
+      time: baseTime + i * MS_PER_DAY,
+      open,
+      high,
+      low,
+      close,
+      volume: 1000,
+    });
+    price = close;
+  }
+  return candles;
+}
+
+describe("createSwingPoints", () => {
+  const candles = generateCandles(200);
+
+  it("emits the same confirmed swing highs / lows as batch", () => {
+    const leftBars = 3;
+    const rightBars = 3;
+    const batch = swingPoints(candles, { leftBars, rightBars });
+    const batchHighs = new Set<number>();
+    const batchLows = new Set<number>();
+    for (const r of batch) {
+      if (r.value.isSwingHigh) batchHighs.add(r.time);
+      if (r.value.isSwingLow) batchLows.add(r.time);
+    }
+    expect(batchHighs.size).toBeGreaterThan(0);
+    expect(batchLows.size).toBeGreaterThan(0);
+
+    const ind = createSwingPoints({ leftBars, rightBars });
+    const liveHighs = new Set<number>();
+    const liveLows = new Set<number>();
+    for (const c of candles) {
+      const r = ind.next(c);
+      if (r.value.isSwingHigh) liveHighs.add(r.time);
+      if (r.value.isSwingLow) liveLows.add(r.time);
+    }
+
+    expect([...liveHighs].sort()).toEqual([...batchHighs].sort());
+    expect([...liveLows].sort()).toEqual([...batchLows].sort());
+  });
+
+  it("tracks trailing swingHighPrice/swingLowPrice", () => {
+    const ind = createSwingPoints({ leftBars: 2, rightBars: 2 });
+    let sawHigh = false;
+    let sawLow = false;
+    for (const c of candles.slice(0, 100)) {
+      const { value } = ind.next(c);
+      if (value.isSwingHigh) sawHigh = true;
+      if (value.isSwingLow) sawLow = true;
+      if (sawHigh) expect(value.swingHighPrice).not.toBeNull();
+      if (sawLow) expect(value.swingLowPrice).not.toBeNull();
+    }
+  });
+
+  it("restores from state without drift", () => {
+    const a = createSwingPoints({ leftBars: 3, rightBars: 3 });
+    for (let i = 0; i < 80; i++) a.next(candles[i]);
+    const b = createSwingPoints({ leftBars: 3, rightBars: 3 }, { fromState: a.getState() });
+    for (let i = 80; i < candles.length; i++) {
+      const va = a.next(candles[i]).value;
+      const vb = b.next(candles[i]).value;
+      expect(vb.isSwingHigh).toBe(va.isSwingHigh);
+      expect(vb.isSwingLow).toBe(va.isSwingLow);
+      expect(vb.swingHighPrice).toBe(va.swingHighPrice);
+      expect(vb.swingLowPrice).toBe(va.swingLowPrice);
+    }
+  });
+
+  it("peek does not mutate state", () => {
+    const ind = createSwingPoints({ leftBars: 3, rightBars: 3 });
+    for (let i = 0; i < 50; i++) ind.next(candles[i]);
+    const before = JSON.stringify(ind.getState());
+    ind.peek(candles[50]);
+    expect(JSON.stringify(ind.getState())).toBe(before);
+  });
+
+  it("returns null value during warm-up", () => {
+    const ind = createSwingPoints({ leftBars: 5, rightBars: 5 });
+    for (let i = 0; i < 10; i++) {
+      const { value } = ind.next(candles[i]);
+      expect(value.isSwingHigh).toBe(false);
+      expect(value.isSwingLow).toBe(false);
+    }
+    expect(ind.isWarmedUp).toBe(false);
+    ind.next(candles[10]);
+    expect(ind.isWarmedUp).toBe(true);
+  });
+
+  it("throws on invalid bars", () => {
+    expect(() => createSwingPoints({ leftBars: 0, rightBars: 3 })).toThrow();
+    expect(() => createSwingPoints({ leftBars: 3, rightBars: 0 })).toThrow();
+  });
+});

--- a/packages/core/src/indicators/incremental/__tests__/zigzag.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/zigzag.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Parity tests for incremental Zigzag vs batch zigzag().
+ *
+ * Both should confirm the same set of pivot points (same bar times, same
+ * direction). Pivot detection in zigzag is deterministic and causal, so the
+ * incremental version should produce byte-identical pivot sets.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../../types";
+import { zigzag } from "../../price/zigzag";
+import { createZigzag } from "../price/zigzag";
+
+function generateCandles(count: number, seed = 7): NormalizedCandle[] {
+  const candles: NormalizedCandle[] = [];
+  const MS = 86400000;
+  const base = new Date("2020-01-01").getTime();
+  let price = 100;
+  let s = seed;
+  const r = () => {
+    s = (s * 16807) % 2147483647;
+    return s / 2147483647;
+  };
+  for (let i = 0; i < count; i++) {
+    const change = (r() - 0.5) * 6;
+    const open = price;
+    const close = price * (1 + change / 100);
+    const high = Math.max(open, close) * (1 + r() * 0.02);
+    const low = Math.min(open, close) * (1 - r() * 0.02);
+    candles.push({ time: base + i * MS, open, high, low, close, volume: 1000 });
+    price = close;
+  }
+  return candles;
+}
+
+type Pivot = { time: number; point: "high" | "low"; price: number };
+
+function pivotsFromSeries(
+  series: Array<{ time: number; value: { point: "high" | "low" | null; price: number | null } }>,
+): Pivot[] {
+  const out: Pivot[] = [];
+  for (const r of series) {
+    if (r.value.point !== null && r.value.price !== null) {
+      out.push({ time: r.time, point: r.value.point, price: r.value.price });
+    }
+  }
+  return out;
+}
+
+/**
+ * Collapse streamed pivots the same way batch does: when multiple pivots
+ * land on the same bar time (a bar that is both the prior trend's extreme
+ * and the new trend's seed), batch overwrites `result[i]` so the last-confirmed
+ * direction wins. Apply that rule here to reconstruct batch-equivalent output.
+ */
+function collapseByTimeLastWins(pivots: Pivot[]): Pivot[] {
+  const byTime = new Map<number, Pivot>();
+  for (const p of pivots) byTime.set(p.time, p);
+  return [...byTime.values()].sort((a, b) => a.time - b.time);
+}
+
+describe("createZigzag", () => {
+  const candles = generateCandles(300);
+
+  it("matches batch pivots for percent-deviation mode (same last-write-wins semantics)", () => {
+    const batch = pivotsFromSeries(zigzag(candles, { deviation: 3 }));
+    const live = createZigzag({ deviation: 3 });
+    const liveOut: Array<{
+      time: number;
+      value: { point: "high" | "low" | null; price: number | null };
+    }> = [];
+    for (const c of candles) liveOut.push(live.next(c));
+    const livePivots = collapseByTimeLastWins(pivotsFromSeries(liveOut));
+
+    expect(livePivots.length).toBeGreaterThan(0);
+    expect(livePivots.length).toBe(batch.length);
+    for (let i = 0; i < batch.length; i++) {
+      expect(livePivots[i].time).toBe(batch[i].time);
+      expect(livePivots[i].point).toBe(batch[i].point);
+      expect(livePivots[i].price).toBeCloseTo(batch[i].price, 10);
+    }
+  });
+
+  it("matches batch pivots for ATR mode", () => {
+    const opts = { useAtr: true, atrPeriod: 14, atrMultiplier: 2 };
+    const batch = pivotsFromSeries(zigzag(candles, opts));
+    const live = createZigzag(opts);
+    const liveOut: Array<{
+      time: number;
+      value: { point: "high" | "low" | null; price: number | null };
+    }> = [];
+    for (const c of candles) liveOut.push(live.next(c));
+    const livePivots = collapseByTimeLastWins(pivotsFromSeries(liveOut));
+
+    expect(livePivots.length).toBe(batch.length);
+    for (let i = 0; i < batch.length; i++) {
+      expect(livePivots[i].time).toBe(batch[i].time);
+      expect(livePivots[i].point).toBe(batch[i].point);
+      expect(livePivots[i].price).toBeCloseTo(batch[i].price, 10);
+    }
+  });
+
+  it("restores from snapshot and continues consistently", () => {
+    const a = createZigzag({ deviation: 3 });
+    for (let i = 0; i < 120; i++) a.next(candles[i]);
+    const b = createZigzag({ deviation: 3 }, { fromState: a.getState() });
+    for (let i = 120; i < 200; i++) {
+      const va = a.next(candles[i]).value;
+      const vb = b.next(candles[i]).value;
+      expect(vb.point).toBe(va.point);
+      if (va.price !== null) {
+        expect(vb.price).toBeCloseTo(va.price, 10);
+      }
+    }
+  });
+
+  it("peek does not mutate state", () => {
+    const z = createZigzag({ deviation: 3 });
+    for (let i = 0; i < 50; i++) z.next(candles[i]);
+    const before = JSON.stringify(z.getState());
+    z.peek(candles[50]);
+    expect(JSON.stringify(z.getState())).toBe(before);
+  });
+
+  it("throws on invalid deviation", () => {
+    expect(() => createZigzag({ deviation: 0 })).toThrow();
+    expect(() => createZigzag({ deviation: -1 })).toThrow();
+  });
+});

--- a/packages/core/src/indicators/incremental/filter/roofing-filter.ts
+++ b/packages/core/src/indicators/incremental/filter/roofing-filter.ts
@@ -1,0 +1,179 @@
+/**
+ * Incremental Ehlers Roofing Filter
+ *
+ * Bandpass filter: 2-pole high-pass (removes low-frequency trend) followed
+ * by a Super Smoother (removes high-frequency noise). Mirrors the batch
+ * `roofingFilter()` exactly — first 2 bars emit null, subsequent bars
+ * apply the cascaded recurrences.
+ */
+
+import type { NormalizedCandle, PriceSource } from "../../../types";
+import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { getSourcePrice } from "../utils";
+
+export type RoofingFilterState = {
+  highPassPeriod: number;
+  lowPassPeriod: number;
+  source: PriceSource;
+  /** price[i-1] */
+  prevPrice: number | null;
+  /** price[i-2] */
+  prevPrice2: number | null;
+  /** hp[i-1] */
+  hpPrev1: number;
+  /** hp[i-2] */
+  hpPrev2: number;
+  /** filt[i-1] */
+  filtPrev1: number;
+  /** filt[i-2] */
+  filtPrev2: number;
+  count: number;
+};
+
+function highPassCoeffs(period: number) {
+  const a1 = Math.exp((-Math.SQRT2 * Math.PI) / period);
+  const b1 = 2 * a1 * Math.cos((Math.SQRT2 * Math.PI) / period);
+  const c2 = b1;
+  const c3 = -(a1 * a1);
+  // 2-pole Butterworth high-pass
+  const c1 = (1 + c2 - c3) / 4;
+  return { c1, c2, c3 };
+}
+
+function superSmootherCoeffs(period: number) {
+  const a1 = Math.exp((-Math.SQRT2 * Math.PI) / period);
+  const b1 = 2 * a1 * Math.cos((Math.SQRT2 * Math.PI) / period);
+  const c2 = b1;
+  const c3 = -(a1 * a1);
+  const c1 = 1 - c2 - c3;
+  return { c1, c2, c3 };
+}
+
+/**
+ * Create an incremental Ehlers Roofing Filter.
+ *
+ * @example
+ * ```ts
+ * const rf = createRoofingFilter({ highPassPeriod: 48, lowPassPeriod: 10 });
+ * for (const candle of stream) {
+ *   const { value } = rf.next(candle);
+ *   if (value !== null) console.log(value);
+ * }
+ * ```
+ */
+export function createRoofingFilter(
+  options: { highPassPeriod?: number; lowPassPeriod?: number; source?: PriceSource } = {},
+  warmUpOptions?: WarmUpOptions<RoofingFilterState>,
+): IncrementalIndicator<number | null, RoofingFilterState> {
+  const highPassPeriod = options.highPassPeriod ?? 48;
+  const lowPassPeriod = options.lowPassPeriod ?? 10;
+  const source: PriceSource = options.source ?? "close";
+
+  if (highPassPeriod < 1) throw new Error("Roofing filter highPassPeriod must be at least 1");
+  if (lowPassPeriod < 1) throw new Error("Roofing filter lowPassPeriod must be at least 1");
+
+  const hp = highPassCoeffs(highPassPeriod);
+  const ss = superSmootherCoeffs(lowPassPeriod);
+
+  let prevPrice: number | null;
+  let prevPrice2: number | null;
+  let hpPrev1: number;
+  let hpPrev2: number;
+  let filtPrev1: number;
+  let filtPrev2: number;
+  let count: number;
+
+  if (warmUpOptions?.fromState) {
+    const s = warmUpOptions.fromState;
+    prevPrice = s.prevPrice;
+    prevPrice2 = s.prevPrice2;
+    hpPrev1 = s.hpPrev1;
+    hpPrev2 = s.hpPrev2;
+    filtPrev1 = s.filtPrev1;
+    filtPrev2 = s.filtPrev2;
+    count = s.count;
+  } else {
+    prevPrice = null;
+    prevPrice2 = null;
+    hpPrev1 = 0;
+    hpPrev2 = 0;
+    filtPrev1 = 0;
+    filtPrev2 = 0;
+    count = 0;
+  }
+
+  function step(price: number): { hpVal: number; filtVal: number } {
+    // batch index: i, with prevPrice = price[i-1], prevPrice2 = price[i-2]
+    const p1 = prevPrice as number;
+    const p2 = prevPrice2 as number;
+    const hpVal = hp.c1 * (price - 2 * p1 + p2) + hp.c2 * hpPrev1 + hp.c3 * hpPrev2;
+    // batch: filt[i] = c1SS * (hp[i] + hp[i-1]) / 2 + c2SS * filt[i-1] + c3SS * filt[i-2]
+    const filtVal = (ss.c1 * (hpVal + hpPrev1)) / 2 + ss.c2 * filtPrev1 + ss.c3 * filtPrev2;
+    return { hpVal, filtVal };
+  }
+
+  const indicator: IncrementalIndicator<number | null, RoofingFilterState> = {
+    next(candle: NormalizedCandle) {
+      const price = getSourcePrice(candle, source);
+
+      if (count < 2) {
+        // batch seeds hp[0..1] = 0 and filt[0..1] = 0; emit null
+        // Maintain price history through prevPrice/prevPrice2 so step() at i=2 is correct.
+        prevPrice2 = prevPrice;
+        prevPrice = price;
+        count++;
+        return { time: candle.time, value: null };
+      }
+
+      const { hpVal, filtVal } = step(price);
+      // Shift filter memories
+      hpPrev2 = hpPrev1;
+      hpPrev1 = hpVal;
+      filtPrev2 = filtPrev1;
+      filtPrev1 = filtVal;
+      prevPrice2 = prevPrice;
+      prevPrice = price;
+      count++;
+      return { time: candle.time, value: filtVal };
+    },
+
+    peek(candle: NormalizedCandle) {
+      const price = getSourcePrice(candle, source);
+      if (count < 2) return { time: candle.time, value: null };
+      const { filtVal } = step(price);
+      return { time: candle.time, value: filtVal };
+    },
+
+    getState(): RoofingFilterState {
+      return {
+        highPassPeriod,
+        lowPassPeriod,
+        source,
+        prevPrice,
+        prevPrice2,
+        hpPrev1,
+        hpPrev2,
+        filtPrev1,
+        filtPrev2,
+        count,
+      };
+    },
+
+    get count() {
+      return count;
+    },
+
+    get isWarmedUp() {
+      // First two bars emit null; the first real output appears on bar 3.
+      return count >= 3;
+    },
+  };
+
+  if (warmUpOptions?.warmUp) {
+    for (const candle of warmUpOptions.warmUp) {
+      indicator.next(candle);
+    }
+  }
+
+  return indicator;
+}

--- a/packages/core/src/indicators/incremental/filter/roofing-filter.ts
+++ b/packages/core/src/indicators/incremental/filter/roofing-filter.ts
@@ -65,9 +65,11 @@ export function createRoofingFilter(
   options: { highPassPeriod?: number; lowPassPeriod?: number; source?: PriceSource } = {},
   warmUpOptions?: WarmUpOptions<RoofingFilterState>,
 ): IncrementalIndicator<number | null, RoofingFilterState> {
-  const highPassPeriod = options.highPassPeriod ?? 48;
-  const lowPassPeriod = options.lowPassPeriod ?? 10;
-  const source: PriceSource = options.source ?? "close";
+  // Saved snapshot wins so the cascaded HP / SS memories keep being applied
+  // with the coefficients they were computed under.
+  const highPassPeriod = warmUpOptions?.fromState?.highPassPeriod ?? options.highPassPeriod ?? 48;
+  const lowPassPeriod = warmUpOptions?.fromState?.lowPassPeriod ?? options.lowPassPeriod ?? 10;
+  const source: PriceSource = warmUpOptions?.fromState?.source ?? options.source ?? "close";
 
   if (highPassPeriod < 1) throw new Error("Roofing filter highPassPeriod must be at least 1");
   if (lowPassPeriod < 1) throw new Error("Roofing filter lowPassPeriod must be at least 1");

--- a/packages/core/src/indicators/incremental/filter/super-smoother.ts
+++ b/packages/core/src/indicators/incremental/filter/super-smoother.ts
@@ -51,8 +51,10 @@ export function createSuperSmoother(
   options: { period?: number; source?: PriceSource } = {},
   warmUpOptions?: WarmUpOptions<SuperSmootherState>,
 ): IncrementalIndicator<number | null, SuperSmootherState> {
-  const period = options.period ?? 10;
-  const source: PriceSource = options.source ?? "close";
+  // Saved snapshot wins so the IIR memories (outPrev1/outPrev2) keep being
+  // applied with the coefficients they were computed under.
+  const period = warmUpOptions?.fromState?.period ?? options.period ?? 10;
+  const source: PriceSource = warmUpOptions?.fromState?.source ?? options.source ?? "close";
 
   if (period < 1) {
     throw new Error("Super Smoother period must be at least 1");

--- a/packages/core/src/indicators/incremental/filter/super-smoother.ts
+++ b/packages/core/src/indicators/incremental/filter/super-smoother.ts
@@ -1,0 +1,139 @@
+/**
+ * Incremental Ehlers Super Smoother (2-pole IIR filter)
+ *
+ * Mirrors batch `superSmoother()` exactly: emits `null` for the first two
+ * bars (seeds the IIR memory with raw prices), then applies
+ *
+ *   out[i] = c1 * (price[i] + price[i-1]) / 2 + c2 * out[i-1] + c3 * out[i-2]
+ *
+ * with coefficients derived from the cutoff `period`. State carries the
+ * last input + last two outputs.
+ */
+
+import type { NormalizedCandle, PriceSource } from "../../../types";
+import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { getSourcePrice } from "../utils";
+
+export type SuperSmootherState = {
+  period: number;
+  source: PriceSource;
+  prevPrice: number | null;
+  /** Memory `out[i-2]` after the last `next()` call. */
+  outPrev2: number;
+  /** Memory `out[i-1]` after the last `next()` call. */
+  outPrev1: number;
+  count: number;
+};
+
+function coefficients(period: number) {
+  const piOverPeriod = Math.PI / period;
+  const a1 = Math.exp(-Math.SQRT2 * piOverPeriod);
+  const b1 = 2 * a1 * Math.cos(Math.SQRT2 * piOverPeriod);
+  const c2 = b1;
+  const c3 = -(a1 * a1);
+  const c1 = 1 - c2 - c3;
+  return { c1, c2, c3 };
+}
+
+/**
+ * Create an incremental Ehlers Super Smoother filter.
+ *
+ * @example
+ * ```ts
+ * const ss = createSuperSmoother({ period: 10 });
+ * for (const candle of stream) {
+ *   const { value } = ss.next(candle);
+ *   if (value !== null) console.log(value);
+ * }
+ * ```
+ */
+export function createSuperSmoother(
+  options: { period?: number; source?: PriceSource } = {},
+  warmUpOptions?: WarmUpOptions<SuperSmootherState>,
+): IncrementalIndicator<number | null, SuperSmootherState> {
+  const period = options.period ?? 10;
+  const source: PriceSource = options.source ?? "close";
+
+  if (period < 1) {
+    throw new Error("Super Smoother period must be at least 1");
+  }
+
+  const { c1, c2, c3 } = coefficients(period);
+
+  let prevPrice: number | null;
+  let outPrev2: number;
+  let outPrev1: number;
+  let count: number;
+
+  if (warmUpOptions?.fromState) {
+    const s = warmUpOptions.fromState;
+    prevPrice = s.prevPrice;
+    outPrev2 = s.outPrev2;
+    outPrev1 = s.outPrev1;
+    count = s.count;
+  } else {
+    prevPrice = null;
+    outPrev2 = 0;
+    outPrev1 = 0;
+    count = 0;
+  }
+
+  const indicator: IncrementalIndicator<number | null, SuperSmootherState> = {
+    next(candle: NormalizedCandle) {
+      const price = getSourcePrice(candle, source);
+
+      if (count === 0) {
+        // First bar: seed memory with raw price, emit null
+        outPrev2 = price;
+        outPrev1 = price;
+        prevPrice = price;
+        count++;
+        return { time: candle.time, value: null };
+      }
+      if (count === 1) {
+        // Second bar: shift memory, still emit null
+        outPrev2 = outPrev1;
+        outPrev1 = price;
+        prevPrice = price;
+        count++;
+        return { time: candle.time, value: null };
+      }
+
+      // Steady state
+      const out = (c1 * (price + (prevPrice as number))) / 2 + c2 * outPrev1 + c3 * outPrev2;
+      outPrev2 = outPrev1;
+      outPrev1 = out;
+      prevPrice = price;
+      count++;
+      return { time: candle.time, value: out };
+    },
+
+    peek(candle: NormalizedCandle) {
+      const price = getSourcePrice(candle, source);
+      if (count < 2) return { time: candle.time, value: null };
+      const out = (c1 * (price + (prevPrice as number))) / 2 + c2 * outPrev1 + c3 * outPrev2;
+      return { time: candle.time, value: out };
+    },
+
+    getState(): SuperSmootherState {
+      return { period, source, prevPrice, outPrev2, outPrev1, count };
+    },
+
+    get count() {
+      return count;
+    },
+
+    get isWarmedUp() {
+      // First two bars emit null; the first real output appears on bar 3.
+      return count >= 3;
+    },
+  };
+
+  if (warmUpOptions?.warmUp) {
+    for (const candle of warmUpOptions.warmUp) {
+      indicator.next(candle);
+    }
+  }
+
+  return indicator;
+}

--- a/packages/core/src/indicators/incremental/index.ts
+++ b/packages/core/src/indicators/incremental/index.ts
@@ -144,6 +144,11 @@ export { createParabolicSar } from "./trend/parabolic-sar";
 export type { ParabolicSarState, ParabolicSarValue } from "./trend/parabolic-sar";
 export { createIchimoku } from "./trend/ichimoku";
 export type { IchimokuState, IchimokuValue as IncrementalIchimokuValue } from "./trend/ichimoku";
+export { createLinearRegression } from "./trend/linear-regression";
+export type {
+  LinearRegressionState,
+  LinearRegressionValue as IncrementalLinearRegressionValue,
+} from "./trend/linear-regression";
 
 // Volume
 export { createObv } from "./volume/obv";

--- a/packages/core/src/indicators/incremental/index.ts
+++ b/packages/core/src/indicators/incremental/index.ts
@@ -196,6 +196,13 @@ export type {
 } from "./price/opening-range";
 export { createFairValueGap } from "./price/fair-value-gap";
 export type { FairValueGapState, FvgValue as IncrementalFvgValue } from "./price/fair-value-gap";
+export { createHeikinAshi } from "./price/heikin-ashi";
+export type {
+  HeikinAshiState,
+  HeikinAshiValue as IncrementalHeikinAshiValue,
+} from "./price/heikin-ashi";
+export { createReturns } from "./price/returns";
+export type { ReturnsState } from "./price/returns";
 
 // Wyckoff
 export { createVsa } from "./wyckoff/vsa";

--- a/packages/core/src/indicators/incremental/index.ts
+++ b/packages/core/src/indicators/incremental/index.ts
@@ -203,6 +203,25 @@ export type {
 } from "./price/heikin-ashi";
 export { createReturns } from "./price/returns";
 export type { ReturnsState } from "./price/returns";
+export { createSwingPoints } from "./price/swing-points";
+export type {
+  SwingPointsState,
+  SwingPointValue as IncrementalSwingPointValue,
+} from "./price/swing-points";
+export { createZigzag } from "./price/zigzag";
+export type {
+  ZigzagState,
+  ZigzagValue as IncrementalZigzagValue,
+} from "./price/zigzag";
+export {
+  createBreakOfStructure,
+  createChangeOfCharacter,
+} from "./price/break-of-structure";
+export type {
+  BosState,
+  ChochState,
+  BosValue as IncrementalBosValue,
+} from "./price/break-of-structure";
 
 // Wyckoff
 export { createVsa } from "./wyckoff/vsa";

--- a/packages/core/src/indicators/incremental/index.ts
+++ b/packages/core/src/indicators/incremental/index.ts
@@ -128,6 +128,14 @@ export { createAtrStops } from "./volatility/atr-stops";
 export type { AtrStopsState } from "./volatility/atr-stops";
 export { createUlcerIndex } from "./volatility/ulcer-index";
 export type { UlcerIndexState } from "./volatility/ulcer-index";
+export { createStandardDeviation } from "./volatility/standard-deviation";
+export type { StandardDeviationState } from "./volatility/standard-deviation";
+
+// Filter (Ehlers)
+export { createSuperSmoother } from "./filter/super-smoother";
+export type { SuperSmootherState } from "./filter/super-smoother";
+export { createRoofingFilter } from "./filter/roofing-filter";
+export type { RoofingFilterState } from "./filter/roofing-filter";
 
 // Trend
 export { createSupertrend } from "./trend/supertrend";

--- a/packages/core/src/indicators/incremental/momentum/connors-rsi.ts
+++ b/packages/core/src/indicators/incremental/momentum/connors-rsi.ts
@@ -4,10 +4,10 @@
  * CRSI = (RSI(close, rsiPeriod) + RSI(streak, streakPeriod) + PercentRank(ROC(1), rocPeriod)) / 3
  */
 
-import type { NormalizedCandle } from "../../../types";
+import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
-import { makeCandle } from "../utils";
+import { getSourcePrice, makeCandle } from "../utils";
 import { createRsi } from "./rsi";
 import type { RsiState } from "./rsi";
 
@@ -43,12 +43,18 @@ export type ConnorsRsiState = {
  * ```
  */
 export function createConnorsRsi(
-  options: { rsiPeriod?: number; streakPeriod?: number; rocPeriod?: number } = {},
+  options: {
+    rsiPeriod?: number;
+    streakPeriod?: number;
+    rocPeriod?: number;
+    source?: PriceSource;
+  } = {},
   warmUpOptions?: WarmUpOptions<ConnorsRsiState>,
 ): IncrementalIndicator<ConnorsRsiValue, ConnorsRsiState> {
   const rsiPeriod = options.rsiPeriod ?? 3;
   const streakPeriod = options.streakPeriod ?? 2;
   const rocPeriod = options.rocPeriod ?? 100;
+  const source: PriceSource = options.source ?? "close";
 
   let priceRsi: ReturnType<typeof createRsi>;
   let streakRsi: ReturnType<typeof createRsi>;
@@ -59,14 +65,14 @@ export function createConnorsRsi(
 
   if (warmUpOptions?.fromState) {
     const s = warmUpOptions.fromState;
-    priceRsi = createRsi({ period: rsiPeriod }, { fromState: s.priceRsiState });
+    priceRsi = createRsi({ period: rsiPeriod, source }, { fromState: s.priceRsiState });
     streakRsi = createRsi({ period: streakPeriod }, { fromState: s.streakRsiState });
     rocBuffer = CircularBuffer.fromSnapshot(s.rocBuffer);
     prevClose = s.prevClose;
     streak = s.streak;
     count = s.count;
   } else {
-    priceRsi = createRsi({ period: rsiPeriod });
+    priceRsi = createRsi({ period: rsiPeriod, source });
     streakRsi = createRsi({ period: streakPeriod });
     rocBuffer = new CircularBuffer<number>(rocPeriod);
     prevClose = null;
@@ -77,6 +83,7 @@ export function createConnorsRsi(
   const indicator: IncrementalIndicator<ConnorsRsiValue, ConnorsRsiState> = {
     next(candle: NormalizedCandle) {
       count++;
+      const price = getSourcePrice(candle, source);
 
       // Component 1: RSI of price
       const priceRsiResult = priceRsi.next(candle);
@@ -84,9 +91,9 @@ export function createConnorsRsi(
 
       // Component 2: Streak + RSI of streak
       if (prevClose !== null) {
-        if (candle.close > prevClose) {
+        if (price > prevClose) {
           streak = streak > 0 ? streak + 1 : 1;
-        } else if (candle.close < prevClose) {
+        } else if (price < prevClose) {
           streak = streak < 0 ? streak - 1 : -1;
         } else {
           streak = 0;
@@ -99,7 +106,7 @@ export function createConnorsRsi(
       // Component 3: Percent rank of 1-period ROC
       let rocPercentile: number | null = null;
       if (prevClose !== null && prevClose !== 0) {
-        const roc1 = ((candle.close - prevClose) / prevClose) * 100;
+        const roc1 = ((price - prevClose) / prevClose) * 100;
 
         // Calculate percent rank from buffer
         if (rocBuffer.length > 0) {
@@ -115,7 +122,7 @@ export function createConnorsRsi(
         rocBuffer.push(roc1);
       }
 
-      prevClose = candle.close;
+      prevClose = price;
 
       // Combine
       let crsi: number | null = null;
@@ -130,14 +137,15 @@ export function createConnorsRsi(
     },
 
     peek(candle: NormalizedCandle) {
+      const price = getSourcePrice(candle, source);
       const rsiVal = priceRsi.peek(candle).value;
 
       // Peek streak
       let peekStreak = streak;
       if (prevClose !== null) {
-        if (candle.close > prevClose) {
+        if (price > prevClose) {
           peekStreak = streak > 0 ? streak + 1 : 1;
-        } else if (candle.close < prevClose) {
+        } else if (price < prevClose) {
           peekStreak = streak < 0 ? streak - 1 : -1;
         } else {
           peekStreak = 0;
@@ -147,7 +155,7 @@ export function createConnorsRsi(
 
       let rocPercentile: number | null = null;
       if (prevClose !== null && prevClose !== 0) {
-        const roc1 = ((candle.close - prevClose) / prevClose) * 100;
+        const roc1 = ((price - prevClose) / prevClose) * 100;
         if (rocBuffer.length > 0) {
           let lessOrEqual = 0;
           for (let i = 0; i < rocBuffer.length; i++) {

--- a/packages/core/src/indicators/incremental/momentum/stoch-rsi.ts
+++ b/packages/core/src/indicators/incremental/momentum/stoch-rsi.ts
@@ -10,9 +10,10 @@
  * 4. Smooth %K with SMA for %D
  */
 
-import type { NormalizedCandle } from "../../../types";
+import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { getSourcePrice } from "../utils";
 
 /**
  * StochRSI output value
@@ -70,6 +71,7 @@ export function createStochRsi(
     stochPeriod?: number;
     kPeriod?: number;
     dPeriod?: number;
+    source?: PriceSource;
   } = {},
   warmUpOptions?: WarmUpOptions<StochRsiState>,
 ): IncrementalIndicator<StochRsiValue, StochRsiState> {
@@ -77,6 +79,7 @@ export function createStochRsi(
   const stochPeriod = options.stochPeriod ?? 14;
   const kPeriod = options.kPeriod ?? 3;
   const dPeriod = options.dPeriod ?? 3;
+  const source: PriceSource = options.source ?? "close";
 
   let count: number;
   let prevClose: number | null;
@@ -235,7 +238,7 @@ export function createStochRsi(
   const indicator: IncrementalIndicator<StochRsiValue, StochRsiState> = {
     next(candle: NormalizedCandle) {
       count++;
-      const rsiVal = computeRsi(candle.close);
+      const rsiVal = computeRsi(getSourcePrice(candle, source));
       const value = processRsi(rsiVal);
       return { time: candle.time, value };
     },

--- a/packages/core/src/indicators/incremental/price/break-of-structure.ts
+++ b/packages/core/src/indicators/incremental/price/break-of-structure.ts
@@ -1,0 +1,266 @@
+/**
+ * Incremental Break of Structure (BOS) and Change of Character (CHoCH).
+ *
+ * Swing detection is identical to `createSwingPoints` (a 2*swingPeriod+1
+ * window, strict inequality) but we only track the last confirmed swing
+ * high / low (plus trend state) — no per-bar swing-point series is exposed.
+ * BOS fires on the current candle's time when its close crosses the last
+ * confirmed swing level; matches batch `breakOfStructure()` bar-by-bar.
+ *
+ * CHoCH derives from BOS: it marks only the first BOS that flips the prior
+ * trend direction.
+ */
+
+import type { NormalizedCandle } from "../../../types";
+import { CircularBuffer } from "../circular-buffer";
+import type { IncrementalIndicator, WarmUpOptions } from "../types";
+
+export type BosValue = {
+  bullishBos: boolean;
+  bearishBos: boolean;
+  brokenLevel: number | null;
+  trend: "bullish" | "bearish" | "neutral";
+  swingHighLevel: number | null;
+  swingLowLevel: number | null;
+};
+
+type WindowEntry = { high: number; low: number };
+
+export type BosState = {
+  swingPeriod: number;
+  buffer: ReturnType<CircularBuffer<WindowEntry>["snapshot"]>;
+  lastSwingHigh: number | null;
+  lastSwingLow: number | null;
+  trend: "bullish" | "bearish" | "neutral";
+  count: number;
+};
+
+/**
+ * Create an incremental Break of Structure indicator.
+ *
+ * @example
+ * ```ts
+ * const bos = createBreakOfStructure({ swingPeriod: 5 });
+ * for (const candle of stream) {
+ *   const { value } = bos.next(candle);
+ *   if (value.bullishBos) console.log("bullish BOS at", value.brokenLevel);
+ * }
+ * ```
+ */
+export function createBreakOfStructure(
+  options: { swingPeriod?: number } = {},
+  warmUpOptions?: WarmUpOptions<BosState>,
+): IncrementalIndicator<BosValue, BosState> {
+  const swingPeriod = options.swingPeriod ?? 5;
+  if (swingPeriod < 1) throw new Error("swingPeriod must be at least 1");
+
+  const windowSize = 2 * swingPeriod + 1;
+
+  let buffer: CircularBuffer<WindowEntry>;
+  let lastSwingHigh: number | null;
+  let lastSwingLow: number | null;
+  let trend: "bullish" | "bearish" | "neutral";
+  let count: number;
+
+  if (warmUpOptions?.fromState) {
+    const s = warmUpOptions.fromState;
+    buffer = CircularBuffer.fromSnapshot(s.buffer);
+    lastSwingHigh = s.lastSwingHigh;
+    lastSwingLow = s.lastSwingLow;
+    trend = s.trend;
+    count = s.count;
+  } else {
+    buffer = new CircularBuffer<WindowEntry>(windowSize);
+    lastSwingHigh = null;
+    lastSwingLow = null;
+    trend = "neutral";
+    count = 0;
+  }
+
+  function evaluateMid(): { isHigh: boolean; isLow: boolean; mid: WindowEntry } | null {
+    if (buffer.length < windowSize) return null;
+    const mid = buffer.get(swingPeriod);
+    let isHigh = true;
+    let isLow = true;
+    for (let i = 0; i < windowSize; i++) {
+      if (i === swingPeriod) continue;
+      const e = buffer.get(i);
+      if (e.high >= mid.high) isHigh = false;
+      if (e.low <= mid.low) isLow = false;
+      if (!isHigh && !isLow) break;
+    }
+    return { isHigh, isLow, mid };
+  }
+
+  const indicator: IncrementalIndicator<BosValue, BosState> = {
+    next(candle: NormalizedCandle) {
+      buffer.push({ high: candle.high, low: candle.low });
+      count++;
+
+      // Confirm the middle bar as a swing point if applicable.
+      const mid = evaluateMid();
+      if (mid) {
+        if (mid.isHigh) {
+          lastSwingHigh = mid.mid.high;
+        }
+        if (mid.isLow) {
+          lastSwingLow = mid.mid.low;
+        }
+      }
+
+      // BOS check against the current bar's close.
+      let bullishBos = false;
+      let bearishBos = false;
+      let brokenLevel: number | null = null;
+
+      if (lastSwingHigh !== null && candle.close > lastSwingHigh) {
+        bullishBos = true;
+        brokenLevel = lastSwingHigh;
+        trend = "bullish";
+        lastSwingHigh = null;
+      }
+      if (lastSwingLow !== null && candle.close < lastSwingLow) {
+        bearishBos = true;
+        brokenLevel = lastSwingLow;
+        trend = "bearish";
+        lastSwingLow = null;
+      }
+
+      return {
+        time: candle.time,
+        value: {
+          bullishBos,
+          bearishBos,
+          brokenLevel,
+          trend,
+          swingHighLevel: lastSwingHigh,
+          swingLowLevel: lastSwingLow,
+        },
+      };
+    },
+
+    peek(candle: NormalizedCandle) {
+      const saved = indicator.getState();
+      const result = indicator.next(candle);
+      buffer = CircularBuffer.fromSnapshot(saved.buffer);
+      lastSwingHigh = saved.lastSwingHigh;
+      lastSwingLow = saved.lastSwingLow;
+      trend = saved.trend;
+      count = saved.count;
+      return result;
+    },
+
+    getState(): BosState {
+      return {
+        swingPeriod,
+        buffer: buffer.snapshot(),
+        lastSwingHigh,
+        lastSwingLow,
+        trend,
+        count,
+      };
+    },
+
+    get count() {
+      return count;
+    },
+
+    get isWarmedUp() {
+      return count >= windowSize;
+    },
+  };
+
+  if (warmUpOptions?.warmUp) {
+    for (const candle of warmUpOptions.warmUp) {
+      indicator.next(candle);
+    }
+  }
+
+  return indicator;
+}
+
+export type ChochState = {
+  bosState: BosState;
+  prevTrend: "bullish" | "bearish" | "neutral";
+};
+
+/**
+ * Create an incremental Change of Character indicator.
+ *
+ * CHoCH is a BOS in the opposite direction of the previous (post-BOS) trend.
+ *
+ * @example
+ * ```ts
+ * const choch = createChangeOfCharacter({ swingPeriod: 5 });
+ * for (const candle of stream) {
+ *   const { value } = choch.next(candle);
+ *   if (value.bullishBos) console.log("bullish CHoCH — trend reversal");
+ * }
+ * ```
+ */
+export function createChangeOfCharacter(
+  options: { swingPeriod?: number } = {},
+  warmUpOptions?: WarmUpOptions<ChochState>,
+): IncrementalIndicator<BosValue, ChochState> {
+  const bos = createBreakOfStructure(
+    options,
+    warmUpOptions?.fromState ? { fromState: warmUpOptions.fromState.bosState } : undefined,
+  );
+  let prevTrend: "bullish" | "bearish" | "neutral" = warmUpOptions?.fromState
+    ? warmUpOptions.fromState.prevTrend
+    : "neutral";
+
+  const indicator: IncrementalIndicator<BosValue, ChochState> = {
+    next(candle: NormalizedCandle) {
+      const { time, value } = bos.next(candle);
+      const isBullishChoch = value.bullishBos && prevTrend === "bearish";
+      const isBearishChoch = value.bearishBos && prevTrend === "bullish";
+      if (value.bullishBos || value.bearishBos) {
+        prevTrend = value.trend;
+      }
+      return {
+        time,
+        value: {
+          ...value,
+          bullishBos: isBullishChoch,
+          bearishBos: isBearishChoch,
+        },
+      };
+    },
+
+    peek(candle: NormalizedCandle) {
+      const savedPrev = prevTrend;
+      const { time, value } = bos.peek(candle);
+      const isBullishChoch = value.bullishBos && savedPrev === "bearish";
+      const isBearishChoch = value.bearishBos && savedPrev === "bullish";
+      return {
+        time,
+        value: {
+          ...value,
+          bullishBos: isBullishChoch,
+          bearishBos: isBearishChoch,
+        },
+      };
+    },
+
+    getState(): ChochState {
+      return { bosState: bos.getState(), prevTrend };
+    },
+
+    get count() {
+      return bos.count;
+    },
+
+    get isWarmedUp() {
+      return bos.isWarmedUp;
+    },
+  };
+
+  if (warmUpOptions?.warmUp) {
+    for (const candle of warmUpOptions.warmUp) {
+      indicator.next(candle);
+    }
+  }
+
+  return indicator;
+}

--- a/packages/core/src/indicators/incremental/price/heikin-ashi.ts
+++ b/packages/core/src/indicators/incremental/price/heikin-ashi.ts
@@ -1,0 +1,112 @@
+/**
+ * Incremental Heikin-Ashi
+ *
+ * Smoothed candles that depend on the previous HA open/close.
+ */
+
+import type { NormalizedCandle } from "../../../types";
+import type { IncrementalIndicator, WarmUpOptions } from "../types";
+
+const EPSILON = 1e-10;
+
+export type HeikinAshiValue = {
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  trend: 1 | -1 | 0;
+};
+
+export type HeikinAshiState = {
+  prevHaOpen: number | null;
+  prevHaClose: number | null;
+  count: number;
+};
+
+/**
+ * Create an incremental Heikin-Ashi indicator.
+ *
+ * @example
+ * ```ts
+ * const ha = createHeikinAshi();
+ * for (const candle of stream) {
+ *   const { value } = ha.next(candle);
+ *   if (value.trend === 1) console.log("bullish");
+ * }
+ * ```
+ */
+export function createHeikinAshi(
+  _options: Record<string, never> = {},
+  warmUpOptions?: WarmUpOptions<HeikinAshiState>,
+): IncrementalIndicator<HeikinAshiValue, HeikinAshiState> {
+  let prevHaOpen: number | null;
+  let prevHaClose: number | null;
+  let count: number;
+
+  if (warmUpOptions?.fromState) {
+    prevHaOpen = warmUpOptions.fromState.prevHaOpen;
+    prevHaClose = warmUpOptions.fromState.prevHaClose;
+    count = warmUpOptions.fromState.count;
+  } else {
+    prevHaOpen = null;
+    prevHaClose = null;
+    count = 0;
+  }
+
+  function compute(
+    candle: NormalizedCandle,
+    prevOpen: number | null,
+    prevClose: number | null,
+  ): HeikinAshiValue {
+    const haClose = (candle.open + candle.high + candle.low + candle.close) / 4;
+    const haOpen =
+      prevOpen === null || prevClose === null
+        ? (candle.open + candle.close) / 2
+        : (prevOpen + prevClose) / 2;
+    const haHigh = Math.max(candle.high, haOpen, haClose);
+    const haLow = Math.min(candle.low, haOpen, haClose);
+
+    let trend: 1 | -1 | 0 = 0;
+    if (haClose > haOpen + EPSILON && Math.abs(haLow - haOpen) < EPSILON) {
+      trend = 1;
+    } else if (haClose < haOpen - EPSILON && Math.abs(haHigh - haOpen) < EPSILON) {
+      trend = -1;
+    }
+
+    return { open: haOpen, high: haHigh, low: haLow, close: haClose, trend };
+  }
+
+  const indicator: IncrementalIndicator<HeikinAshiValue, HeikinAshiState> = {
+    next(candle: NormalizedCandle) {
+      const value = compute(candle, prevHaOpen, prevHaClose);
+      prevHaOpen = value.open;
+      prevHaClose = value.close;
+      count++;
+      return { time: candle.time, value };
+    },
+
+    peek(candle: NormalizedCandle) {
+      return { time: candle.time, value: compute(candle, prevHaOpen, prevHaClose) };
+    },
+
+    getState(): HeikinAshiState {
+      return { prevHaOpen, prevHaClose, count };
+    },
+
+    get count() {
+      return count;
+    },
+
+    get isWarmedUp() {
+      return count > 0;
+    },
+  };
+
+  if (warmUpOptions?.warmUp) {
+    for (const candle of warmUpOptions.warmUp) {
+      indicator.next(candle);
+    }
+  }
+
+  return indicator;
+}

--- a/packages/core/src/indicators/incremental/price/returns.ts
+++ b/packages/core/src/indicators/incremental/price/returns.ts
@@ -1,0 +1,101 @@
+/**
+ * Incremental Returns
+ *
+ * n-period simple or log returns of close prices.
+ * Holds the last `period` close values in a CircularBuffer.
+ */
+
+import type { NormalizedCandle } from "../../../types";
+import { CircularBuffer } from "../circular-buffer";
+import type { IncrementalIndicator, WarmUpOptions } from "../types";
+
+export type ReturnsState = {
+  period: number;
+  type: "simple" | "log";
+  buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
+  count: number;
+};
+
+/**
+ * Create an incremental Returns indicator.
+ *
+ * `period` >= 1 controls the lookback distance used to compute the return; the
+ * output is `null` until at least `period + 1` candles have been seen.
+ *
+ * @example
+ * ```ts
+ * const r = createReturns({ period: 1, type: "log" });
+ * for (const candle of stream) {
+ *   const { value } = r.next(candle);
+ *   if (value !== null) console.log(value);
+ * }
+ * ```
+ */
+export function createReturns(
+  options: { period?: number; type?: "simple" | "log" } = {},
+  warmUpOptions?: WarmUpOptions<ReturnsState>,
+): IncrementalIndicator<number | null, ReturnsState> {
+  const period = options.period ?? 1;
+  const type: "simple" | "log" = options.type ?? "simple";
+
+  if (period < 1) {
+    throw new Error("Returns period must be at least 1");
+  }
+
+  // Buffer holds the last `period` closes (i.e. closes at index t-period..t-1);
+  // when a new close arrives, the oldest slot is the reference price.
+  let buffer: CircularBuffer<number>;
+  let count: number;
+
+  if (warmUpOptions?.fromState) {
+    buffer = CircularBuffer.fromSnapshot(warmUpOptions.fromState.buffer);
+    count = warmUpOptions.fromState.count;
+  } else {
+    buffer = new CircularBuffer<number>(period);
+    count = 0;
+  }
+
+  function calc(current: number, prev: number): number | null {
+    if (prev === 0) return null;
+    return type === "log" ? Math.log(current / prev) : (current - prev) / prev;
+  }
+
+  const indicator: IncrementalIndicator<number | null, ReturnsState> = {
+    next(candle: NormalizedCandle) {
+      const current = candle.close;
+      let value: number | null = null;
+      if (buffer.isFull) {
+        const prev = buffer.oldest();
+        value = calc(current, prev);
+      }
+      buffer.push(current);
+      count++;
+      return { time: candle.time, value };
+    },
+
+    peek(candle: NormalizedCandle) {
+      if (!buffer.isFull) return { time: candle.time, value: null };
+      return { time: candle.time, value: calc(candle.close, buffer.oldest()) };
+    },
+
+    getState(): ReturnsState {
+      return { period, type, buffer: buffer.snapshot(), count };
+    },
+
+    get count() {
+      return count;
+    },
+
+    get isWarmedUp() {
+      return buffer.isFull;
+    },
+  };
+
+  if (warmUpOptions?.warmUp) {
+    for (const candle of warmUpOptions.warmUp) {
+      indicator.next(candle);
+    }
+  }
+
+  return indicator;
+}

--- a/packages/core/src/indicators/incremental/price/swing-points.ts
+++ b/packages/core/src/indicators/incremental/price/swing-points.ts
@@ -1,0 +1,237 @@
+/**
+ * Incremental Swing Points
+ *
+ * Identifies swing highs/lows using a 2-sided window: a bar at position t is a
+ * swing high iff its high is strictly greater than all highs within `leftBars`
+ * to its left and all highs within `rightBars` to its right (swing low is
+ * symmetric on lows). Confirmation is delayed by `rightBars` bars.
+ *
+ * Output time = the swing candidate bar's own time (not the streaming candle's
+ * time), following the same convention as `createFractals`. During the warm-up
+ * window the output time falls back to the streaming candle's time with all
+ * fields nulled.
+ */
+
+import type { NormalizedCandle } from "../../../types";
+import { CircularBuffer } from "../circular-buffer";
+import type { IncrementalIndicator, WarmUpOptions } from "../types";
+
+export type SwingPointValue = {
+  isSwingHigh: boolean;
+  isSwingLow: boolean;
+  swingHighPrice: number | null;
+  swingLowPrice: number | null;
+  /** Bars between the emitted bar and the most recent swing high (0 if the emitted bar IS the swing) */
+  swingHighIndex: number | null;
+  /** Bars between the emitted bar and the most recent swing low */
+  swingLowIndex: number | null;
+};
+
+type WindowEntry = { high: number; low: number; time: number; index: number };
+
+export type SwingPointsState = {
+  leftBars: number;
+  rightBars: number;
+  buffer: ReturnType<CircularBuffer<WindowEntry>["snapshot"]>;
+  /** Index of the last confirmed swing high (absolute bar index, 0-based) */
+  lastSwingHighIdx: number | null;
+  lastSwingHighPrice: number | null;
+  lastSwingLowIdx: number | null;
+  lastSwingLowPrice: number | null;
+  count: number;
+};
+
+const nullValue: SwingPointValue = {
+  isSwingHigh: false,
+  isSwingLow: false,
+  swingHighPrice: null,
+  swingLowPrice: null,
+  swingHighIndex: null,
+  swingLowIndex: null,
+};
+
+/**
+ * Create an incremental Swing Points indicator.
+ *
+ * Emission is delayed by `rightBars` bars: `next(candle_t)` confirms whether
+ * `candle_{t-rightBars}` is a swing point. For the first `leftBars + rightBars`
+ * calls, the returned value is fully null.
+ *
+ * @example
+ * ```ts
+ * const swings = createSwingPoints({ leftBars: 5, rightBars: 5 });
+ * for (const candle of stream) {
+ *   const { time, value } = swings.next(candle);
+ *   if (value.isSwingHigh) console.log(`Swing high confirmed at ${time}`);
+ * }
+ * ```
+ */
+export function createSwingPoints(
+  options: { leftBars?: number; rightBars?: number } = {},
+  warmUpOptions?: WarmUpOptions<SwingPointsState>,
+): IncrementalIndicator<SwingPointValue, SwingPointsState> {
+  const leftBars = options.leftBars ?? 5;
+  const rightBars = options.rightBars ?? 5;
+
+  if (leftBars < 1) throw new Error("leftBars must be at least 1");
+  if (rightBars < 1) throw new Error("rightBars must be at least 1");
+
+  const windowSize = leftBars + 1 + rightBars;
+
+  let buffer: CircularBuffer<WindowEntry>;
+  let lastSwingHighIdx: number | null;
+  let lastSwingHighPrice: number | null;
+  let lastSwingLowIdx: number | null;
+  let lastSwingLowPrice: number | null;
+  let count: number;
+
+  if (warmUpOptions?.fromState) {
+    const s = warmUpOptions.fromState;
+    buffer = CircularBuffer.fromSnapshot(s.buffer);
+    lastSwingHighIdx = s.lastSwingHighIdx;
+    lastSwingHighPrice = s.lastSwingHighPrice;
+    lastSwingLowIdx = s.lastSwingLowIdx;
+    lastSwingLowPrice = s.lastSwingLowPrice;
+    count = s.count;
+  } else {
+    buffer = new CircularBuffer<WindowEntry>(windowSize);
+    lastSwingHighIdx = null;
+    lastSwingHighPrice = null;
+    lastSwingLowIdx = null;
+    lastSwingLowPrice = null;
+    count = 0;
+  }
+
+  /**
+   * Evaluate the middle entry of `buf` (at offset `leftBars`) against the
+   * left/right neighbors. Uses strict inequality (>=) for rejection, matching
+   * the batch implementation.
+   */
+  function evaluateMid(buf: CircularBuffer<WindowEntry>): {
+    isHigh: boolean;
+    isLow: boolean;
+    mid: WindowEntry;
+  } {
+    const mid = buf.get(leftBars);
+    let isHigh = true;
+    let isLow = true;
+    for (let i = 0; i < windowSize; i++) {
+      if (i === leftBars) continue;
+      const e = buf.get(i);
+      if (e.high >= mid.high) isHigh = false;
+      if (e.low <= mid.low) isLow = false;
+      if (!isHigh && !isLow) break;
+    }
+    return { isHigh, isLow, mid };
+  }
+
+  const indicator: IncrementalIndicator<SwingPointValue, SwingPointsState> = {
+    next(candle: NormalizedCandle) {
+      buffer.push({
+        high: candle.high,
+        low: candle.low,
+        time: candle.time,
+        index: count,
+      });
+      count++;
+
+      if (buffer.length < windowSize) {
+        return { time: candle.time, value: { ...nullValue } };
+      }
+
+      const { isHigh, isLow, mid } = evaluateMid(buffer);
+      if (isHigh) {
+        lastSwingHighIdx = mid.index;
+        lastSwingHighPrice = mid.high;
+      }
+      if (isLow) {
+        lastSwingLowIdx = mid.index;
+        lastSwingLowPrice = mid.low;
+      }
+
+      return {
+        time: mid.time,
+        value: {
+          isSwingHigh: isHigh,
+          isSwingLow: isLow,
+          swingHighPrice: lastSwingHighPrice,
+          swingLowPrice: lastSwingLowPrice,
+          swingHighIndex: lastSwingHighIdx !== null ? mid.index - lastSwingHighIdx : null,
+          swingLowIndex: lastSwingLowIdx !== null ? mid.index - lastSwingLowIdx : null,
+        },
+      };
+    },
+
+    peek(candle: NormalizedCandle) {
+      // Simulate the buffer state after push without mutating.
+      const needed = windowSize - 1;
+      if (buffer.length < needed) {
+        return { time: candle.time, value: { ...nullValue } };
+      }
+      // Build a temporary window from the last (windowSize - 1) entries of
+      // `buffer` plus the incoming candle.
+      const temp: WindowEntry[] = [];
+      const startIdx = buffer.length >= windowSize ? 1 : 0;
+      for (let i = startIdx; i < buffer.length; i++) temp.push(buffer.get(i));
+      temp.push({ high: candle.high, low: candle.low, time: candle.time, index: count });
+
+      const mid = temp[leftBars];
+      let isHigh = true;
+      let isLow = true;
+      for (let i = 0; i < windowSize; i++) {
+        if (i === leftBars) continue;
+        const e = temp[i];
+        if (e.high >= mid.high) isHigh = false;
+        if (e.low <= mid.low) isLow = false;
+        if (!isHigh && !isLow) break;
+      }
+
+      // Compute would-be trailing state without committing.
+      const peekHighIdx = isHigh ? mid.index : lastSwingHighIdx;
+      const peekHighPrice = isHigh ? mid.high : lastSwingHighPrice;
+      const peekLowIdx = isLow ? mid.index : lastSwingLowIdx;
+      const peekLowPrice = isLow ? mid.low : lastSwingLowPrice;
+
+      return {
+        time: mid.time,
+        value: {
+          isSwingHigh: isHigh,
+          isSwingLow: isLow,
+          swingHighPrice: peekHighPrice,
+          swingLowPrice: peekLowPrice,
+          swingHighIndex: peekHighIdx !== null ? mid.index - peekHighIdx : null,
+          swingLowIndex: peekLowIdx !== null ? mid.index - peekLowIdx : null,
+        },
+      };
+    },
+
+    getState(): SwingPointsState {
+      return {
+        leftBars,
+        rightBars,
+        buffer: buffer.snapshot(),
+        lastSwingHighIdx,
+        lastSwingHighPrice,
+        lastSwingLowIdx,
+        lastSwingLowPrice,
+        count,
+      };
+    },
+
+    get count() {
+      return count;
+    },
+
+    get isWarmedUp() {
+      return count >= windowSize;
+    },
+  };
+
+  if (warmUpOptions?.warmUp) {
+    for (const candle of warmUpOptions.warmUp) {
+      indicator.next(candle);
+    }
+  }
+
+  return indicator;
+}

--- a/packages/core/src/indicators/incremental/price/zigzag.ts
+++ b/packages/core/src/indicators/incremental/price/zigzag.ts
@@ -1,0 +1,294 @@
+/**
+ * Incremental Zigzag
+ *
+ * Emits a pivot (high or low) the moment a reversal of at least `deviation`
+ * percent (or `atrMultiplier * ATR` if `useAtr: true`) is confirmed against
+ * the running extreme of the current trend.
+ *
+ * Output time per `next(candle)` call:
+ *  - when no pivot is confirmed, the current candle's time with a null value
+ *  - when a pivot is confirmed, the original time of the extremum bar (so
+ *    streamed output aligns with batch zigzag() output on pivot bars)
+ */
+
+import type { NormalizedCandle } from "../../../types";
+import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import type { AtrState } from "../volatility/atr";
+import { createAtr } from "../volatility/atr";
+
+export type ZigzagValue = {
+  point: "high" | "low" | null;
+  price: number | null;
+  changePercent: number | null;
+};
+
+export type ZigzagState = {
+  deviation: number;
+  useAtr: boolean;
+  atrPeriod: number;
+  atrMultiplier: number;
+  trend: "up" | "down" | null;
+  lastPivotPrice: number;
+  currentHigh: number;
+  currentHighTime: number;
+  currentLow: number;
+  currentLowTime: number;
+  firstHigh: number;
+  firstLow: number;
+  count: number;
+  maxInitBars: number;
+  atrState: AtrState | null;
+};
+
+const nullValue: ZigzagValue = { point: null, price: null, changePercent: null };
+
+/**
+ * Create an incremental Zigzag indicator.
+ *
+ * @example
+ * ```ts
+ * const zz = createZigzag({ deviation: 5 });
+ * for (const candle of stream) {
+ *   const { time, value } = zz.next(candle);
+ *   if (value.point) console.log(`Pivot ${value.point} at ${time}: ${value.price}`);
+ * }
+ * ```
+ */
+export function createZigzag(
+  options: {
+    deviation?: number;
+    useAtr?: boolean;
+    atrPeriod?: number;
+    atrMultiplier?: number;
+  } = {},
+  warmUpOptions?: WarmUpOptions<ZigzagState>,
+): IncrementalIndicator<ZigzagValue, ZigzagState> {
+  const deviation = options.deviation ?? 5;
+  const useAtr = options.useAtr ?? false;
+  const atrPeriod = options.atrPeriod ?? 14;
+  const atrMultiplier = options.atrMultiplier ?? 2;
+
+  if (deviation <= 0) {
+    throw new Error("Zigzag deviation must be positive");
+  }
+
+  const maxInitBars = Math.max(20, atrPeriod * 2);
+
+  let trend: "up" | "down" | null;
+  let lastPivotPrice: number;
+  let currentHigh: number;
+  let currentHighTime: number;
+  let currentLow: number;
+  let currentLowTime: number;
+  let firstHigh: number;
+  let firstLow: number;
+  let count: number;
+  let atr: IncrementalIndicator<number | null, AtrState> | null;
+
+  if (warmUpOptions?.fromState) {
+    const s = warmUpOptions.fromState;
+    trend = s.trend;
+    lastPivotPrice = s.lastPivotPrice;
+    currentHigh = s.currentHigh;
+    currentHighTime = s.currentHighTime;
+    currentLow = s.currentLow;
+    currentLowTime = s.currentLowTime;
+    firstHigh = s.firstHigh;
+    firstLow = s.firstLow;
+    count = s.count;
+    atr = useAtr
+      ? createAtr({ period: atrPeriod }, s.atrState ? { fromState: s.atrState } : undefined)
+      : null;
+  } else {
+    trend = null;
+    lastPivotPrice = 0;
+    currentHigh = 0;
+    currentHighTime = 0;
+    currentLow = 0;
+    currentLowTime = 0;
+    firstHigh = 0;
+    firstLow = 0;
+    count = 0;
+    atr = useAtr ? createAtr({ period: atrPeriod }) : null;
+  }
+
+  function currentThreshold(atrVal: number | null, anchorPrice: number): number {
+    if (useAtr && atrVal !== null && atrVal > 0) return atrVal * atrMultiplier;
+    return Math.abs(anchorPrice) * (deviation / 100);
+  }
+
+  const indicator: IncrementalIndicator<ZigzagValue, ZigzagState> = {
+    next(candle: NormalizedCandle) {
+      const atrVal = atr ? atr.next(candle).value : null;
+      const isFirst = count === 0;
+      count++;
+
+      if (isFirst) {
+        currentHigh = candle.high;
+        currentHighTime = candle.time;
+        currentLow = candle.low;
+        currentLowTime = candle.time;
+        firstHigh = candle.high;
+        firstLow = candle.low;
+        return { time: candle.time, value: { ...nullValue } };
+      }
+
+      const { high, low } = candle;
+
+      if (trend === null) {
+        if (high > currentHigh) {
+          currentHigh = high;
+          currentHighTime = candle.time;
+        }
+        if (low < currentLow) {
+          currentLow = low;
+          currentLowTime = candle.time;
+        }
+
+        const initAnchor = lastPivotPrice || currentHigh;
+        const threshold = currentThreshold(atrVal, initAnchor);
+
+        if (currentHigh - firstLow >= threshold) {
+          trend = "up";
+          lastPivotPrice = currentLow;
+          return {
+            time: currentLowTime,
+            value: { point: "low", price: currentLow, changePercent: null },
+          };
+        }
+        if (firstHigh - currentLow >= threshold) {
+          trend = "down";
+          lastPivotPrice = currentHigh;
+          return {
+            time: currentHighTime,
+            value: { point: "high", price: currentHigh, changePercent: null },
+          };
+        }
+        if (count >= maxInitBars) {
+          const upRange = currentHigh - firstLow;
+          const downRange = firstHigh - currentLow;
+          if (upRange >= downRange) {
+            trend = "up";
+            lastPivotPrice = currentLow;
+            return {
+              time: currentLowTime,
+              value: { point: "low", price: currentLow, changePercent: null },
+            };
+          }
+          trend = "down";
+          lastPivotPrice = currentHigh;
+          return {
+            time: currentHighTime,
+            value: { point: "high", price: currentHigh, changePercent: null },
+          };
+        }
+        return { time: candle.time, value: { ...nullValue } };
+      }
+
+      if (trend === "up") {
+        if (high > currentHigh) {
+          currentHigh = high;
+          currentHighTime = candle.time;
+        }
+        const drop = currentHigh - low;
+        const dropThreshold = currentThreshold(atrVal, currentHigh);
+        if (drop >= dropThreshold) {
+          const changePct =
+            lastPivotPrice > 0 ? ((currentHigh - lastPivotPrice) / lastPivotPrice) * 100 : null;
+          const pivotTime = currentHighTime;
+          const pivotPrice = currentHigh;
+          lastPivotPrice = currentHigh;
+          trend = "down";
+          currentLow = low;
+          currentLowTime = candle.time;
+          return {
+            time: pivotTime,
+            value: { point: "high", price: pivotPrice, changePercent: changePct },
+          };
+        }
+        return { time: candle.time, value: { ...nullValue } };
+      }
+
+      // trend === "down"
+      if (low < currentLow) {
+        currentLow = low;
+        currentLowTime = candle.time;
+      }
+      const rise = high - currentLow;
+      const riseThreshold = currentThreshold(atrVal, currentLow);
+      if (rise >= riseThreshold) {
+        const changePct =
+          lastPivotPrice > 0 ? ((currentLow - lastPivotPrice) / lastPivotPrice) * 100 : null;
+        const pivotTime = currentLowTime;
+        const pivotPrice = currentLow;
+        lastPivotPrice = currentLow;
+        trend = "up";
+        currentHigh = high;
+        currentHighTime = candle.time;
+        return {
+          time: pivotTime,
+          value: { point: "low", price: pivotPrice, changePercent: changePct },
+        };
+      }
+      return { time: candle.time, value: { ...nullValue } };
+    },
+
+    peek(candle: NormalizedCandle) {
+      const saved = indicator.getState();
+      const result = indicator.next(candle);
+      // restore
+      trend = saved.trend;
+      lastPivotPrice = saved.lastPivotPrice;
+      currentHigh = saved.currentHigh;
+      currentHighTime = saved.currentHighTime;
+      currentLow = saved.currentLow;
+      currentLowTime = saved.currentLowTime;
+      firstHigh = saved.firstHigh;
+      firstLow = saved.firstLow;
+      count = saved.count;
+      atr = useAtr
+        ? createAtr(
+            { period: atrPeriod },
+            saved.atrState ? { fromState: saved.atrState } : undefined,
+          )
+        : null;
+      return result;
+    },
+
+    getState(): ZigzagState {
+      return {
+        deviation,
+        useAtr,
+        atrPeriod,
+        atrMultiplier,
+        trend,
+        lastPivotPrice,
+        currentHigh,
+        currentHighTime,
+        currentLow,
+        currentLowTime,
+        firstHigh,
+        firstLow,
+        count,
+        maxInitBars,
+        atrState: atr ? atr.getState() : null,
+      };
+    },
+
+    get count() {
+      return count;
+    },
+
+    get isWarmedUp() {
+      return trend !== null;
+    },
+  };
+
+  if (warmUpOptions?.warmUp) {
+    for (const candle of warmUpOptions.warmUp) {
+      indicator.next(candle);
+    }
+  }
+
+  return indicator;
+}

--- a/packages/core/src/indicators/incremental/trend/linear-regression.ts
+++ b/packages/core/src/indicators/incremental/trend/linear-regression.ts
@@ -1,0 +1,210 @@
+/**
+ * Incremental Linear Regression
+ *
+ * Rolling least-squares fit over the last `period` prices with x = 0..period-1
+ * indexed within the window. State is kept as O(1)-updateable running sums
+ * (sumY, sumY², sumXY) plus a CircularBuffer of `period` y-values needed
+ * to know which y is being evicted when the window slides.
+ *
+ * Update law (proved under the change of variable k = j+1 against the batch
+ * sumXY = Σ j·y_{i-period+1+j}):
+ *
+ *   sumXY_new = sumXY_old + (period-1) * y_new - (sumY_old - y_drop)
+ *
+ * where y_drop is the oldest value in the window before the push.
+ *
+ * R² is computed from running sums via the Pearson form
+ *   R² = (n·sumXY − sumX·sumY)² / ((n·sumXX − sumX²) · (n·sumYY − sumY²))
+ * so we never have to iterate the buffer to get ssRes / ssTot.
+ */
+
+import type { NormalizedCandle, PriceSource } from "../../../types";
+import { CircularBuffer } from "../circular-buffer";
+import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { getSourcePrice } from "../utils";
+
+export type LinearRegressionValue = {
+  value: number;
+  slope: number;
+  intercept: number;
+  rSquared: number;
+};
+
+export type LinearRegressionState = {
+  period: number;
+  source: PriceSource;
+  buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
+  sumY: number;
+  sumY2: number;
+  sumXY: number;
+  count: number;
+};
+
+/**
+ * Create an incremental Linear Regression indicator.
+ *
+ * @example
+ * ```ts
+ * const lr = createLinearRegression({ period: 14 });
+ * for (const candle of stream) {
+ *   const { value } = lr.next(candle);
+ *   if (value && value.rSquared > 0.8) console.log("strong trend, slope=", value.slope);
+ * }
+ * ```
+ */
+export function createLinearRegression(
+  options: { period?: number; source?: PriceSource } = {},
+  warmUpOptions?: WarmUpOptions<LinearRegressionState>,
+): IncrementalIndicator<LinearRegressionValue | null, LinearRegressionState> {
+  // When restoring from a snapshot, the saved period/source MUST win over the
+  // factory-call defaults — otherwise sumY / sumXY / buffer values that were
+  // computed under one configuration would be reused with a different one,
+  // silently corrupting outputs from the first resumed candle onward.
+  const period = warmUpOptions?.fromState?.period ?? options.period ?? 14;
+  const source: PriceSource = warmUpOptions?.fromState?.source ?? options.source ?? "close";
+
+  if (period < 2) {
+    throw new Error("Linear Regression period must be at least 2");
+  }
+
+  // Closed-form constants for x = 0..period-1
+  const sumX = (period * (period - 1)) / 2;
+  const sumX2 = (period * (period - 1) * (2 * period - 1)) / 6;
+  const denomX = period * sumX2 - sumX * sumX;
+
+  let buffer: CircularBuffer<number>;
+  let sumY: number;
+  let sumY2: number;
+  let sumXY: number;
+  let count: number;
+
+  if (warmUpOptions?.fromState) {
+    const s = warmUpOptions.fromState;
+    buffer = CircularBuffer.fromSnapshot(s.buffer);
+    sumY = s.sumY;
+    sumY2 = s.sumY2;
+    sumXY = s.sumXY;
+    count = s.count;
+  } else {
+    buffer = new CircularBuffer<number>(period);
+    sumY = 0;
+    sumY2 = 0;
+    sumXY = 0;
+    count = 0;
+  }
+
+  function compute(): LinearRegressionValue | null {
+    if (count < period) return null;
+    const slope = (period * sumXY - sumX * sumY) / denomX;
+    const intercept = (sumY - slope * sumX) / period;
+    const value = intercept + slope * (period - 1);
+    // Pearson R² via running sums; clamp to [0, 1] for float safety.
+    const denomY = period * sumY2 - sumY * sumY;
+    const numerR2 = (period * sumXY - sumX * sumY) ** 2;
+    const rSquared = denomY > 0 && denomX > 0 ? numerR2 / (denomX * denomY) : 0;
+    return {
+      value,
+      slope,
+      intercept,
+      rSquared: Math.min(1, Math.max(0, rSquared)),
+    };
+  }
+
+  const indicator: IncrementalIndicator<LinearRegressionValue | null, LinearRegressionState> = {
+    next(candle: NormalizedCandle) {
+      const y = getSourcePrice(candle, source);
+      const willEvict = buffer.isFull;
+      const yDrop = willEvict ? buffer.oldest() : 0;
+
+      // Window already full → use the slide-update law BEFORE mutating sumY.
+      if (count >= period) {
+        sumXY = sumXY + (period - 1) * y - (sumY - yDrop);
+      }
+
+      sumY = sumY - yDrop + y;
+      sumY2 = sumY2 - yDrop * yDrop + y * y;
+      buffer.push(y);
+      count++;
+
+      // First time the buffer is full → seed sumXY from the explicit sum.
+      if (count === period) {
+        sumXY = 0;
+        for (let j = 0; j < period; j++) {
+          sumXY += j * buffer.get(j);
+        }
+      }
+
+      return { time: candle.time, value: compute() };
+    },
+
+    peek(candle: NormalizedCandle) {
+      const y = getSourcePrice(candle, source);
+      const willEvict = buffer.isFull;
+      const yDrop = willEvict ? buffer.oldest() : 0;
+      const peekCount = count + 1;
+      if (peekCount < period) return { time: candle.time, value: null };
+
+      let peekSumY: number;
+      let peekSumY2: number;
+      let peekSumXY: number;
+
+      if (count < period) {
+        // Buffer just becomes full; peek the seeded sumXY from buffer + new y.
+        peekSumY = sumY + y;
+        peekSumY2 = sumY2 + y * y;
+        peekSumXY = 0;
+        // Buffer currently has count elements, peek-pushing y at the end.
+        for (let j = 0; j < count; j++) peekSumXY += j * buffer.get(j);
+        peekSumXY += count * y;
+      } else {
+        peekSumY = sumY - yDrop + y;
+        peekSumY2 = sumY2 - yDrop * yDrop + y * y;
+        peekSumXY = sumXY + (period - 1) * y - (sumY - yDrop);
+      }
+
+      const slope = (period * peekSumXY - sumX * peekSumY) / denomX;
+      const intercept = (peekSumY - slope * sumX) / period;
+      const value = intercept + slope * (period - 1);
+      const denomY = period * peekSumY2 - peekSumY * peekSumY;
+      const numerR2 = (period * peekSumXY - sumX * peekSumY) ** 2;
+      const rSquared = denomY > 0 && denomX > 0 ? numerR2 / (denomX * denomY) : 0;
+      return {
+        time: candle.time,
+        value: {
+          value,
+          slope,
+          intercept,
+          rSquared: Math.min(1, Math.max(0, rSquared)),
+        },
+      };
+    },
+
+    getState(): LinearRegressionState {
+      return {
+        period,
+        source,
+        buffer: buffer.snapshot(),
+        sumY,
+        sumY2,
+        sumXY,
+        count,
+      };
+    },
+
+    get count() {
+      return count;
+    },
+
+    get isWarmedUp() {
+      return count >= period;
+    },
+  };
+
+  if (warmUpOptions?.warmUp) {
+    for (const candle of warmUpOptions.warmUp) {
+      indicator.next(candle);
+    }
+  }
+
+  return indicator;
+}

--- a/packages/core/src/indicators/incremental/volatility/standard-deviation.ts
+++ b/packages/core/src/indicators/incremental/volatility/standard-deviation.ts
@@ -37,8 +37,10 @@ export function createStandardDeviation(
   options: { period?: number; source?: PriceSource } = {},
   warmUpOptions?: WarmUpOptions<StandardDeviationState>,
 ): IncrementalIndicator<number | null, StandardDeviationState> {
-  const period = options.period ?? 20;
-  const source: PriceSource = options.source ?? "close";
+  // Saved snapshot wins so resumed sums match the configuration they were
+  // computed under, even if the caller forgets to pass period / source again.
+  const period = warmUpOptions?.fromState?.period ?? options.period ?? 20;
+  const source: PriceSource = warmUpOptions?.fromState?.source ?? options.source ?? "close";
 
   if (period < 1) {
     throw new Error("Standard Deviation period must be at least 1");

--- a/packages/core/src/indicators/incremental/volatility/standard-deviation.ts
+++ b/packages/core/src/indicators/incremental/volatility/standard-deviation.ts
@@ -1,0 +1,120 @@
+/**
+ * Incremental Standard Deviation
+ *
+ * Rolling population standard deviation (divides by N, matching the batch
+ * `standardDeviation()` and TA-Lib convention). Maintains running sum and
+ * sum-of-squares plus a CircularBuffer of the last `period` prices, so
+ * each `next()` call is O(1).
+ */
+
+import type { NormalizedCandle, PriceSource } from "../../../types";
+import { CircularBuffer } from "../circular-buffer";
+import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { getSourcePrice } from "../utils";
+
+export type StandardDeviationState = {
+  period: number;
+  source: PriceSource;
+  buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
+  sum: number;
+  sumSq: number;
+  count: number;
+};
+
+/**
+ * Create an incremental Standard Deviation indicator.
+ *
+ * @example
+ * ```ts
+ * const sd = createStandardDeviation({ period: 20 });
+ * for (const candle of stream) {
+ *   const { value } = sd.next(candle);
+ *   if (sd.isWarmedUp) console.log(value);
+ * }
+ * ```
+ */
+export function createStandardDeviation(
+  options: { period?: number; source?: PriceSource } = {},
+  warmUpOptions?: WarmUpOptions<StandardDeviationState>,
+): IncrementalIndicator<number | null, StandardDeviationState> {
+  const period = options.period ?? 20;
+  const source: PriceSource = options.source ?? "close";
+
+  if (period < 1) {
+    throw new Error("Standard Deviation period must be at least 1");
+  }
+
+  let buffer: CircularBuffer<number>;
+  let sum: number;
+  let sumSq: number;
+  let count: number;
+
+  if (warmUpOptions?.fromState) {
+    const s = warmUpOptions.fromState;
+    buffer = CircularBuffer.fromSnapshot(s.buffer);
+    sum = s.sum;
+    sumSq = s.sumSq;
+    count = s.count;
+  } else {
+    buffer = new CircularBuffer<number>(period);
+    sum = 0;
+    sumSq = 0;
+    count = 0;
+  }
+
+  function compute(): number | null {
+    if (count < period) return null;
+    const mean = sum / period;
+    // Variance = E[X²] - (E[X])²; clamp tiny negatives from float error.
+    const variance = Math.max(0, sumSq / period - mean * mean);
+    return Math.sqrt(variance);
+  }
+
+  const indicator: IncrementalIndicator<number | null, StandardDeviationState> = {
+    next(candle: NormalizedCandle) {
+      const price = getSourcePrice(candle, source);
+      if (buffer.isFull) {
+        const oldest = buffer.oldest();
+        sum -= oldest;
+        sumSq -= oldest * oldest;
+      }
+      buffer.push(price);
+      sum += price;
+      sumSq += price * price;
+      count++;
+      return { time: candle.time, value: compute() };
+    },
+
+    peek(candle: NormalizedCandle) {
+      const price = getSourcePrice(candle, source);
+      const willEvict = buffer.isFull;
+      const peekSum = sum + price - (willEvict ? buffer.oldest() : 0);
+      const peekSumSq = sumSq + price * price - (willEvict ? buffer.oldest() * buffer.oldest() : 0);
+      const peekCount = count + 1;
+      if (peekCount < period) return { time: candle.time, value: null };
+      const mean = peekSum / period;
+      const variance = Math.max(0, peekSumSq / period - mean * mean);
+      return { time: candle.time, value: Math.sqrt(variance) };
+    },
+
+    getState(): StandardDeviationState {
+      return { period, source, buffer: buffer.snapshot(), sum, sumSq, count };
+    },
+
+    get count() {
+      return count;
+    },
+
+    get isWarmedUp() {
+      return count >= period;
+    },
+  };
+
+  if (warmUpOptions?.warmUp) {
+    for (const candle of warmUpOptions.warmUp) {
+      indicator.next(candle);
+    }
+  }
+
+  return indicator;
+}

--- a/packages/core/src/indicators/momentum/connors-rsi.ts
+++ b/packages/core/src/indicators/momentum/connors-rsi.ts
@@ -9,9 +9,9 @@
  * CRSI = (RSI(close, rsiPeriod) + RSI(streak, streakPeriod) + PercentRank(ROC(1), rocPeriod)) / 3
  */
 
-import { isNormalized, normalizeCandles } from "../../core/normalize";
+import { getPrice, isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
-import type { Candle, NormalizedCandle, Series } from "../../types";
+import type { Candle, NormalizedCandle, PriceSource, Series } from "../../types";
 import { CONNORS_RSI_META } from "../indicator-meta";
 import { rsi } from "./rsi";
 
@@ -25,6 +25,8 @@ export type ConnorsRsiOptions = {
   streakPeriod?: number;
   /** Lookback period for ROC percent rank (default: 100) */
   rocPeriod?: number;
+  /** Price source used for all three components (default: "close") */
+  source?: PriceSource;
 };
 
 /**
@@ -65,7 +67,7 @@ export function connorsRsi(
   candles: Candle[] | NormalizedCandle[],
   options: ConnorsRsiOptions = {},
 ): Series<ConnorsRsiValue> {
-  const { rsiPeriod = 3, streakPeriod = 2, rocPeriod = 100 } = options;
+  const { rsiPeriod = 3, streakPeriod = 2, rocPeriod = 100, source = "close" } = options;
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
 
@@ -73,16 +75,18 @@ export function connorsRsi(
     return [];
   }
 
+  const sourcePrices = normalized.map((c) => getPrice(c, source));
+
   // Component 1: RSI of price
-  const priceRsi = rsi(normalized, { period: rsiPeriod });
+  const priceRsi = rsi(normalized, { period: rsiPeriod, source });
 
   // Component 2: Calculate streak and RSI of streak
   // Streak: consecutive up days = positive count, consecutive down days = negative count
   const streaks: number[] = new Array(normalized.length).fill(0);
   for (let i = 1; i < normalized.length; i++) {
-    if (normalized[i].close > normalized[i - 1].close) {
+    if (sourcePrices[i] > sourcePrices[i - 1]) {
       streaks[i] = streaks[i - 1] > 0 ? streaks[i - 1] + 1 : 1;
-    } else if (normalized[i].close < normalized[i - 1].close) {
+    } else if (sourcePrices[i] < sourcePrices[i - 1]) {
       streaks[i] = streaks[i - 1] < 0 ? streaks[i - 1] - 1 : -1;
     } else {
       streaks[i] = 0;
@@ -101,12 +105,12 @@ export function connorsRsi(
   const streakRsiResult = rsi(streakCandles, { period: streakPeriod });
 
   // Component 3: Percent rank of 1-period ROC
-  // ROC(1) = (close - prevClose) / prevClose * 100
+  // ROC(1) = (price - prevPrice) / prevPrice * 100
   const roc1: (number | null)[] = new Array(normalized.length).fill(null);
   for (let i = 1; i < normalized.length; i++) {
-    const prevClose = normalized[i - 1].close;
-    if (prevClose !== 0) {
-      roc1[i] = ((normalized[i].close - prevClose) / prevClose) * 100;
+    const prev = sourcePrices[i - 1];
+    if (prev !== 0) {
+      roc1[i] = ((sourcePrices[i] - prev) / prev) * 100;
     }
   }
 

--- a/packages/core/src/indicators/momentum/stoch-rsi.ts
+++ b/packages/core/src/indicators/momentum/stoch-rsi.ts
@@ -6,7 +6,7 @@
 
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
-import type { Candle, NormalizedCandle, Series } from "../../types";
+import type { Candle, NormalizedCandle, PriceSource, Series } from "../../types";
 import { STOCH_RSI_META } from "../indicator-meta";
 import { rsi } from "./rsi";
 
@@ -34,6 +34,8 @@ export type StochRsiOptions = {
   kPeriod?: number;
   /** Period for %D (signal line) smoothing (default: 3) */
   dPeriod?: number;
+  /** Price source for the underlying RSI input (default: "close") */
+  source?: PriceSource;
 };
 
 /**
@@ -73,7 +75,7 @@ export function stochRsi(
   candles: Candle[] | NormalizedCandle[],
   options: StochRsiOptions = {},
 ): Series<StochRsiValue> {
-  const { rsiPeriod = 14, stochPeriod = 14, kPeriod = 3, dPeriod = 3 } = options;
+  const { rsiPeriod = 14, stochPeriod = 14, kPeriod = 3, dPeriod = 3, source = "close" } = options;
 
   if (rsiPeriod < 1) throw new Error("RSI period must be at least 1");
   if (stochPeriod < 1) throw new Error("Stoch period must be at least 1");
@@ -87,7 +89,7 @@ export function stochRsi(
   }
 
   // Step 1: Calculate RSI
-  const rsiData = rsi(normalized, { period: rsiPeriod });
+  const rsiData = rsi(normalized, { period: rsiPeriod, source });
   const rsiValues = rsiData.map((d) => d.value);
 
   // Step 2: Calculate raw StochRSI

--- a/packages/core/src/indicators/volatility/garch.ts
+++ b/packages/core/src/indicators/volatility/garch.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import { type AnnualizationOptions, annualizationFactor } from "../../calendar";
 import { tagSeries } from "../../core/tag-series";
 import type { Series } from "../../types";
 
@@ -16,7 +17,7 @@ import type { Series } from "../../types";
 // ---------------------------------------------------------------------------
 
 /** GARCH model options */
-export type GarchOptions = {
+export type GarchOptions = AnnualizationOptions & {
   /** GARCH lag order (default: 1) */
   p?: number;
   /** ARCH lag order (default: 1) */
@@ -42,7 +43,7 @@ export type GarchResult = {
 };
 
 /** EWMA volatility options */
-export type EwmaVolatilityOptions = {
+export type EwmaVolatilityOptions = AnnualizationOptions & {
   /** Decay factor (default: 0.94, RiskMetrics standard) */
   lambda?: number;
 };
@@ -201,6 +202,7 @@ function sampleVariance(values: number[]): number {
 export function garch(returns: number[], options?: GarchOptions): GarchResult {
   const maxIterations = options?.maxIterations ?? 100;
   const tolerance = options?.tolerance ?? 1e-6;
+  const sqrtAnnualization = Math.sqrt(annualizationFactor(options));
 
   const T = returns.length;
   if (T < 3) {
@@ -208,7 +210,7 @@ export function garch(returns: number[], options?: GarchOptions): GarchResult {
     const v = sampleVariance(returns);
     return {
       conditionalVariance: returns.map((_, i) => ({ time: i, value: v })),
-      volatilityForecast: Math.sqrt(v) * Math.sqrt(252) * 100,
+      volatilityForecast: Math.sqrt(v) * sqrtAnnualization * 100,
       params: { omega: v, alpha: 0, beta: 0 },
       logLikelihood: Number.NEGATIVE_INFINITY,
       converged: false,
@@ -274,7 +276,7 @@ export function garch(returns: number[], options?: GarchOptions): GarchResult {
 
   // One-step-ahead forecast
   const forecastVar = sigma2; // already computed for t = T
-  const volatilityForecast = Math.sqrt(forecastVar) * Math.sqrt(252) * 100;
+  const volatilityForecast = Math.sqrt(forecastVar) * sqrtAnnualization * 100;
 
   return {
     conditionalVariance: condVar,
@@ -320,12 +322,12 @@ export function ewmaVolatility(returns: number[], options?: EwmaVolatilityOption
   let sigma2 = sampleVariance(returns.slice(0, seedCount));
   if (sigma2 === 0) sigma2 = 1e-10; // prevent zero variance
 
-  const SQRT_252 = Math.sqrt(252);
+  const sqrtAnnualization = Math.sqrt(annualizationFactor(options));
   const result: Series<number> = [];
 
   for (let t = 0; t < T; t++) {
     sigma2 = lambda * sigma2 + (1 - lambda) * returns[t] ** 2;
-    result.push({ time: t, value: Math.sqrt(sigma2) * SQRT_252 * 100 });
+    result.push({ time: t, value: Math.sqrt(sigma2) * sqrtAnnualization * 100 });
   }
 
   return tagSeries(result, { kind: "garch", overlay: false, label: "GARCH" });

--- a/packages/core/src/indicators/volatility/regime.ts
+++ b/packages/core/src/indicators/volatility/regime.ts
@@ -5,6 +5,7 @@
  * using ATR percentile, Bollinger Bandwidth percentile, and historical volatility.
  */
 
+import { annualizationFactor } from "../../calendar";
 import { normalizeCandles } from "../../core/normalize";
 import type {
   Candle,
@@ -95,7 +96,11 @@ export function volatilityRegime(
   const bbSeries = bollingerBands(normalized, { period: opts.bbPeriod });
 
   // Calculate historical volatility (rolling standard deviation of log returns)
-  const hvSeries = calculateHistoricalVolatility(normalized, opts.lookbackPeriod);
+  const periodsPerYear = annualizationFactor({
+    calendar: options.calendar,
+    periodsPerYear: options.periodsPerYear,
+  });
+  const hvSeries = calculateHistoricalVolatility(normalized, opts.lookbackPeriod, periodsPerYear);
 
   const result: Series<VolatilityRegimeValue> = [];
 
@@ -217,9 +222,9 @@ function calculateBandwidthPercentile(
 function calculateHistoricalVolatility(
   candles: NormalizedCandle[],
   lookbackPeriod: number,
+  tradingDaysPerYear: number,
 ): (number | null)[] {
   const result: (number | null)[] = [];
-  const tradingDaysPerYear = 252;
 
   for (let i = 0; i < candles.length; i++) {
     if (i < lookbackPeriod) {

--- a/packages/core/src/risk/drawdown-analysis.ts
+++ b/packages/core/src/risk/drawdown-analysis.ts
@@ -8,6 +8,8 @@
  * - Ulcer Performance Index (risk-adjusted return metric)
  */
 
+import { type AnnualizationOptions, annualizationFactor } from "../calendar";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -313,7 +315,11 @@ export function estimateRecoveryTime(
  * console.log(`UPI: ${upi.toFixed(2)}`);
  * ```
  */
-export function ulcerPerformanceIndex(equityCurve: number[], riskFreeRate = 0): number {
+export function ulcerPerformanceIndex(
+  equityCurve: number[],
+  riskFreeRate = 0,
+  annualizationOpts: AnnualizationOptions = {},
+): number {
   if (equityCurve.length < 2) return 0;
 
   // Calculate percentage drawdowns from running peak
@@ -329,10 +335,11 @@ export function ulcerPerformanceIndex(equityCurve: number[], riskFreeRate = 0): 
   const ulcerIndex = Math.sqrt(sumSqDD / equityCurve.length);
   if (ulcerIndex === 0) return 0;
 
-  // Annualised return (assume 252 trading days)
+  // Annualised return using the configured trading-days-per-year (default: 252)
   const totalReturn = equityCurve[equityCurve.length - 1] / equityCurve[0] - 1;
   const n = equityCurve.length;
-  const annualReturn = (1 + totalReturn) ** (252 / n) - 1;
+  const periodsPerYear = annualizationFactor(annualizationOpts);
+  const annualReturn = (1 + totalReturn) ** (periodsPerYear / n) - 1;
 
   return (annualReturn - riskFreeRate) / (ulcerIndex / 100);
 }

--- a/packages/core/src/risk/stress-test.ts
+++ b/packages/core/src/risk/stress-test.ts
@@ -7,6 +7,8 @@
  * @packageDocumentation
  */
 
+import { type AnnualizationOptions, annualizationFactor } from "../calendar";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -200,7 +202,10 @@ export function generateShockedReturns(baseReturns: number[], shock: ReturnShock
  * // metrics.sharpe ≈ annualised risk-adjusted return
  * ```
  */
-export function calculateMetricsFromReturns(returns: number[]): {
+export function calculateMetricsFromReturns(
+  returns: number[],
+  annualizationOpts: AnnualizationOptions = {},
+): {
   totalReturn: number;
   maxDrawdown: number;
   sharpe: number;
@@ -226,7 +231,7 @@ export function calculateMetricsFromReturns(returns: number[]): {
   // Annualized Sharpe ratio
   const mean = returns.reduce((s, v) => s + v, 0) / returns.length;
   const sd = stddev(returns);
-  const sharpe = sd === 0 ? 0 : (mean / sd) * Math.sqrt(252);
+  const sharpe = sd === 0 ? 0 : (mean / sd) * Math.sqrt(annualizationFactor(annualizationOpts));
 
   return { totalReturn, maxDrawdown: maxDd, sharpe };
 }
@@ -256,9 +261,10 @@ export function stressTest(
   returns: number[],
   scenario: StressScenario,
   initialCapital = 100_000,
+  annualizationOpts: AnnualizationOptions = {},
 ): StressTestResult {
   // Original metrics
-  const originalMetrics = calculateMetricsFromReturns(returns);
+  const originalMetrics = calculateMetricsFromReturns(returns, annualizationOpts);
 
   // Apply shocks sequentially
   let stressed = [...returns];
@@ -267,7 +273,7 @@ export function stressTest(
   }
 
   // Stressed metrics
-  const stressedMetrics = calculateMetricsFromReturns(stressed);
+  const stressedMetrics = calculateMetricsFromReturns(stressed, annualizationOpts);
 
   // Build equity curve for worst-case analysis
   const equityCurve: number[] = [1];
@@ -360,11 +366,15 @@ export function stressTest(
  * console.log(`Max stressed drawdown: ${(summary.maxStressedDrawdown * 100).toFixed(1)}%`);
  * ```
  */
-export function runAllStressTests(returns: number[], initialCapital = 100_000): StressTestSummary {
+export function runAllStressTests(
+  returns: number[],
+  initialCapital = 100_000,
+  annualizationOpts: AnnualizationOptions = {},
+): StressTestSummary {
   const results: StressTestResult[] = [];
 
   for (const scenario of Object.values(PRESET_SCENARIOS)) {
-    results.push(stressTest(returns, scenario, initialCapital));
+    results.push(stressTest(returns, scenario, initialCapital, annualizationOpts));
   }
 
   // Find worst scenario by maxDrawdown

--- a/packages/core/src/streaming/indicator-presets.ts
+++ b/packages/core/src/streaming/indicator-presets.ts
@@ -148,7 +148,7 @@ import {
   ZIGZAG_META,
 } from "../indicators/indicator-meta";
 import type { NormalizedCandle, Series } from "../types";
-import type { SeriesMeta } from "../types/candle";
+import type { PriceSource, SeriesMeta } from "../types/candle";
 import { livePresets } from "./live-presets";
 import type { LiveIndicatorFactory } from "./types";
 
@@ -225,15 +225,43 @@ const period = (def = 14, min = 2, max = 200): ParamSchema => ({
   step: 1,
 });
 
-/** Helper to extend a livePreset entry with a batch compute function + catalog metadata */
-function withCompute(
+/** Type-only helper for bare `compute:` properties on manually-assembled entries
+ *  (ones that don't go through `withCompute`). Lets the author declare a
+ *  `Partial<TParams>` shape for `params` while the returned function is still
+ *  assignable to `IndicatorPreset.compute`'s erased signature. */
+function typedCompute<TParams extends Record<string, unknown> = Record<string, unknown>>(
+  // biome-ignore lint/suspicious/noExplicitAny: Series<unknown> output is narrowed per-indicator
+  fn: (candles: NormalizedCandle[], params: Partial<TParams>) => Series<any>,
+): IndicatorPreset["compute"] {
+  return fn as IndicatorPreset["compute"];
+}
+
+/** Helper to extend a livePreset entry with a batch compute function + catalog metadata.
+ *
+ *  `TParams` is optional: when supplied, `params` inside `computeFn` is narrowed
+ *  to `Partial<TParams>` so callers can write `p.period ?? 20` without
+ *  `as number` casts. When omitted, `params` falls back to the permissive
+ *  `any` used by pre-0.3.0 call sites — preserves compatibility for entries
+ *  that haven't been migrated. Mirrors the `factory<TParams>()` pattern in
+ *  live-presets.ts. */
+function withCompute<TParams extends Record<string, unknown> | undefined = undefined>(
   key: string,
-  // biome-ignore lint/suspicious/noExplicitAny: bridging typed batch fns with generic params
-  computeFn: (candles: NormalizedCandle[], params: any) => Series<any>,
+  computeFn: TParams extends Record<string, unknown>
+    ? // biome-ignore lint/suspicious/noExplicitAny: Series<unknown> output is narrowed per-indicator
+      (candles: NormalizedCandle[], params: Partial<TParams>) => Series<any>
+    : // biome-ignore lint/suspicious/noExplicitAny: untyped fallback preserves pre-0.3.0 call sites
+      (candles: NormalizedCandle[], params: any) => Series<any>,
   catalog?: CatalogInfo,
 ): IndicatorPreset {
   const live = livePresets[key];
-  return { ...live, compute: computeFn, ...catalog };
+  return {
+    ...live,
+    compute: computeFn as (
+      candles: NormalizedCandle[],
+      params: Record<string, unknown>,
+    ) => Series<unknown>,
+    ...catalog,
+  };
 }
 
 /**
@@ -731,8 +759,9 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: DPO_META,
     defaultParams: { period: 20 },
     snapshotName: (p: Record<string, unknown>) => `dpo${p.period}`,
-    compute: (c, p) =>
-      dpo(c, { period: (p.period as number) ?? 20, source: p.source as "close" | undefined }),
+    compute: typedCompute<{ period?: number; source?: PriceSource }>((c, p) =>
+      dpo(c, { period: p.period ?? 20, source: p.source }),
+    ),
     category: "Momentum",
     name: "Detrended Price Oscillator",
     description: "Removes trend to identify cycles by comparing price to a displaced MA.",
@@ -1392,12 +1421,16 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
       description: "Classic support/resistance levels calculated from prior period's OHLC.",
     },
   ),
-  fractals: withCompute("fractals", (c, p) => fractals(c, { period: (p.period as number) ?? 2 }), {
-    category: "Price",
-    name: "Williams Fractals",
-    description: "Marks local highs and lows using surrounding bar comparison.",
-    paramSchema: [period(2, 1, 10)],
-  }),
+  fractals: withCompute<{ period?: number }>(
+    "fractals",
+    (c, p) => fractals(c, { period: p.period ?? 2 }),
+    {
+      category: "Price",
+      name: "Williams Fractals",
+      description: "Marks local highs and lows using surrounding bar comparison.",
+      paramSchema: [period(2, 1, 10)],
+    },
+  ),
   gapAnalysis: withCompute(
     "gapAnalysis",
     (c, p) => gapAnalysis(c, { minGapPercent: p.minGapPercent ?? 0.5 }),
@@ -1519,12 +1552,13 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: ADAPTIVE_RSI_META,
     defaultParams: { basePeriod: 14, minPeriod: 6, maxPeriod: 28 },
     snapshotName: "adaptiveRsi",
-    compute: (c, p) =>
+    compute: typedCompute<{ basePeriod?: number; minPeriod?: number; maxPeriod?: number }>((c, p) =>
       adaptiveRsi(c, {
-        basePeriod: (p.basePeriod as number) ?? 14,
-        minPeriod: (p.minPeriod as number) ?? 6,
-        maxPeriod: (p.maxPeriod as number) ?? 28,
+        basePeriod: p.basePeriod ?? 14,
+        minPeriod: p.minPeriod ?? 6,
+        maxPeriod: p.maxPeriod ?? 28,
       }),
+    ),
     category: "Adaptive",
     name: "Adaptive RSI",
     description: "RSI with period that adjusts based on market volatility.",
@@ -1538,7 +1572,9 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: ADAPTIVE_MA_META,
     defaultParams: { erPeriod: 10 },
     snapshotName: "adaptiveMa",
-    compute: (c, p) => adaptiveMa(c, { erPeriod: (p.erPeriod as number) ?? 10 }),
+    compute: typedCompute<{ erPeriod?: number }>((c, p) =>
+      adaptiveMa(c, { erPeriod: p.erPeriod ?? 10 }),
+    ),
     category: "Adaptive",
     name: "Adaptive Moving Average",
     description: "EMA with speed adapting to Kaufman efficiency ratio.",
@@ -1558,11 +1594,12 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: ADAPTIVE_BB_META,
     defaultParams: { period: 20, baseStdDev: 2 },
     snapshotName: "adaptiveBb",
-    compute: (c, p) =>
+    compute: typedCompute<{ period?: number; baseStdDev?: number }>((c, p) =>
       adaptiveBollinger(c, {
-        period: (p.period as number) ?? 20,
-        baseStdDev: (p.baseStdDev as number) ?? 2,
+        period: p.period ?? 20,
+        baseStdDev: p.baseStdDev ?? 2,
       }),
+    ),
     category: "Adaptive",
     name: "Adaptive Bollinger Bands",
     description: "Bollinger Bands with multiplier adapting to kurtosis.",
@@ -1583,7 +1620,9 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: ADAPTIVE_STOCH_META,
     defaultParams: { basePeriod: 14 },
     snapshotName: "adaptiveStoch",
-    compute: (c, p) => adaptiveStochastics(c, { basePeriod: (p.basePeriod as number) ?? 14 }),
+    compute: typedCompute<{ basePeriod?: number }>((c, p) =>
+      adaptiveStochastics(c, { basePeriod: p.basePeriod ?? 14 }),
+    ),
     category: "Adaptive",
     name: "Adaptive Stochastics",
     description: "Stochastic oscillator with period adapting to ADX-based trend strength.",
@@ -1607,17 +1646,19 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: STD_DEV_META,
     defaultParams: { period: 20 },
     snapshotName: "stdDev",
-    compute: (c, p) => standardDeviation(c, { period: (p.period as number) ?? 20 }),
+    compute: typedCompute<{ period?: number }>((c, p) =>
+      standardDeviation(c, { period: p.period ?? 20 }),
+    ),
     category: "Volatility",
     name: "Standard Deviation",
     description: "Raw standard deviation of closing prices over a rolling window.",
     paramSchema: [period(20)],
   },
-  ewmaVol: withCompute(
+  ewmaVol: withCompute<{ lambda?: number }>(
     "ewmaVol",
     (c, p) => {
       const returns = c.slice(1).map((bar, i) => Math.log(bar.close / c[i].close));
-      const raw = ewmaVolatility(returns, { lambda: (p.lambda as number) ?? 0.94 });
+      const raw = ewmaVolatility(returns, { lambda: p.lambda ?? 0.94 });
       // Map index-based time back to candle timestamps (offset by 1 for returns)
       return raw.map((pt, i) => ({ time: c[i + 1].time, value: pt.value }));
     },
@@ -1642,11 +1683,12 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: VOL_REGIME_META,
     defaultParams: { atrPeriod: 14, lookbackPeriod: 100 },
     snapshotName: "volRegime",
-    compute: (c, p) =>
+    compute: typedCompute<{ atrPeriod?: number; lookbackPeriod?: number }>((c, p) =>
       volatilityRegime(c, {
-        atrPeriod: (p.atrPeriod as number) ?? 14,
-        lookbackPeriod: (p.lookbackPeriod as number) ?? 100,
+        atrPeriod: p.atrPeriod ?? 14,
+        lookbackPeriod: p.lookbackPeriod ?? 100,
       }),
+    ),
     category: "Volatility",
     name: "Volatility Regime",
     description: "Classifies market volatility as low, normal, high, or extreme.",
@@ -1679,10 +1721,10 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: LINEAR_REG_META,
     defaultParams: { period: 20 },
     snapshotName: "linReg",
-    compute: (c, p) => {
-      const raw = linearRegression(c, { period: (p.period as number) ?? 20 });
+    compute: typedCompute<{ period?: number }>((c, p) => {
+      const raw = linearRegression(c, { period: p.period ?? 20 });
       // Convert to band format: regression line ± standard deviation
-      const per = (p.period as number) ?? 20;
+      const per = p.period ?? 20;
       // Calculate residual stdDev for channel bands
       const values: (number | null)[] = raw.map((d) => d.value?.value ?? null);
       const closes = c.map((bar) => bar.close);
@@ -1704,7 +1746,7 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
         const stdDev = count > 0 ? Math.sqrt(sumSq / count) : 0;
         return { time: d.time, value: { upper: v + stdDev, middle: v, lower: v - stdDev } };
       });
-    },
+    }),
     category: "Trend",
     name: "Linear Regression Channel",
     description: "Regression line with standard deviation channel bands.",
@@ -1718,7 +1760,7 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: VOLUME_MA_META,
     defaultParams: { period: 20 },
     snapshotName: "volMa",
-    compute: (c, p) => volumeMa(c, { period: (p.period as number) ?? 20 }),
+    compute: typedCompute<{ period?: number }>((c, p) => volumeMa(c, { period: p.period ?? 20 })),
     category: "Volume",
     name: "Volume Moving Average",
     description: "Simple moving average of volume.",
@@ -1728,7 +1770,9 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: CVD_SIGNAL_META,
     defaultParams: { signalPeriod: 9 },
     snapshotName: "cvdSignal",
-    compute: (c, p) => cvdWithSignal(c, { signalPeriod: (p.signalPeriod as number) ?? 9 }),
+    compute: typedCompute<{ signalPeriod?: number }>((c, p) =>
+      cvdWithSignal(c, { signalPeriod: p.signalPeriod ?? 9 }),
+    ),
     category: "Volume",
     name: "CVD with Signal",
     description: "Cumulative Volume Delta with EMA signal line for crossover detection.",
@@ -1751,11 +1795,12 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: FAST_STOCH_META,
     defaultParams: { kPeriod: 14, dPeriod: 3 },
     snapshotName: "fastStoch",
-    compute: (c, p) =>
+    compute: typedCompute<{ kPeriod?: number; dPeriod?: number }>((c, p) =>
       fastStochastics(c, {
-        kPeriod: (p.kPeriod as number) ?? 14,
-        dPeriod: (p.dPeriod as number) ?? 3,
+        kPeriod: p.kPeriod ?? 14,
+        dPeriod: p.dPeriod ?? 3,
       }),
+    ),
     category: "Momentum",
     name: "Fast Stochastics",
     description: "Stochastic oscillator without smoothing (slowing=1).",
@@ -1768,11 +1813,12 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: SLOW_STOCH_META,
     defaultParams: { kPeriod: 14, dPeriod: 3 },
     snapshotName: "slowStoch",
-    compute: (c, p) =>
+    compute: typedCompute<{ kPeriod?: number; dPeriod?: number }>((c, p) =>
       slowStochastics(c, {
-        kPeriod: (p.kPeriod as number) ?? 14,
-        dPeriod: (p.dPeriod as number) ?? 3,
+        kPeriod: p.kPeriod ?? 14,
+        dPeriod: p.dPeriod ?? 3,
       }),
+    ),
     category: "Momentum",
     name: "Slow Stochastics",
     description: "Stochastic oscillator with extra smoothing (slowing=3).",
@@ -1798,11 +1844,12 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: SWING_POINTS_META,
     defaultParams: { leftBars: 5, rightBars: 5 },
     snapshotName: "swing",
-    compute: (c, p) =>
+    compute: typedCompute<{ leftBars?: number; rightBars?: number }>((c, p) =>
       swingPoints(c, {
-        leftBars: (p.leftBars as number) ?? 5,
-        rightBars: (p.rightBars as number) ?? 5,
+        leftBars: p.leftBars ?? 5,
+        rightBars: p.rightBars ?? 5,
       }),
+    ),
     category: "Price",
     name: "Swing Points",
     description: "Confirmed swing highs and lows using surrounding bar comparison.",
@@ -1823,8 +1870,8 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: ZIGZAG_META,
     defaultParams: { deviation: 5 },
     snapshotName: "zigzag",
-    compute: (c, p) => {
-      const raw = zigzag(c, { deviation: (p.deviation as number) ?? 5 });
+    compute: typedCompute<{ deviation?: number }>((c, p) => {
+      const raw = zigzag(c, { deviation: p.deviation ?? 5 });
       // Interpolate between pivot points for line rendering
       const result: Series<number | null> = raw.map((d) => ({
         time: d.time,
@@ -1845,7 +1892,7 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
         }
       }
       return result;
-    },
+    }),
     category: "Price",
     name: "Zigzag",
     description: "Connects significant swing points, filtering minor price movements.",
@@ -1882,7 +1929,9 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: ORDER_BLOCK_META,
     defaultParams: { swingPeriod: 5 },
     snapshotName: "ob",
-    compute: (c, p) => orderBlock(c, { swingPeriod: (p.swingPeriod as number) ?? 5 }),
+    compute: typedCompute<{ swingPeriod?: number }>((c, p) =>
+      orderBlock(c, { swingPeriod: p.swingPeriod ?? 5 }),
+    ),
     category: "SMC",
     name: "Order Block",
     description: "Detects institutional order blocks — supply and demand zones.",
@@ -1902,7 +1951,9 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: LIQUIDITY_SWEEP_META,
     defaultParams: { swingPeriod: 5 },
     snapshotName: "liqSweep",
-    compute: (c, p) => liquiditySweep(c, { swingPeriod: (p.swingPeriod as number) ?? 5 }),
+    compute: typedCompute<{ swingPeriod?: number }>((c, p) =>
+      liquiditySweep(c, { swingPeriod: p.swingPeriod ?? 5 }),
+    ),
     category: "SMC",
     name: "Liquidity Sweep",
     description: "Detects stop-hunt sweeps beyond swing highs/lows that quickly reverse.",
@@ -1926,7 +1977,9 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: { kind: "superSmoother", overlay: true, label: "SuperSmoother" },
     defaultParams: { period: 10 },
     snapshotName: (p: Record<string, unknown>) => `ss${p.period}`,
-    compute: (c, p) => superSmoother(c, { period: (p.period as number) ?? 10 }),
+    compute: typedCompute<{ period?: number }>((c, p) =>
+      superSmoother(c, { period: p.period ?? 10 }),
+    ),
     category: "Filter",
     name: "Super Smoother (Ehlers)",
     description: "Low-pass filter that smooths price with minimal lag via 2-pole IIR.",
@@ -1936,11 +1989,12 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: { kind: "roofingFilter", overlay: false, label: "Roofing" },
     defaultParams: { highPassPeriod: 48, lowPassPeriod: 10 },
     snapshotName: (p: Record<string, unknown>) => `roof${p.highPassPeriod}-${p.lowPassPeriod}`,
-    compute: (c, p) =>
+    compute: typedCompute<{ highPassPeriod?: number; lowPassPeriod?: number }>((c, p) =>
       roofingFilter(c, {
-        highPassPeriod: (p.highPassPeriod as number) ?? 48,
-        lowPassPeriod: (p.lowPassPeriod as number) ?? 10,
+        highPassPeriod: p.highPassPeriod ?? 48,
+        lowPassPeriod: p.lowPassPeriod ?? 10,
       }),
+    ),
     category: "Filter",
     name: "Roofing Filter (Ehlers)",
     description: "Bandpass that isolates medium-frequency cycles by removing trend and noise.",
@@ -1973,7 +2027,7 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: { kind: "highest", overlay: true, label: "Highest" },
     defaultParams: { period: 20 },
     snapshotName: (p: Record<string, unknown>) => `hi${p.period}`,
-    compute: (c, p) => highest(c, (p.period as number) ?? 20),
+    compute: typedCompute<{ period?: number }>((c, p) => highest(c, p.period ?? 20)),
     category: "Price",
     name: "Highest High",
     description: "Rolling maximum of candle highs over N bars.",
@@ -1983,7 +2037,7 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: { kind: "lowest", overlay: true, label: "Lowest" },
     defaultParams: { period: 20 },
     snapshotName: (p: Record<string, unknown>) => `lo${p.period}`,
-    compute: (c, p) => lowest(c, (p.period as number) ?? 20),
+    compute: typedCompute<{ period?: number }>((c, p) => lowest(c, p.period ?? 20)),
     category: "Price",
     name: "Lowest Low",
     description: "Rolling minimum of candle lows over N bars.",
@@ -1993,11 +2047,12 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: { kind: "returns", overlay: false, label: "Returns" },
     defaultParams: { period: 1, type: "simple" },
     snapshotName: (p: Record<string, unknown>) => `ret${p.period}-${p.type ?? "simple"}`,
-    compute: (c, p) =>
+    compute: typedCompute<{ period?: number; type?: "simple" | "log" }>((c, p) =>
       returns(c, {
-        period: (p.period as number) ?? 1,
-        type: (p.type as "simple" | "log") ?? "simple",
+        period: p.period ?? 1,
+        type: p.type ?? "simple",
       }),
+    ),
     category: "Price",
     name: "Returns",
     description: "Bar-over-bar percentage or log returns of close prices.",
@@ -2007,7 +2062,9 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: { kind: "cumulativeReturns", overlay: false, label: "Cum. Returns" },
     defaultParams: { type: "simple" },
     snapshotName: (p: Record<string, unknown>) => `cumret-${p.type ?? "simple"}`,
-    compute: (c, p) => cumulativeReturns(c, (p.type as "simple" | "log") ?? "simple"),
+    compute: typedCompute<{ type?: "simple" | "log" }>((c, p) =>
+      cumulativeReturns(c, p.type ?? "simple"),
+    ),
     category: "Price",
     name: "Cumulative Returns",
     description: "Growth of $1 invested at the first bar's close.",
@@ -2047,7 +2104,7 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     meta: { kind: "atrPercent", overlay: false, label: "ATR%" },
     defaultParams: { period: 14 },
     snapshotName: (p: Record<string, unknown>) => `atrpct${p.period}`,
-    compute: (c, p) => atrPercentSeries(c, (p.period as number) ?? 14),
+    compute: typedCompute<{ period?: number }>((c, p) => atrPercentSeries(c, p.period ?? 14)),
     category: "Volatility",
     name: "ATR Percent",
     description: "ATR expressed as a percentage of price — normalized volatility metric.",

--- a/packages/core/src/streaming/live-presets.ts
+++ b/packages/core/src/streaming/live-presets.ts
@@ -176,7 +176,7 @@ import {
   WMA_META,
   ZLEMA_META,
 } from "../indicators/indicator-meta";
-import type { SeriesMeta } from "../types/candle";
+import type { PriceSource, SeriesMeta } from "../types/candle";
 import type { LiveIndicatorFactory } from "./types";
 
 /**
@@ -195,14 +195,43 @@ export type LivePreset = {
   createFactory: (params: Record<string, unknown>) => LiveIndicatorFactory;
 };
 
+/**
+ * Infer the incremental state type `S` from a `create*` factory's signature
+ * so `restoreState<S>()` stays strongly typed without an explicit generic
+ * at each call site.
+ */
+type StateOf<TCreate> = TCreate extends (
+  params: unknown,
+  warmUp?: WarmUpOptions<infer S>,
+) => ReturnType<LiveIndicatorFactory>
+  ? S
+  : unknown;
+
 /** Helper to create a factory builder with restoreState wiring.
- *  S is inferred from the create function's WarmUpOptions<S> parameter,
- *  allowing restoreState<S>() to produce the correctly-typed state. */
-function factory<T, S>(
-  create: (params: T, warmUp?: WarmUpOptions<S>) => ReturnType<LiveIndicatorFactory>,
-  mapParams: (p: Record<string, unknown>) => T,
-): (params: Record<string, unknown>) => LiveIndicatorFactory {
-  return (params) => (state) => create(mapParams(params), restoreState<S>(state));
+ *
+ *  Curried so callers can declare `TParams` (the preset's param shape)
+ *  explicitly while `TCreate` still infers from the `create*` argument:
+ *
+ *    factory<{ period: number }>()(createSma, (p) => ({ period: p.period ?? 20 }))
+ *
+ *  Inside `mapParams`, incoming `Record<string, unknown>` is narrowed to
+ *  `Partial<TParams>` so `?? default` fallbacks work without `as number` /
+ *  `as string` casts. `Parameters<TCreate>[0]` pins the mapped options to
+ *  whatever `create*` expects; `StateOf<TCreate>` recovers the snapshot
+ *  state type used by `restoreState<S>()`.
+ *
+ *  Omitting the type argument (`factory()(create, mapParams)`) falls back
+ *  to `Record<string, unknown>` — equivalent to the pre-0.3.0 behavior.
+ */
+function factory<TParams extends Record<string, unknown> = Record<string, unknown>>(): <
+  // biome-ignore lint/suspicious/noExplicitAny: factory accepts any create* signature; typed narrowly via Parameters/StateOf
+  TCreate extends (params: any, warmUp?: WarmUpOptions<any>) => ReturnType<LiveIndicatorFactory>,
+>(
+  create: TCreate,
+  mapParams: (p: Partial<TParams>) => Parameters<TCreate>[0],
+) => (params: Record<string, unknown>) => LiveIndicatorFactory {
+  return (create, mapParams) => (params) => (state) =>
+    create(mapParams(params as Partial<TParams>), restoreState<StateOf<typeof create>>(state));
 }
 
 /**
@@ -220,106 +249,113 @@ export const livePresets: Record<string, LivePreset> = {
     meta: SMA_META,
     defaultParams: { period: 20 },
     snapshotName: (p) => `sma${p.period}`,
-    createFactory: factory(createSma, (p) => ({
-      period: (p.period as number) ?? 20,
-      source: p.source as "close" | undefined,
+    createFactory: factory<{ source?: PriceSource; period?: number }>()(createSma, (p) => ({
+      period: p.period ?? 20,
+      source: p.source,
     })),
   },
   ema: {
     meta: EMA_META,
     defaultParams: { period: 20 },
     snapshotName: (p) => `ema${p.period}`,
-    createFactory: factory(createEma, (p) => ({ period: (p.period as number) ?? 20 })),
+    createFactory: factory<{ period?: number }>()(createEma, (p) => ({ period: p.period ?? 20 })),
   },
   wma: {
     meta: WMA_META,
     defaultParams: { period: 20 },
     snapshotName: (p) => `wma${p.period}`,
-    createFactory: factory(createWma, (p) => ({ period: (p.period as number) ?? 20 })),
+    createFactory: factory<{ period?: number }>()(createWma, (p) => ({ period: p.period ?? 20 })),
   },
   vwma: {
     meta: VWMA_META,
     defaultParams: { period: 20 },
     snapshotName: (p) => `vwma${p.period}`,
-    createFactory: factory(createVwma, (p) => ({ period: (p.period as number) ?? 20 })),
+    createFactory: factory<{ period?: number }>()(createVwma, (p) => ({ period: p.period ?? 20 })),
   },
   kama: {
     meta: KAMA_META,
     defaultParams: { period: 10 },
     snapshotName: (p) => `kama${p.period}`,
-    createFactory: factory(createKama, (p) => ({ period: (p.period as number) ?? 10 })),
+    createFactory: factory<{ period?: number }>()(createKama, (p) => ({ period: p.period ?? 10 })),
   },
   hma: {
     meta: HMA_META,
     defaultParams: { period: 16 },
     snapshotName: (p) => `hma${p.period}`,
-    createFactory: factory(createHma, (p) => ({ period: (p.period as number) ?? 16 })),
+    createFactory: factory<{ period?: number }>()(createHma, (p) => ({ period: p.period ?? 16 })),
   },
   t3: {
     meta: T3_META,
     defaultParams: { period: 5 },
     snapshotName: (p) => `t3_${p.period}`,
-    createFactory: factory(createT3, (p) => ({ period: (p.period as number) ?? 5 })),
+    createFactory: factory<{ period?: number }>()(createT3, (p) => ({ period: p.period ?? 5 })),
   },
   mcginley: {
     meta: MCGINLEY_META,
     defaultParams: { period: 14 },
     snapshotName: (p) => `mcginley${p.period}`,
-    createFactory: factory(createMcGinleyDynamic, (p) => ({ period: (p.period as number) ?? 14 })),
+    createFactory: factory<{ period?: number }>()(createMcGinleyDynamic, (p) => ({
+      period: p.period ?? 14,
+    })),
   },
   emaRibbon: {
     meta: EMA_RIBBON_META,
     defaultParams: { periods: [8, 13, 21, 34, 55] },
     snapshotName: "emaRibbon",
-    createFactory: factory(createEmaRibbon, (p) => ({
-      periods: p.periods as number[] | undefined,
+    createFactory: factory<{ periods?: number[] }>()(createEmaRibbon, (p) => ({
+      periods: p.periods,
     })),
   },
   dema: {
     meta: DEMA_META,
     defaultParams: { period: 20 },
     snapshotName: (p) => `dema${p.period}`,
-    createFactory: factory(createDema, (p) => ({
-      period: (p.period as number) ?? 20,
-      source: p.source as "close" | undefined,
+    createFactory: factory<{ source?: PriceSource; period?: number }>()(createDema, (p) => ({
+      period: p.period ?? 20,
+      source: p.source,
     })),
   },
   tema: {
     meta: TEMA_META,
     defaultParams: { period: 20 },
     snapshotName: (p) => `tema${p.period}`,
-    createFactory: factory(createTema, (p) => ({
-      period: (p.period as number) ?? 20,
-      source: p.source as "close" | undefined,
+    createFactory: factory<{ source?: PriceSource; period?: number }>()(createTema, (p) => ({
+      period: p.period ?? 20,
+      source: p.source,
     })),
   },
   zlema: {
     meta: ZLEMA_META,
     defaultParams: { period: 20 },
     snapshotName: (p) => `zlema${p.period}`,
-    createFactory: factory(createZlema, (p) => ({
-      period: (p.period as number) ?? 20,
-      source: p.source as "close" | undefined,
+    createFactory: factory<{ source?: PriceSource; period?: number }>()(createZlema, (p) => ({
+      period: p.period ?? 20,
+      source: p.source,
     })),
   },
   alma: {
     meta: ALMA_META,
     defaultParams: { period: 9, offset: 0.85, sigma: 6 },
     snapshotName: (p) => `alma${p.period}_${p.offset ?? 0.85}_${p.sigma ?? 6}`,
-    createFactory: factory(createAlma, (p) => ({
-      period: (p.period as number) ?? 9,
-      offset: (p.offset as number) ?? 0.85,
-      sigma: (p.sigma as number) ?? 6,
-      source: p.source as "close" | undefined,
+    createFactory: factory<{
+      source?: PriceSource;
+      period?: number;
+      offset?: number;
+      sigma?: number;
+    }>()(createAlma, (p) => ({
+      period: p.period ?? 9,
+      offset: p.offset ?? 0.85,
+      sigma: p.sigma ?? 6,
+      source: p.source,
     })),
   },
   frama: {
     meta: FRAMA_META,
     defaultParams: { period: 16 },
     snapshotName: (p) => `frama${p.period}`,
-    createFactory: factory(createFrama, (p) => ({
-      period: (p.period as number) ?? 16,
-      source: p.source as "close" | undefined,
+    createFactory: factory<{ source?: PriceSource; period?: number }>()(createFrama, (p) => ({
+      period: p.period ?? 16,
+      source: p.source,
     })),
   },
 
@@ -328,161 +364,194 @@ export const livePresets: Record<string, LivePreset> = {
     meta: RSI_META,
     defaultParams: { period: 14 },
     snapshotName: (p) => `rsi${p.period}`,
-    createFactory: factory(createRsi, (p) => ({ period: (p.period as number) ?? 14 })),
+    createFactory: factory<{ period?: number }>()(createRsi, (p) => ({ period: p.period ?? 14 })),
   },
   macd: {
     meta: MACD_META,
     defaultParams: { fastPeriod: 12, slowPeriod: 26, signalPeriod: 9 },
     snapshotName: "macd",
-    createFactory: factory(createMacd, (p) => ({
-      fastPeriod: p.fastPeriod as number | undefined,
-      slowPeriod: p.slowPeriod as number | undefined,
-      signalPeriod: p.signalPeriod as number | undefined,
-    })),
+    createFactory: factory<{ fastPeriod?: number; slowPeriod?: number; signalPeriod?: number }>()(
+      createMacd,
+      (p) => ({
+        fastPeriod: p.fastPeriod,
+        slowPeriod: p.slowPeriod,
+        signalPeriod: p.signalPeriod,
+      }),
+    ),
   },
   stochastics: {
     meta: STOCHASTICS_META,
     defaultParams: { kPeriod: 14, dPeriod: 3, slowing: 3 },
     snapshotName: "stoch",
-    createFactory: factory(createStochastics, (p) => ({
-      kPeriod: p.kPeriod as number | undefined,
-      dPeriod: p.dPeriod as number | undefined,
-      slowing: p.slowing as number | undefined,
-    })),
+    createFactory: factory<{ kPeriod?: number; dPeriod?: number; slowing?: number }>()(
+      createStochastics,
+      (p) => ({
+        kPeriod: p.kPeriod,
+        dPeriod: p.dPeriod,
+        slowing: p.slowing,
+      }),
+    ),
   },
   dmi: {
     meta: DMI_META,
     defaultParams: { period: 14 },
     snapshotName: "dmi",
-    createFactory: factory(createDmi, (p) => ({ period: (p.period as number) ?? 14 })),
+    createFactory: factory<{ period?: number }>()(createDmi, (p) => ({ period: p.period ?? 14 })),
   },
   roc: {
     meta: ROC_META,
     defaultParams: { period: 12 },
     snapshotName: (p) => `roc${p.period}`,
-    createFactory: factory(createRoc, (p) => ({ period: (p.period as number) ?? 12 })),
+    createFactory: factory<{ period?: number }>()(createRoc, (p) => ({ period: p.period ?? 12 })),
   },
   williamsR: {
     meta: WILLIAMS_R_META,
     defaultParams: { period: 14 },
     snapshotName: (p) => `willR${p.period}`,
-    createFactory: factory(createWilliamsR, (p) => ({ period: (p.period as number) ?? 14 })),
+    createFactory: factory<{ period?: number }>()(createWilliamsR, (p) => ({
+      period: p.period ?? 14,
+    })),
   },
   cci: {
     meta: CCI_META,
     defaultParams: { period: 20 },
     snapshotName: (p) => `cci${p.period}`,
-    createFactory: factory(createCci, (p) => ({ period: (p.period as number) ?? 20 })),
+    createFactory: factory<{ period?: number }>()(createCci, (p) => ({ period: p.period ?? 20 })),
   },
   stochRsi: {
     meta: STOCH_RSI_META,
     defaultParams: { rsiPeriod: 14, stochPeriod: 14, kPeriod: 3, dPeriod: 3 },
     snapshotName: "stochRsi",
-    createFactory: factory(createStochRsi, (p) => ({
-      rsiPeriod: p.rsiPeriod as number | undefined,
-      stochPeriod: p.stochPeriod as number | undefined,
-      kPeriod: p.kPeriod as number | undefined,
-      dPeriod: p.dPeriod as number | undefined,
+    createFactory: factory<{
+      rsiPeriod?: number;
+      stochPeriod?: number;
+      kPeriod?: number;
+      dPeriod?: number;
+    }>()(createStochRsi, (p) => ({
+      rsiPeriod: p.rsiPeriod,
+      stochPeriod: p.stochPeriod,
+      kPeriod: p.kPeriod,
+      dPeriod: p.dPeriod,
     })),
   },
   trix: {
     meta: TRIX_META,
     defaultParams: { period: 15 },
     snapshotName: (p) => `trix${p.period}`,
-    createFactory: factory(createTrix, (p) => ({ period: (p.period as number) ?? 15 })),
+    createFactory: factory<{ period?: number }>()(createTrix, (p) => ({ period: p.period ?? 15 })),
   },
   aroon: {
     meta: AROON_META,
     defaultParams: { period: 25 },
     snapshotName: "aroon",
-    createFactory: factory(createAroon, (p) => ({ period: (p.period as number) ?? 25 })),
+    createFactory: factory<{ period?: number }>()(createAroon, (p) => ({ period: p.period ?? 25 })),
   },
   connorsRsi: {
     meta: CONNORS_RSI_META,
     defaultParams: { rsiPeriod: 3, streakPeriod: 2, rocPeriod: 100 },
     snapshotName: "crsi",
-    createFactory: factory(createConnorsRsi, (p) => ({
-      rsiPeriod: p.rsiPeriod as number | undefined,
-      streakPeriod: p.streakPeriod as number | undefined,
-      rocPeriod: p.rocPeriod as number | undefined,
-    })),
+    createFactory: factory<{ rsiPeriod?: number; streakPeriod?: number; rocPeriod?: number }>()(
+      createConnorsRsi,
+      (p) => ({
+        rsiPeriod: p.rsiPeriod,
+        streakPeriod: p.streakPeriod,
+        rocPeriod: p.rocPeriod,
+      }),
+    ),
   },
   cmo: {
     meta: CMO_META,
     defaultParams: { period: 14 },
     snapshotName: (p) => `cmo${p.period}`,
-    createFactory: factory(createCmo, (p) => ({ period: (p.period as number) ?? 14 })),
+    createFactory: factory<{ period?: number }>()(createCmo, (p) => ({ period: p.period ?? 14 })),
   },
   adxr: {
     meta: ADXR_META,
     defaultParams: { period: 14 },
     snapshotName: "adxr",
-    createFactory: factory(createAdxr, (p) => ({ period: (p.period as number) ?? 14 })),
+    createFactory: factory<{ period?: number }>()(createAdxr, (p) => ({ period: p.period ?? 14 })),
   },
   imi: {
     meta: IMI_META,
     defaultParams: { period: 14 },
     snapshotName: (p) => `imi${p.period}`,
-    createFactory: factory(createImi, (p) => ({ period: (p.period as number) ?? 14 })),
+    createFactory: factory<{ period?: number }>()(createImi, (p) => ({ period: p.period ?? 14 })),
   },
   vortex: {
     meta: VORTEX_META,
     defaultParams: { period: 14 },
     snapshotName: "vortex",
-    createFactory: factory(createVortex, (p) => ({ period: (p.period as number) ?? 14 })),
+    createFactory: factory<{ period?: number }>()(createVortex, (p) => ({
+      period: p.period ?? 14,
+    })),
   },
   ao: {
     meta: AO_META,
     defaultParams: { fastPeriod: 5, slowPeriod: 34 },
     snapshotName: "ao",
-    createFactory: factory(createAwesomeOscillator, (p) => ({
-      fastPeriod: (p.fastPeriod as number) ?? 5,
-      slowPeriod: (p.slowPeriod as number) ?? 34,
-    })),
+    createFactory: factory<{ fastPeriod?: number; slowPeriod?: number }>()(
+      createAwesomeOscillator,
+      (p) => ({
+        fastPeriod: p.fastPeriod ?? 5,
+        slowPeriod: p.slowPeriod ?? 34,
+      }),
+    ),
   },
   bop: {
     meta: BOP_META,
     defaultParams: { smoothPeriod: 14 },
     snapshotName: (p) => `bop${p.smoothPeriod}`,
-    createFactory: factory(createBalanceOfPower, (p) => ({
-      smoothPeriod: (p.smoothPeriod as number) ?? 14,
+    createFactory: factory<{ smoothPeriod?: number }>()(createBalanceOfPower, (p) => ({
+      smoothPeriod: p.smoothPeriod ?? 14,
     })),
   },
   qstick: {
     meta: QSTICK_META,
     defaultParams: { period: 14 },
     snapshotName: (p) => `qstick${p.period}`,
-    createFactory: factory(createQStick, (p) => ({ period: (p.period as number) ?? 14 })),
+    createFactory: factory<{ period?: number }>()(createQStick, (p) => ({
+      period: p.period ?? 14,
+    })),
   },
   ppo: {
     meta: PPO_META,
     defaultParams: { fastPeriod: 12, slowPeriod: 26, signalPeriod: 9 },
     snapshotName: "ppo",
-    createFactory: factory(createPpo, (p) => ({
-      fastPeriod: (p.fastPeriod as number) ?? 12,
-      slowPeriod: (p.slowPeriod as number) ?? 26,
-      signalPeriod: (p.signalPeriod as number) ?? 9,
-      source: p.source as "close" | undefined,
+    createFactory: factory<{
+      source?: PriceSource;
+      fastPeriod?: number;
+      slowPeriod?: number;
+      signalPeriod?: number;
+    }>()(createPpo, (p) => ({
+      fastPeriod: p.fastPeriod ?? 12,
+      slowPeriod: p.slowPeriod ?? 26,
+      signalPeriod: p.signalPeriod ?? 9,
+      source: p.source,
     })),
   },
   coppock: {
     meta: COPPOCK_META,
     defaultParams: { wmaPeriod: 10, longRocPeriod: 14, shortRocPeriod: 11 },
     snapshotName: "coppock",
-    createFactory: factory(createCoppockCurve, (p) => ({
-      wmaPeriod: (p.wmaPeriod as number) ?? 10,
-      longRocPeriod: (p.longRocPeriod as number) ?? 14,
-      shortRocPeriod: (p.shortRocPeriod as number) ?? 11,
-      source: p.source as "close" | undefined,
+    createFactory: factory<{
+      source?: PriceSource;
+      wmaPeriod?: number;
+      longRocPeriod?: number;
+      shortRocPeriod?: number;
+    }>()(createCoppockCurve, (p) => ({
+      wmaPeriod: p.wmaPeriod ?? 10,
+      longRocPeriod: p.longRocPeriod ?? 14,
+      shortRocPeriod: p.shortRocPeriod ?? 11,
+      source: p.source,
     })),
   },
   massIndex: {
     meta: MASS_INDEX_META,
     defaultParams: { emaPeriod: 9, sumPeriod: 25 },
     snapshotName: "massIndex",
-    createFactory: factory(createMassIndex, (p) => ({
-      emaPeriod: (p.emaPeriod as number) ?? 9,
-      sumPeriod: (p.sumPeriod as number) ?? 25,
+    createFactory: factory<{ emaPeriod?: number; sumPeriod?: number }>()(createMassIndex, (p) => ({
+      emaPeriod: p.emaPeriod ?? 9,
+      sumPeriod: p.sumPeriod ?? 25,
     })),
   },
   // DPO is intentionally excluded from live presets.
@@ -493,51 +562,67 @@ export const livePresets: Record<string, LivePreset> = {
     meta: UO_META,
     defaultParams: { period1: 7, period2: 14, period3: 28 },
     snapshotName: "uo",
-    createFactory: factory(createUltimateOscillator, (p) => ({
-      period1: (p.period1 as number) ?? 7,
-      period2: (p.period2 as number) ?? 14,
-      period3: (p.period3 as number) ?? 28,
-    })),
+    createFactory: factory<{ period1?: number; period2?: number; period3?: number }>()(
+      createUltimateOscillator,
+      (p) => ({
+        period1: p.period1 ?? 7,
+        period2: p.period2 ?? 14,
+        period3: p.period3 ?? 28,
+      }),
+    ),
   },
   tsi: {
     meta: TSI_META,
     defaultParams: { longPeriod: 25, shortPeriod: 13, signalPeriod: 7 },
     snapshotName: "tsi",
-    createFactory: factory(createTsi, (p) => ({
-      longPeriod: (p.longPeriod as number) ?? 25,
-      shortPeriod: (p.shortPeriod as number) ?? 13,
-      signalPeriod: (p.signalPeriod as number) ?? 7,
-      source: p.source as "close" | undefined,
+    createFactory: factory<{
+      source?: PriceSource;
+      longPeriod?: number;
+      shortPeriod?: number;
+      signalPeriod?: number;
+    }>()(createTsi, (p) => ({
+      longPeriod: p.longPeriod ?? 25,
+      shortPeriod: p.shortPeriod ?? 13,
+      signalPeriod: p.signalPeriod ?? 7,
+      source: p.source,
     })),
   },
   kst: {
     meta: KST_META,
     defaultParams: { signalPeriod: 9 },
     snapshotName: "kst",
-    createFactory: factory(createKst, (p) => ({
-      signalPeriod: (p.signalPeriod as number) ?? 9,
-      source: p.source as "close" | undefined,
+    createFactory: factory<{ source?: PriceSource; signalPeriod?: number }>()(createKst, (p) => ({
+      signalPeriod: p.signalPeriod ?? 9,
+      source: p.source,
     })),
   },
   hurst: {
     meta: HURST_META,
     defaultParams: { minWindow: 20, maxWindow: 100 },
     snapshotName: "hurst",
-    createFactory: factory(createHurst, (p) => ({
-      minWindow: (p.minWindow as number) ?? 20,
-      maxWindow: (p.maxWindow as number) ?? 100,
-      source: p.source as "close" | undefined,
-    })),
+    createFactory: factory<{ source?: PriceSource; minWindow?: number; maxWindow?: number }>()(
+      createHurst,
+      (p) => ({
+        minWindow: p.minWindow ?? 20,
+        maxWindow: p.maxWindow ?? 100,
+        source: p.source,
+      }),
+    ),
   },
   stc: {
     meta: STC_META,
     defaultParams: { fastPeriod: 23, slowPeriod: 50, cyclePeriod: 10 },
     snapshotName: "stc",
-    createFactory: factory(createStc, (p) => ({
-      fastPeriod: (p.fastPeriod as number) ?? 23,
-      slowPeriod: (p.slowPeriod as number) ?? 50,
-      cyclePeriod: (p.cyclePeriod as number) ?? 10,
-      source: p.source as "close" | undefined,
+    createFactory: factory<{
+      source?: PriceSource;
+      fastPeriod?: number;
+      slowPeriod?: number;
+      cyclePeriod?: number;
+    }>()(createStc, (p) => ({
+      fastPeriod: p.fastPeriod ?? 23,
+      slowPeriod: p.slowPeriod ?? 50,
+      cyclePeriod: p.cyclePeriod ?? 10,
+      source: p.source,
     })),
   },
 
@@ -546,93 +631,116 @@ export const livePresets: Record<string, LivePreset> = {
     meta: ATR_META,
     defaultParams: { period: 14 },
     snapshotName: (p) => `atr${p.period}`,
-    createFactory: factory(createAtr, (p) => ({ period: (p.period as number) ?? 14 })),
+    createFactory: factory<{ period?: number }>()(createAtr, (p) => ({ period: p.period ?? 14 })),
   },
   bb: {
     meta: BB_META,
     defaultParams: { period: 20, stdDev: 2 },
     snapshotName: (p) => `bb${p.period}`,
-    createFactory: factory(createBollingerBands, (p) => ({
-      period: (p.period as number) ?? 20,
-      stdDev: p.stdDev as number | undefined,
+    createFactory: factory<{ period?: number; stdDev?: number }>()(createBollingerBands, (p) => ({
+      period: p.period ?? 20,
+      stdDev: p.stdDev,
     })),
   },
   donchian: {
     meta: DONCHIAN_META,
     defaultParams: { period: 20 },
     snapshotName: (p) => `donchian${p.period}`,
-    createFactory: factory(createDonchianChannel, (p) => ({ period: (p.period as number) ?? 20 })),
+    createFactory: factory<{ period?: number }>()(createDonchianChannel, (p) => ({
+      period: p.period ?? 20,
+    })),
   },
   keltner: {
     meta: KELTNER_META,
     defaultParams: { emaPeriod: 20, atrPeriod: 10, multiplier: 1.5 },
     snapshotName: "keltner",
-    createFactory: factory(createKeltnerChannel, (p) => ({
-      emaPeriod: p.emaPeriod as number | undefined,
-      atrPeriod: p.atrPeriod as number | undefined,
-      multiplier: p.multiplier as number | undefined,
-    })),
+    createFactory: factory<{ emaPeriod?: number; atrPeriod?: number; multiplier?: number }>()(
+      createKeltnerChannel,
+      (p) => ({
+        emaPeriod: p.emaPeriod,
+        atrPeriod: p.atrPeriod,
+        multiplier: p.multiplier,
+      }),
+    ),
   },
   chandelierExit: {
     meta: CHANDELIER_EXIT_META,
     defaultParams: { period: 22, multiplier: 3 },
     snapshotName: "chandelier",
-    createFactory: factory(createChandelierExit, (p) => ({
-      period: (p.period as number) ?? 22,
-      multiplier: (p.multiplier as number) ?? 3,
-    })),
+    createFactory: factory<{ period?: number; multiplier?: number }>()(
+      createChandelierExit,
+      (p) => ({
+        period: p.period ?? 22,
+        multiplier: p.multiplier ?? 3,
+      }),
+    ),
   },
   choppiness: {
     meta: CHOPPINESS_META,
     defaultParams: { period: 14 },
     snapshotName: (p) => `chop${p.period}`,
-    createFactory: factory(createChoppinessIndex, (p) => ({ period: (p.period as number) ?? 14 })),
+    createFactory: factory<{ period?: number }>()(createChoppinessIndex, (p) => ({
+      period: p.period ?? 14,
+    })),
   },
   ewmaVol: {
     meta: EWMA_VOL_META,
     defaultParams: { lambda: 0.94 },
     snapshotName: (p) => `ewma${p.lambda}`,
-    createFactory: factory(createEwmaVolatility, (p) => ({
-      lambda: (p.lambda as number) ?? 0.94,
-      source: p.source as "close" | undefined,
-    })),
+    createFactory: factory<{ source?: PriceSource; lambda?: number }>()(
+      createEwmaVolatility,
+      (p) => ({
+        lambda: p.lambda ?? 0.94,
+        source: p.source,
+      }),
+    ),
   },
   garmanKlass: {
     meta: GARMAN_KLASS_META,
     defaultParams: { period: 20 },
     snapshotName: (p) => `gk${p.period}`,
-    createFactory: factory(createGarmanKlass, (p) => ({
-      period: (p.period as number) ?? 20,
-      annualFactor: (p.annualFactor as number) ?? 252,
-    })),
+    createFactory: factory<{ period?: number; annualFactor?: number }>()(
+      createGarmanKlass,
+      (p) => ({
+        period: p.period ?? 20,
+        annualFactor: p.annualFactor ?? 252,
+      }),
+    ),
   },
   hv: {
     meta: HV_META,
     defaultParams: { period: 20 },
     snapshotName: (p) => `hv${p.period}`,
-    createFactory: factory(createHistoricalVolatility, (p) => ({
-      period: (p.period as number) ?? 20,
-      annualFactor: (p.annualFactor as number) ?? 252,
-      source: p.source as "close" | undefined,
-    })),
+    createFactory: factory<{ source?: PriceSource; period?: number; annualFactor?: number }>()(
+      createHistoricalVolatility,
+      (p) => ({
+        period: p.period ?? 20,
+        annualFactor: p.annualFactor ?? 252,
+        source: p.source,
+      }),
+    ),
   },
   atrStops: {
     meta: ATR_STOPS_META,
     defaultParams: { period: 14, stopMultiplier: 2, takeProfitMultiplier: 3 },
     snapshotName: "atrStops",
-    createFactory: factory(createAtrStops, (p) => ({
-      period: (p.period as number) ?? 14,
-      stopMultiplier: (p.stopMultiplier as number) ?? 2,
-      takeProfitMultiplier: (p.takeProfitMultiplier as number) ?? 3,
+    createFactory: factory<{
+      period?: number;
+      stopMultiplier?: number;
+      takeProfitMultiplier?: number;
+    }>()(createAtrStops, (p) => ({
+      period: p.period ?? 14,
+      stopMultiplier: p.stopMultiplier ?? 2,
+      takeProfitMultiplier: p.takeProfitMultiplier ?? 3,
     })),
   },
   ulcer: {
     meta: ULCER_META,
     defaultParams: { period: 14 },
     snapshotName: (p) => `ulcer${p.period}`,
-    createFactory: factory(createUlcerIndex, (p) => ({
-      period: (p.period as number) ?? 14,
-      source: p.source as "close" | undefined,
+    createFactory: factory<{ source?: PriceSource; period?: number }>()(createUlcerIndex, (p) => ({
+      period: p.period ?? 14,
+      source: p.source,
     })),
   },
 
@@ -641,29 +749,34 @@ export const livePresets: Record<string, LivePreset> = {
     meta: SUPERTREND_META,
     defaultParams: { period: 10, multiplier: 3 },
     snapshotName: "supertrend",
-    createFactory: factory(createSupertrend, (p) => ({
-      period: (p.period as number) ?? 10,
-      multiplier: (p.multiplier as number) ?? 3,
+    createFactory: factory<{ period?: number; multiplier?: number }>()(createSupertrend, (p) => ({
+      period: p.period ?? 10,
+      multiplier: p.multiplier ?? 3,
     })),
   },
   parabolicSar: {
     meta: PARABOLIC_SAR_META,
     defaultParams: {},
     snapshotName: "sar",
-    createFactory: factory(createParabolicSar, (p) => ({
-      step: p.step as number | undefined,
-      max: p.max as number | undefined,
+    createFactory: factory<{ step?: number; max?: number }>()(createParabolicSar, (p) => ({
+      step: p.step,
+      max: p.max,
     })),
   },
   ichimoku: {
     meta: ICHIMOKU_META,
     defaultParams: {},
     snapshotName: "ichimoku",
-    createFactory: factory(createIchimoku, (p) => ({
-      tenkanPeriod: p.tenkanPeriod as number | undefined,
-      kijunPeriod: p.kijunPeriod as number | undefined,
-      senkouBPeriod: p.senkouBPeriod as number | undefined,
-      displacement: p.displacement as number | undefined,
+    createFactory: factory<{
+      tenkanPeriod?: number;
+      kijunPeriod?: number;
+      senkouBPeriod?: number;
+      displacement?: number;
+    }>()(createIchimoku, (p) => ({
+      tenkanPeriod: p.tenkanPeriod,
+      kijunPeriod: p.kijunPeriod,
+      senkouBPeriod: p.senkouBPeriod,
+      displacement: p.displacement,
     })),
   },
 
@@ -672,62 +785,67 @@ export const livePresets: Record<string, LivePreset> = {
     meta: OBV_META,
     defaultParams: {},
     snapshotName: "obv",
-    createFactory: factory(createObv, () => ({})),
+    createFactory: factory()(createObv, () => ({})),
   },
   cmf: {
     meta: CMF_META,
     defaultParams: { period: 20 },
     snapshotName: (p) => `cmf${p.period}`,
-    createFactory: factory(createCmf, (p) => ({ period: (p.period as number) ?? 20 })),
+    createFactory: factory<{ period?: number }>()(createCmf, (p) => ({ period: p.period ?? 20 })),
   },
   mfi: {
     meta: MFI_META,
     defaultParams: { period: 14 },
     snapshotName: (p) => `mfi${p.period}`,
-    createFactory: factory(createMfi, (p) => ({ period: (p.period as number) ?? 14 })),
+    createFactory: factory<{ period?: number }>()(createMfi, (p) => ({ period: p.period ?? 14 })),
   },
   vwap: {
     meta: VWAP_META,
     defaultParams: {},
     snapshotName: "vwap",
-    createFactory: factory(createVwap, () => ({})),
+    createFactory: factory()(createVwap, () => ({})),
   },
   adl: {
     meta: ADL_META,
     defaultParams: {},
     snapshotName: "adl",
-    createFactory: factory(createAdl, () => ({})),
+    createFactory: factory()(createAdl, () => ({})),
   },
   twap: {
     meta: TWAP_META,
     defaultParams: {},
     snapshotName: "twap",
-    createFactory: factory(createTwap, () => ({})),
+    createFactory: factory()(createTwap, () => ({})),
   },
   elderForceIndex: {
     meta: ELDER_FORCE_INDEX_META,
     defaultParams: { period: 13 },
     snapshotName: "efi",
-    createFactory: factory(createElderForceIndex, (p) => ({ period: (p.period as number) ?? 13 })),
+    createFactory: factory<{ period?: number }>()(createElderForceIndex, (p) => ({
+      period: p.period ?? 13,
+    })),
   },
   volumeAnomaly: {
     meta: VOLUME_ANOMALY_META,
     defaultParams: {},
     snapshotName: "volAnomaly",
-    createFactory: factory(createVolumeAnomaly, (p) => ({
-      period: p.period as number | undefined,
-      threshold: p.threshold as number | undefined,
+    createFactory: factory<{ period?: number; threshold?: number }>()(createVolumeAnomaly, (p) => ({
+      period: p.period,
+      threshold: p.threshold,
     })),
   },
   klinger: {
     meta: KLINGER_META,
     defaultParams: {},
     snapshotName: "klinger",
-    createFactory: factory(createKlinger, (p) => ({
-      fastPeriod: p.fastPeriod as number | undefined,
-      slowPeriod: p.slowPeriod as number | undefined,
-      signalPeriod: p.signalPeriod as number | undefined,
-    })),
+    createFactory: factory<{ fastPeriod?: number; slowPeriod?: number; signalPeriod?: number }>()(
+      createKlinger,
+      (p) => ({
+        fastPeriod: p.fastPeriod,
+        slowPeriod: p.slowPeriod,
+        signalPeriod: p.signalPeriod,
+      }),
+    ),
   },
   pvt: {
     meta: PVT_META,
@@ -739,8 +857,8 @@ export const livePresets: Record<string, LivePreset> = {
     meta: NVI_META,
     defaultParams: { initialValue: 1000 },
     snapshotName: "nvi",
-    createFactory: factory(createNvi, (p) => ({
-      initialValue: (p.initialValue as number) ?? 1000,
+    createFactory: factory<{ initialValue?: number }>()(createNvi, (p) => ({
+      initialValue: p.initialValue ?? 1000,
     })),
   },
   cvd: {
@@ -753,38 +871,46 @@ export const livePresets: Record<string, LivePreset> = {
     meta: WEIS_WAVE_META,
     defaultParams: { method: "close", threshold: 0 },
     snapshotName: "weisWave",
-    createFactory: factory(createWeisWave, (p) => ({
-      method: (p.method as "close" | "highlow") ?? "close",
-      threshold: (p.threshold as number) ?? 0,
-    })),
+    createFactory: factory<{ method?: "close" | "highlow"; threshold?: number }>()(
+      createWeisWave,
+      (p) => ({
+        method: p.method ?? "close",
+        threshold: p.threshold ?? 0,
+      }),
+    ),
   },
   anchoredVwap: {
     meta: ANCHORED_VWAP_META,
     defaultParams: { bands: 0 },
     snapshotName: "avwap",
-    createFactory: factory(createAnchoredVwap, (p) => ({
-      anchorTime: (p.anchorTime as number) ?? 0,
-      bands: (p.bands as number) ?? 0,
+    createFactory: factory<{ anchorTime?: number; bands?: number }>()(createAnchoredVwap, (p) => ({
+      anchorTime: p.anchorTime ?? 0,
+      bands: p.bands ?? 0,
     })),
   },
   emv: {
     meta: EMV_META,
     defaultParams: { period: 14 },
     snapshotName: (p) => `emv${p.period}`,
-    createFactory: factory(createEmv, (p) => ({
-      period: (p.period as number) ?? 14,
-      volumeDivisor: (p.volumeDivisor as number) ?? 10000,
+    createFactory: factory<{ period?: number; volumeDivisor?: number }>()(createEmv, (p) => ({
+      period: p.period ?? 14,
+      volumeDivisor: p.volumeDivisor ?? 10000,
     })),
   },
   volumeTrend: {
     meta: VOLUME_TREND_META,
     defaultParams: { pricePeriod: 10, volumePeriod: 10, maPeriod: 20 },
     snapshotName: "volTrend",
-    createFactory: factory(createVolumeTrend, (p) => ({
-      pricePeriod: (p.pricePeriod as number) ?? 10,
-      volumePeriod: (p.volumePeriod as number) ?? 10,
-      maPeriod: (p.maPeriod as number) ?? 20,
-      minPriceChange: (p.minPriceChange as number) ?? 2.0,
+    createFactory: factory<{
+      pricePeriod?: number;
+      volumePeriod?: number;
+      maPeriod?: number;
+      minPriceChange?: number;
+    }>()(createVolumeTrend, (p) => ({
+      pricePeriod: p.pricePeriod ?? 10,
+      volumePeriod: p.volumePeriod ?? 10,
+      maPeriod: p.maPeriod ?? 20,
+      minPriceChange: p.minPriceChange ?? 2.0,
     })),
   },
 
@@ -793,51 +919,58 @@ export const livePresets: Record<string, LivePreset> = {
     meta: HIGHEST_LOWEST_META,
     defaultParams: { period: 20 },
     snapshotName: (p) => `hilo${p.period}`,
-    createFactory: factory(createHighestLowest, (p) => ({
-      period: (p.period as number) ?? 20,
+    createFactory: factory<{ period?: number }>()(createHighestLowest, (p) => ({
+      period: p.period ?? 20,
     })),
   },
   pivotPoints: {
     meta: PIVOT_POINTS_META,
     defaultParams: { method: "standard" },
     snapshotName: (p) => `pivot_${p.method}`,
-    createFactory: factory(createPivotPoints, (p) => ({
-      method: (p.method as "standard") ?? "standard",
+    createFactory: factory<{ method?: "standard" }>()(createPivotPoints, (p) => ({
+      method: p.method ?? "standard",
     })),
   },
   fractals: {
     meta: FRACTALS_META,
     defaultParams: { period: 2 },
     snapshotName: (p) => `frac${p.period}`,
-    createFactory: factory(createFractals, (p) => ({
-      period: (p.period as number) ?? 2,
+    createFactory: factory<{ period?: number }>()(createFractals, (p) => ({
+      period: p.period ?? 2,
     })),
   },
   gapAnalysis: {
     meta: GAP_ANALYSIS_META,
     defaultParams: { minGapPercent: 0.5 },
     snapshotName: "gap",
-    createFactory: factory(createGapAnalysis, (p) => ({
-      minGapPercent: (p.minGapPercent as number) ?? 0.5,
+    createFactory: factory<{ minGapPercent?: number }>()(createGapAnalysis, (p) => ({
+      minGapPercent: p.minGapPercent ?? 0.5,
     })),
   },
   orb: {
     meta: ORB_META,
     defaultParams: { minutes: 30 },
     snapshotName: "orb",
-    createFactory: factory(createOpeningRange, (p) => ({
-      minutes: (p.minutes as number) ?? 30,
-      sessionResetPeriod: (p.sessionResetPeriod as "day" | number) ?? "day",
-    })),
+    createFactory: factory<{ minutes?: number; sessionResetPeriod?: "day" | number }>()(
+      createOpeningRange,
+      (p) => ({
+        minutes: p.minutes ?? 30,
+        sessionResetPeriod: p.sessionResetPeriod ?? "day",
+      }),
+    ),
   },
   fvg: {
     meta: FVG_META,
     defaultParams: { minGapPercent: 0, maxActiveFvgs: 10 },
     snapshotName: "fvg",
-    createFactory: factory(createFairValueGap, (p) => ({
-      minGapPercent: (p.minGapPercent as number) ?? 0,
-      maxActiveFvgs: (p.maxActiveFvgs as number) ?? 10,
-      partialFill: (p.partialFill as boolean) ?? true,
+    createFactory: factory<{
+      minGapPercent?: number;
+      maxActiveFvgs?: number;
+      partialFill?: boolean;
+    }>()(createFairValueGap, (p) => ({
+      minGapPercent: p.minGapPercent ?? 0,
+      maxActiveFvgs: p.maxActiveFvgs ?? 10,
+      partialFill: p.partialFill ?? true,
     })),
   },
 
@@ -846,9 +979,9 @@ export const livePresets: Record<string, LivePreset> = {
     meta: VSA_META,
     defaultParams: { volumeMaPeriod: 20, atrPeriod: 14 },
     snapshotName: "vsa",
-    createFactory: factory(createVsa, (p) => ({
-      volumeMaPeriod: (p.volumeMaPeriod as number) ?? 20,
-      atrPeriod: (p.atrPeriod as number) ?? 14,
+    createFactory: factory<{ volumeMaPeriod?: number; atrPeriod?: number }>()(createVsa, (p) => ({
+      volumeMaPeriod: p.volumeMaPeriod ?? 20,
+      atrPeriod: p.atrPeriod ?? 14,
     })),
   },
 };

--- a/packages/core/src/types/scoring.ts
+++ b/packages/core/src/types/scoring.ts
@@ -181,6 +181,10 @@ export type VolatilityRegimeOptions = {
     /** Extreme volatility threshold (default: 95) */
     extreme?: number;
   };
+  /** Calendar preset for annualizing historical volatility (default: US equity, 252) */
+  calendar?: import("../calendar").TradingCalendar;
+  /** Raw override for periods per year when no calendar is supplied */
+  periodsPerYear?: number;
 };
 
 /**


### PR DESCRIPTION
## Summary

Eight commits aimed at the next `trendcraft` (core) minor release. All changes are additive on top of `0.2.0` — no public type or runtime behavior was removed.

### Highlights

- **+10 incremental indicators** (`incremental.create*` factories) with batch parity tests:
  Heikin-Ashi, Returns, Swing Points, Zigzag, Break of Structure, Change of Character, Standard Deviation, Super Smoother, Roofing Filter, Linear Regression.
- **LivePreset / IndicatorPreset typing refactor** — 170+ `as number` / `as PriceSource` casts removed via curried `factory<TParams>()` and `withCompute<TParams>` helpers; public types unchanged.
- **Trading Calendar** (`src/calendar/`) — minimal `TradingCalendar` interface plus US / JPX / HKEX / Crypto / FX presets, threaded through `stressTest`, `ulcerPerformanceIndex`, `garch`, `ewmaVolatility`, `volatilityRegime`, and `calculateRuntimeMetrics` so multi-market Sharpe / volatility comparisons stop assuming 252 days/year.
- **Price source pass-through** for derived RSIs (`stochRsi`, `connorsRsi`).
- **Docs**: new "Price Source Helpers" section in `docs/API.md` / `docs/API.ja.md` covering the previously-undocumented `getPrice` / `getPriceSeries` helpers.
- **Snapshot resume safety**: when `warmUpOptions.fromState` is provided, the saved `period` / `source` (and `highPassPeriod` / `lowPassPeriod`) now win over factory-call defaults across `createLinearRegression`, `createStandardDeviation`, `createSuperSmoother`, and `createRoofingFilter`. Prevents silent corruption when callers omit options on resume.

### Commit list

- `2d7675e` feat(core): thread price source through StochRSI and Connors RSI
- `2b5afa8` feat(core): add incremental Heikin-Ashi and Returns
- `c00665d` feat(core): add incremental Swing Points, Zigzag, BOS, CHoCH
- `4e347c3` refactor(core): remove 170+ param casts via generic preset helpers
- `10d3aff` feat(core): add Trading Calendar for market-specific annualization
- `c3ed044` feat(core): add incremental Standard Deviation and Ehlers filters
- `c642919` docs(core): document getPrice / getPriceSeries price source helpers
- `ce645d7` feat(core): add incremental Linear Regression and prefer snapshot params

### Diff stats

41 files changed, 3726 insertions(+), 315 deletions(-)

## Compatibility

- All option additions are optional with previously-used defaults preserved (`source` defaults to `"close"`, `calendar` omitted yields 252).
- `LivePreset` / `IndicatorPreset` exported types are unchanged.
- Tests: 4771 → 4818 passing (+47).

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm test` — 314 files, 4818 tests pass
- [x] `pnpm build` — main bundle 370.11 kB / gzip 103.89 kB
- [x] `pnpm tsc --noEmit` — no errors in `live-presets.ts` / `indicator-presets.ts` / new `src/calendar/`
- [x] Two Codex `/codex:review` rounds, all flagged issues addressed
- [x] CI green on this PR