### PR TITLE
audit + feat(core): expand indicator manifest from 30 to 96 entries (full coverage)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ coverage/
 # QA sweep output
 packages/core/qa-report.json
 
+# Manifest verification sidecar (web search sources, spot-check scripts)
+packages/core/src/manifest/sources/
+
 .claude/projects/
 .claude/commands/release.md
 .plans/

--- a/packages/core/src/manifest/entries/momentum.ts
+++ b/packages/core/src/manifest/entries/momentum.ts
@@ -239,4 +239,308 @@ export const MOMENTUM_MANIFESTS: IndicatorManifest[] = [
       rocPeriod: "100 default — percentile lookback over 1-day ROC",
     },
   },
+  {
+    kind: "stochRsi",
+    displayName: "Stochastic RSI",
+    category: "momentum",
+    oneLiner:
+      "Tushar Chande & Stanley Kroll's stochastic applied to RSI values — more sensitive than plain RSI.",
+    whenToUse: [
+      "When plain RSI rarely reaches extremes and you want more frequent OB/OS signals",
+      "Short-term mean reversion in ranges",
+      "Confirming RSI reversals with %K/%D crossovers",
+    ],
+    signals: [
+      "StochRSI > 80 = overbought (Chande/Kroll's threshold, stricter than RSI's 70)",
+      "StochRSI < 20 = oversold (stricter than RSI's 30)",
+      "Above 0.5 (50%) sustained = uptrend bias; below 0.5 = downtrend bias",
+      "%K crosses above %D in <20 zone = oversold reversal cue",
+    ],
+    pitfalls: [
+      "Indicator-of-an-indicator — amplifies noise as well as signal",
+      "Spends extended time pinned at 0 or 100 in strong trends",
+      "Output scale depends on platform: trendcraft outputs 0-100, some platforms use 0-1",
+    ],
+    synergy: [
+      "Plain RSI for divergence cross-check",
+      "Higher-timeframe trend filter (200 MA) to gate signals",
+    ],
+    marketRegime: ["ranging"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      rsiPeriod: "14 default — RSI lookback (Chande/Kroll's original)",
+      stochPeriod: "14 default — high/low window applied to RSI",
+      kPeriod: "3 default — %K smoothing",
+      dPeriod: "3 default — %D (signal) smoothing",
+    },
+  },
+  {
+    kind: "trix",
+    displayName: "TRIX",
+    category: "momentum",
+    oneLiner:
+      "Jack Hutson's 1-period rate of change of a triple-smoothed EMA; filters noise to expose the underlying trend.",
+    whenToUse: [
+      "Trend-following with built-in noise filtering",
+      "Signal-line crossover systems where MACD whipsaws too much",
+      "Divergence detection against price",
+    ],
+    signals: [
+      "TRIX > 0 = uptrend; TRIX < 0 = downtrend",
+      "TRIX crosses above signal line = bullish",
+      "TRIX crosses below signal line = bearish",
+      "Divergence with price = trend exhaustion warning",
+    ],
+    pitfalls: [
+      "Triple-smoothing means significant lag at trend turns",
+      "trendcraft impl is more permissive about warmup than canonical TRIX: null EMA values are treated as 0 inside the nested EMA passes, so TRIX becomes non-null around index `period` rather than after a strict 3-stage EMA warmup. Early values may differ from references like StockCharts until all three EMAs are fully populated",
+      "Crossovers in flat/zero-line areas produce whipsaws",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      period: "15 default for the triple-EMA smoothing (Hutson's original)",
+      signalPeriod: "9 default for the EMA-based signal line",
+    },
+  },
+  {
+    kind: "aroon",
+    displayName: "Aroon",
+    category: "momentum",
+    oneLiner:
+      "Tushar Chande's time-since-high/low indicator — measures how recently the period's extremes printed.",
+    whenToUse: [
+      "Detecting whether a market is trending or ranging",
+      "Identifying the start of a new trend (Aroon-Up or -Down crossing 70)",
+      "Confirming ADX-style trend strength with a complementary lens (time vs price)",
+    ],
+    signals: [
+      "Aroon-Up > 70 with Aroon-Down < 30 = strong uptrend underway",
+      "Aroon-Down > 70 with Aroon-Up < 30 = strong downtrend underway",
+      "Aroon-Up crosses above Aroon-Down = bullish trend ignition",
+      "Oscillator (Up - Down) > 0 = bullish bias; < 0 = bearish; near 0 = ranging",
+    ],
+    pitfalls: [
+      "Lags the trend — confirms after the high/low has printed",
+      "Best used as confirmation, not entry trigger; a single Aroon reading is rarely tradeable alone",
+      "On 25-period default, requires 25+ bars before first non-null reading",
+    ],
+    synergy: ["ADX/DMI to cross-confirm trend strength from a price-momentum angle"],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      period: "25 default (Chande's original recommendation)",
+    },
+  },
+  {
+    kind: "awesomeOscillator",
+    displayName: "Awesome Oscillator",
+    category: "momentum",
+    oneLiner:
+      "Bill Williams' SMA(median, 5) - SMA(median, 34) histogram — momentum from median (high+low)/2 prices.",
+    whenToUse: [
+      "Visual momentum gauge alongside Bill Williams' broader trading system",
+      "Bill Williams' 'Saucer' and 'Twin Peaks' patterns for entries",
+      "Zero-line crossovers as trend direction shifts",
+    ],
+    signals: [
+      "AO > 0 = bullish momentum; AO < 0 = bearish momentum",
+      "Saucer (bullish): 3-bar reversal above zero where bar 2 is red (lower than bar 1) and bar 3 is green (higher than bar 2)",
+      "Twin Peaks (bullish): two troughs below zero with the second trough higher than the first, while the bars between stay below zero, followed by a green bar",
+      "Zero-line crossover = trend direction shift",
+    ],
+    pitfalls: [
+      "Median-price input ignores close, which discards intra-bar information",
+      "Default 5/34 has a long warmup (34 bars before first non-null)",
+      "Saucer/Twin Peaks are pattern-based — coding them reliably is non-trivial",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing"],
+    paramHints: {
+      fastPeriod: "5 default (Bill Williams' original)",
+      slowPeriod: "34 default (Bill Williams' original)",
+    },
+  },
+  {
+    kind: "ppo",
+    displayName: "Percentage Price Oscillator",
+    category: "momentum",
+    oneLiner:
+      "MACD-equivalent expressed as percentage — comparable across instruments with different price levels.",
+    whenToUse: [
+      "Cross-asset momentum comparison (where MACD's absolute units fail)",
+      "Divergence detection with price-level-independent magnitude",
+      "Replacement for MACD in long-history backtests where price scale changes significantly",
+    ],
+    signals: [
+      "PPO crosses above signal = bullish momentum shift",
+      "PPO crosses below signal = bearish momentum shift",
+      "Histogram peaks/troughs = momentum acceleration/deceleration",
+      "Zero-line crossovers = longer-term trend direction change",
+    ],
+    pitfalls: [
+      "Same lag/whipsaw issues as MACD in chop or low-volatility regimes",
+      "Less name-recognition than MACD — harder to communicate signals to non-quant audiences",
+      "Default 12/26/9 inherited from MACD; same daily-bar convention caveats apply",
+      "PPO normalizes before the signal EMA, so PPO signal/histogram timing can diverge from MACD's — not a strict cosmetic rescale",
+    ],
+    synergy: [
+      "Use PPO instead of MACD when comparing momentum across stocks at different price levels",
+      "Higher-timeframe trend filter for direction bias",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      fastPeriod: "12 standard (MACD parity)",
+      slowPeriod: "26 standard",
+      signalPeriod: "9 standard",
+    },
+  },
+  {
+    kind: "tsi",
+    displayName: "True Strength Index",
+    category: "momentum",
+    oneLiner:
+      "William Blau's double-smoothed momentum oscillator — momentum filtered by two nested EMAs.",
+    whenToUse: [
+      "Trend-following with smoother momentum than MACD/PPO",
+      "Divergence detection on swing/position timeframes",
+      "Zero-line crossovers as longer-term trend cues",
+    ],
+    signals: [
+      "TSI > 0 = bullish momentum; TSI < 0 = bearish momentum",
+      "TSI crosses above signal line = bullish entry cue",
+      "TSI crosses below signal line = bearish entry cue",
+      "Divergence with price = trend exhaustion",
+    ],
+    pitfalls: [
+      "Double smoothing creates significant lag at sharp turns",
+      "Signal-line crossovers are 'quite frequent' (StockCharts) — require additional filtering",
+      "Blau's defaults (25/13/7) tuned for daily charts; intraday/longer needs adjustment",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      longPeriod: "25 default — first (long) EMA of momentum",
+      shortPeriod: "13 default — second (short) EMA of long-smoothed momentum",
+      signalPeriod: "7 default — EMA of TSI for the signal line",
+    },
+  },
+  {
+    kind: "ultimateOscillator",
+    displayName: "Ultimate Oscillator",
+    category: "momentum",
+    oneLiner:
+      "Larry Williams' weighted average of buying-pressure ratios across three timeframes (4:2:1).",
+    whenToUse: [
+      "OB/OS detection that's more robust than single-timeframe oscillators",
+      "Divergence-based entry systems (Williams' canonical use)",
+    ],
+    signals: [
+      "UO > 70 = overbought; UO < 30 = oversold",
+      "Bullish divergence formed below 30, then UO rises above the divergence high = buy signal (Williams' three-step setup)",
+      "Bearish divergence formed above 70, then UO falls below the divergence low = sell signal",
+    ],
+    pitfalls: [
+      "Three-period weighting (4:2:1) is fixed by Williams' design — alternatives are non-canonical",
+      "Multi-timeframe averaging dampens reaction speed — late entries on fast moves",
+      "Long warmup: needs `period3` bars (28 default) before first non-null",
+    ],
+    marketRegime: ["ranging", "trending"],
+    timeframe: ["swing"],
+    paramHints: {
+      period1: "7 default — short timeframe (highest weight in 4:2:1)",
+      period2: "14 default — medium timeframe",
+      period3: "28 default — long timeframe (lowest weight)",
+    },
+  },
+  {
+    kind: "stc",
+    displayName: "Schaff Trend Cycle",
+    category: "momentum",
+    oneLiner:
+      "Doug Schaff's (publicly released ~2008) double-smoothed Stochastic of MACD — bounded 0-100 trend cycle indicator.",
+    whenToUse: [
+      "Faster reversal cues than MACD with built-in OB/OS bounds",
+      "Trend cycle identification across instruments where MACD lags",
+    ],
+    signals: [
+      "STC > 75 = overbought zone (uptrend likely tiring)",
+      "STC < 25 = oversold zone",
+      "STC crosses up through 25 = end of oversold, potential long entry",
+      "STC crosses down through 75 = end of overbought, potential short entry",
+    ],
+    pitfalls: [
+      "Combines MACD lag with double-smoothed Stochastic — interpretation requires understanding both layers",
+      "Whipsaws hard in chop despite the smoothing, especially on shorter timeframes",
+      "Default 23/50/10 differs from MACD's 12/26/9 — not a direct drop-in replacement",
+      "Long warmup: needs `slowPeriod` (50) bars for the inner MACD plus the two Stochastic passes — first non-null is well past 60 bars on defaults",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      fastPeriod: "23 default — fast EMA for the underlying MACD (Schaff's original)",
+      slowPeriod: "50 default — slow EMA",
+      cyclePeriod: "10 default — Stochastic cycle length applied to MACD values",
+    },
+  },
+  {
+    kind: "cmo",
+    displayName: "Chande Momentum Oscillator",
+    category: "momentum",
+    oneLiner:
+      "Tushar Chande's pure momentum oscillator using both up and down moves; bounded -100 to +100.",
+    whenToUse: [
+      "OB/OS detection without RSI's denominator-asymmetry issues",
+      "Zero-line crossovers as trend direction shifts",
+      "Divergence with price",
+    ],
+    signals: [
+      "CMO > +50 = overbought",
+      "CMO < -50 = oversold",
+      "Zero-line crossover = trend direction change",
+      "Divergence with price = trend exhaustion warning",
+    ],
+    pitfalls: [
+      "Tushar Chande's original CMO used raw sums (no smoothing); trendcraft impl uses Wilder's smoothing to match TA-Lib — values differ from the strict-original CMO",
+      "Stays at extremes during strong trends like RSI",
+      "Chande's recommended period: 9 for daily (high sensitivity); trendcraft default 14 favors swing-style stability",
+    ],
+    marketRegime: ["ranging"],
+    timeframe: ["swing"],
+    paramHints: {
+      period:
+        "14 default in trendcraft (TA-Lib parity). Chande's original recommended 9 for daily charts",
+    },
+  },
+  {
+    kind: "adxr",
+    displayName: "ADX Rating (ADXR)",
+    category: "momentum",
+    oneLiner: "Wilder's smoothed ADX: average of current ADX and ADX from `period - 1` bars ago.",
+    whenToUse: [
+      "Smoother trend-strength filter than raw ADX for slower systems",
+      "Wilder's original Directional Movement system entry filter (ADXR > 25)",
+    ],
+    signals: [
+      "ADXR > 25 = strong trend (Wilder's threshold to enable trend-following entries)",
+      "ADXR < 20 = weak trend / range — Wilder's rule: do NOT trade trend-following systems",
+    ],
+    pitfalls: [
+      "Direction-agnostic — never use alone for entries (use +DI/-DI for direction)",
+      "Smoothing makes ADXR slightly less responsive than ADX — late on fresh trend ignition",
+      "Long warmup: requires DMI/ADX warmup PLUS the `period` lookback for the rating average",
+    ],
+    synergy: [
+      "+DI / -DI from DMI for direction once ADXR > 25",
+      "Higher-timeframe ADXR for regime confirmation",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      period: "14 default — ADXR rating lookback (Wilder's original)",
+      dmiPeriod: "14 default — DMI/ATR smoothing",
+      adxPeriod: "14 default — ADX smoothing window",
+    },
+  },
 ];

--- a/packages/core/src/manifest/entries/momentum.ts
+++ b/packages/core/src/manifest/entries/momentum.ts
@@ -800,4 +800,72 @@ export const MOMENTUM_MANIFESTS: IndicatorManifest[] = [
       adxPeriod: "14 default — ADX smoothing window",
     },
   },
+  {
+    kind: "adaptiveRsi",
+    displayName: "Adaptive RSI",
+    category: "momentum",
+    oneLiner:
+      "RSI whose lookback period adapts to ATR-based volatility regime; emits effective period and volatility percentile for transparency.",
+    whenToUse: [
+      "Single RSI input across volatility regimes — auto-shortens in volatile periods, lengthens in calm",
+      "Strategies sensitive to RSI period choice that need automated tuning",
+    ],
+    signals: [
+      "Standard RSI signals apply (30/70 OB/OS) — interpretation matches plain RSI",
+      "effectivePeriod < basePeriod = high-volatility regime detected",
+      "effectivePeriod > basePeriod = low-volatility regime detected",
+    ],
+    pitfalls: [
+      "trendcraft custom variant — values are not directly comparable to fixed-period RSI",
+      "Adapting period creates a 'moving target' that can mask divergences",
+      "ATR-based volatility regime detection has its own warmup (`volLookback` = 100 default)",
+    ],
+    synergy: ["Plot `volatilityPercentile` alongside RSI to see why the period adapted at any bar"],
+    marketRegime: ["volatile", "low-volatility"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      basePeriod: "14 default — anchor RSI period",
+      minPeriod: "6 default — period in high-volatility regime (faster response)",
+      maxPeriod: "28 default — period in low-volatility regime (smoother)",
+      atrPeriod: "14 default — ATR period for volatility measurement",
+      volLookback: "100 default — lookback for ATR percentile normalization",
+    },
+  },
+  {
+    kind: "adaptiveStochastics",
+    displayName: "Adaptive Stochastics",
+    category: "momentum",
+    oneLiner:
+      "Stochastic oscillator whose lookback adapts to ADX trend strength; longer in trends (avoid whipsaws), shorter in ranges.",
+    whenToUse: [
+      "Mixed-regime markets where fixed-period Stochastics misfires",
+      "Trend-following strategies that need a smoother Stoch in clean trends",
+      "Range strategies that need responsive Stoch in chop",
+    ],
+    signals: [
+      "Standard Stochastics signals apply (20/80 OB/OS) — interpretation matches plain Stoch",
+      "effectivePeriod increases as ADX rises (longer = avoids trend whipsaws)",
+      "effectivePeriod decreases as ADX falls (shorter = catches range moves)",
+    ],
+    pitfalls: [
+      "trendcraft custom variant — values are not directly comparable to fixed-period Stochastics",
+      "ADX-driven adaptation lags actual regime changes (ADX itself is laggy)",
+      "Long warmup: needs DMI/ADX warmup (~28 bars) before adaptation engages",
+    ],
+    synergy: [
+      "Plot `adx` alongside to see why the period adapted",
+      "DMI for trend direction context",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["swing"],
+    paramHints: {
+      basePeriod: "14 default — anchor stochastic lookback",
+      minPeriod: "5 default — period for low-ADX (range) regime",
+      maxPeriod: "21 default — period for high-ADX (trend) regime",
+      adxPeriod: "14 default — ADX smoothing window",
+      adxThreshold: "40 default — ADX value at which adaptation reaches full extension",
+      kSmoothing: "3 default — %K smoothing",
+      dSmoothing: "3 default — %D smoothing",
+    },
+  },
 ];

--- a/packages/core/src/manifest/entries/momentum.ts
+++ b/packages/core/src/manifest/entries/momentum.ts
@@ -514,6 +514,263 @@ export const MOMENTUM_MANIFESTS: IndicatorManifest[] = [
     },
   },
   {
+    kind: "imi",
+    displayName: "Intraday Momentum Index",
+    category: "momentum",
+    oneLiner:
+      "Tushar Chande's RSI-style oscillator using open-to-close moves instead of close-to-close.",
+    whenToUse: [
+      "Day trading where intraday open-to-close conviction matters more than overnight gaps",
+      "Filtering RSI signals on instruments where close-to-close changes are dominated by overnight moves",
+    ],
+    signals: [
+      "IMI > 70 = overbought intraday (common default; some traders use stricter 80/20)",
+      "IMI < 30 = oversold intraday",
+      "Crosses through 50 with volume confirmation = intraday momentum shift",
+    ],
+    pitfalls: [
+      "Sums of raw gains/losses (no Wilder smoothing) — values are jumpier than RSI",
+      "On instruments with frequent gaps, results differ markedly from RSI; don't treat them as interchangeable",
+      "Less battle-tested than RSI; fewer canonical reference values to cross-check against",
+    ],
+    marketRegime: ["ranging"],
+    timeframe: ["intraday"],
+    paramHints: {
+      period: "14 default rolling-sum window",
+    },
+  },
+  {
+    kind: "vortex",
+    displayName: "Vortex Indicator",
+    category: "momentum",
+    oneLiner:
+      "Etienne Botes & Douglas Siepman's VI+/VI- pair (S&C Jan 2010) — trend ignition via crossovers.",
+    whenToUse: [
+      "Identifying the start of a new trend",
+      "Confirming an existing trend's continuation",
+      "Alternative to DMI/+DI/-DI with a different formulation (uses cross-bar high-low distances)",
+    ],
+    signals: [
+      "VI+ > VI- = uptrend",
+      "VI- > VI+ = downtrend",
+      "VI+ crosses above VI- = bullish trend ignition",
+      "VI- crosses above VI+ = bearish trend ignition",
+      "Botes/Siepman canonical entry: enter at the crossing bar's extreme high (long) or low (short), not at the close",
+    ],
+    pitfalls: [
+      "Crossovers are frequent in chop — needs a regime filter (ADX or Choppiness) for clean signals",
+      "Less well-known than ADX/DMI; tools and reference values are sparser",
+      "TR-normalized denominator can produce extreme readings in low-volatility periods",
+    ],
+    synergy: [
+      "ADX/Choppiness Index regime filter",
+      "DMI for cross-confirmation when both indicators agree on trend direction",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      period:
+        "14 is the common default used across most platforms and in Botes/Siepman's original tests. Common range: 14-30",
+    },
+  },
+  {
+    kind: "dpo",
+    displayName: "Detrended Price Oscillator",
+    category: "momentum",
+    oneLiner:
+      "Removes the trend component to isolate price cycles by comparing price to a backshifted SMA.",
+    whenToUse: [
+      "Cycle analysis — finding rhythmic peaks and troughs independent of trend",
+      "Building a regime-aware system that needs cycle phase as a separate input",
+      "Estimating typical cycle length when paired with peak/trough detection",
+    ],
+    signals: [
+      "DPO > 0 = price above its detrended baseline (cycle high)",
+      "DPO < 0 = price below baseline (cycle low)",
+      "Zero crossings = cycle turning points",
+    ],
+    pitfalls: [
+      "DPO is plotted displaced into the past — the last `period/2 + 1` bars are simply undefined on a centered chart. Does NOT require future market data; it is just not aligned to the latest bar",
+      "Cycle detection assumes the period roughly matches the dominant cycle length; mismatched periods produce noise rather than signal",
+      "Don't use as an entry trigger by itself — it's a context indicator",
+    ],
+    marketRegime: ["ranging"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      period: "20 default — half-cycle lookback for the SMA, shifted back period/2+1 = 11 bars",
+    },
+  },
+  {
+    kind: "kst",
+    displayName: "Know Sure Thing",
+    category: "momentum",
+    oneLiner:
+      "Martin Pring's weighted sum of four smoothed ROCs (1992) — multi-timeframe momentum oscillator.",
+    whenToUse: [
+      "Long-term trend confirmation across multiple ROC timeframes",
+      "Signal-line crossover systems that smooth out single-timeframe noise",
+      "Trend-line breaks on the KST line itself (Pring's preferred technique)",
+    ],
+    signals: [
+      "KST > 0 = bullish; KST < 0 = bearish",
+      "KST crosses above signal = bullish entry cue",
+      "KST crosses below signal = bearish entry cue",
+      "Trend-line breaks on KST line itself (Pring's signature method)",
+    ],
+    pitfalls: [
+      "Many parameters (4 ROC + 4 SMA + weights + signal) — easy to overfit",
+      "Defaults are tuned for daily charts; intraday or longer timeframes need re-tuning",
+      "Signal-line crossovers can be late on fast moves due to multi-timeframe smoothing",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      rocPeriods:
+        "[10, 15, 20, 30] default — four ROC timeframes from short to long (Pring's original)",
+      smaPeriods: "[10, 10, 10, 15] default — SMA smoothing on each ROC",
+      weights: "[1, 2, 3, 4] default — shortest ROC gets weight 1, longest gets 4",
+      signalPeriod: "9 default — SMA of KST for signal line",
+    },
+  },
+  {
+    kind: "massIndex",
+    displayName: "Mass Index",
+    category: "momentum",
+    oneLiner:
+      "Donald Dorsey's range-expansion-based reversal indicator using nested EMAs of (high - low).",
+    whenToUse: [
+      "Predicting trend reversals when the high-low range expands then contracts",
+      "Confirming reversal signals from other indicators with a non-price-direction lens",
+    ],
+    signals: [
+      "Reversal Bulge: Mass Index rises above 27, then drops below 26.5 = potential reversal imminent",
+      "Direction NOT given by Mass Index — use 9-period EMA trend/slope as the directional filter: a reversal bulge in a downtrend suggests a buy setup; in an uptrend, a sell setup (Dorsey's canonical procedure)",
+    ],
+    pitfalls: [
+      "Direction-agnostic — Mass Index alone cannot tell you bullish vs bearish",
+      "27/26.5 thresholds are Dorsey's empirical levels — they don't transfer cleanly to all instruments/timeframes",
+      "Long warmup: nested 9-period EMAs plus 25-bar sum require ~50+ bars before stable",
+    ],
+    synergy: ["EMA(9) of price as the directional companion (Dorsey's recommended pairing)"],
+    marketRegime: ["volatile"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      emaPeriod: "9 default — single and double EMA of (high - low) range",
+      sumPeriod: "25 default — summation window for the EMA ratio",
+    },
+  },
+  {
+    kind: "qstick",
+    displayName: "QStick",
+    category: "momentum",
+    oneLiner:
+      "Tushar Chande's moving average of (close - open) — measures aggregate buying vs selling pressure within bars.",
+    whenToUse: [
+      "Detecting bar-by-bar buying/selling pressure when intra-bar action matters",
+      "Confirming trend direction with a complementary lens to close-to-close oscillators",
+    ],
+    signals: [
+      "QStick > 0 = closes above opens on average (buying pressure)",
+      "QStick < 0 = closes below opens on average (selling pressure)",
+      "Zero-line crossover = sentiment shift",
+    ],
+    pitfalls: [
+      "Uses ONLY open/close — ignores high/low and intra-bar range",
+      "On instruments where opens are unreliable (some FX, after-hours), QStick is noisy",
+      "Less name-recognition; sparse reference data for cross-validation",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      period: "14 default SMA window",
+    },
+  },
+  {
+    kind: "coppockCurve",
+    displayName: "Coppock Curve",
+    category: "momentum",
+    oneLiner:
+      "Edwin Coppock's 1962 long-term buy-signal indicator originally designed for monthly S&P 500 / DJIA.",
+    whenToUse: [
+      "Long-term position-trade entries on broad equity indexes (Coppock's original use case)",
+      "Identifying major bottoms after bear markets when curve turns up from below zero",
+    ],
+    signals: [
+      "Buy signal: curve turns upward from below zero (Coppock's canonical signal)",
+      "Sell signal NOT given by Coppock — he treated this as a buy-only system",
+    ],
+    pitfalls: [
+      "Originally designed for MONTHLY data — applying to daily/intraday materially changes its character",
+      "14- and 11-month ROC periods come from a commonly-repeated anecdotal origin story (the '11-14 month grief period' that Coppock supposedly used); not a quantitatively-derived choice",
+      "Pure long signal — doesn't tell you when to exit",
+      "Lagging: turns up well after the bottom prints",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["position"],
+    paramHints: {
+      wmaPeriod: "10 default — WMA smoothing on combined ROC sum (Coppock's original)",
+      longRocPeriod: "14 default — long ROC period",
+      shortRocPeriod: "11 default — short ROC period",
+    },
+  },
+  {
+    kind: "balanceOfPower",
+    displayName: "Balance of Power",
+    category: "momentum",
+    oneLiner:
+      "Igor Levshin's bar-shape oscillator: (close - open) / (high - low), smoothed by SMA. Range -1 to +1.",
+    whenToUse: [
+      "Detecting buyer/seller dominance from bar shape",
+      "Cross-confirming trend direction with a non-momentum, non-volume signal",
+    ],
+    signals: [
+      "BOP > 0 = buyers in charge (close above open within range)",
+      "BOP < 0 = sellers in charge",
+      "Reading near zero = balance / indecision, sometimes precedes trend reversal",
+    ],
+    pitfalls: [
+      "Bars with high=low (range=0) are undefined — trendcraft handles via fallback",
+      "Single-bar BOP (smoothing=1) is very noisy; default 14-period smoothing is the canonical",
+      "Doesn't capture volume or close-to-close moves — combine with OBV/CMF for fuller picture",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      smoothPeriod:
+        "14 default SMA smoothing (canonical for daily charts). Set to 1 for raw, unsmoothed BOP",
+    },
+  },
+  {
+    kind: "hurst",
+    displayName: "Hurst Exponent",
+    category: "momentum",
+    oneLiner:
+      "Rescaled Range (R/S) analysis estimator of long-term memory: H>0.5 trending, H<0.5 mean-reverting, H≈0.5 random walk.",
+    whenToUse: [
+      "Regime classification: deciding whether to deploy a trend-following or mean-reversion strategy",
+      "Quantifying market efficiency / persistence of returns",
+      "Long-term portfolio analytics (returns persistence)",
+    ],
+    signals: [
+      "H > 0.5 = trending / persistent — favor trend-following strategies",
+      "H < 0.5 = mean-reverting / anti-persistent — favor mean-reversion strategies",
+      "H ≈ 0.5 = random walk — markets behave efficiently, edge is hard",
+      "H ≈ 1.0 = strong trend persistence; H ≈ 0.0 = strong mean reversion",
+    ],
+    pitfalls: [
+      "R/S analysis is sensitive to short-term outliers and the chosen window range",
+      "Estimation noise is high on small samples; 100+ bars is a practical minimum",
+      "Hurst is a STATISTIC, not a tradeable signal — don't enter trades because H crossed 0.5",
+      "Different estimation methods (R/S vs DFA vs Whittle) yield different H values; trendcraft uses R/S",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      minWindow: "20 default — smallest sub-window in R/S analysis",
+      maxWindow: "100 default — largest sub-window / total lookback",
+    },
+  },
+  {
     kind: "adxr",
     displayName: "ADX Rating (ADXR)",
     category: "momentum",

--- a/packages/core/src/manifest/entries/momentum.ts
+++ b/packages/core/src/manifest/entries/momentum.ts
@@ -868,4 +868,63 @@ export const MOMENTUM_MANIFESTS: IndicatorManifest[] = [
       dSmoothing: "3 default — %D smoothing",
     },
   },
+  {
+    kind: "fastStochastics",
+    displayName: "Fast Stochastics",
+    category: "momentum",
+    oneLiner:
+      "Convenience wrapper for `stochastics({ slowing: 1 })` — the original Lane formulation, more responsive than slow stochastics.",
+    whenToUse: [
+      "Short-term mean reversion where slow stochastic's smoothing is too laggy",
+      "Quick OB/OS reads on intraday timeframes",
+      "Confirming faster momentum shifts than slow stochastics catches",
+    ],
+    signals: [
+      "%K crosses above %D in <20 zone = oversold reversal cue",
+      "%K crosses below %D in >80 zone = overbought reversal cue",
+      "Standard Stochastics signals apply — see `stochastics` for full guidance",
+    ],
+    pitfalls: [
+      "Commonly described as noisier than slow stochastics — more whipsaws. Slow stochastic is the more commonly used variant in modern trading",
+      "Same trend-pinning issue as standard stochastics: stays at extremes during strong trends",
+      "trendcraft impl: %K = raw %K (no SMA smoothing applied since slowing=1). Compare to slowStochastics which applies SMA(raw %K, 3)",
+    ],
+    synergy: ["See `stochastics` entry — same synergies (higher-timeframe trend filter, etc.)"],
+    marketRegime: ["ranging"],
+    timeframe: ["intraday"],
+    paramHints: {
+      kPeriod: "14 default — %K lookback",
+      dPeriod: "3 default — %D smoothing",
+    },
+  },
+  {
+    kind: "slowStochastics",
+    displayName: "Slow Stochastics",
+    category: "momentum",
+    oneLiner:
+      "Convenience wrapper for `stochastics({ slowing: 3 })` — modern default; smoother than fast stochastics, less noise.",
+    whenToUse: [
+      "Standard stochastic OB/OS detection on swing timeframes",
+      "Range-bound mean reversion with reduced false signals vs fast stochastics",
+      "The default modern interpretation when 'stochastic' is mentioned",
+    ],
+    signals: [
+      "%K crosses above %D in <20 zone = oversold reversal cue",
+      "%K crosses below %D in >80 zone = overbought reversal cue",
+      "Standard Stochastics signals apply — see `stochastics` for full guidance",
+    ],
+    pitfalls: [
+      "Smoothing introduces lag — can be late on sharp reversals",
+      "Functionally identical to `stochastics` with default options (slowing=3 is the trendcraft default), differing only in that `slowing` is fixed to 3 here. Wrapper exists primarily for explicit naming",
+      "trendcraft impl: %K = SMA(raw %K, 3) — extra SMA applied to raw %K vs fastStochastics",
+      "Stays pinned at extremes during strong trends — same caveat as standard stochastics",
+    ],
+    synergy: ["See `stochastics` entry — same synergies (higher-timeframe trend filter, etc.)"],
+    marketRegime: ["ranging"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      kPeriod: "14 default — %K lookback",
+      dPeriod: "3 default — %D smoothing",
+    },
+  },
 ];

--- a/packages/core/src/manifest/entries/momentum.ts
+++ b/packages/core/src/manifest/entries/momentum.ts
@@ -14,13 +14,16 @@ export const MOMENTUM_MANIFESTS: IndicatorManifest[] = [
     signals: [
       "RSI < 30 = oversold (potential bounce in range)",
       "RSI > 70 = overbought (potential pullback in range)",
+      "In bullish RSI ranges (~40-80) pullbacks tend to hold near 40-50 instead of 30 — useful for buying dips in uptrends",
       "Bullish divergence (price lower low, RSI higher low) = reversal cue",
-      "Failure swings (RSI fails to retake 70/30) = trend weakening",
+      "Failure swings (RSI fails to retake 70/30 after a pullback) = trend weakening",
     ],
     pitfalls: [
       "Strong trends keep RSI overbought/oversold for long stretches — naive 30/70 entries get crushed",
+      "Divergences are misleading in strong trends; bearish divergence in a strong uptrend can repeat many times before a top",
       "Lookback of 14 is convention, not law — shorter periods amplify noise",
       "Absolute level meaningless without trend context",
+      "Wilder himself recommended RSI as confirmation, never a standalone system",
     ],
     synergy: [
       "ADX or DMI to gate RSI signals to ranging regimes (low ADX) only",
@@ -49,13 +52,16 @@ export const MOMENTUM_MANIFESTS: IndicatorManifest[] = [
       "Zero-line crosses = longer-term trend direction change",
     ],
     pitfalls: [
-      "Signal-line crosses are laggy in fast markets",
-      "Whipsaws hard in low-volatility chop",
+      "Signal-line crosses are laggy in fast markets — many pros find 12/26/9 too slow",
+      "Whipsaws hard in low-volatility chop and sideways markets",
       "Default 12/26/9 is daily-bar convention; smaller bars need adjustment",
+      "Raw MACD is in absolute price units — fine within one instrument, but poor for cross-asset or long-history comparison. Use PPO (percentage-based) for those",
+      "Crossovers at extremes often signal momentum slowing rather than continuation",
     ],
     synergy: [
       "200-period MA as a higher-timeframe trend filter",
       "RSI for divergence cross-confirmation",
+      "PPO when comparing momentum across stocks at different price levels",
     ],
     marketRegime: ["trending"],
     timeframe: ["swing", "position"],
@@ -74,17 +80,25 @@ export const MOMENTUM_MANIFESTS: IndicatorManifest[] = [
     signals: [
       "K crosses above D in <20 zone = oversold reversal cue",
       "K crosses below D in >80 zone = overbought reversal cue",
+      "Crossovers in the 20-80 neutral zone are unreliable — only trade extreme-zone signals",
       "Hidden divergence = trend continuation",
     ],
     pitfalls: [
-      "Stays pinned in extremes during strong trends — fade signals fail",
+      "Stays pinned at extremes during strong trends — fade signals fail in trends",
+      "Selling every cross above 80 in a bull market is counter-trend trading",
+      "'Overbought' does NOT mean sell, 'oversold' does NOT mean buy without trend context",
       "Very sensitive to lookback choice",
+    ],
+    synergy: [
+      "Higher-timeframe trend filter (200 MA) — only take bullish crosses in uptrend, bearish in downtrend",
     ],
     marketRegime: ["ranging"],
     timeframe: ["intraday", "swing"],
     paramHints: {
-      kPeriod: "14 standard for swing",
-      dPeriod: "3 standard smoothing",
+      kPeriod: "14 standard for swing — %K lookback",
+      dPeriod: "3 standard smoothing for signal line",
+      slowing:
+        "trendcraft default = 3 (Slow Stochastic). slowing=1 = Fast Stochastic. With all three knobs exposed this is sometimes called the 'Full Stochastic' configured to slow defaults",
     },
   },
   {
@@ -105,6 +119,7 @@ export const MOMENTUM_MANIFESTS: IndicatorManifest[] = [
     pitfalls: [
       "ADX is direction-agnostic — never use alone for entries",
       "ADX rises during strong moves in either direction; can be late at the end of a trend",
+      "+DI/-DI crossovers are frequent without an ADX filter — Wilder's original system gated on ADX > 25; later chartists relaxed to ADX > 20-25",
     ],
     synergy: [
       "RSI gated by ADX < 20 for clean range fades",
@@ -113,26 +128,41 @@ export const MOMENTUM_MANIFESTS: IndicatorManifest[] = [
     marketRegime: ["trending", "ranging"],
     timeframe: ["swing", "position"],
     paramHints: {
-      period: "14 is the Wilder standard",
+      period: "14 is the Wilder standard for both DI and ADX smoothing",
+      adxPeriod: "14 default — separate ADX smoothing window in trendcraft impl",
     },
   },
   {
     kind: "cci",
     displayName: "Commodity Channel Index",
     category: "momentum",
-    oneLiner: "Distance of price from its mean, scaled by mean deviation.",
-    whenToUse: ["Detecting cyclical extremes", "Catching breakout momentum past ±100"],
+    oneLiner:
+      "Scaled distance of typical price from its SMA; Lambert's 0.015 constant targets most readings into ±100.",
+    whenToUse: [
+      "Detecting cyclical overbought/oversold in ranges (±100 fade signals)",
+      "Catching breakout momentum past ±100 in trending markets",
+      "Spotting divergence between price and CCI",
+    ],
     signals: [
-      "CCI > +100 = strong bullish momentum",
-      "CCI < -100 = strong bearish momentum",
-      "Reverse-cross of ±100 = trend exhaustion",
+      "CCI > +100 = overbought (range fade) OR strong bullish breakout (trend follow) — interpretation depends on regime",
+      "CCI < -100 = oversold (range fade) OR strong bearish breakdown (trend follow)",
+      "±200 is practitioner shorthand for a much rarer extreme reading — useful as a stronger exhaustion filter",
+      "Reverse-cross of ±100 = trend exhaustion in extended moves",
     ],
     pitfalls: [
-      "Unbounded — extreme values do not have a fixed ceiling",
+      "Unbounded — extreme values do not have a fixed ceiling, unlike RSI/Stochastics",
+      "±100 means different things in trends vs ranges — never trade CCI without regime context",
       "Whipsaws in low-volatility regimes",
     ],
     marketRegime: ["trending", "ranging"],
     timeframe: ["intraday", "swing"],
+    paramHints: {
+      period: "20 default (Lambert's original) — not 14 like RSI",
+      constant:
+        "0.015 (Lambert's constant) — designed to keep most readings in ±100 (proportion is period-dependent, often cited around ~70-80%); do not change without reason",
+      source:
+        "hlc3 (typical price) is the canonical input, not close — trendcraft default reflects this",
+    },
   },
   {
     kind: "roc",
@@ -142,14 +172,20 @@ export const MOMENTUM_MANIFESTS: IndicatorManifest[] = [
     whenToUse: ["Cross-asset momentum ranking", "Filtering trades by momentum strength threshold"],
     signals: [
       "ROC > 0 with rising slope = accelerating uptrend",
-      "ROC zero-line cross = trend direction change",
+      "ROC crosses from below zero to above zero = bullish momentum shift",
+      "ROC crosses from above zero to below zero = bearish momentum shift",
+      "Divergence with price = trend exhaustion warning",
     ],
     pitfalls: [
       "No bounded interpretation — needs comparable peers or historical context",
-      "Sensitive to gaps and outlier bars",
+      "Sensitive to gaps and outlier bars (uses single point n bars ago, not an average)",
+      "Best used as confirmation, not standalone signal",
     ],
     marketRegime: ["trending"],
     timeframe: ["swing", "position"],
+    paramHints: {
+      period: "12 standard; 12-21 smooths well for swing trading; longer for stable indices",
+    },
   },
   {
     kind: "williamsR",
@@ -160,10 +196,20 @@ export const MOMENTUM_MANIFESTS: IndicatorManifest[] = [
       "Range mean reversion (alternative to stochastics)",
       "Short-cycle overbought/oversold detection",
     ],
-    signals: ["%R < -80 = oversold", "%R > -20 = overbought"],
-    pitfalls: ["Same as stochastics — gets stuck in extremes during trends"],
+    signals: [
+      "%R below -80 = oversold (potential bounce in range)",
+      "%R above -20 = overbought (potential pullback in range)",
+      "Mathematically the inverse of Fast Stochastic %K — a Stoch reading of 80 = -20 on Williams %R",
+    ],
+    pitfalls: [
+      "Same as stochastics — gets stuck in extremes during strong trends",
+      "Fast oscillator: noisy without higher-timeframe trend confirmation",
+    ],
     marketRegime: ["ranging"],
     timeframe: ["intraday", "swing"],
+    paramHints: {
+      period: "14 default suits daily charts; 7 for shorter cycles",
+    },
   },
   {
     kind: "connorsRsi",
@@ -174,18 +220,23 @@ export const MOMENTUM_MANIFESTS: IndicatorManifest[] = [
       "Short-term mean reversion on equities",
       "Pullback timing within established trends",
     ],
-    signals: ["CRSI < 5 in uptrend = strong pullback buy signal", "CRSI > 95 = exhaustion"],
+    signals: [
+      "CRSI < 10 = oversold (Larry Connors' standard/default threshold; stricter 5/95 variants also used)",
+      "CRSI > 90 = overbought (Larry Connors' standard/default threshold)",
+      "In an uptrend filter, CRSI < 10 is a high-probability pullback buy",
+    ],
     pitfalls: [
-      "Designed for daily equities; less reliable on FX or 24h crypto",
+      "Designed for daily US equities; less reliable on FX or 24h crypto",
       "Streak component is sensitive to gap-driven false streaks",
+      "ROC percentile component requires `rocPeriod` bars of warmup (default 100) before CRSI is non-null",
     ],
     synergy: ["200-day MA as trend filter to avoid catching falling knives"],
     marketRegime: ["ranging", "trending"],
     timeframe: ["swing"],
     paramHints: {
-      rsiPeriod: "3 default — intentionally short",
-      streakPeriod: "2 default",
-      rocPeriod: "100 default for percentile lookback",
+      rsiPeriod: "3 default — intentionally short for fast mean reversion",
+      streakPeriod: "2 default — RSI of consecutive up/down day count",
+      rocPeriod: "100 default — percentile lookback over 1-day ROC",
     },
   },
 ];

--- a/packages/core/src/manifest/entries/moving-average.ts
+++ b/packages/core/src/manifest/entries/moving-average.ts
@@ -370,4 +370,39 @@ export const MOVING_AVERAGE_MANIFESTS: IndicatorManifest[] = [
         "[8, 13, 21, 34, 55] Fibonacci default. Common alternatives: [5, 8, 13, 21, 34] (faster) or [10, 20, 30, 40, 50] (uniform)",
     },
   },
+  {
+    kind: "adaptiveMa",
+    displayName: "Adaptive Moving Average",
+    category: "moving-average",
+    oneLiner:
+      "MA whose smoothing speed adapts to the Efficiency Ratio (Perry Kaufman style); exposes ER and SC for analysis vs KAMA's hidden internals.",
+    whenToUse: [
+      "Mixed-regime markets where a fixed-period MA over- or under-reacts",
+      "Trend following that auto-tightens in clean trends and loosens in chop",
+      "Diagnostic studies where the efficiency ratio itself is needed (KAMA hides it)",
+    ],
+    signals: [
+      "Price above rising AMA = bullish bias with regime-aware smoothing",
+      "Flat AMA + low efficiencyRatio = noise regime, avoid trend trades",
+      "Rising efficiencyRatio toward 1 = trend cleaning up — AMA tightens to follow",
+    ],
+    pitfalls: [
+      "Functionally similar to KAMA — choose AMA when you need ER/SC exposed, KAMA when you don't",
+      "Defaults `fastConstant=0.6667` (≈ EMA(2)) and `slowConstant=0.0645` (≈ EMA(30)) match Kaufman's original setup",
+      "Adaptive smoothing can mask genuine trend changes when efficiency ratio collapses",
+    ],
+    synergy: [
+      "Plot efficiencyRatio alongside AMA as a regime indicator",
+      "KAMA when only the smoothed price is needed (less computation)",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      erPeriod: "10 default — efficiency ratio lookback (Kaufman's recommendation)",
+      fastConstant:
+        "2/(2+1) ≈ 0.6667 — fast-bound smoothing constant (EMA(2)-equivalent constant; AMA approaches but does not equal EMA(2) at full ER)",
+      slowConstant:
+        "2/(30+1) ≈ 0.0645 — slow-bound smoothing constant (EMA(30)-equivalent constant)",
+    },
+  },
 ];

--- a/packages/core/src/manifest/entries/moving-average.ts
+++ b/packages/core/src/manifest/entries/moving-average.ts
@@ -163,4 +163,211 @@ export const MOVING_AVERAGE_MANIFESTS: IndicatorManifest[] = [
     marketRegime: ["trending"],
     timeframe: ["intraday", "swing"],
   },
+  {
+    kind: "wma",
+    displayName: "Weighted Moving Average",
+    category: "moving-average",
+    oneLiner: "Linearly-weighted MA: most recent bar weighted N, oldest weighted 1.",
+    whenToUse: [
+      "Short-term trend following where SMA's lag is too costly",
+      "Building block for HMA and other lag-reducing averages",
+      "When a precise, deterministic weighting scheme is preferred over EMA's recursive nature",
+    ],
+    signals: [
+      "Price above rising WMA = bullish bias",
+      "WMA cross of two periods = momentum shift (faster than SMA cross)",
+    ],
+    pitfalls: [
+      "Faster than SMA but choppier — more false signals in noisy markets",
+      "Linear weights still include older prices; reacts more slowly than EMA on sharp moves",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      period: "Required. Common: 20 short-term, 50 medium",
+    },
+  },
+  {
+    kind: "dema",
+    displayName: "Double Exponential Moving Average",
+    category: "moving-average",
+    oneLiner: "Patrick Mulloy's lag-reduced EMA: 2×EMA - EMA(EMA).",
+    whenToUse: [
+      "Trend following where standard EMA lag is unacceptable",
+      "Short-term swing entries on directional moves",
+      "Replacement for EMA in MACD-style systems wanting faster signals",
+    ],
+    signals: [
+      "Price above rising DEMA = bullish bias with reduced lag vs EMA",
+      "DEMA cross of two periods = earlier momentum shift than EMA cross",
+    ],
+    pitfalls: [
+      "Reduced lag comes with more whipsaws in chop",
+      "More complex to interpret than plain EMA — overshoots are characteristic, not anomalies",
+      "Introduced 1994 by Patrick Mulloy; less battle-tested than SMA/EMA",
+      "Warmup of 2×period - 1 bars before first non-null value (the inner EMA-of-EMA needs the outer EMA populated first)",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      period: "20 default — same convention as Mulloy's original Stocks & Commodities article",
+    },
+  },
+  {
+    kind: "tema",
+    displayName: "Triple Exponential Moving Average",
+    category: "moving-average",
+    oneLiner: "Patrick Mulloy's three-fold EMA composition: 3×EMA1 - 3×EMA2 + EMA3.",
+    whenToUse: [
+      "Trend following with even less lag than DEMA",
+      "Short-term systems that need crossovers to fire earlier than DEMA's",
+    ],
+    signals: [
+      "TEMA crossovers typically happen earlier than corresponding DEMA or EMA crossovers",
+      "Price above rising TEMA = strong bullish bias",
+    ],
+    pitfalls: [
+      "Even more whipsaws than DEMA in chop — faster reaction = more noise",
+      "Three nested EMAs amplify any seed-method differences across implementations",
+      "Warmup of 3×period - 2 bars before first non-null value (e.g. period=20 needs 58 bars)",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      period: "20 default — same convention as DEMA",
+    },
+  },
+  {
+    kind: "zlema",
+    displayName: "Zero-Lag Exponential Moving Average",
+    category: "moving-average",
+    oneLiner: "John Ehlers/Ric Way's de-lagged EMA: EMA(2×price - price[lag], period).",
+    whenToUse: [
+      "Trend following where DEMA/TEMA still feel laggy",
+      "Building block for systems that compose with EMAs",
+    ],
+    signals: [
+      "Price above rising ZLEMA = bullish bias with minimal lag",
+      "ZLEMA color/slope change = early reversal cue",
+    ],
+    pitfalls: [
+      "'Zero lag' is a marketing label — lag is reduced, not eliminated",
+      "More false reversals in choppy markets than EMA",
+      "Introduced ~2010 — less battle-tested than older MAs",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      period:
+        "20 default. trendcraft impl uses lag = floor((period-1)/2). Ehlers' typical guidance: 9 intraday, 20 swing, 40-50 position",
+    },
+  },
+  {
+    kind: "alma",
+    displayName: "Arnaud Legoux Moving Average",
+    category: "moving-average",
+    oneLiner:
+      "Gaussian-weighted MA with tunable offset (smoothness↔responsiveness) and sigma (width).",
+    whenToUse: [
+      "When a smooth-yet-responsive MA is needed and EMA-family overshoots are unwanted",
+      "Custom weighting profiles via offset/sigma tuning",
+    ],
+    signals: ["Price above rising ALMA = bullish bias", "Slope change = trend shift cue"],
+    pitfalls: [
+      "Two extra parameters (offset, sigma) make tuning harder than EMA",
+      "Less name-recognition with traders — harder to explain in strategy reviews",
+      "Per-bar Gaussian recompute is more expensive than recursive EMA",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      period: "9 default in trendcraft impl. Larger windows (e.g. 50) also seen on some platforms",
+      offset:
+        "0.85 default. Range 0-1: closer to 1 centers the Gaussian on recent bars (more responsive / less lag); closer to 0 centers earlier (smoother / more lag)",
+      sigma:
+        "6 default. trendcraft uses s = period / sigma, so higher sigma = narrower bell = more responsive; lower sigma = broader bell = smoother",
+    },
+  },
+  {
+    kind: "frama",
+    displayName: "Fractal Adaptive Moving Average",
+    category: "moving-average",
+    oneLiner:
+      "John Ehlers' MA with smoothing factor driven by the price series' fractal dimension.",
+    whenToUse: [
+      "Mixed-regime markets where a fixed-period MA over- or under-reacts",
+      "Following strong trends while slowing during consolidation, similar to KAMA",
+    ],
+    signals: [
+      "Price above rising FRAMA = bullish bias with regime-aware smoothing",
+      "Flat FRAMA = price acting like a 2D random walk (high fractal dimension) — avoid trend trades",
+    ],
+    pitfalls: [
+      "trendcraft impl silently rounds odd periods up to the next even number (e.g. period=5 becomes effectivePeriod=6) — to halve the lookback for the two sub-range fractals",
+      "Less intuitive to tune than fixed-period or KAMA-style MAs",
+      "Adaptive smoothing can mask genuine trend changes when the fractal estimate stays high",
+      "Sensitive to zero-range source windows (computed from the configured source series, default close, not high/low) — when sub-range becomes 0 trendcraft falls back to alpha=0.01",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      period:
+        "16 default. Must be integer >= 4. Even values are canonical — odd values rounded up by trendcraft impl",
+    },
+  },
+  {
+    kind: "mcginley",
+    displayName: "McGinley Dynamic",
+    category: "moving-average",
+    oneLiner:
+      "John R. McGinley's self-adjusting MA that speeds up in fast markets and slows in chop.",
+    whenToUse: [
+      "EMA replacement when you want automatic adaptation to volatility without tuning",
+      "Trend following on swing/position timeframes",
+    ],
+    signals: [
+      "Price above rising McGinley = bullish bias",
+      "McGinley flattens during chop — visual regime cue",
+    ],
+    pitfalls: [
+      "(close/MD)^4 term can cause aggressive jumps when price diverges sharply from the MA — mitigated by k constant but still worth watching",
+      "Less name-recognition than EMA family — harder to explain to non-quant audiences",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      period: "14 default lookback (N in McGinley's formula)",
+      k: "0.6 default constant (60% adjustment, McGinley's original recommendation)",
+    },
+  },
+  {
+    kind: "emaRibbon",
+    displayName: "EMA Ribbon",
+    category: "moving-average",
+    oneLiner:
+      "Multiple EMAs (Fibonacci periods by default) plotted together for trend alignment visualization.",
+    whenToUse: [
+      "At-a-glance trend strength: stacked alignment = strong trend, tangled = chop",
+      "Multi-timeframe trend bias on a single chart",
+      "Ribbon expansion/contraction as a regime cue",
+    ],
+    signals: [
+      "Bullish: shorter EMAs above longer ones, properly stacked (e.g. EMA8 > EMA13 > EMA21 > EMA34 > EMA55)",
+      "Bearish: shorter EMAs below longer ones",
+      "Ribbon expanding = trend strengthening; contracting = trend weakening / regime shift",
+      "Tangled / overlapping ribbon = no clear trend, chop regime",
+    ],
+    pitfalls: [
+      "Visual indicator — alignment is qualitative; thresholds for 'expanding' vs 'tangled' need codification",
+      "Lots of crossovers in chop produce noisy partial-alignment states",
+      "Default Fibonacci periods (8/13/21/34/55) work for swing; smaller stacks needed intraday",
+    ],
+    synergy: ["ADX or Choppiness regime filter to suppress ribbon entries during tangled states"],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      periods:
+        "[8, 13, 21, 34, 55] Fibonacci default. Common alternatives: [5, 8, 13, 21, 34] (faster) or [10, 20, 30, 40, 50] (uniform)",
+    },
+  },
 ];

--- a/packages/core/src/manifest/entries/moving-average.ts
+++ b/packages/core/src/manifest/entries/moving-average.ts
@@ -18,8 +18,9 @@ export const MOVING_AVERAGE_MANIFESTS: IndicatorManifest[] = [
     ],
     pitfalls: [
       "Lags strongly — turning points are visible only after the move",
+      "Crossover signals print well after the move began; the lag is instrument- and regime-dependent",
       "Equal weighting means stale prices distort the signal as much as recent prices",
-      "Whipsaws often in ranging markets",
+      "Whipsaws repeatedly when 50/200 weave around each other in ranging markets",
     ],
     synergy: [
       "ATR for volatility-adjusted stop placement around the SMA",
@@ -49,7 +50,7 @@ export const MOVING_AVERAGE_MANIFESTS: IndicatorManifest[] = [
     pitfalls: [
       "Still lags on sharp reversals",
       "More whipsaws than SMA in choppy conditions",
-      "Initial values are sensitive to seed method (SMA seed vs first-value seed)",
+      "Initial values are sensitive to seed method — trendcraft's impl uses SMA-of-period seed (TA-Lib style)",
     ],
     synergy: [
       "MACD for momentum confirmation (it is built from EMAs)",
@@ -102,11 +103,14 @@ export const MOVING_AVERAGE_MANIFESTS: IndicatorManifest[] = [
     pitfalls: [
       "Adaptive nature can mask genuine trend changes if the efficiency ratio collapses",
       "Less intuitive to tune than fixed-period MAs",
+      "Impl detail: trendcraft seeds the recursion at index `period` with the input price at `period-1` (TA-Lib compatible). First non-null output is at index `period`, not `period-1`. Variants that SMA-seed differ slightly in early bars",
     ],
     marketRegime: ["trending", "ranging"],
     timeframe: ["swing", "position"],
     paramHints: {
-      period: "10 default; fastPeriod=2 and slowPeriod=30 are standard",
+      period: "10 default ER lookback (Perry Kaufman recommendation)",
+      fastPeriod: "2 default — fastest EMA constant, hardcoded in TA-Lib",
+      slowPeriod: "30 default — slowest EMA constant, hardcoded in TA-Lib",
     },
   },
   {
@@ -123,8 +127,9 @@ export const MOVING_AVERAGE_MANIFESTS: IndicatorManifest[] = [
       "Price holding above a rising T3 = strong trend integrity",
     ],
     pitfalls: [
-      "Long warmup (6×(period-1) bars before first value)",
-      "vFactor tuning is non-obvious",
+      "Long warmup: 6×(period-1) bars before first non-null value (e.g. period=5 → first value at index 24)",
+      "Higher vFactor = faster signals but less smooth; lower = smoother but more lag",
+      "Six cascaded EMAs amplify any seed-method differences across implementations",
     ],
     marketRegime: ["trending"],
     timeframe: ["swing", "position"],
@@ -142,12 +147,14 @@ export const MOVING_AVERAGE_MANIFESTS: IndicatorManifest[] = [
       "Detecting divergence between price MA and volume-weighted MA",
     ],
     signals: [
-      "VWMA above SMA = volume is concentrating on up-bars (bullish)",
-      "VWMA below SMA = volume is concentrating on down-bars (bearish)",
+      "VWMA above SMA = within the window, higher-volume bars closed at relatively higher prices (bullish skew)",
+      "VWMA below SMA = within the window, higher-volume bars closed at relatively lower prices (bearish skew)",
+      "Larger spread between VWMA and SMA = stronger volume-confirmed trend",
     ],
     pitfalls: [
-      "Useless on instruments with unreliable volume (some FX)",
-      "Sensitive to volume spikes from news events",
+      "Useless on instruments with unreliable volume (some FX, OTC)",
+      "Sensitive to volume spikes from news events — a single huge bar can drag VWMA",
+      "trendcraft impl returns null when all volumes in the window are 0",
     ],
     synergy: [
       "OBV for cumulative volume flow context",

--- a/packages/core/src/manifest/entries/price.ts
+++ b/packages/core/src/manifest/entries/price.ts
@@ -1,0 +1,285 @@
+import type { IndicatorManifest } from "../types";
+
+export const PRICE_MANIFESTS: IndicatorManifest[] = [
+  {
+    kind: "highestLowest",
+    displayName: "Highest / Lowest",
+    category: "price",
+    oneLiner:
+      "Rolling-window highest high and lowest low — the elemental support/resistance primitive.",
+    whenToUse: [
+      "Building block for breakout systems (Donchian, Turtle)",
+      "Stop placement: use period-N low for stops on long positions",
+      "Reference levels for visual chart annotation",
+    ],
+    signals: [
+      "Close > previous N-period highest high = breakout above range",
+      "Close < previous N-period lowest low = breakdown below range",
+    ],
+    pitfalls: [
+      "Direction-agnostic primitive — only meaningful relative to current price",
+      "Bare highest/lowest gives raw levels but no trend or strength info",
+      "Sensitive to single outlier bars (one wick spike redefines the level)",
+    ],
+    synergy: ["Donchian Channel for the canonical envelope formulation around this primitive"],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["intraday", "swing", "position"],
+    paramHints: {
+      period: "Required (no default). Common: 20 short-term, 55 swing (Turtle System 2)",
+    },
+  },
+  {
+    kind: "pivotPoints",
+    displayName: "Pivot Points",
+    category: "price",
+    oneLiner:
+      "Daily-pivot support/resistance levels; supports five calculation methods. trendcraft's `standard`/`fibonacci`/`camarilla` use prior H/L/C; `woodie`/`demark` also incorporate the current bar's open.",
+    whenToUse: [
+      "Intraday (1m, 5m, 15m) support/resistance reference for day traders",
+      "Pre-market planning: levels are known before the session begins",
+      "Quick context for entry/exit and stop placement around objective levels",
+    ],
+    signals: [
+      "Price holding above pivot = bullish bias for the session",
+      "Price holding below pivot = bearish bias",
+      "R1/R2/R3 act as resistance on rallies; S1/S2/S3 as support on declines",
+      "Method choice tunes the levels: standard (mainstream HLC), woodie (uses current open: (H+L+2*open)/4), camarilla (tight reversals by Nick Scott), demark (open/close emphasis), fibonacci (38.2/61.8 ratio levels)",
+    ],
+    pitfalls: [
+      "Calculated from PREVIOUS session — first bar of new session must wait for prior bar",
+      "Different methods produce materially different levels — don't compare across methods",
+      "Levels are reference, not signals — confluence with other indicators improves quality",
+      "Less useful on multi-day timeframes (pivots reset daily by definition)",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["intraday"],
+    paramHints: {
+      method:
+        "'standard' default. 'fibonacci' (38.2/61.8 ratios), 'woodie' (uses current bar open in pivot calc), 'camarilla' (tighter levels by Nick Scott), 'demark' (uses current bar open + prev close)",
+    },
+  },
+  {
+    kind: "fractals",
+    displayName: "Bill Williams Fractals",
+    category: "price",
+    oneLiner:
+      "5-bar fractal pattern: middle bar's high/low exceeds the surrounding 2 bars on each side.",
+    whenToUse: [
+      "Swing high/low confirmation in Bill Williams' broader trading system",
+      "Building block for fractal-based breakout strategies",
+      "Visual support/resistance markers",
+    ],
+    signals: [
+      "Up fractal (swing high) = potential resistance level",
+      "Down fractal (swing low) = potential support level",
+      "Trade direction: enter long on close above an up fractal's high, short on close below a down fractal's low",
+    ],
+    pitfalls: [
+      "CONFIRMATION lag: a fractal is identified `period` bars AFTER it forms (default 2 bars right). Not predictive — use as confirmation",
+      "Most fractals are noise — Bill Williams pairs them with Alligator and AC for filtering",
+      "Smaller `period` produces more frequent (and noisier) fractals; larger filters but increases lag",
+    ],
+    synergy: [
+      "Alligator indicator (Bill Williams' broader system)",
+      "Wait for fractal break (close above/below) rather than fractal formation alone",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      period:
+        "2 default — produces classic 5-bar fractal (2 left + middle + 2 right). Larger value = stricter filter",
+    },
+  },
+  {
+    kind: "gapAnalysis",
+    displayName: "Gap Analysis",
+    category: "price",
+    oneLiner:
+      "Detects price gaps between consecutive bars. Emits gap `type`, `classification` (full vs partial open-location), and a separate boolean `filled` for fill status.",
+    whenToUse: [
+      "Detecting opening gaps for gap-fill or gap-and-go strategies",
+      "Confirming breakaway / runaway gap patterns from technical analysis",
+      "Risk management: identifying unfilled gaps as future targets / S-R levels",
+    ],
+    signals: [
+      "Gap up + open above prior high = potential breakaway/runaway gap",
+      "Gap down + open below prior low = potential breakaway/runaway gap",
+      "Filled === false on a long-standing gap = significant unfilled level (often S/R)",
+      "Filled === true rapidly = exhaustion gap (failed move, often reversal)",
+    ],
+    pitfalls: [
+      "trendcraft impl exposes TWO orthogonal fields: `classification` ('full' = open beyond prior H/L, 'partial' = open beyond close but inside H/L; canonical TA usually only uses 'full') AND a separate boolean `filled` for fill status",
+      "Does NOT classify by trend context (breakaway / runaway / exhaustion / common / island) — that requires trend & volume context layered on top",
+      "Default `minGapPercent=0.5` filters tiny gaps; tune per instrument volatility",
+      "Cryptocurrency 24/7 markets rarely gap — indicator most useful on equities/futures with overnight breaks",
+    ],
+    synergy: ["Volume + trend context to classify gap type (breakaway vs exhaustion)"],
+    marketRegime: ["volatile"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      minGapPercent: "0.5 default (%) — minimum gap size to register",
+    },
+  },
+  {
+    kind: "openingRange",
+    displayName: "Opening Range Breakout (ORB)",
+    category: "price",
+    oneLiner:
+      "Captures the first N minutes' high/low of a session and detects breakouts. trendcraft default reset is by CALENDAR DAY (not exchange-session-aligned).",
+    whenToUse: [
+      "Day trading: classic 9:30-10:00 ET (or 9:30-9:45) ORB strategy",
+      "Identifying directional bias on intraday timeframes after the open",
+      "Filtering trades to the dominant intraday direction",
+    ],
+    signals: [
+      "Close above opening-range high = bullish breakout, long entry candidate",
+      "Close below opening-range low = bearish breakout, short entry candidate",
+      "Best ORB moves often resolve within 30-90 minutes of breakout",
+    ],
+    pitfalls: [
+      "Failed breakouts (price briefly breaks then reverses) are common — wait for confirmation (close + volume)",
+      "Range size matters: very tight opening range = high probability of false breakout (compression)",
+      "30-minute default is one of several conventions — 15-minute and 60-minute also widely used; results differ materially",
+      "Less useful in low-volatility sessions or on instruments without clear session boundaries",
+    ],
+    synergy: [
+      "VWAP for institutional cost reference within the session",
+      "Volume spike confirmation on the breakout bar",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["intraday"],
+    paramHints: {
+      minutes: "30 default. Other common conventions: 5, 15, 60",
+      sessionResetPeriod:
+        "'day' default (CALENDAR-day reset, not exchange session). Pass a number for fixed N-bar reset",
+    },
+  },
+  {
+    kind: "fairValueGap",
+    displayName: "Fair Value Gap",
+    category: "price",
+    oneLiner:
+      "3-candle imbalance pattern where candle 1 and candle 3 wicks don't overlap — a price-imbalance zone often retested. Concept popularized in ICT/SMC trading communities.",
+    whenToUse: [
+      "Smart Money Concepts (SMC) / ICT trading methodology",
+      "Identifying institutional imbalance zones for entries on retests",
+      "Mean-reversion targets within trends (FVGs often act as magnets)",
+    ],
+    signals: [
+      "Bullish FVG (uptrend): candle 3's low > candle 1's high → gap acts as support on retest",
+      "Bearish FVG (downtrend): candle 3's high < candle 1's low → gap acts as resistance on retest",
+      "Filled FVG = imbalance resolved; unfilled FVG = open target",
+    ],
+    pitfalls: [
+      "ICT/SMC framework is community-defined, not academic — formal definitions vary by source",
+      "Many 'FVGs' are noise on intraday timeframes — higher-timeframe FVGs are more meaningful",
+      "Inverse FVG (IFVG): when an FVG fails and price slices through, the level can flip polarity — trendcraft does NOT track IFVG explicitly",
+      "trendcraft tracks active and filled FVGs; cleanup when filled is automatic",
+    ],
+    synergy: [
+      "Order Block (also SMC concept) for confluence",
+      "Liquidity Sweep (SMC) for ICT-style entry timing",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {},
+  },
+  {
+    kind: "swingPoints",
+    displayName: "Swing Points",
+    category: "price",
+    oneLiner:
+      "Confirmed swing highs/lows requiring N bars of confirmation on each side; emits price and bars-since metadata.",
+    whenToUse: [
+      "Building block for trend structure analysis (HH/HL = uptrend, LH/LL = downtrend)",
+      "Pivot reference points for support/resistance, channel construction, Fibonacci levels",
+      "Inputs to Break of Structure (BOS) and Change of Character (CHoCH) detection",
+    ],
+    signals: [
+      "isSwingHigh === true = confirmed swing high (potential resistance)",
+      "isSwingLow === true = confirmed swing low (potential support)",
+      "swingHighPrice / swingLowPrice expose the most recent swing levels for downstream logic",
+    ],
+    pitfalls: [
+      "CONFIRMATION lag: swing point identified `rightBars` bars AFTER it forms. Not real-time",
+      "Larger leftBars/rightBars = stricter swings (fewer, more meaningful); smaller = noise-prone",
+      "Default 5/5 is moderate strictness — Bill Williams' 2/2 is the looser fractal convention",
+      "Test fixtures need enough bars: with leftBars=1, rightBars=1, need 7+ candles for 3 alternating swings",
+    ],
+    synergy: [
+      "Bill Williams Fractals (same idea with looser default 2/2)",
+      "Zigzag for connecting only 'significant' swings filtered by deviation",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["intraday", "swing", "position"],
+    paramHints: {
+      leftBars: "5 default — bars left of pivot required for confirmation",
+      rightBars: "5 default — bars right of pivot required (= confirmation lag)",
+    },
+  },
+  {
+    kind: "zigzag",
+    displayName: "Zigzag",
+    category: "price",
+    oneLiner:
+      "Connects significant swing pivots filtered by minimum deviation (% or ATR-multiple); ignores moves below threshold.",
+    whenToUse: [
+      "Elliott Wave analysis — visualize impulse and corrective structure",
+      "Filtering noise from swing-point detection: only meaningful turning points",
+      "Pattern recognition: head-and-shoulders, double tops, etc. on cleaned swings",
+    ],
+    signals: [
+      "Each new pivot = confirmed change of swing direction (after threshold met)",
+      "ChangePercent metadata exposes the size of each completed swing",
+    ],
+    pitfalls: [
+      "REPAINTS: the latest prospective/unconfirmed pivot can change as price evolves until reversal threshold is crossed — never use latest zigzag pivot for live entries",
+      "Pure indicator — never tradeable in real time on the latest bar",
+      "Default 5% deviation is a common heuristic; tune per instrument volatility",
+      "ATR-mode requires ATR warmup; trendcraft uses percentage-based fallback during warmup and after `max(20, atrPeriod*2)` bars of flat action",
+    ],
+    synergy: [
+      "Elliott Wave analysis tools",
+      "Swing Points (zigzag is a filtered version of swing point detection)",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      deviation: "5 default (%) — minimum move size to confirm a new pivot",
+      useAtr: "false default — pass true to use ATR-multiple threshold instead",
+      atrPeriod: "14 default — only used when useAtr=true",
+      atrMultiplier: "2 default — only used when useAtr=true",
+    },
+  },
+  {
+    kind: "heikinAshi",
+    displayName: "Heikin-Ashi",
+    category: "price",
+    oneLiner:
+      "Smoothed candlestick representation using averaged OHLC ('average bar' in Japanese); cleaner trend identification. Often attributed to 18th-century Japan but the modern formalization is 20th-century.",
+    whenToUse: [
+      "Trend identification on noisy charts (filters indecision candles)",
+      "Trend-following systems where standard candles produce too many false reversals",
+      "Visual confirmation of sustained trend direction",
+    ],
+    signals: [
+      "Series of green HA candles with no lower wicks = strong uptrend (trend === 1)",
+      "Series of red HA candles with no upper wicks = strong downtrend (trend === -1)",
+      "Mixed candles with both wicks = indecision / consolidation (trend === 0)",
+      "Color change after sustained run = potential trend reversal cue",
+    ],
+    pitfalls: [
+      "HA prices are NOT actual market prices — never use HA values for entry/exit limits or backtests against real fills",
+      "Smoothing introduces 1-bar lag relative to actual prices — late on sharp reversals",
+      "Tendency to keep color longer makes 'time in trade' look better than reality on real-price charts",
+      "Munehisa Homma attribution is folkloric — Heikin-Ashi as charted today is a 20th-century formalization",
+    ],
+    synergy: [
+      "Standard candlesticks for actual price levels alongside HA for trend context",
+      "ADX for trend-strength cross-confirmation when HA shows long color runs",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["intraday", "swing", "position"],
+    paramHints: {},
+  },
+];

--- a/packages/core/src/manifest/entries/specialized.ts
+++ b/packages/core/src/manifest/entries/specialized.ts
@@ -1,0 +1,185 @@
+import type { IndicatorManifest } from "../types";
+
+export const SPECIALIZED_MANIFESTS: IndicatorManifest[] = [
+  {
+    kind: "vsa",
+    displayName: "Volume Spread Analysis (VSA)",
+    category: "wyckoff",
+    oneLiner:
+      "Bar-by-bar classification combining volume, spread (range vs ATR), and close position; modern Wyckoff Effort-vs-Result formalization popularized by Tom Williams (TradeGuider, late 20th century).",
+    whenToUse: [
+      "Wyckoff-style discretionary trading where each bar's character matters",
+      "Detecting smart-money vs retail activity via effort-result mismatches",
+      "Spotting climactic action, springs, and upthrusts at structure points",
+    ],
+    signals: [
+      "noSupply / noDemand: low-volume narrow-spread bars suggesting professional disinterest",
+      "stoppingVolume: high volume + close in lower third of bar = supply being absorbed (often near lows)",
+      "climacticAction: extreme volume + wide spread = capitulation or blow-off",
+      "spring: false break below a swing low followed by recovery (Wyckoff signature) — trendcraft impl uses bar-shape rules, NOT a strict low-volume requirement",
+      "upthrust: false break above a swing high followed by rejection — trendcraft impl uses bar-shape rules, NOT a strict low-volume requirement",
+      "test: low-volume retest of prior high/low = confirmation of strength",
+      "effortDivergence: high volume (effort) without commensurate price progress (result) = absorption",
+    ],
+    pitfalls: [
+      "VSA is interpretive — automated bar classification gives a label, but Wyckoff context is needed for trading decisions",
+      "11 bar types in trendcraft impl: noSupply, noDemand, stoppingVolume, climacticAction, test, upthrust, spring, absorption, effortUp, effortDown, normal",
+      "Thresholds (`highVolumeThreshold=1.5`, `wideSpreadThreshold=1.2`, etc.) are heuristic — tune per instrument",
+      "Useless on instruments with unreliable volume",
+      "Single-bar classification ignores multi-bar context (Wyckoff phases, market structure) which matters more",
+    ],
+    synergy: [
+      "Wyckoff Phase Detection for higher-level context",
+      "Weis Wave for accumulated effort across waves",
+    ],
+    marketRegime: ["trending", "ranging", "volatile"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      volumeMaPeriod: "20 default — moving-average baseline for relative volume",
+      atrPeriod: "14 default — ATR baseline for spread normalization",
+      highVolumeThreshold: "1.5 default — multiple of average for 'high' volume",
+      lowVolumeThreshold: "0.7 default — multiple of average for 'low' volume",
+      wideSpreadThreshold: "1.2 default — multiple of ATR for 'wide' spread",
+      narrowSpreadThreshold: "0.7 default — multiple of ATR for 'narrow' spread",
+    },
+  },
+  {
+    kind: "orderBlock",
+    displayName: "Order Block",
+    category: "smc",
+    oneLiner:
+      "ICT/SMC concept: the last opposing candle before an impulsive move that breaks structure (BOS) — institutional order zone often retested.",
+    whenToUse: [
+      "Smart Money Concepts (SMC) / ICT trading methodology",
+      "Identifying institutional accumulation/distribution zones",
+      "Entries on retest of unmitigated order blocks",
+    ],
+    signals: [
+      "Bullish OB: last bearish candle before a bullish BOS — acts as support on retest",
+      "Bearish OB: last bullish candle before a bearish BOS — acts as resistance on retest",
+      "atBullishOB === true: price currently inside an active bullish OB zone",
+      "atBearishOB === true: price currently inside an active bearish OB zone",
+      "mitigated === true: price returned to and traded back through the OB",
+    ],
+    pitfalls: [
+      "ICT/SMC is community-defined — definitions of 'order block' vary by source",
+      "Many ICT traders require DISPLACEMENT (impulsive ATR-multiple move that breaks structure) for OB validity — trendcraft's `displacementAtr` parameter gates this; default 0 disables the filter",
+      "trendcraft default mitigation = close-through the OB zone (`partialMitigation=false`). Set `partialMitigation=true` to use the touch-interpretation (price wicks into the OB)",
+      "Many supposed 'order blocks' don't precede true displacement — strength score helps filter",
+    ],
+    synergy: [
+      "Fair Value Gap (FVG) for confluence at the same retest level",
+      "Liquidity Sweep before the BOS = stronger institutional setup",
+      "Break of Structure (BOS) — the prerequisite move",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {},
+  },
+  {
+    kind: "liquiditySweep",
+    displayName: "Liquidity Sweep",
+    category: "smc",
+    oneLiner:
+      "ICT/SMC concept: price briefly breaks a swing high/low (triggering stop orders) then quickly reverses — institutional liquidity-grab pattern.",
+    whenToUse: [
+      "Smart Money Concepts (SMC) / ICT trading methodology",
+      "Detecting false breakouts at obvious S/R levels (where retail stops cluster)",
+      "Confirming reversal setups via liquidity-grab + Market Structure Shift (MSS)",
+    ],
+    signals: [
+      "Bullish sweep: price breaks below a swing low, then recovers above it = potential long",
+      "Bearish sweep: price breaks above a swing high, then recovers below it = potential short",
+      "recovered === true: confirmed sweep (price returned past the broken level on the same bar)",
+      "sweepDepthPercent: how deeply the sweep went (size of the wick beyond the level)",
+    ],
+    pitfalls: [
+      "Sweeps look identical to genuine breakouts in real-time — confirmation requires recovery",
+      "trendcraft impl marks `recovered=true` when the bar that broke the level closes back past it. Multi-bar recoveries (sweep on bar N, recovery on bar N+1) need different logic",
+      "Most 'sweeps' at minor swings are noise — focus on sweeps at major equal-highs/lows where stops cluster",
+      "Combine with order-flow context: a sweep without follow-through reversal is just a trend continuation",
+    ],
+    synergy: [
+      "Order Block + FVG entry levels after a confirmed sweep",
+      "Market Structure Shift (MSS) / Break of Structure following the sweep = confluence",
+      "ICT Kill Zones (London/NY open) where sweeps most often occur",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["intraday"],
+    paramHints: {},
+  },
+  {
+    kind: "hmmRegimes",
+    displayName: "HMM Regime Detection",
+    category: "regime",
+    oneLiner:
+      "Gaussian Hidden Markov Model with Baum-Welch fitting and Viterbi decoding; classifies bars into 'trending-up' / 'ranging' / 'trending-down' regimes.",
+    whenToUse: [
+      "Probabilistic regime classification for strategy gating",
+      "Position sizing scaled by regime probability",
+      "Regime-conditional backtests (run different strategies in each regime)",
+      "Risk-on / risk-off detection on broad indices",
+    ],
+    signals: [
+      "regime === 0,1,2 (or N) — discrete state assignment from Viterbi decoding",
+      "label === 'trending-up' / 'ranging' / 'trending-down' (default 3-state human-readable labels)",
+      "probabilities[]: full posterior over states — useful for soft-gating (e.g. only trade when P(trending) > 0.7)",
+      "Expected duration metadata: stickiness of each regime (1 / (1 - self-transition prob))",
+    ],
+    pitfalls: [
+      "Gaussian assumption per state may be violated during crashes/bubbles (fat tails)",
+      "First-order Markov property: latent-state transitions depend only on the current hidden state — ignores longer-term context that often matters in finance",
+      "Baum-Welch is non-convex: trendcraft uses 5 random restarts (numRestarts default) to mitigate local optima — final fit can still vary across runs",
+      "State labels ('trending-up', etc.) are heuristic post-hoc assignments based on mean returns — actual state semantics depend on fit",
+      "Long warmup: HMM needs enough data to fit reliably (typically 100+ bars per state)",
+    ],
+    synergy: [
+      "Volatility Regime indicator for cross-confirmation of regime classification (ATR/BB-based)",
+      "ChoppinessIndex for trend-vs-range orthogonal axis",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      numStates:
+        "3 default — typical for trending-up / ranging / trending-down. 2-state common for risk-on/off only",
+      maxIterations: "100 default — Baum-Welch EM iterations cap",
+      seed: "42 default — for reproducible random restarts",
+      numRestarts: "5 default — random restarts to mitigate Baum-Welch local optima",
+    },
+  },
+  {
+    kind: "sessionBreakout",
+    displayName: "Session Breakout",
+    category: "session",
+    oneLiner:
+      "Tracks the most recently completed trading session's high/low and detects breakouts above/below that range on every subsequent bar (including bars inside a different active session).",
+    whenToUse: [
+      "ICT-style session-range breakout setups (e.g. London breaks Asian range)",
+      "Day-trading session-transition strategies (Asian → London → NY)",
+      "Confirming directional bias when one session breaks the prior session's range",
+    ],
+    signals: [
+      "breakout === 'above': close above prior session's high — bullish breakout candidate",
+      "breakout === 'below': close below prior session's low — bearish breakdown candidate",
+      "fromSession: which prior session formed the broken range (e.g. 'asian', 'london')",
+    ],
+    pitfalls: [
+      "Default uses ICT session definitions: Asia, London, NY AM, NY PM (4 sessions; NY is split into AM/PM in trendcraft) — non-FX instruments may need custom session windows",
+      "Only tracks the MOST RECENT completed session — overlapping or chained breakouts (London breaks Asian, then NY breaks London) require checking session-by-session",
+      "Breakout detection runs on every bar after a range exists, including bars inside a different active session — interpret in context",
+      "Session boundaries depend on timezone — getTzHourMinute resolves; ensure candle timestamps are correct",
+      "Failed breakouts (sweeps) common at session opens — combine with liquidity-sweep detection",
+    ],
+    synergy: [
+      "Liquidity Sweep at session-range extremes = potential reversal setup vs continuation",
+      "ICT Kill Zones for time-of-day filtering",
+      "Opening Range Breakout (ORB) for the within-session variant",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["intraday"],
+    paramHints: {
+      sessions:
+        "Default = ICT sessions (Asia, London, NY AM, NY PM — 4 sessions, NY split). Pass custom SessionDefinition[] for other markets",
+    },
+  },
+];

--- a/packages/core/src/manifest/entries/trend.ts
+++ b/packages/core/src/manifest/entries/trend.ts
@@ -92,4 +92,36 @@ export const TREND_MANIFESTS: IndicatorManifest[] = [
       displacement: "26 default — Kumo and Chikou shift",
     },
   },
+  {
+    kind: "linearRegression",
+    displayName: "Linear Regression",
+    category: "trend",
+    oneLiner:
+      "Least-squares regression line over a rolling window — emits regression value, slope, intercept, and R-squared.",
+    whenToUse: [
+      "Quantifying trend direction (slope sign) and strength (R²) statistically",
+      "Replacing visual trend lines with an objective best-fit line",
+      "Building block for regression-channel strategies and statistical arbitrage",
+    ],
+    signals: [
+      "slope > 0 = uptrend; slope < 0 = downtrend",
+      "Steeper slope = stronger trend (compare relative slope, not absolute)",
+      "R² close to 1 = trend is statistically clean / linear",
+      "R² close to 0 = chop / noisy price action",
+      "Some practitioners use ~0.7 as a heuristic for a relatively clean linear trend — not a standard statistical cutoff",
+    ],
+    pitfalls: [
+      "R² measures goodness-of-fit to a straight line over the window — correlates with trend 'cleanliness', not economic/trading strength",
+      "R² measures linearity — a curved (parabolic) trend can have low R² yet strong directional bias",
+      "Slope is in price-units-per-bar, not directly comparable across instruments without normalization",
+      "Linear regression assumes a linear relationship — useless on highly cyclical or mean-reverting series",
+      "Sensitive to outliers (least-squares minimizes squared error, amplifying outlier influence)",
+    ],
+    synergy: ["ADX or Choppiness Index for cross-confirmation of trend strength"],
+    marketRegime: ["trending"],
+    timeframe: ["intraday", "swing", "position"],
+    paramHints: {
+      period: "14 default rolling window",
+    },
+  },
 ];

--- a/packages/core/src/manifest/entries/trend.ts
+++ b/packages/core/src/manifest/entries/trend.ts
@@ -18,14 +18,19 @@ export const TREND_MANIFESTS: IndicatorManifest[] = [
     ],
     pitfalls: [
       "Whipsaws hard in choppy ranges (this is its main weakness)",
-      "Multiplier tuning matters more than period",
+      "Late entries: the flip requires a close beyond the band — by which point price has already moved an ATR-chunk",
+      "Smaller multiplier flips more often (more whipsaws); larger multiplier holds longer but reacts later",
     ],
-    synergy: ["ADX/Choppiness to disable Supertrend entries during chop"],
+    synergy: [
+      "ADX > 20 or Choppiness Index regime filter to disable Supertrend entries in chop",
+      "VWMA / volume confirmation on flip signals",
+    ],
     marketRegime: ["trending"],
     timeframe: ["intraday", "swing"],
     paramHints: {
-      period: "10 default ATR period",
-      multiplier: "3 default; 2 tighter, 4 wider",
+      period:
+        "10 default ATR period. Heuristic examples (not canonical): intraday 7/3; swing 14/2 or 20/3",
+      multiplier: "3 default. 2 = tighter / more flips, 4 = wider / fewer flips",
     },
   },
   {
@@ -39,11 +44,17 @@ export const TREND_MANIFESTS: IndicatorManifest[] = [
       "Dots flip from above to below price = trend reversal to up",
     ],
     pitfalls: [
-      "Reverses prematurely in ranges or pullbacks",
-      "Acceleration factor tuning is finicky",
+      "Reverses prematurely in ranges or pullbacks — the indicator only works well in clearly trending markets",
+      "Lagging indicator: follows price action, useful only when a strong trend is established",
+      "Too tight an acceleration factor causes premature reversals; too loose lets stops drift far from price",
     ],
+    synergy: ["ADX or Choppiness regime filter to disable PSAR entries during chop"],
     marketRegime: ["trending"],
     timeframe: ["intraday", "swing"],
+    paramHints: {
+      step: "0.02 default acceleration step (Wilder's classic)",
+      max: "0.20 default acceleration cap (Wilder's classic)",
+    },
   },
   {
     kind: "ichimoku",
@@ -64,9 +75,21 @@ export const TREND_MANIFESTS: IndicatorManifest[] = [
     pitfalls: [
       "Many components — risk of overfitting interpretations",
       "Lagging on fast reversals",
-      "Originally designed for daily Japanese equities; tuning needed elsewhere",
+      "Originally designed for daily Japanese equities; default 9/26/52 is widely cited as reflecting Japan's historical 6-day trading week — tuning needed elsewhere",
+      "Cross signals inside the cloud are weak/neutral; treat thin clouds as weak S/R",
+      "Ignoring the Chikou span often leads to false-confidence entries against the longer-term picture",
+    ],
+    synergy: [
+      "Use Kijun-sen as a dynamic trailing stop rather than Tenkan (less noisy)",
+      "Wait for retest entries on Kumo breakouts to reduce false signals",
     ],
     marketRegime: ["trending"],
     timeframe: ["swing", "position"],
+    paramHints: {
+      tenkanPeriod: "9 default (short-term)",
+      kijunPeriod: "26 default (medium-term, also used as displacement)",
+      senkouBPeriod: "52 default (long-term, drives second cloud boundary)",
+      displacement: "26 default — Kumo and Chikou shift",
+    },
   },
 ];

--- a/packages/core/src/manifest/entries/volatility.ts
+++ b/packages/core/src/manifest/entries/volatility.ts
@@ -388,4 +388,40 @@ export const VOLATILITY_MANIFESTS: IndicatorManifest[] = [
       thresholds: "{ low: 25, high: 75, extreme: 95 } percentiles by default",
     },
   },
+  {
+    kind: "adaptiveBollinger",
+    displayName: "Adaptive Bollinger Bands",
+    category: "volatility",
+    oneLiner:
+      "Bollinger Bands whose stddev multiplier adapts to rolling excess kurtosis of CLOSE PRICES (not returns) — wider in fat-tail price-distribution regimes.",
+    whenToUse: [
+      "Markets with regime-shifting price-distribution shape where fixed 2σ either over- or under-reacts",
+      "Mean-reversion strategies that get burned by fat-tail false breakouts",
+      "Adapting risk envelopes to the current price-distribution shape",
+    ],
+    signals: [
+      "Standard Bollinger interpretations apply (band touches, squeeze, band-walk)",
+      "effectiveMultiplier > baseStdDev = fat-tail regime, bands widened",
+      "effectiveMultiplier ≈ baseStdDev = near-normal kurtosis, standard bands",
+    ],
+    pitfalls: [
+      "trendcraft custom variant — values are not directly comparable to fixed-multiplier BB",
+      "Kurtosis here is computed on CLOSE PRICES, not log-returns. Differs from textbook 'fat tails of returns' framing — interpretation is about price-level distribution shape over the window",
+      "Kurtosis is sensitive to outliers in the lookback window — large `kurtosisLookback` (default 100) reduces sensitivity but lags regime shifts",
+      "Multiplier capped at min 1.5 / max 3.0 by default — extreme tail-shape regimes still see bounded widening",
+    ],
+    synergy: [
+      "Plot `kurtosis` alongside to see what the band width is responding to",
+      "Volatility Regime indicator for cross-confirmation",
+    ],
+    marketRegime: ["volatile"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      period: "20 default SMA centerline period (Bollinger's original)",
+      baseStdDev: "2 default base multiplier (Bollinger's original)",
+      kurtosisLookback: "100 default — rolling window for excess kurtosis estimation",
+      minMultiplier: "1.5 default lower bound",
+      maxMultiplier: "3.0 default upper bound",
+    },
+  },
 ];

--- a/packages/core/src/manifest/entries/volatility.ts
+++ b/packages/core/src/manifest/entries/volatility.ts
@@ -172,4 +172,220 @@ export const VOLATILITY_MANIFESTS: IndicatorManifest[] = [
       takeProfitMultiplier: "3.0 default — produces 1.5x stop distance for 1:1.5 RR",
     },
   },
+  {
+    kind: "chandelierExit",
+    displayName: "Chandelier Exit",
+    category: "volatility",
+    oneLiner:
+      "Charles Le Beau's ATR-based trailing stop that 'hangs' from the period high (long) or low (short).",
+    whenToUse: [
+      "Trailing stop placement on trend trades — stays loose in volatile periods, tightens in calm",
+      "Letting winners run while protecting profits in established trends",
+    ],
+    signals: [
+      "Long exit: close below long Chandelier (period-high - 3×ATR by default)",
+      "Short exit: close above short Chandelier (period-low + 3×ATR)",
+      "Trend direction: price above long Chandelier = bullish; below short Chandelier = bearish",
+    ],
+    pitfalls: [
+      "Late on trend reversals — by the time price closes through the chandelier the trend is well over",
+      "On choppy ranges, chandelier oscillates and offers no protection",
+      "Period and multiplier need recalibration across instruments / timeframes",
+    ],
+    synergy: [
+      "ADX or Choppiness regime filter to disable chandelier in chop",
+      "Use as an exit stop, not entry trigger",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      period: "22 default (Le Beau's classic)",
+      multiplier: "3.0 default ATR multiplier (Le Beau's classic)",
+      lookback:
+        "Optional separate lookback for the high/low; defaults to `period` if not specified",
+    },
+  },
+  {
+    kind: "ulcerIndex",
+    displayName: "Ulcer Index",
+    category: "volatility",
+    oneLiner:
+      "Peter Martin's downside-only volatility measure (developed 1987, first published with Byron McCann in 1989) — depth and duration of drawdowns from period highs.",
+    whenToUse: [
+      "Risk-adjusted performance metrics (Ulcer Performance Index = (return - rf) / Ulcer Index)",
+      "Comparing strategies/funds on downside risk rather than total volatility",
+      "Long-only equity portfolio risk monitoring",
+    ],
+    signals: [
+      "Lower UI = less drawdown stress (better for risk-averse investors)",
+      "Higher UI = more drawdown stress",
+      "Trend-following systems: UI rising during a position is a warning sign",
+    ],
+    pitfalls: [
+      "Direction-specific: only measures DOWNSIDE volatility, ignores upside",
+      "Useless for short strategies (would need an inverted version)",
+      "Magnitude is instrument-dependent; only meaningful in relative comparison",
+    ],
+    synergy: ["Pair with Sharpe ratio as a downside-risk-aware alternative (Martin Ratio / UPI)"],
+    marketRegime: ["trending", "volatile"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      period: "14 default lookback",
+    },
+  },
+  {
+    kind: "historicalVolatility",
+    displayName: "Historical Volatility",
+    category: "volatility",
+    oneLiner:
+      "Annualized standard deviation of log returns — the textbook close-to-close volatility estimator.",
+    whenToUse: [
+      "Annualized volatility for options pricing, risk metrics, position sizing",
+      "Comparing volatility across instruments at different price levels (returns are scale-invariant)",
+      "Detecting volatility regime shifts when paired with rolling percentile",
+    ],
+    signals: [
+      "Rising HV = volatility expanding (often near trend changes or news)",
+      "Falling HV = volatility contracting (consolidation / coiling)",
+      "Mean-reverting tendency on most equity instruments",
+    ],
+    pitfalls: [
+      "Uses ONLY closes — ignores intra-bar information (Garman-Klass uses OHLC for ~7.4× more efficiency under its assumptions)",
+      "Annualization assumes 252 trading days — adjust for crypto (365) or other markets",
+      "trendcraft uses sample stddev (/N-1); some platforms use population stddev (/N) yielding slightly smaller values. Document this when comparing across platforms",
+      "Past volatility ≠ future volatility — HV is descriptive, not predictive",
+    ],
+    marketRegime: ["volatile", "low-volatility"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      period: "20 default — short-term volatility window (10-30 typical)",
+      annualFactor:
+        "252 default for daily US equity. Use 365 for 24/7 crypto, 256 for some intraday conventions",
+    },
+  },
+  {
+    kind: "garmanKlass",
+    displayName: "Garman-Klass Volatility",
+    category: "volatility",
+    oneLiner:
+      "Mark Garman & Michael Klass's OHLC-based volatility estimator — ~7.4× more efficient than close-to-close HV.",
+    whenToUse: [
+      "Volatility estimation when fewer bars are available (small-sample efficiency)",
+      "Option pricing models needing tighter volatility estimates",
+      "Replacing HV when intraday range information matters",
+    ],
+    signals: [
+      "Same regime interpretation as HV (rising = expansion, falling = contraction)",
+      "Spread vs HV (close-to-close) reveals intra-bar volatility content",
+    ],
+    pitfalls: [
+      "Assumes Brownian motion with ZERO drift — biased when drift is non-zero (e.g. sustained directional moves)",
+      "Assumes NO opening jumps (overnight gaps) — biased on instruments with weekend/overnight gaps",
+      "Less battle-tested in trader workflows than HV; many platforms don't expose it",
+    ],
+    synergy: [
+      "Cross-check with HV — large divergence indicates intraday range vs close-to-close mismatch",
+    ],
+    marketRegime: ["volatile", "low-volatility"],
+    timeframe: ["swing"],
+    paramHints: {
+      period: "20 default — same convention as HV",
+      annualFactor: "252 default for daily US equity",
+    },
+  },
+  {
+    kind: "ewmaVolatility",
+    displayName: "EWMA Volatility (RiskMetrics)",
+    category: "volatility",
+    oneLiner:
+      "Exponentially weighted moving average of squared returns — JP Morgan's RiskMetrics 1994 standard.",
+    whenToUse: [
+      "Risk management: VaR, position sizing, regulatory capital",
+      "Volatility forecasting where recent observations should weigh more than equal-weight HV",
+      "Daily portfolio variance updates without storing the full window",
+    ],
+    signals: [
+      "Rising EWMA volatility = recent returns more dispersed than recent baseline",
+      "Falling EWMA volatility = recent returns concentrating",
+    ],
+    pitfalls: [
+      "API differs from other indicators: takes `returns: number[]`, NOT candles. Compute returns yourself first",
+      "Single-parameter (λ) — convenient but inflexible compared to GARCH",
+      "λ = 0.94 is RiskMetrics' daily standard; 0.97 is canonical for monthly. Don't change without reason",
+      "Exponential weighting means very old returns still carry tiny weight — no clean cutoff window",
+    ],
+    synergy: ["GARCH for richer volatility modeling when EWMA's single λ isn't sufficient"],
+    marketRegime: ["volatile", "low-volatility"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      lambda:
+        "0.94 default (RiskMetrics 1994 recommendation for 1-day forecast horizon). 0.97 for 1-month horizon. Range 0 < λ < 1",
+    },
+  },
+  {
+    kind: "standardDeviation",
+    displayName: "Standard Deviation",
+    category: "volatility",
+    oneLiner: "Rolling standard deviation of price (not returns) — direct dispersion measure.",
+    whenToUse: [
+      "Building block for Bollinger Bands and other volatility envelopes",
+      "Z-score-style normalization of price relative to its rolling mean",
+      "Cross-check with HV (which operates on log returns instead of raw price)",
+    ],
+    signals: [
+      "Rising stddev = price dispersion expanding",
+      "Falling stddev = price dispersion contracting (squeeze)",
+    ],
+    pitfalls: [
+      "Operates on RAW PRICE, not returns — values scale with price level (compare HV for price-level-independent volatility)",
+      "Population stddev (/N) used by trendcraft to match TA-Lib and Bollinger Bands convention; sample stddev (/N-1) yields slightly larger values",
+      "Direction-agnostic — never use alone for entries",
+    ],
+    synergy: [
+      "Bollinger Bands (uses this internally as the band-width source)",
+      "HV when scale-independent volatility is needed",
+    ],
+    marketRegime: ["volatile", "low-volatility"],
+    timeframe: ["intraday", "swing", "position"],
+    paramHints: {
+      period: "20 default — Bollinger Bands convention",
+    },
+  },
+  {
+    kind: "volatilityRegime",
+    displayName: "Volatility Regime",
+    category: "volatility",
+    oneLiner:
+      "Volatility-regime classifier averaging ATR percentile and Bollinger Bandwidth percentile into 'low' / 'normal' / 'high' / 'extreme'. Historical volatility is reported as metadata but does NOT enter the classification.",
+    whenToUse: [
+      "Strategy gating: enable/disable systems based on regime (mean-reversion in low, trend in high)",
+      "Position sizing: scale size inversely with regime severity",
+      "Risk management dashboards: at-a-glance current vol regime",
+    ],
+    signals: [
+      "regime === 'low' (avg of ATR + BB percentile <= 25) — favor range / mean-reversion strategies",
+      "regime === 'normal' — favor trend-following with standard sizing",
+      "regime === 'high' (avg percentile >= 75) — wider stops, smaller positions",
+      "regime === 'extreme' (avg percentile >= 95) — defensive, consider standing aside",
+      "HV value emitted as `historicalVol` metadata for context but is NOT in the regime classification",
+    ],
+    pitfalls: [
+      "Classification averages ATR + BB Bandwidth percentiles — large disagreement between them is masked by the average. Inspect individual percentiles when `confidence` is low",
+      "Long warmup: needs `lookbackPeriod` (default 100) bars to establish percentile baseline",
+      "Percentile thresholds (25/75/95) are heuristic — recalibrate per instrument if needed",
+      "'Regime' is a categorical signal — implies stability that doesn't always hold (regimes flip fast around events)",
+    ],
+    synergy: [
+      "Pair with HMM regime detection for cross-confirmation of regime classification",
+      "Choppiness Index for trend-vs-range orthogonal axis",
+    ],
+    marketRegime: ["volatile", "low-volatility"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      atrPeriod: "14 default — ATR window for regime input",
+      bbPeriod: "20 default — Bollinger Bandwidth window",
+      lookbackPeriod: "100 default — historical window for percentile ranking",
+      thresholds: "{ low: 25, high: 75, extreme: 95 } percentiles by default",
+    },
+  },
 ];

--- a/packages/core/src/manifest/entries/volatility.ts
+++ b/packages/core/src/manifest/entries/volatility.ts
@@ -18,6 +18,8 @@ export const VOLATILITY_MANIFESTS: IndicatorManifest[] = [
     pitfalls: [
       "Direction-agnostic — never use alone for entries",
       "Absolute ATR varies by instrument; normalize as ATR%/price for cross-asset comparison",
+      "Switching the period frequently introduces inconsistency in stop placement and position sizing — pick a value and stick with it",
+      "Common stop multiplier ranges 1.5-3 — too tight = stopped out by noise, too loose = giving up too much per trade",
     ],
     synergy: ["Bollinger Bands or Keltner for volatility-based bands", "Supertrend (ATR-based)"],
     marketRegime: ["volatile", "low-volatility"],

--- a/packages/core/src/manifest/entries/volatility.ts
+++ b/packages/core/src/manifest/entries/volatility.ts
@@ -47,7 +47,8 @@ export const VOLATILITY_MANIFESTS: IndicatorManifest[] = [
     pitfalls: [
       "Band-walking traps fade traders during trends",
       "Default 20/2 is convention only — context matters",
-      "Population vs sample stddev choice can shift signals subtly",
+      "trendcraft uses population stddev (/N), TA-Lib compatible — implementations using sample stddev (/N-1) yield slightly wider bands",
+      "%B and Bandwidth are useful derived studies but secondary to the core bands in many workflows",
     ],
     synergy: [
       "ADX for distinguishing range (fade bands) from trend (band-walk)",
@@ -64,26 +65,33 @@ export const VOLATILITY_MANIFESTS: IndicatorManifest[] = [
     kind: "keltnerChannel",
     displayName: "Keltner Channel",
     category: "volatility",
-    oneLiner: "EMA with ATR-scaled bands — Bollinger's smoother cousin.",
+    oneLiner:
+      "EMA centerline with ATR-scaled bands; smoother and less reactive than Bollinger Bands.",
     whenToUse: [
       "Trend-following band breakout systems",
       "Filtering false Bollinger band touches via ATR-based bands",
-      "TTM Squeeze setups (Bollinger inside Keltner = compression)",
+      "TTM Squeeze setups (Bollinger inside Keltner = compression preceding expansion)",
     ],
     signals: [
       "Close above upper Keltner = trend breakout (not necessarily exhausted)",
       "Close back inside band after walk = trend cooling",
+      "Bollinger Bands fully enclosed within Keltner = squeeze (low-vol regime, expansion likely)",
     ],
     pitfalls: [
       "Less sensitive than Bollinger to short volatility spikes",
-      "Tuning multiplier requires asset/timeframe-specific calibration",
+      "Tuning multiplier requires asset/timeframe-specific calibration — multiplier has the largest effect on channel width",
     ],
-    synergy: ["Bollinger Bands for squeeze detection (Bollinger inside Keltner)"],
+    synergy: [
+      "Bollinger Bands for TTM Squeeze detection (BB inside KC = compression)",
+      "ATR family — both rely on the same underlying volatility measure",
+    ],
     marketRegime: ["trending", "volatile"],
     timeframe: ["intraday", "swing"],
     paramHints: {
-      period: "20 default EMA period",
-      multiplier: "2 default; 1.5 tighter, 3 wider",
+      emaPeriod: "20 default EMA period for centerline (Linda Bradford Raschke modernization)",
+      atrPeriod:
+        "10 in trendcraft impl. Other common defaults: 14, 20 — platform-dependent. Separate from emaPeriod here",
+      multiplier: "2 default; 1.5 tighter, 3 wider — multiplier dominates channel width",
     },
   },
   {
@@ -95,15 +103,20 @@ export const VOLATILITY_MANIFESTS: IndicatorManifest[] = [
       "Classical breakout systems (Turtle 20/55-bar breakouts)",
       "Range-extreme stop placement",
     ],
-    signals: ["Close > upper Donchian = breakout buy", "Close < lower Donchian = breakdown sell"],
+    signals: [
+      "Close > upper Donchian = breakout buy",
+      "Close < lower Donchian = breakdown sell",
+      "Turtle System 1: enter on 20-day high/low, exit on 10-day opposite. System 2: enter on 55-day high/low, exit on 20-day opposite",
+    ],
     pitfalls: [
       "Whipsaws on every false breakout in ranges",
       "Lookback is brittle — small period changes shift signals dramatically",
+      "Modern Turtle-style win rate is often 30-40% — many small whipsaw losses are the cost of catching the rare large trend",
     ],
     marketRegime: ["trending", "volatile"],
     timeframe: ["swing", "position"],
     paramHints: {
-      period: "20 short-term, 55 medium (Turtle) classics",
+      period: "20 = Turtle System 1 (short-term breakout), 55 = System 2 (long-term)",
     },
   },
   {
@@ -116,10 +129,15 @@ export const VOLATILITY_MANIFESTS: IndicatorManifest[] = [
       "Detecting consolidation periods preceding breakouts",
     ],
     signals: [
-      "CI > 61.8 = choppy / range — favor mean-reversion",
-      "CI < 38.2 = trending — favor trend-following",
+      "CI > 61.8 = choppy / range — favor mean-reversion (Fibonacci 0.618)",
+      "CI < 38.2 = trending — favor trend-following (Fibonacci 0.382)",
+      "38.2-61.8 transitional zone — wait for clearer regime before committing",
     ],
-    pitfalls: ["Lagging — confirms regime after the fact", "Direction-agnostic"],
+    pitfalls: [
+      "Lagging — confirms regime after the fact",
+      "Direction-agnostic",
+      "Fibonacci thresholds are zones of transition, not hard boundaries",
+    ],
     synergy: ["ADX for cross-confirmation of trend strength"],
     marketRegime: ["ranging", "trending"],
     timeframe: ["intraday", "swing"],
@@ -131,13 +149,27 @@ export const VOLATILITY_MANIFESTS: IndicatorManifest[] = [
     kind: "atrStops",
     displayName: "ATR Stops",
     category: "volatility",
-    oneLiner: "ATR-multiplied trailing stop levels above/below price.",
-    whenToUse: ["Volatility-adjusted exits in trend systems", "Chandelier-style trailing stops"],
-    signals: ["Price crossing ATR stop = exit / trend invalidation"],
+    oneLiner: "ATR-multiplied stop-loss and take-profit levels for both long and short positions.",
+    whenToUse: [
+      "Volatility-adjusted exits in trend systems",
+      "Chandelier-style trailing stops",
+      "Position sizing: shares = risk_amount / stopDistance (returns stopDistance directly)",
+      "Consistent risk/reward sizing across instruments with different volatility",
+    ],
+    signals: [
+      "Price crossing longStopLevel = exit long / trend invalidation",
+      "Price reaching longTakeProfitLevel = scale out / take profit",
+    ],
     pitfalls: [
       "Multiplier tuning is asset-specific — same setting can be tight on stocks and loose on crypto",
+      "Take-profit at 3×ATR with 2×ATR stop assumes 1:1.5 RR — verify the assumption holds for your edge",
     ],
     marketRegime: ["trending", "volatile"],
     timeframe: ["intraday", "swing", "position"],
+    paramHints: {
+      period: "14 default ATR period",
+      stopMultiplier: "2.0 default — common range 1.5-3.0",
+      takeProfitMultiplier: "3.0 default — produces 1.5x stop distance for 1:1.5 RR",
+    },
   },
 ];

--- a/packages/core/src/manifest/entries/volume.ts
+++ b/packages/core/src/manifest/entries/volume.ts
@@ -176,4 +176,329 @@ export const VOLUME_MANIFESTS: IndicatorManifest[] = [
     marketRegime: ["trending", "ranging"],
     timeframe: ["intraday", "swing"],
   },
+  {
+    kind: "twap",
+    displayName: "Time-Weighted Average Price",
+    category: "volume",
+    oneLiner:
+      "Equal-weighted average of typical prices over a session — execution benchmark that ignores volume.",
+    whenToUse: [
+      "Simple, predictable execution benchmark that doesn't adapt to volume distribution",
+      "Slicing large orders evenly through the session to minimize market impact",
+      "Mean-reversion reference when intraday volume distribution is unreliable",
+    ],
+    signals: [
+      "Price above TWAP = intraday strength relative to time-equal benchmark",
+      "Price below TWAP = intraday weakness",
+    ],
+    pitfalls: [
+      "Ignores volume entirely — in illiquid markets TWAP can produce suboptimal fills since it doesn't adapt to liquidity",
+      "TWAP and VWAP can diverge meaningfully on event days when volume is concentrated",
+      "Not a market-direction reference; primarily an execution benchmark",
+      "Resets per session by default — meaningless on multi-day timeframes without anchoring",
+    ],
+    synergy: ["VWAP for cross-check; large TWAP-VWAP gap signals uneven volume distribution"],
+    marketRegime: ["ranging"],
+    timeframe: ["intraday"],
+    paramHints: {
+      sessionResetPeriod:
+        "'session' default (resets per trading day). Pass a number for fixed N-bar reset",
+    },
+  },
+  {
+    kind: "elderForceIndex",
+    displayName: "Elder's Force Index",
+    category: "volume",
+    oneLiner:
+      "Alexander Elder's momentum × volume oscillator (Trading for a Living): EMA-smoothed (Close - PrevClose) × Volume.",
+    whenToUse: [
+      "Confirming trend strength with combined price/volume thrust",
+      "Spotting bullish/bearish divergence between price and force",
+      "Validating breakouts: strong breakout should show large positive Force Index",
+    ],
+    signals: [
+      "Force Index > 0 sustained = bullish; < 0 sustained = bearish",
+      "Bullish divergence (price LL, FI HL) = trend reversal cue",
+      "Bearish divergence (price HH, FI LH) = trend exhaustion warning",
+      "Zero-line crossover = momentum direction shift",
+    ],
+    pitfalls: [
+      "Volume spike on a tiny price move yields a large Force value — can mislead",
+      "Default 13 EMA smoothes substantial intra-period variation; raw 1-period FI is very noisy",
+      "Elder explicitly prescribes BOTH a short-period (2) FI for entries AND long-period (13) for trend; trendcraft's single-period default tilts to the long",
+    ],
+    synergy: [
+      "Pair with a separate short-period Force Index (period=2) for entries vs long-period (13) for trend (Elder's canonical setup)",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing"],
+    paramHints: {
+      period:
+        "13 default EMA smoothing (Elder's long-period). Use period=2 for short-period entry signals",
+    },
+  },
+  {
+    kind: "easeOfMovement",
+    displayName: "Ease of Movement",
+    category: "volume",
+    oneLiner:
+      "Richard Arms' volume-based oscillator measuring how easily price moves: midpoint shift divided by a volume-vs-range box ratio.",
+    whenToUse: [
+      "Detecting low-volume price moves (high EMV — easy advance)",
+      "Detecting effort-vs-result mismatches (high volume + small move = low EMV)",
+      "Cross-confirmation with VSA / Wyckoff effort-vs-result frameworks",
+    ],
+    signals: [
+      "EMV > 0 = price advancing with relative ease (less volume needed per move)",
+      "EMV < 0 = price declining with relative ease",
+      "Zero-line crossovers = ease shifts (often after exhaustion)",
+    ],
+    pitfalls: [
+      "Range-zero bars (high=low) make the box ratio explode — trendcraft handles with fallback",
+      "trendcraft uses `volumeDivisor=10000` by default; canonical Arms formula uses 100,000,000. Magnitudes differ — focus on sign and slope, not absolute values",
+      "Useless on instruments with unreliable volume",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing"],
+    paramHints: {
+      period: "14 default SMA smoothing",
+      volumeDivisor:
+        "10000 default in trendcraft (NOT the canonical 100,000,000) — keeps values readable but values are not directly comparable to ChartSchool examples",
+    },
+  },
+  {
+    kind: "klinger",
+    displayName: "Klinger Volume Oscillator",
+    category: "volume",
+    oneLiner:
+      "Stephen Klinger's volume-force oscillator combining short and long EMA differences with a signal line; common platform defaults 34/55/13 (Fibonacci numbers).",
+    whenToUse: [
+      "Long-term money flow trend identification while remaining sensitive to short-term reversals",
+      "Divergence detection between volume force and price",
+      "Signal-line crossover systems",
+    ],
+    signals: [
+      "KVO crosses above signal = bullish entry cue",
+      "KVO crosses below signal = bearish entry cue",
+      "KVO > 0 = bullish bias; KVO < 0 = bearish bias",
+      "Divergence between KVO and price = trend exhaustion",
+    ],
+    pitfalls: [
+      "Volume Force formula is intricate (trend continuation tracking) — debugging anomalies requires understanding the cm/dm accumulator",
+      "Fibonacci 34/55/13 defaults are heuristic, not derived from optimization",
+      "Long warmup: needs `longPeriod` (55) bars at minimum",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      shortPeriod: "34 default — common platform setting (Fibonacci number)",
+      longPeriod: "55 default — common platform setting (Fibonacci number)",
+      signalPeriod: "13 default — common platform setting (Fibonacci number) for signal line EMA",
+    },
+  },
+  {
+    kind: "pvt",
+    displayName: "Price Volume Trend",
+    category: "volume",
+    oneLiner:
+      "OBV-style cumulative line that weights volume by percent price change instead of all-or-nothing.",
+    whenToUse: [
+      "More nuanced volume confirmation than OBV (proportional to move size)",
+      "Divergence detection between price and cumulative volume flow",
+      "Long-term accumulation/distribution analysis",
+    ],
+    signals: [
+      "Rising PVT = uptrend confirmed by proportional volume",
+      "Falling PVT = downtrend confirmed",
+      "Bullish divergence (price LL, PVT HL) = potential reversal up",
+      "Bearish divergence (price HH, PVT LH) = potential reversal down",
+    ],
+    pitfalls: [
+      "Cumulative absolute value is meaningless — only slope and divergence matter",
+      "Sensitive to extremely small percent changes magnifying volume contribution near support",
+      "Requires reliable volume data; useless on instruments where volume is unreliable",
+    ],
+    synergy: [
+      "OBV for cross-check; OBV is unweighted, PVT is percent-weighted — disagreement reveals which moves were proportional",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+  },
+  {
+    kind: "nvi",
+    displayName: "Negative Volume Index",
+    category: "volume",
+    oneLiner:
+      "Tracks price changes only on quiet-volume days. Originally developed by Paul Dysart in the 1930s; Norman Fosback's 1976 'Stock Market Logic' added the modern price-change formula and the 255-day EMA rule.",
+    whenToUse: [
+      "Long-term primary trend identification using Fosback's NVI > 255-day EMA rule",
+      "'Smart money' tracking — assumes informed traders dominate quiet sessions",
+    ],
+    signals: [
+      "NVI above its 255-day EMA = ~96% historical odds of a bull market (Fosback's empirical rule)",
+      "NVI below its 255-day EMA = ~53% odds of a bear market (asymmetric — bull bias of stock market over time)",
+      "Steady upward NVI on declining-volume days = stealth accumulation",
+    ],
+    pitfalls: [
+      "Fosback's 96% bull-market figure is HISTORICAL across US equities — does not generalize to all markets/regimes",
+      "Cumulative scale is arbitrary (depends on initial value, default 1000) — only direction vs MA matters",
+      "Indicator stays unchanged on rising-volume days, so it is silent during many active trading sessions",
+    ],
+    synergy: ["255-day EMA of NVI itself is the canonical companion (Fosback's signal line)"],
+    marketRegime: ["trending"],
+    timeframe: ["position"],
+    paramHints: {
+      initialValue: "1000 default — arbitrary starting value (only changes vs MA matter)",
+    },
+  },
+  {
+    kind: "weisWave",
+    displayName: "Weis Wave Volume",
+    category: "volume",
+    oneLiner:
+      "David Weis's accumulator of volume within directional price waves — Wyckoff Effort-vs-Result tool.",
+    whenToUse: [
+      "Wyckoff effort-vs-result analysis (volume = effort, price progress = result)",
+      "Identifying accumulation/distribution zones via wave-volume shifts",
+      "Spotting capitulation: huge wave volume + small price progress = effort wasted",
+    ],
+    signals: [
+      "Up wave with growing volume + progressing price = healthy uptrend",
+      "Up wave with growing volume but stalled price = effort wasted, potential top",
+      "Down wave with growing volume but stalled decline = absorption, potential bottom",
+      "Direction flips when price reverses (close-based or high/low-based per `method`)",
+    ],
+    pitfalls: [
+      "Wave detection depends on `method` (close vs highlow) and `threshold` — different settings produce different waves",
+      "Manual Wyckoff analysis adds context that automated wave detection misses",
+      "Less canonical than OBV/CMF; sparse reference data for cross-validation",
+    ],
+    synergy: [
+      "VSA (Volume Spread Analysis) for bar-level effort-vs-result confirmation",
+      "Wyckoff Phase Detection for higher-level context",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      method: "'close' default — reverse on close direction. 'highlow' uses high/low for direction",
+      threshold: "0 default — minimum price change to trigger a new wave (filters tiny reversals)",
+    },
+  },
+  {
+    kind: "volumeAnomaly",
+    displayName: "Volume Anomaly Detection",
+    category: "volume",
+    oneLiner:
+      "Detects abnormal volume spikes via ratio-vs-average and Z-score, classifying as 'high' or 'extreme'.",
+    whenToUse: [
+      "Capitulation/breakout detection where institutional activity is suspected",
+      "Filter for trade entries — confirm signals only when volume confirms the move",
+      "Post-news / earnings monitoring",
+    ],
+    signals: [
+      "level === 'high' (>= 2× average OR z-score >= 2.0) = notable spike",
+      "level === 'extreme' (>= 3× average OR z-score >= 1.5× threshold) = significant event, likely heightened participation / event-driven activity",
+      "Combine with price action: extreme volume on a breakout = strong; on a doji = potential exhaustion",
+    ],
+    pitfalls: [
+      "Detection thresholds are heuristic — recalibrate per instrument (different baselines for stocks vs crypto)",
+      "20-bar baseline is short — major events span multiple bars and may distort future baselines",
+      "Doesn't tell you direction — combine with price/CVD/CMF for context",
+    ],
+    marketRegime: ["volatile"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      period: "20 default — moving-average baseline window",
+      highThreshold: "2.0 default — ratio multiplier for 'high' level",
+      extremeThreshold: "3.0 default — ratio multiplier for 'extreme' level",
+      useZScore: "true default — also flag based on Z-score of volume",
+      zScoreThreshold: "2.0 default — Z-score (≈2 sigma) threshold",
+    },
+  },
+  {
+    kind: "volumeTrend",
+    displayName: "Volume Trend Confirmation",
+    category: "volume",
+    oneLiner:
+      "Composite analysis of whether volume confirms or diverges from the current price trend.",
+    whenToUse: [
+      "Filtering trade entries to require volume confirmation",
+      "Detecting trend exhaustion via price-volume divergence",
+      "Risk management: scaling out when volume stops confirming",
+    ],
+    signals: [
+      "isConfirmed === true && priceTrend === 'up' = healthy uptrend (price + volume both rising)",
+      "isConfirmed === true && priceTrend === 'down' = strong selling (price falling + volume rising)",
+      "hasDivergence === true && priceTrend === 'down' = bullish divergence (selling exhaustion)",
+      "hasDivergence === true && priceTrend === 'up' = bearish divergence (weak rally)",
+    ],
+    pitfalls: [
+      "Trend determination requires `minPriceChange` threshold (default 2%) — sub-threshold moves are tagged 'sideways'",
+      "Both price and volume trends use simple slope direction — sophisticated trend definitions may differ",
+      "trendcraft-specific composite indicator; reference values are not standardized across platforms",
+    ],
+    marketRegime: ["trending"],
+    timeframe: ["swing", "position"],
+    paramHints: {
+      pricePeriod: "10 default — price-trend window",
+      volumePeriod: "10 default — volume-trend window",
+      maPeriod: "20 default — volume MA baseline",
+      minPriceChange: "2.0 default — minimum % price change to register as a trend",
+    },
+  },
+  {
+    kind: "volumeMa",
+    displayName: "Volume Moving Average",
+    category: "volume",
+    oneLiner: "SMA or EMA of volume — baseline for spike detection and volume trend analysis.",
+    whenToUse: [
+      "Volume baseline for breakout confirmation (current vs 20-period MA)",
+      "Building block for custom volume oscillators and anomaly detectors",
+      "Visual reference for 'normal' volume on a chart",
+    ],
+    signals: [
+      "Current volume > 1.5-2× volumeMa = elevated activity",
+      "Current volume sustained < volumeMa during a price move = weak conviction",
+    ],
+    pitfalls: [
+      "Volume series can be highly skewed (long tail) — SMA on raw volume is sensitive to single huge bars",
+      "EMA mode adapts faster but can mask gradual structural shifts in baseline volume",
+    ],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["intraday", "swing", "position"],
+    paramHints: {
+      period: "Required (no default). Common: 20 for spike detection, 50 for medium-term baseline",
+      type: "'sma' default. 'ema' for faster response to recent volume",
+    },
+  },
+  {
+    kind: "cvdWithSignal",
+    displayName: "CVD with Signal Line",
+    category: "volume",
+    oneLiner:
+      "Cumulative Volume Delta (bar-position approximation) plus an EMA signal line for crossover-based timing.",
+    whenToUse: [
+      "Order-flow-style entries via CVD/signal crossovers",
+      "Smoothing CVD to filter noise while preserving directional bias",
+      "Layering CVD on price chart for accumulation/distribution divergences",
+    ],
+    signals: [
+      "CVD crosses above signal = bullish flow shift",
+      "CVD crosses below signal = bearish flow shift",
+      "CVD divergence with price (price up, CVD down) = bearish divergence (sellers absorbing)",
+    ],
+    pitfalls: [
+      "Inherits all CVD limitations — bar-position approximation, NOT true tick-aggressor data",
+      "Signal-line crossovers can lag in fast markets",
+      "Smoothing CVD itself (`smoothing` > 1) further dampens signal speed",
+    ],
+    synergy: ["Plain CVD for raw flow inspection; this composition adds trigger timing"],
+    marketRegime: ["trending", "ranging"],
+    timeframe: ["intraday", "swing"],
+    paramHints: {
+      smoothing:
+        "1 default (no extra smoothing of CVD). Set >1 to apply EMA to CVD itself before computing the signal",
+      signalPeriod: "9 default — EMA period for the signal line over CVD",
+    },
+  },
 ];

--- a/packages/core/src/manifest/entries/volume.ts
+++ b/packages/core/src/manifest/entries/volume.ts
@@ -17,12 +17,22 @@ export const VOLUME_MANIFESTS: IndicatorManifest[] = [
       "Pullback to VWAP in trend = continuation entry zone",
     ],
     pitfalls: [
-      "Resets daily — meaningless on multi-day timeframes",
+      "Session-reset VWAP loses most of its intended relevance across multiple days; trendcraft offers `resetPeriod: 'rolling' | number` for non-session use",
       "Less useful pre-market or in low-volume sessions",
+      "Anchored variants (anchoredVwap) are often more meaningful for multi-day context",
     ],
-    synergy: ["VWAP bands (stddev-scaled) for overshoot/undershoot detection"],
+    synergy: [
+      "VWAP ±1σ bands always emitted by trendcraft impl; pass `bandMultipliers: [2, 3]` for ±2σ/±3σ overshoot detection",
+    ],
     marketRegime: ["trending", "ranging"],
     timeframe: ["intraday"],
+    paramHints: {
+      resetPeriod:
+        "'session' default (resets per trading day). 'rolling' for windowed VWAP, or number for fixed N-bar reset",
+      period: "Used only when resetPeriod='rolling' — sets the rolling window length",
+      bandMultipliers:
+        "Extra ±N σ band pairs beyond the default ±1σ (e.g. [2, 3] adds ±2σ and ±3σ)",
+    },
   },
   {
     kind: "anchoredVwap",
@@ -38,9 +48,20 @@ export const VOLUME_MANIFESTS: IndicatorManifest[] = [
       "Price holding above anchored VWAP from a low = bullish accumulation",
       "Rejection at anchored VWAP from a high = sellers defending",
     ],
-    pitfalls: ["Anchor choice is subjective — bad anchors give meaningless levels"],
+    pitfalls: [
+      "Anchor choice is subjective — bad anchors give meaningless levels",
+      "Anchored to a major high → declining VWAP can act as resistance for trapped buyers selling to break even",
+      "Anchored to a major low → rising VWAP can act as support for the accumulation crowd",
+    ],
+    synergy: [
+      "trendcraft impl emits optional ±1σ and ±2σ bands when `bands: 1` or `bands: 2` is set — use for overshoot/mean-reversion zones",
+    ],
     marketRegime: ["trending", "ranging"],
     timeframe: ["intraday", "swing"],
+    paramHints: {
+      anchorTime: "Unix ms timestamp of the anchor bar — earnings, swing high/low, breakout bar",
+      bands: "0 (default) = no bands. 1 = ±1σ. 2 = ±1σ and ±2σ",
+    },
   },
   {
     kind: "obv",
@@ -56,8 +77,12 @@ export const VOLUME_MANIFESTS: IndicatorManifest[] = [
       "Price new high but OBV does not = bearish divergence",
     ],
     pitfalls: [
-      "Treats every up-day equally regardless of close magnitude",
-      "Cumulative absolute value is meaningless — only changes/divergences matter",
+      "Treats every up-day equally regardless of close magnitude — adds full bar volume even on tiny up-moves",
+      "Cumulative absolute value is meaningless — only slope and divergences matter",
+      "Misleading during gaps or when intraday action contradicts the close direction",
+      "Can oscillate in sideways markets without offering clear direction",
+      "Volume spikes can disrupt the indicator and require a settling period",
+      "trendcraft impl seeds OBV at 0 on the first bar (some implementations seed at first-bar volume — values differ by a constant offset only)",
     ],
     synergy: ["Price chart for divergence comparison"],
     marketRegime: ["trending"],
@@ -75,10 +100,12 @@ export const VOLUME_MANIFESTS: IndicatorManifest[] = [
     signals: [
       "MFI < 20 = oversold with volume confirmation",
       "MFI > 80 = overbought with volume confirmation",
+      "Bullish divergence (price LL, MFI HL) — stronger than plain RSI divergence due to volume weighting",
     ],
     pitfalls: [
       "Same as RSI — gets stuck in extremes during strong trends",
       "Useless on instruments with unreliable volume",
+      "'Squat' pattern (MFI drops while volume rises) signals indecision, not direction",
     ],
     marketRegime: ["ranging"],
     timeframe: ["swing"],
@@ -90,28 +117,39 @@ export const VOLUME_MANIFESTS: IndicatorManifest[] = [
     kind: "cmf",
     displayName: "Chaikin Money Flow",
     category: "volume",
-    oneLiner: "Volume-weighted accumulation/distribution oscillator (-1 to +1).",
+    oneLiner: "Marc Chaikin's volume-weighted accumulation/distribution oscillator (-1 to +1).",
     whenToUse: ["Detecting buying vs selling pressure", "Confirming trend with money flow"],
     signals: [
       "CMF > 0 sustained = accumulation",
       "CMF < 0 sustained = distribution",
       "Divergence with price = trend weakness",
     ],
-    pitfalls: ["Lagging — confirms but rarely leads", "Sensitive to closing range within bar"],
+    pitfalls: [
+      "Lagging — confirms but rarely leads",
+      "Sensitive to closing range within bar (close-location-value)",
+      "Doji bars (close near midrange) contribute near-zero money flow regardless of volume",
+    ],
     marketRegime: ["trending", "ranging"],
     timeframe: ["swing"],
+    paramHints: {
+      period: "20 default lookback",
+    },
   },
   {
     kind: "adl",
     displayName: "Accumulation/Distribution Line",
     category: "volume",
-    oneLiner: "Cumulative volume × close-location-value.",
+    oneLiner: "Marc Chaikin's cumulative running sum of (close-location-value × volume).",
     whenToUse: ["Long-term accumulation/distribution divergence with price"],
     signals: [
       "ADL rising while price flat = stealth accumulation",
       "ADL falling while price holds = stealth distribution",
     ],
-    pitfalls: ["Cumulative value irrelevant — slope and divergence matter"],
+    pitfalls: [
+      "Cumulative absolute value is irrelevant — only slope and divergence with price matter",
+      "Doji bars (close at midrange, CLV ≈ 0) contribute near-zero regardless of volume",
+      "Range=0 bars (high=low) trendcraft impl assigns CLV=0 to avoid div-by-zero",
+    ],
     marketRegime: ["trending"],
     timeframe: ["swing", "position"],
   },
@@ -130,8 +168,10 @@ export const VOLUME_MANIFESTS: IndicatorManifest[] = [
       "Price up + CVD flat or down = bearish divergence (sellers absorbing)",
     ],
     pitfalls: [
-      "Approximation only — real CVD needs tick-level bid/ask data",
+      "Approximation only — real CVD requires tick-level aggressor data (executed-at-bid vs executed-at-ask)",
+      "trendcraft impl uses bar-position approximation: buyVolume = volume × (close-low) / (high-low). Does NOT drill down into lower-timeframe bars",
       "Cumulative scale not directly comparable across instruments",
+      "Bars with high=low (no range) fall back gracefully but contribute zero delta",
     ],
     marketRegime: ["trending", "ranging"],
     timeframe: ["intraday", "swing"],

--- a/packages/core/src/manifest/index.ts
+++ b/packages/core/src/manifest/index.ts
@@ -18,6 +18,7 @@
 
 import { MOMENTUM_MANIFESTS } from "./entries/momentum";
 import { MOVING_AVERAGE_MANIFESTS } from "./entries/moving-average";
+import { PRICE_MANIFESTS } from "./entries/price";
 import { TREND_MANIFESTS } from "./entries/trend";
 import { VOLATILITY_MANIFESTS } from "./entries/volatility";
 import { VOLUME_MANIFESTS } from "./entries/volume";
@@ -31,6 +32,7 @@ const ALL_MANIFESTS: readonly IndicatorManifest[] = [
   ...VOLATILITY_MANIFESTS,
   ...TREND_MANIFESTS,
   ...VOLUME_MANIFESTS,
+  ...PRICE_MANIFESTS,
 ];
 
 const MANIFEST_BY_KIND: ReadonlyMap<string, IndicatorManifest> = new Map(

--- a/packages/core/src/manifest/index.ts
+++ b/packages/core/src/manifest/index.ts
@@ -19,6 +19,7 @@
 import { MOMENTUM_MANIFESTS } from "./entries/momentum";
 import { MOVING_AVERAGE_MANIFESTS } from "./entries/moving-average";
 import { PRICE_MANIFESTS } from "./entries/price";
+import { SPECIALIZED_MANIFESTS } from "./entries/specialized";
 import { TREND_MANIFESTS } from "./entries/trend";
 import { VOLATILITY_MANIFESTS } from "./entries/volatility";
 import { VOLUME_MANIFESTS } from "./entries/volume";
@@ -33,6 +34,7 @@ const ALL_MANIFESTS: readonly IndicatorManifest[] = [
   ...TREND_MANIFESTS,
   ...VOLUME_MANIFESTS,
   ...PRICE_MANIFESTS,
+  ...SPECIALIZED_MANIFESTS,
 ];
 
 const MANIFEST_BY_KIND: ReadonlyMap<string, IndicatorManifest> = new Map(


### PR DESCRIPTION
## Summary

Expands `trendcraft/manifest` from the 30-entry PoC (#93) to **full coverage of all 96 `kind`s** in `indicator-meta.ts`. Every entry — including the original 30 — has been verified through web search of canonical sources, spot-computation against the actual implementation, and a Codex `codex-rescue` second-opinion fact-check.

- **Audit (Phases 0a/0b):** all 30 PoC entries reverified and refined
- **Expansion (Phases 1-9):** 66 new entries across moving-average / momentum / volatility / trend / volume / price / wyckoff / smc / regime / session
- **2 new category files:** `entries/price.ts`, `entries/specialized.ts` (covers wyckoff/smc/regime/session)
- **Manifest count: 96 entries** = 100% of `indicator-meta.ts` `kind`s
- **Implementation bugs found: 0** — all impl deviations are documented variants, captured in `pitfalls`/`paramHints`

## Why

The PoC delivered the manifest infrastructure but covered only ~31% of indicators. LLM agents (alpaca-demo's strategy generator, future MCP server) need full coverage to make informed indicator-selection decisions. Quality matters more than coverage breadth — an LLM citing wrong canonical levels for a single indicator is worse than no metadata at all — so each entry went through a rigorous workflow:

1. Read source (`packages/core/src/indicators/<category>/*.ts`)
2. Web-search canonical formula / signals / pitfalls (StockCharts, Wikipedia, Investopedia, original-author writeups)
3. Spot-compute against actual `trendcraft` impl with category-specific test fixtures (10 throwaway scripts under `sources/spot-check-*.mjs`, gitignored)
4. Codex `codex-rescue` fact-check
5. Apply corrections
6. Document source URLs and spot-check results

## Phase breakdown

| Phase | Scope | Net entries | Commit |
|---|---|---|---|
| 0a | Audit batch A (15) | 30 | `47f9f9b` |
| 0b | Audit batch B (15) | 30 | `a555de2` |
| 1 | MA additions | +8 → 38 | `828adb5` |
| 2 | Mainstream momentum | +10 → 48 | `1cbf9dc` |
| 3 | Secondary momentum | +9 → 57 | `804b891` |
| 4 | Volatility extras | +7 → 64 | `ff03554` |
| 5 | Volume extras | +11 → 75 | `f065895` |
| 6 | Trend & adaptive | +5 → 80 | `221b913` |
| 7 | Price action | +9 → 89 | `43a5cd1` |
| 8 | Specialized | +5 → 94 | `23b3025` |
| 9 | Stochastics variants | +2 → **96** | `9e8d70c` |

## Notable Codex fact-check corrections (~30 across phases)

These are the most consequential ones an LLM could have quoted incorrectly:

- **ALMA** (Phase 1): offset/sigma semantics were inverted in PoC. Fixed: `offset → 1` = more responsive (Gaussian centered on newer bars); `sigma` higher = narrower bell = more responsive
- **VWAP** (Phase 0b): manifest claimed "session-only" but impl supports `session`/`rolling`/N-bar reset modes plus custom band multipliers
- **TRIX** (Phase 2): warmup logic is intentionally lenient — null EMA values treated as 0 in nested passes, so TRIX becomes non-null around `index = period` rather than after a strict 3-stage warmup. Documented in pitfall
- **adaptiveBollinger** (Phase 6): rolling kurtosis is computed on **close prices**, not log-returns. Important semantic distinction vs textbook fat-tail framing
- **ADXR** (Phase 2): formula clarified as `(ADX[i] + ADX[i - (period-1)]) / 2` matching impl's `lookback = period - 1`
- **Awesome Oscillator** (Phase 2): Saucer / Twin Peaks pattern descriptions corrected to canonical Bill Williams definitions
- **Order Block** (Phase 8): trendcraft default mitigation = close-through (NOT touch); touch is opt-in via `partialMitigation: true`
- **Session Breakout** (Phase 8): default ICT sessions are 4 (Asia / London / NY AM / NY PM), not 3
- **NVI** (Phase 5): attribution corrected — Paul Dysart 1930s original, Norman Fosback 1976 added the modern price-change formula and 255-day EMA rule
- **Pivot Points** (Phase 7): `woodie` / `demark` methods use the **current bar's open** in addition to prior H/L/C — not pure prior-session calculations
- **CMO** (Phase 2): trendcraft uses Wilder smoothing (TA-Lib parity), but Chande's original CMO used raw sums

## Implementation deviations surfaced (NOT bugs)

All documented in manifest `pitfalls` / `paramHints`:

- **KAMA**: TA-Lib-compatible seed (`source[period-1]`); first non-null at `index = period`
- **FRAMA**: silently rounds odd `period` to next even number internally
- **DEMA / TEMA**: warmup of `2N-1` / `3N-2` bars
- **Easeof Movement**: `volumeDivisor=10000` default differs from canonical 100,000,000
- **ewmaVolatility**: API takes `returns: number[]`, NOT candles
- **historicalVolatility**: sample stddev (`/N-1`) vs `standardDeviation` population (`/N`)
- **OBV**: trendcraft seeds at 0 (some platforms seed at first-bar volume)
- **Force Index**: trendcraft default = 13 (long-period only); Elder canonically uses both 2 and 13

## Files changed

**New:**
- `packages/core/src/manifest/entries/price.ts` (9 entries)
- `packages/core/src/manifest/entries/specialized.ts` (5 entries — wyckoff/smc/regime/session)

**Modified:**
- `packages/core/src/manifest/entries/{moving-average,momentum,volatility,trend,volume}.ts` (entries added/refined)
- `packages/core/src/manifest/index.ts` (wire in `PRICE_MANIFESTS` + `SPECIALIZED_MANIFESTS`)

**Gitignored sidecar (not in this PR):**
- `packages/core/src/manifest/sources/{moving-average,momentum,volatility,trend,volume,price,specialized}.md` — per-entry source citations + spot-check summaries
- `packages/core/src/manifest/sources/spot-check-{0a,0b,1..8}.mjs` — throwaway verification scripts

## Followup tracked separately

Memory note `project_manifest_audit_findings.md` records 9 implementation quirks worth considering as quality improvements. None block release. Highest priority:
- TRIX warmup tightening
- adaptiveBollinger switching from price kurtosis to return kurtosis

## Test plan

- [x] `cd packages/core && pnpm test src/manifest` (9/9 schema tests pass)
- [x] `cd packages/core && pnpm build` (builds green; manifest emitted as separate `dist/manifest/*` entry, zero leak into main bundle)
- [x] `pnpm lint` clean on `packages/core/src/manifest/**`
- [x] Per-phase spot-compute verification against canonical formulas / published worked examples
- [x] Per-phase Codex `codex-rescue` fact-check pass with corrections applied