### PR TITLE
feat(core): add trendcraft/manifest entry point for LLM-facing indicator metadata

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,11 @@
       "types": "./dist/indicators/safe/index.d.ts",
       "import": "./dist/indicators/safe/index.js",
       "require": "./dist/indicators/safe/index.cjs"
+    },
+    "./manifest": {
+      "types": "./dist/manifest/index.d.ts",
+      "import": "./dist/manifest/index.js",
+      "require": "./dist/manifest/index.cjs"
     }
   },
   "sideEffects": false,

--- a/packages/core/src/manifest/__tests__/manifest.test.ts
+++ b/packages/core/src/manifest/__tests__/manifest.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import * as indicatorMeta from "../../indicators/indicator-meta";
+import type { SeriesMeta } from "../../types/candle";
+import {
+  formatManifestMarkdown,
+  getManifest,
+  indicatorManifests,
+  listManifests,
+  suggestForRegime,
+} from "../index";
+
+const KNOWN_KINDS = new Set(
+  Object.values(indicatorMeta)
+    .filter((v): v is SeriesMeta => typeof v === "object" && v !== null && "kind" in v)
+    .map((v) => v.kind),
+);
+
+describe("indicator manifest", () => {
+  it("has at least one manifest entry", () => {
+    expect(indicatorManifests.length).toBeGreaterThan(0);
+  });
+
+  it("every manifest kind matches a known SeriesMeta kind", () => {
+    const orphans = indicatorManifests.filter((m) => !KNOWN_KINDS.has(m.kind));
+    expect(orphans.map((o) => o.kind)).toEqual([]);
+  });
+
+  it("manifest kinds are unique", () => {
+    const seen = new Set<string>();
+    const dupes: string[] = [];
+    for (const m of indicatorManifests) {
+      if (seen.has(m.kind)) dupes.push(m.kind);
+      seen.add(m.kind);
+    }
+    expect(dupes).toEqual([]);
+  });
+
+  it("every entry populates required fields", () => {
+    for (const m of indicatorManifests) {
+      expect(m.kind, m.kind).toBeTruthy();
+      expect(m.displayName, m.kind).toBeTruthy();
+      expect(m.category, m.kind).toBeTruthy();
+      expect(m.oneLiner, m.kind).toBeTruthy();
+      expect(m.whenToUse.length, `${m.kind} whenToUse`).toBeGreaterThan(0);
+      expect(m.signals.length, `${m.kind} signals`).toBeGreaterThan(0);
+      expect(m.pitfalls.length, `${m.kind} pitfalls`).toBeGreaterThan(0);
+      expect(m.marketRegime.length, `${m.kind} marketRegime`).toBeGreaterThan(0);
+      expect(m.timeframe.length, `${m.kind} timeframe`).toBeGreaterThan(0);
+    }
+  });
+
+  it("getManifest returns a known entry", () => {
+    const rsi = getManifest("rsi");
+    expect(rsi).toBeDefined();
+    expect(rsi?.kind).toBe("rsi");
+    expect(rsi?.category).toBe("momentum");
+  });
+
+  it("getManifest returns undefined for unknown kind", () => {
+    expect(getManifest("does-not-exist")).toBeUndefined();
+  });
+
+  it("listManifests filters by category", () => {
+    const ma = listManifests({ category: "moving-average" });
+    expect(ma.length).toBeGreaterThan(0);
+    expect(ma.every((m) => m.category === "moving-average")).toBe(true);
+  });
+
+  it("suggestForRegime returns regime-tagged entries only", () => {
+    const ranging = suggestForRegime("ranging");
+    expect(ranging.length).toBeGreaterThan(0);
+    expect(ranging.every((m) => m.marketRegime.includes("ranging"))).toBe(true);
+  });
+
+  it("formatManifestMarkdown produces non-empty markdown", () => {
+    const rsi = getManifest("rsi");
+    expect(rsi).toBeDefined();
+    const md = formatManifestMarkdown(rsi as NonNullable<typeof rsi>);
+    expect(md).toContain("Relative Strength Index");
+    expect(md).toContain("When to use");
+    expect(md).toContain("Pitfalls");
+  });
+});

--- a/packages/core/src/manifest/entries/momentum.ts
+++ b/packages/core/src/manifest/entries/momentum.ts
@@ -1,0 +1,191 @@
+import type { IndicatorManifest } from "../types";
+
+export const MOMENTUM_MANIFESTS: IndicatorManifest[] = [
+  {
+    kind: "rsi",
+    displayName: "Relative Strength Index",
+    category: "momentum",
+    oneLiner: "Bounded oscillator (0-100) measuring magnitude of recent gains vs losses.",
+    whenToUse: [
+      "Mean-reversion entries in ranging markets",
+      "Spotting bullish/bearish divergence against price",
+      "Confirming momentum exhaustion at trend extremes",
+    ],
+    signals: [
+      "RSI < 30 = oversold (potential bounce in range)",
+      "RSI > 70 = overbought (potential pullback in range)",
+      "Bullish divergence (price lower low, RSI higher low) = reversal cue",
+      "Failure swings (RSI fails to retake 70/30) = trend weakening",
+    ],
+    pitfalls: [
+      "Strong trends keep RSI overbought/oversold for long stretches — naive 30/70 entries get crushed",
+      "Lookback of 14 is convention, not law — shorter periods amplify noise",
+      "Absolute level meaningless without trend context",
+    ],
+    synergy: [
+      "ADX or DMI to gate RSI signals to ranging regimes (low ADX) only",
+      "MACD for momentum direction confirmation",
+    ],
+    marketRegime: ["ranging"],
+    timeframe: ["intraday", "swing", "position"],
+    paramHints: {
+      period: "14 standard; 9 for shorter cycles, 21 for smoother long-term",
+    },
+  },
+  {
+    kind: "macd",
+    displayName: "MACD",
+    category: "momentum",
+    oneLiner: "Difference of two EMAs with a signal line — momentum and trend in one.",
+    whenToUse: [
+      "Trend-following entries via signal line crosses",
+      "Divergence detection on swing timeframes",
+      "Histogram momentum analysis (rising/falling pace)",
+    ],
+    signals: [
+      "MACD crosses above signal = bullish momentum shift",
+      "MACD crosses below signal = bearish momentum shift",
+      "Histogram peaks/troughs = momentum acceleration/deceleration",
+      "Zero-line crosses = longer-term trend direction change",
+    ],
+    pitfalls: [
+      "Signal-line crosses are laggy in fast markets",
+      "Whipsaws hard in low-volatility chop",
+      "Default 12/26/9 is daily-bar convention; smaller bars need adjustment",
+    ],
+    synergy: [
+      "200-period MA as a higher-timeframe trend filter",
+      "RSI for divergence cross-confirmation",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      fastPeriod: "12 standard",
+      slowPeriod: "26 standard",
+      signalPeriod: "9 standard",
+    },
+  },
+  {
+    kind: "stochastics",
+    displayName: "Stochastic Oscillator",
+    category: "momentum",
+    oneLiner: "Position of close within recent high-low range, smoothed K and D lines (0-100).",
+    whenToUse: ["Range-bound mean reversion", "Confirming entries with K/D cross in extreme zones"],
+    signals: [
+      "K crosses above D in <20 zone = oversold reversal cue",
+      "K crosses below D in >80 zone = overbought reversal cue",
+      "Hidden divergence = trend continuation",
+    ],
+    pitfalls: [
+      "Stays pinned in extremes during strong trends — fade signals fail",
+      "Very sensitive to lookback choice",
+    ],
+    marketRegime: ["ranging"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      kPeriod: "14 standard for swing",
+      dPeriod: "3 standard smoothing",
+    },
+  },
+  {
+    kind: "dmi",
+    displayName: "DMI / ADX",
+    category: "momentum",
+    oneLiner: "+DI, -DI, and ADX for trend direction and strength.",
+    whenToUse: [
+      "Filtering trend vs range regimes (ADX threshold)",
+      "Confirming trend direction via +DI vs -DI dominance",
+      "Sizing trend-follower aggressiveness by ADX magnitude",
+    ],
+    signals: [
+      "ADX > 25 = strong trend (direction from +DI/-DI)",
+      "ADX < 20 = no trend (favor range strategies)",
+      "+DI crosses above -DI with rising ADX = trend ignition",
+    ],
+    pitfalls: [
+      "ADX is direction-agnostic — never use alone for entries",
+      "ADX rises during strong moves in either direction; can be late at the end of a trend",
+    ],
+    synergy: [
+      "RSI gated by ADX < 20 for clean range fades",
+      "MACD gated by ADX > 25 for clean trend follows",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      period: "14 is the Wilder standard",
+    },
+  },
+  {
+    kind: "cci",
+    displayName: "Commodity Channel Index",
+    category: "momentum",
+    oneLiner: "Distance of price from its mean, scaled by mean deviation.",
+    whenToUse: ["Detecting cyclical extremes", "Catching breakout momentum past ±100"],
+    signals: [
+      "CCI > +100 = strong bullish momentum",
+      "CCI < -100 = strong bearish momentum",
+      "Reverse-cross of ±100 = trend exhaustion",
+    ],
+    pitfalls: [
+      "Unbounded — extreme values do not have a fixed ceiling",
+      "Whipsaws in low-volatility regimes",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["intraday", "swing"],
+  },
+  {
+    kind: "roc",
+    displayName: "Rate of Change",
+    category: "momentum",
+    oneLiner: "Percent change of price over N bars — pure momentum.",
+    whenToUse: ["Cross-asset momentum ranking", "Filtering trades by momentum strength threshold"],
+    signals: [
+      "ROC > 0 with rising slope = accelerating uptrend",
+      "ROC zero-line cross = trend direction change",
+    ],
+    pitfalls: [
+      "No bounded interpretation — needs comparable peers or historical context",
+      "Sensitive to gaps and outlier bars",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+  },
+  {
+    kind: "williamsR",
+    displayName: "Williams %R",
+    category: "momentum",
+    oneLiner: "Inverted stochastic-style oscillator (-100 to 0).",
+    whenToUse: [
+      "Range mean reversion (alternative to stochastics)",
+      "Short-cycle overbought/oversold detection",
+    ],
+    signals: ["%R < -80 = oversold", "%R > -20 = overbought"],
+    pitfalls: ["Same as stochastics — gets stuck in extremes during trends"],
+    marketRegime: ["ranging"],
+    timeframe: ["intraday", "swing"],
+  },
+  {
+    kind: "connorsRsi",
+    displayName: "Connors RSI",
+    category: "momentum",
+    oneLiner: "Composite of short RSI, streak RSI, and ROC percentile (0-100).",
+    whenToUse: [
+      "Short-term mean reversion on equities",
+      "Pullback timing within established trends",
+    ],
+    signals: ["CRSI < 5 in uptrend = strong pullback buy signal", "CRSI > 95 = exhaustion"],
+    pitfalls: [
+      "Designed for daily equities; less reliable on FX or 24h crypto",
+      "Streak component is sensitive to gap-driven false streaks",
+    ],
+    synergy: ["200-day MA as trend filter to avoid catching falling knives"],
+    marketRegime: ["ranging", "trending"],
+    timeframe: ["swing"],
+    paramHints: {
+      rsiPeriod: "3 default — intentionally short",
+      streakPeriod: "2 default",
+      rocPeriod: "100 default for percentile lookback",
+    },
+  },
+];

--- a/packages/core/src/manifest/entries/moving-average.ts
+++ b/packages/core/src/manifest/entries/moving-average.ts
@@ -1,0 +1,159 @@
+import type { IndicatorManifest } from "../types";
+
+export const MOVING_AVERAGE_MANIFESTS: IndicatorManifest[] = [
+  {
+    kind: "sma",
+    displayName: "Simple Moving Average",
+    category: "moving-average",
+    oneLiner: "Arithmetic mean of price over N periods — the baseline trend filter.",
+    whenToUse: [
+      "Long-term trend identification (50/200 SMA crossovers)",
+      "Smoothing noisy series for visual reference",
+      "Defining dynamic support/resistance on higher timeframes",
+    ],
+    signals: [
+      "Price above rising SMA = uptrend bias",
+      "Golden cross (short SMA crosses above long SMA) = bullish trend confirmation",
+      "Dead cross (short SMA crosses below long SMA) = bearish trend confirmation",
+    ],
+    pitfalls: [
+      "Lags strongly — turning points are visible only after the move",
+      "Equal weighting means stale prices distort the signal as much as recent prices",
+      "Whipsaws often in ranging markets",
+    ],
+    synergy: [
+      "ATR for volatility-adjusted stop placement around the SMA",
+      "RSI for momentum confirmation of trend direction",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      period: "20 for short-term, 50 for medium, 200 for primary trend",
+    },
+  },
+  {
+    kind: "ema",
+    displayName: "Exponential Moving Average",
+    category: "moving-average",
+    oneLiner: "Exponentially weighted MA — more responsive than SMA, emphasizes recent prices.",
+    whenToUse: [
+      "Trend following where SMA's lag is too costly",
+      "Short-to-medium term entries (9/21/50 EMA stacks)",
+      "MACD-style crossover systems",
+    ],
+    signals: [
+      "Price above rising EMA = bullish bias",
+      "EMA stack (e.g. 9 > 21 > 50) = strong aligned trend",
+      "EMA cross of two periods = momentum shift",
+    ],
+    pitfalls: [
+      "Still lags on sharp reversals",
+      "More whipsaws than SMA in choppy conditions",
+      "Initial values are sensitive to seed method (SMA seed vs first-value seed)",
+    ],
+    synergy: [
+      "MACD for momentum confirmation (it is built from EMAs)",
+      "VWAP for intraday trend bias relative to institutional cost",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["intraday", "swing", "position"],
+    paramHints: {
+      period: "9 fast, 21 medium, 50 slow are common day-trader stacks",
+    },
+  },
+  {
+    kind: "hma",
+    displayName: "Hull Moving Average",
+    category: "moving-average",
+    oneLiner: "WMA-based MA designed to reduce lag while remaining smooth.",
+    whenToUse: [
+      "Trend following where EMA still feels too laggy",
+      "Short-term swing entries on directional moves",
+      "Inputs to higher-frequency systems requiring smooth-but-fast signals",
+    ],
+    signals: [
+      "Color/slope change of HMA = early trend reversal cue",
+      "Price above rising HMA = bullish bias",
+    ],
+    pitfalls: [
+      "Reduced lag comes with more false reversals in choppy markets",
+      "Very short periods become noisy quickly",
+    ],
+    synergy: ["ADX/DMI to filter HMA signals to trending regimes only"],
+    marketRegime: ["trending"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      period: "9-21 typical for swing, smaller for intraday",
+    },
+  },
+  {
+    kind: "kama",
+    displayName: "Kaufman Adaptive Moving Average",
+    category: "moving-average",
+    oneLiner: "Adaptive MA that speeds up in trends and slows down in chop.",
+    whenToUse: [
+      "Mixed regime markets where a fixed-period MA over- or under-reacts",
+      "Trend following with built-in noise filtering",
+    ],
+    signals: [
+      "Price above rising KAMA = bullish bias with regime-aware smoothing",
+      "Flat KAMA = market is in noise mode — avoid trend trades",
+    ],
+    pitfalls: [
+      "Adaptive nature can mask genuine trend changes if the efficiency ratio collapses",
+      "Less intuitive to tune than fixed-period MAs",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      period: "10 default; fastPeriod=2 and slowPeriod=30 are standard",
+    },
+  },
+  {
+    kind: "t3",
+    displayName: "Tillson T3",
+    category: "moving-average",
+    oneLiner: "Six-cascade EMA delivering ultra-smooth output with minimal lag.",
+    whenToUse: [
+      "Visualizing clean trend without the jitter of a single EMA",
+      "Slow line in custom crossover systems",
+    ],
+    signals: [
+      "Slope change after a sustained trend = potential exhaustion",
+      "Price holding above a rising T3 = strong trend integrity",
+    ],
+    pitfalls: [
+      "Long warmup (6×(period-1) bars before first value)",
+      "vFactor tuning is non-obvious",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      period: "5 default; vFactor 0.7 is the standard smoothness control",
+    },
+  },
+  {
+    kind: "vwma",
+    displayName: "Volume-Weighted Moving Average",
+    category: "moving-average",
+    oneLiner: "SMA weighted by traded volume — emphasizes high-conviction prices.",
+    whenToUse: [
+      "Confirming that a trend is supported by volume",
+      "Detecting divergence between price MA and volume-weighted MA",
+    ],
+    signals: [
+      "VWMA above SMA = volume is concentrating on up-bars (bullish)",
+      "VWMA below SMA = volume is concentrating on down-bars (bearish)",
+    ],
+    pitfalls: [
+      "Useless on instruments with unreliable volume (some FX)",
+      "Sensitive to volume spikes from news events",
+    ],
+    synergy: [
+      "OBV for cumulative volume flow context",
+      "VWAP for intraday institutional cost reference",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["intraday", "swing"],
+  },
+];

--- a/packages/core/src/manifest/entries/trend.ts
+++ b/packages/core/src/manifest/entries/trend.ts
@@ -1,0 +1,72 @@
+import type { IndicatorManifest } from "../types";
+
+export const TREND_MANIFESTS: IndicatorManifest[] = [
+  {
+    kind: "supertrend",
+    displayName: "Supertrend",
+    category: "trend",
+    oneLiner: "ATR-bounded line that flips bullish/bearish as price crosses.",
+    whenToUse: [
+      "Visual trend direction with built-in stop level",
+      "Simple flip-based trend systems",
+      "Stop placement on trend-follow entries",
+    ],
+    signals: [
+      "Supertrend flips green = bullish state begins",
+      "Supertrend flips red = bearish state begins",
+      "Price below red line = downtrend; above green = uptrend",
+    ],
+    pitfalls: [
+      "Whipsaws hard in choppy ranges (this is its main weakness)",
+      "Multiplier tuning matters more than period",
+    ],
+    synergy: ["ADX/Choppiness to disable Supertrend entries during chop"],
+    marketRegime: ["trending"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      period: "10 default ATR period",
+      multiplier: "3 default; 2 tighter, 4 wider",
+    },
+  },
+  {
+    kind: "parabolicSar",
+    displayName: "Parabolic SAR",
+    category: "trend",
+    oneLiner: "Stop-and-reverse dots that accelerate as the trend extends.",
+    whenToUse: ["Trailing stops on trend trades", "Visual trend direction at a glance"],
+    signals: [
+      "Dots flip from below to above price = trend reversal to down",
+      "Dots flip from above to below price = trend reversal to up",
+    ],
+    pitfalls: [
+      "Reverses prematurely in ranges or pullbacks",
+      "Acceleration factor tuning is finicky",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["intraday", "swing"],
+  },
+  {
+    kind: "ichimoku",
+    displayName: "Ichimoku Kinko Hyo",
+    category: "trend",
+    oneLiner: "Multi-component trend system: Tenkan, Kijun, Senkou A/B (cloud), Chikou.",
+    whenToUse: [
+      "All-in-one trend / momentum / support-resistance system",
+      "Multi-timeframe trend bias on swing/position trades",
+    ],
+    signals: [
+      "Price above cloud = bullish bias",
+      "Price below cloud = bearish bias",
+      "Price inside cloud = no trend / chop",
+      "Tenkan/Kijun cross above cloud = strong bullish signal",
+      "Cloud color change = future trend bias shift",
+    ],
+    pitfalls: [
+      "Many components — risk of overfitting interpretations",
+      "Lagging on fast reversals",
+      "Originally designed for daily Japanese equities; tuning needed elsewhere",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+  },
+];

--- a/packages/core/src/manifest/entries/volatility.ts
+++ b/packages/core/src/manifest/entries/volatility.ts
@@ -1,0 +1,141 @@
+import type { IndicatorManifest } from "../types";
+
+export const VOLATILITY_MANIFESTS: IndicatorManifest[] = [
+  {
+    kind: "atr",
+    displayName: "Average True Range",
+    category: "volatility",
+    oneLiner: "Wilder's smoothed average of true range — the volatility workhorse.",
+    whenToUse: [
+      "Sizing stops as a multiple of ATR",
+      "Position sizing scaled to current volatility",
+      "Detecting volatility expansion/contraction regimes",
+    ],
+    signals: [
+      "Rising ATR = volatility expanding (trend or breakout context)",
+      "Falling ATR = volatility contracting (consolidation, breakout setup)",
+    ],
+    pitfalls: [
+      "Direction-agnostic — never use alone for entries",
+      "Absolute ATR varies by instrument; normalize as ATR%/price for cross-asset comparison",
+    ],
+    synergy: ["Bollinger Bands or Keltner for volatility-based bands", "Supertrend (ATR-based)"],
+    marketRegime: ["volatile", "low-volatility"],
+    timeframe: ["intraday", "swing", "position"],
+    paramHints: {
+      period: "14 Wilder standard",
+    },
+  },
+  {
+    kind: "bollingerBands",
+    displayName: "Bollinger Bands",
+    category: "volatility",
+    oneLiner: "SMA with stddev-scaled upper/lower bands — volatility envelope.",
+    whenToUse: [
+      "Mean reversion within ranges (band touches as fade signals)",
+      "Squeeze detection (low band width = breakout pending)",
+      "Trend confirmation via band-walking (price hugs upper band in strong trend)",
+    ],
+    signals: [
+      "Touch of lower band in range = oversold mean-revert signal",
+      "Touch of upper band in range = overbought mean-revert signal",
+      "Squeeze (narrow bands) = volatility compression preceding breakout",
+      "Band-walk (sustained closes outside band) = trend continuation, not reversal",
+    ],
+    pitfalls: [
+      "Band-walking traps fade traders during trends",
+      "Default 20/2 is convention only — context matters",
+      "Population vs sample stddev choice can shift signals subtly",
+    ],
+    synergy: [
+      "ADX for distinguishing range (fade bands) from trend (band-walk)",
+      "RSI divergence inside bands for stronger reversion signals",
+    ],
+    marketRegime: ["ranging", "volatile", "low-volatility"],
+    timeframe: ["intraday", "swing", "position"],
+    paramHints: {
+      period: "20 standard",
+      stdDev: "2 standard; 1.5 for tighter, 2.5 for wider",
+    },
+  },
+  {
+    kind: "keltnerChannel",
+    displayName: "Keltner Channel",
+    category: "volatility",
+    oneLiner: "EMA with ATR-scaled bands — Bollinger's smoother cousin.",
+    whenToUse: [
+      "Trend-following band breakout systems",
+      "Filtering false Bollinger band touches via ATR-based bands",
+      "TTM Squeeze setups (Bollinger inside Keltner = compression)",
+    ],
+    signals: [
+      "Close above upper Keltner = trend breakout (not necessarily exhausted)",
+      "Close back inside band after walk = trend cooling",
+    ],
+    pitfalls: [
+      "Less sensitive than Bollinger to short volatility spikes",
+      "Tuning multiplier requires asset/timeframe-specific calibration",
+    ],
+    synergy: ["Bollinger Bands for squeeze detection (Bollinger inside Keltner)"],
+    marketRegime: ["trending", "volatile"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      period: "20 default EMA period",
+      multiplier: "2 default; 1.5 tighter, 3 wider",
+    },
+  },
+  {
+    kind: "donchianChannel",
+    displayName: "Donchian Channel",
+    category: "volatility",
+    oneLiner: "Highest-high and lowest-low envelope over N bars.",
+    whenToUse: [
+      "Classical breakout systems (Turtle 20/55-bar breakouts)",
+      "Range-extreme stop placement",
+    ],
+    signals: ["Close > upper Donchian = breakout buy", "Close < lower Donchian = breakdown sell"],
+    pitfalls: [
+      "Whipsaws on every false breakout in ranges",
+      "Lookback is brittle — small period changes shift signals dramatically",
+    ],
+    marketRegime: ["trending", "volatile"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      period: "20 short-term, 55 medium (Turtle) classics",
+    },
+  },
+  {
+    kind: "choppinessIndex",
+    displayName: "Choppiness Index",
+    category: "volatility",
+    oneLiner: "Bounded measure (0-100) of how trending vs choppy a market is.",
+    whenToUse: [
+      "Pure regime filter — gate strategy choice by chop level",
+      "Detecting consolidation periods preceding breakouts",
+    ],
+    signals: [
+      "CI > 61.8 = choppy / range — favor mean-reversion",
+      "CI < 38.2 = trending — favor trend-following",
+    ],
+    pitfalls: ["Lagging — confirms regime after the fact", "Direction-agnostic"],
+    synergy: ["ADX for cross-confirmation of trend strength"],
+    marketRegime: ["ranging", "trending"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      period: "14 default",
+    },
+  },
+  {
+    kind: "atrStops",
+    displayName: "ATR Stops",
+    category: "volatility",
+    oneLiner: "ATR-multiplied trailing stop levels above/below price.",
+    whenToUse: ["Volatility-adjusted exits in trend systems", "Chandelier-style trailing stops"],
+    signals: ["Price crossing ATR stop = exit / trend invalidation"],
+    pitfalls: [
+      "Multiplier tuning is asset-specific — same setting can be tight on stocks and loose on crypto",
+    ],
+    marketRegime: ["trending", "volatile"],
+    timeframe: ["intraday", "swing", "position"],
+  },
+];

--- a/packages/core/src/manifest/entries/volume.ts
+++ b/packages/core/src/manifest/entries/volume.ts
@@ -1,0 +1,139 @@
+import type { IndicatorManifest } from "../types";
+
+export const VOLUME_MANIFESTS: IndicatorManifest[] = [
+  {
+    kind: "vwap",
+    displayName: "Volume-Weighted Average Price",
+    category: "volume",
+    oneLiner: "Intraday volume-weighted mean price — institutional cost benchmark.",
+    whenToUse: [
+      "Intraday institutional fair-value reference",
+      "Mean reversion to VWAP within the session",
+      "Trend bias based on price position vs VWAP",
+    ],
+    signals: [
+      "Price above VWAP = intraday bullish bias",
+      "Price below VWAP = intraday bearish bias",
+      "Pullback to VWAP in trend = continuation entry zone",
+    ],
+    pitfalls: [
+      "Resets daily — meaningless on multi-day timeframes",
+      "Less useful pre-market or in low-volume sessions",
+    ],
+    synergy: ["VWAP bands (stddev-scaled) for overshoot/undershoot detection"],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["intraday"],
+  },
+  {
+    kind: "anchoredVwap",
+    displayName: "Anchored VWAP",
+    category: "volume",
+    oneLiner: "VWAP anchored to a specific event (earnings, swing high, session start).",
+    whenToUse: [
+      "Measuring participants' average cost since a key event",
+      "Multi-day intraday context where regular VWAP resets",
+      "Identifying resistance from prior swing highs (anchored at the high)",
+    ],
+    signals: [
+      "Price holding above anchored VWAP from a low = bullish accumulation",
+      "Rejection at anchored VWAP from a high = sellers defending",
+    ],
+    pitfalls: ["Anchor choice is subjective — bad anchors give meaningless levels"],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["intraday", "swing"],
+  },
+  {
+    kind: "obv",
+    displayName: "On-Balance Volume",
+    category: "volume",
+    oneLiner: "Cumulative volume signed by close direction.",
+    whenToUse: [
+      "Confirming trend with volume flow",
+      "Detecting accumulation/distribution divergences",
+    ],
+    signals: [
+      "OBV makes new high with price = healthy uptrend",
+      "Price new high but OBV does not = bearish divergence",
+    ],
+    pitfalls: [
+      "Treats every up-day equally regardless of close magnitude",
+      "Cumulative absolute value is meaningless — only changes/divergences matter",
+    ],
+    synergy: ["Price chart for divergence comparison"],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+  },
+  {
+    kind: "mfi",
+    displayName: "Money Flow Index",
+    category: "volume",
+    oneLiner: "Volume-weighted RSI (0-100) — momentum with volume context.",
+    whenToUse: [
+      "Volume-confirmed overbought/oversold detection",
+      "Divergence with stronger evidence than plain RSI",
+    ],
+    signals: [
+      "MFI < 20 = oversold with volume confirmation",
+      "MFI > 80 = overbought with volume confirmation",
+    ],
+    pitfalls: [
+      "Same as RSI — gets stuck in extremes during strong trends",
+      "Useless on instruments with unreliable volume",
+    ],
+    marketRegime: ["ranging"],
+    timeframe: ["swing"],
+    paramHints: {
+      period: "14 standard",
+    },
+  },
+  {
+    kind: "cmf",
+    displayName: "Chaikin Money Flow",
+    category: "volume",
+    oneLiner: "Volume-weighted accumulation/distribution oscillator (-1 to +1).",
+    whenToUse: ["Detecting buying vs selling pressure", "Confirming trend with money flow"],
+    signals: [
+      "CMF > 0 sustained = accumulation",
+      "CMF < 0 sustained = distribution",
+      "Divergence with price = trend weakness",
+    ],
+    pitfalls: ["Lagging — confirms but rarely leads", "Sensitive to closing range within bar"],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["swing"],
+  },
+  {
+    kind: "adl",
+    displayName: "Accumulation/Distribution Line",
+    category: "volume",
+    oneLiner: "Cumulative volume × close-location-value.",
+    whenToUse: ["Long-term accumulation/distribution divergence with price"],
+    signals: [
+      "ADL rising while price flat = stealth accumulation",
+      "ADL falling while price holds = stealth distribution",
+    ],
+    pitfalls: ["Cumulative value irrelevant — slope and divergence matter"],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+  },
+  {
+    kind: "cvd",
+    displayName: "Cumulative Volume Delta",
+    category: "volume",
+    oneLiner: "Cumulative buying minus selling pressure approximated from OHLCV.",
+    whenToUse: [
+      "Order-flow context without true tick data",
+      "Spotting absorption (price flat but CVD spikes)",
+      "Divergence with price for reversal cues",
+    ],
+    signals: [
+      "Price up + CVD up = healthy bullish flow",
+      "Price up + CVD flat or down = bearish divergence (sellers absorbing)",
+    ],
+    pitfalls: [
+      "Approximation only — real CVD needs tick-level bid/ask data",
+      "Cumulative scale not directly comparable across instruments",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["intraday", "swing"],
+  },
+];

--- a/packages/core/src/manifest/index.ts
+++ b/packages/core/src/manifest/index.ts
@@ -1,0 +1,106 @@
+/**
+ * Indicator Manifest entry point — `trendcraft/manifest`.
+ *
+ * Opt-in module providing LLM-facing metadata for indicators. Not loaded
+ * by the main `trendcraft` bundle. Intended for runtime LLM agents and
+ * MCP servers that embed indicator descriptions in prompts.
+ *
+ * @example
+ * ```ts
+ * import { getManifest, listManifests } from "trendcraft/manifest";
+ *
+ * const rsi = getManifest("rsi");
+ * console.log(rsi?.whenToUse);
+ *
+ * const trendIndicators = listManifests({ category: "trend" });
+ * ```
+ */
+
+import { MOMENTUM_MANIFESTS } from "./entries/momentum";
+import { MOVING_AVERAGE_MANIFESTS } from "./entries/moving-average";
+import { TREND_MANIFESTS } from "./entries/trend";
+import { VOLATILITY_MANIFESTS } from "./entries/volatility";
+import { VOLUME_MANIFESTS } from "./entries/volume";
+import type { IndicatorCategory, IndicatorManifest, MarketRegime, Timeframe } from "./types";
+
+export type { IndicatorCategory, IndicatorManifest, MarketRegime, Timeframe } from "./types";
+
+const ALL_MANIFESTS: readonly IndicatorManifest[] = [
+  ...MOVING_AVERAGE_MANIFESTS,
+  ...MOMENTUM_MANIFESTS,
+  ...VOLATILITY_MANIFESTS,
+  ...TREND_MANIFESTS,
+  ...VOLUME_MANIFESTS,
+];
+
+const MANIFEST_BY_KIND: ReadonlyMap<string, IndicatorManifest> = new Map(
+  ALL_MANIFESTS.map((m) => [m.kind, m]),
+);
+
+/**
+ * Look up the manifest for an indicator by its `kind` (matches
+ * `SeriesMeta.kind` from indicator-meta.ts). Returns `undefined` if no
+ * manifest entry exists for that kind yet.
+ */
+export function getManifest(kind: string): IndicatorManifest | undefined {
+  return MANIFEST_BY_KIND.get(kind);
+}
+
+/**
+ * List all manifest entries, optionally filtered by category, regime, or timeframe.
+ */
+export function listManifests(filter?: {
+  category?: IndicatorCategory;
+  regime?: MarketRegime;
+  timeframe?: Timeframe;
+}): IndicatorManifest[] {
+  if (!filter) return [...ALL_MANIFESTS];
+  return ALL_MANIFESTS.filter((m) => {
+    if (filter.category && m.category !== filter.category) return false;
+    if (filter.regime && !m.marketRegime.includes(filter.regime)) return false;
+    if (filter.timeframe && !m.timeframe.includes(filter.timeframe)) return false;
+    return true;
+  });
+}
+
+/**
+ * Suggest indicators well-suited for a given market regime, ordered as
+ * declared in the manifest list. A convenience for LLM prompts.
+ */
+export function suggestForRegime(regime: MarketRegime): IndicatorManifest[] {
+  return listManifests({ regime });
+}
+
+/**
+ * Render a manifest entry as a compact markdown block — useful for
+ * embedding directly in LLM prompts without custom formatting.
+ */
+export function formatManifestMarkdown(m: IndicatorManifest): string {
+  const lines: string[] = [];
+  lines.push(`### ${m.displayName} (\`${m.kind}\`)`);
+  lines.push(m.oneLiner);
+  lines.push("");
+  lines.push(`- Category: ${m.category}`);
+  lines.push(`- Regimes: ${m.marketRegime.join(", ")}`);
+  lines.push(`- Timeframes: ${m.timeframe.join(", ")}`);
+  if (m.whenToUse.length) {
+    lines.push("- When to use:");
+    for (const w of m.whenToUse) lines.push(`  - ${w}`);
+  }
+  if (m.signals.length) {
+    lines.push("- Signals:");
+    for (const s of m.signals) lines.push(`  - ${s}`);
+  }
+  if (m.pitfalls.length) {
+    lines.push("- Pitfalls:");
+    for (const p of m.pitfalls) lines.push(`  - ${p}`);
+  }
+  if (m.synergy?.length) {
+    lines.push("- Synergy:");
+    for (const s of m.synergy) lines.push(`  - ${s}`);
+  }
+  return lines.join("\n");
+}
+
+/** All manifest entries as a frozen array (read-only). */
+export const indicatorManifests: readonly IndicatorManifest[] = ALL_MANIFESTS;

--- a/packages/core/src/manifest/types.ts
+++ b/packages/core/src/manifest/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Indicator Manifest — LLM-facing metadata for indicators.
+ *
+ * Used by runtime LLM agents (e.g. alpaca-demo strategy generator) and
+ * future MCP servers as prompt context. Describes when/why an indicator
+ * is useful, common signals, pitfalls, and synergies — judgment context
+ * that cannot be derived from function signatures or JSDoc alone.
+ *
+ * `kind` joins to `SeriesMeta.kind` from indicator-meta.ts (single
+ * source of identity). This module ships as a separate entry point
+ * (`trendcraft/manifest`) so the main bundle is unaffected.
+ */
+
+export type IndicatorCategory =
+  | "moving-average"
+  | "momentum"
+  | "volatility"
+  | "trend"
+  | "volume"
+  | "price"
+  | "session"
+  | "regime"
+  | "smc"
+  | "wyckoff";
+
+export type MarketRegime = "trending" | "ranging" | "volatile" | "low-volatility";
+
+export type Timeframe = "intraday" | "swing" | "position";
+
+export interface IndicatorManifest {
+  /** Stable identity key — matches indicator-meta.ts SeriesMeta.kind. */
+  kind: string;
+  /** Human-readable display name. */
+  displayName: string;
+  category: IndicatorCategory;
+  /** Single-sentence summary suitable for compact listings. */
+  oneLiner: string;
+  /** Bullet points: market conditions where this indicator shines. */
+  whenToUse: string[];
+  /** Common signal interpretations (e.g. "RSI > 70 = overbought"). */
+  signals: string[];
+  /** Failure modes the LLM should avoid recommending in. */
+  pitfalls: string[];
+  /** Optional: indicators that pair well, with reason. */
+  synergy?: string[];
+  /** Market regimes this indicator is well-suited for. */
+  marketRegime: MarketRegime[];
+  /** Timeframes this indicator is typically applied to. */
+  timeframe: Timeframe[];
+  /** Optional per-parameter usage notes. */
+  paramHints?: Record<string, string>;
+}

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
         "screening/index": resolve(__dirname, "src/screening/index.ts"),
         "indicators/incremental/index": resolve(__dirname, "src/indicators/incremental/index.ts"),
         "indicators/safe/index": resolve(__dirname, "src/indicators/safe/index.ts"),
+        "manifest/index": resolve(__dirname, "src/manifest/index.ts"),
         "bin/trendcraft-screen": resolve(__dirname, "bin/trendcraft-screen.ts"),
         "bin/trendcraft-backtest": resolve(__dirname, "bin/trendcraft-backtest.ts"),
         "bin/trendcraft-analyze": resolve(__dirname, "bin/trendcraft-analyze.ts"),


### PR DESCRIPTION
## Summary

Adds a new opt-in subpath `trendcraft/manifest` providing structured metadata for indicators (when-to-use, signals, pitfalls, synergy, market regime, timeframe, param hints) intended as runtime prompt context for LLM agents and future MCP servers.

- 26+ PoC entries across moving-average / momentum / volatility / trend / volume
- `kind` joins to existing `SeriesMeta.kind` from `indicator-meta.ts` (single identity registry)
- Lookup helpers: `getManifest`, `listManifests`, `suggestForRegime`, `formatManifestMarkdown`
- Tests verify every kind matches a known SeriesMeta and required fields are populated
- **Zero impact on the main bundle** — separate `dist/manifest` entry, tree-shake friendly
- alpaca-demo's `palette.ts` + `review/llm-prompt.ts` opt-in to enriched LLM context (gitignored, but the API surface is exercised)

## Why

`packages/core` ships 130+ indicators, but LLM-driven agents (alpaca-demo's strategy generator, future MCP server) cannot reliably pick the right indicator from raw JSDoc alone. They need structured "when to use / pitfalls / synergy" judgment context as prompt-embedded data. Existing `palette.ts` in alpaca-demo already does this for a subset, but drifts from core. The manifest is the single source of truth.

## Test plan

- [x] `pnpm test src/manifest` — schema tests pass (kind-vs-meta join, required fields, no duplicates)
- [x] `pnpm build` — manifest emits as `dist/manifest/*` separate from main bundle
- [x] Bundle isolation verified — main bundle has 0 occurrences of manifest content
- [x] `pnpm lint` clean on `src/manifest/**`
- [x] alpaca-demo `palette.ts` + `review/llm-prompt.ts` typecheck clean

## Follow-up work (separate PRs)

Audit + expansion of remaining ~66 kinds is staged on `feat/core-manifest-expansion` (Phase 0a/0b audit + Phase 1 MA additions already committed there).