### PR TITLE
chore(core): 0.3.0 quality pass — TRIX/adaptiveBollinger fixes, ewmaVolatilityFromCandles, publish gate

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -38,7 +38,12 @@
       "node_modules",
       "*.config.ts",
       "packages/core/examples/alpaca-demo/data",
-      "packages/chart/examples/docs-screenshots/data"
+      "packages/chart/examples/docs-screenshots/data",
+      "**/examples/alpaca-demo/data/**",
+      "**/examples/docs-screenshots/data/**",
+      "qa-report.json",
+      "**/qa-report.json",
+      "**/manifest/sources/**"
     ]
   },
   "overrides": [

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## Unreleased
 
+### Breaking — Indicator Quality Fixes
+
+- **TRIX warmup**: nested EMA stages no longer treat `null` upstream values
+  as `0`. Each EMA stage now waits for `period` consecutive non-null
+  upstream samples before seeding its SMA, so the first valid TRIX
+  appears at `index = 3 * (period - 1) + 1` and the early-bar values
+  match StockCharts canonical TRIX. Late-bar values were already correct;
+  only warmup-region values change. The same fix is applied to the
+  signal line so it is no longer contaminated by zero-padded TRIX inputs.
+  Affects both `trix()` (batch) and `createTrix()` (incremental).
+- **`adaptiveBollinger` kurtosis input**: rolling excess kurtosis is now
+  computed on log returns (`ln(p_t / p_{t-1})`), not on raw close prices.
+  This matches the canonical financial definition of fat-tail risk; the
+  prior behavior conflated trend (price level distribution) with tail
+  risk. The `effectiveMultiplier` and `kurtosis` outputs change for
+  trending series. Band shape interpretation is unchanged: high return
+  kurtosis still produces wider bands.
+
+### Added — ewmaVolatilityFromCandles
+
+- `ewmaVolatilityFromCandles(candles, options)` — candle-shaped wrapper
+  around `ewmaVolatility(returns)`. Computes log returns internally and
+  realigns the output onto candle times so the result composes with
+  other candle-based indicators on the same timeline. Accepts the same
+  `lambda` / `calendar` / `periodsPerYear` options as `ewmaVolatility`,
+  plus an optional `source` (default `"close"`). Resolves the long-
+  standing API outlier where every other indicator takes
+  `(candles, options)` but `ewmaVolatility` took `(returns, options)`.
+
+### Documented — Volatility stddev conventions
+
+- `historicalVolatility()` JSDoc now explicitly notes it uses **sample**
+  stddev (`/ (N - 1)`) on log returns; `standardDeviation()` JSDoc notes
+  it uses **population** stddev (`/ N`) for TA-Lib / Bollinger Band
+  parity. The two conventions are intentional and not interchangeable —
+  pick by use case.
+
 ### Added — More Incremental Indicators
 
 - `createLinearRegression()` — incremental rolling least-squares linear

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -5994,8 +5994,56 @@ const vol = ewmaVolatility(dailyReturns, { lambda: 0.94 });
 | オプション | デフォルト | 説明 |
 |--------|---------|-------------|
 | `lambda` | `0.94` | 減衰係数（RiskMetrics標準） |
+| `calendar` | `US_EQUITY_CALENDAR` | 年率化に用いる取引カレンダープリセット |
+| `periodsPerYear` | `252` | 年率化期間の直接指定（`calendar` より優先） |
 
-`number`（年率ボラティリティ）を返します。
+`Series<number>`（年率ボラティリティ、%）を返します。
+
+### `ewmaVolatilityFromCandles(candles, options?)`
+
+`ewmaVolatility` のキャンドル受け取り版。内部でログリターンを計算し、各出力点をキャンドルの `time` に揃えるため、他のキャンドルベースのインジケーターと同一タイムライン上で合成可能です。先頭キャンドルには直前リターンが無いため出力から除外されます（長さは `candles.length - 1`）。
+
+```typescript
+import { ewmaVolatilityFromCandles, JPX_CALENDAR } from "trendcraft";
+
+const vol = ewmaVolatilityFromCandles(candles, {
+  lambda: 0.94,
+  source: "close",
+  calendar: JPX_CALENDAR,
+});
+// vol[i].time === candles[i + 1].time
+```
+
+| オプション | デフォルト | 説明 |
+|--------|---------|-------------|
+| `lambda` | `0.94` | 減衰係数 |
+| `source` | `"close"` | ログリターンの価格ソース（`"close" \| "hl2" \| "hlc3" \| "ohlc4"` 等） |
+| `calendar` | `US_EQUITY_CALENDAR` | 年率化カレンダー |
+| `periodsPerYear` | `252` | 年率化期間の直接指定 |
+
+`Series<number>`（年率ボラティリティ、%）を返します。
+
+---
+
+## 取引カレンダー (Trading Calendar)
+
+市場別の年率化ヘルパー。プリセットは `name` と `tradingDaysPerYear` のみを保持し、休場テーブルは内蔵しません。バー単位の休場ギャップ検出が必要な場合は独自の `isTradingDay(date)` 述語を渡してください。
+
+```typescript
+import {
+  US_EQUITY_CALENDAR, // 252
+  JPX_CALENDAR,        // 245
+  HKEX_CALENDAR,       // 247
+  CRYPTO_CALENDAR,     // 365
+  FX_CALENDAR,         // 260
+  annualizationFactor,
+} from "trendcraft";
+
+const N = annualizationFactor({ calendar: JPX_CALENDAR }); // 245
+```
+
+`AnnualizationOptions`（`{ calendar?, periodsPerYear? }`）は次の API が受け付けます：
+`calculateMetricsFromReturns`, `stressTest`, `runAllStressTests`, `ulcerPerformanceIndex`, `garch`, `ewmaVolatility`, `ewmaVolatilityFromCandles`, `volatilityRegime`, `calculateRuntimeMetrics`。デフォルト動作は従来と互換です。
 
 ---
 

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -6765,8 +6765,64 @@ const vol = ewmaVolatility(dailyReturns, { lambda: 0.94 });
 | Option | Default | Description |
 |--------|---------|-------------|
 | `lambda` | `0.94` | Decay factor (RiskMetrics standard) |
+| `calendar` | `US_EQUITY_CALENDAR` | Trading calendar preset for annualization |
+| `periodsPerYear` | `252` | Override annualization (takes precedence over `calendar`) |
 
-Returns `number` (annualized volatility).
+Returns `Series<number>` (annualized volatility, percent).
+
+### `ewmaVolatilityFromCandles(candles, options?)`
+
+Candle-shaped wrapper around `ewmaVolatility`. Computes log returns internally and aligns each output point to a candle's `time`, so the result composes with other candle-based indicators on the same timeline. The first candle has no preceding return and is omitted from the output (length is `candles.length - 1`).
+
+```typescript
+import { ewmaVolatilityFromCandles, JPX_CALENDAR } from "trendcraft";
+
+const vol = ewmaVolatilityFromCandles(candles, {
+  lambda: 0.94,
+  source: "close",
+  calendar: JPX_CALENDAR,
+});
+// vol[i].time === candles[i + 1].time
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `lambda` | `0.94` | Decay factor (RiskMetrics standard) |
+| `source` | `"close"` | Price source for log returns (`"close" \| "hl2" \| "hlc3" \| "ohlc4"` etc.) |
+| `calendar` | `US_EQUITY_CALENDAR` | Trading calendar preset for annualization |
+| `periodsPerYear` | `252` | Override annualization |
+
+Returns `Series<number>` (annualized volatility, percent), aligned to candle times.
+
+---
+
+## Trading Calendar
+
+Market-specific annualization helpers. Calendar presets carry only `name` and `tradingDaysPerYear`; they do not ship holiday tables. If you need bar-level holiday gap detection, attach your own `isTradingDay(date)` predicate.
+
+```typescript
+import {
+  US_EQUITY_CALENDAR, // 252
+  JPX_CALENDAR,        // 245
+  HKEX_CALENDAR,       // 247
+  CRYPTO_CALENDAR,     // 365
+  FX_CALENDAR,         // 260
+  annualizationFactor,
+  stressTest,
+  PRESET_SCENARIOS,
+} from "trendcraft";
+
+// Sharpe on a Japanese-equity strategy uses 245 bars/year
+const result = stressTest(dailyReturns, PRESET_SCENARIOS.covidCrash2020, 100_000, {
+  calendar: JPX_CALENDAR,
+});
+
+// Single source of truth — sqrt(N) for vol, N for return-exponent
+const N = annualizationFactor({ calendar: JPX_CALENDAR }); // 245
+```
+
+The `AnnualizationOptions` bag (`{ calendar?, periodsPerYear? }`) is accepted by:
+`calculateMetricsFromReturns`, `stressTest`, `runAllStressTests`, `ulcerPerformanceIndex`, `garch`, `ewmaVolatility`, `ewmaVolatilityFromCandles`, `volatilityRegime`, `calculateRuntimeMetrics`. Defaults are unchanged from prior versions.
 
 ---
 

--- a/packages/core/llms.txt
+++ b/packages/core/llms.txt
@@ -90,6 +90,7 @@ const bt = TrendCraft.from(candles)
 - `choppinessIndex(candles, { period })` — Choppiness Index (0-100: >61.8 choppy, <38.2 trending)
 - `garch(returns, opts?)` — GARCH(1,1) volatility model (conditional variance, forecast)
 - `ewmaVolatility(returns, opts?)` — EWMA volatility (RiskMetrics standard, lambda=0.94)
+- `ewmaVolatilityFromCandles(candles, opts?)` — same as `ewmaVolatility` but takes candles; computes log returns internally and aligns output to candle times
 
 ### Volume
 - `obv(candles)` — On Balance Volume
@@ -138,6 +139,13 @@ const bt = TrendCraft.from(candles)
 - `sessionBreakout(candles, opts?)` — Session high/low breakout signals
 - `sessionStats(candles, opts?)` — Session performance analytics
 - `getIctSessions()` / `getIctKillZones()` — ICT session/kill zone presets
+- `getJpxSessions()` / `getHkexSessions()` — Asia-market session presets with lunch breaks
+- `SessionDefinition.breaks?: SessionBreak[]` — intra-session breaks (e.g. JPX/HKEX lunch). Bars inside a break report `inSession: false`; `barIndex` does not advance
+- `SessionDefinition.timezone?: string` — IANA timezone (e.g. `"America/New_York"`, `"Asia/Tokyo"`); DST handled via `Intl.DateTimeFormat`. `KillZoneDefinition.timezone` accepts the same field
+
+### Trading Calendar (market-specific annualization)
+- `US_EQUITY_CALENDAR` (252) / `JPX_CALENDAR` (245) / `HKEX_CALENDAR` (247) / `CRYPTO_CALENDAR` (365) / `FX_CALENDAR` (260) — `TradingCalendar` presets
+- `annualizationFactor({ calendar?, periodsPerYear? })` — single source of truth used across `calculateMetricsFromReturns`, `stressTest`, `runAllStressTests`, `ulcerPerformanceIndex`, `garch`, `ewmaVolatility`, `volatilityRegime`, `calculateRuntimeMetrics`. All accept an `AnnualizationOptions` bag — defaults unchanged
 
 ### HMM Regime Detection
 - `hmmRegimes(candles, opts?)` — Hidden Markov Model regime detection (bull/bear/sideways)
@@ -513,8 +521,14 @@ TrendCraft.from(candles).use(myIndicator, opts).compute();
 ### Incremental Indicators
 ```typescript
 import { incremental } from 'trendcraft';
-// 160+ stateful, update-one-candle-at-a-time indicators for streaming use
+// 170+ stateful, update-one-candle-at-a-time indicators for streaming use
 // Categories: moving-average, momentum, trend, volatility, volume, price, wyckoff
+// All factories support { warmUp, fromState } for resumable sessions
+//   getState() / fromState — snapshot save/restore (same params required)
+//   peek(candle) — what next() would emit, without mutating state
+// 0.3.0 additions: createStandardDeviation, createSuperSmoother, createRoofingFilter,
+//   createLinearRegression, createHeikinAshi, createReturns, createSwingPoints,
+//   createZigzag, createBreakOfStructure, createChangeOfCharacter
 ```
 
 ### Live Streaming (createLiveCandle)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,7 +62,8 @@
     "bench": "vitest bench",
     "size": "size-limit",
     "qa:indicators": "node scripts/qa-sweep.mjs",
-    "prepublishOnly": "pnpm build && pnpm test"
+    "verify:publish": "node scripts/verify-publish.mjs",
+    "prepublishOnly": "pnpm build && pnpm test && pnpm verify:publish"
   },
   "keywords": [
     "trading",

--- a/packages/core/scripts/verify-publish.mjs
+++ b/packages/core/scripts/verify-publish.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Publish gate: verify that every entry point listed in package.json#exports
+ * resolves and produces a working module in both ESM and CJS modes.
+ *
+ * Run after `pnpm build`. Hooked from `prepublishOnly`.
+ *
+ * Catches:
+ *  - Missing dist/ artifact for an entry (stale exports map or broken build)
+ *  - ESM entry that fails to evaluate (bad re-export, circular tree-shake)
+ *  - CJS entry that fails to load via require()
+ *  - .d.ts file missing for any entry
+ *  - Any listed entry that doesn't actually expose its advertised symbols
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(__dirname, "..");
+const pkgJson = JSON.parse(readFileSync(resolve(pkgRoot, "package.json"), "utf8"));
+const exportsMap = pkgJson.exports ?? {};
+const require = createRequire(import.meta.url);
+
+/** Expected top-level symbols per entry. Kept small on purpose — just enough to catch regressions. */
+const EXPECTED_SYMBOLS = {
+  ".": ["sma", "ema", "rsi", "macd", "bollingerBands", "atr", "runBacktest", "createLiveCandle"],
+  "./screening": ["CONDITION_PRESETS", "createCriteriaFromNames", "loadCsvFile"],
+  "./incremental": ["createSma", "createEma", "createRsi", "createMacd", "createBollingerBands"],
+  "./safe": ["sma", "ema", "rsi", "atr", "bollingerBands"],
+  "./manifest": ["getManifest", "indicatorManifests", "listManifests", "suggestForRegime"],
+};
+
+const failures = [];
+const pass = (msg) => console.log(`  ✓ ${msg}`);
+const fail = (msg) => {
+  console.log(`  ✗ ${msg}`);
+  failures.push(msg);
+};
+
+async function verifyEntry(subpath, entry) {
+  console.log(`\n[${subpath}]`);
+  const typesPath = resolve(pkgRoot, entry.types);
+  const esmPath = resolve(pkgRoot, entry.import);
+  const cjsPath = resolve(pkgRoot, entry.require);
+
+  if (existsSync(typesPath)) pass(`types file exists (${entry.types})`);
+  else fail(`missing types file: ${entry.types}`);
+
+  if (existsSync(esmPath)) pass(`esm file exists (${entry.import})`);
+  else fail(`missing esm file: ${entry.import}`);
+
+  if (existsSync(cjsPath)) pass(`cjs file exists (${entry.require})`);
+  else fail(`missing cjs file: ${entry.require}`);
+
+  const expected = EXPECTED_SYMBOLS[subpath] ?? [];
+
+  // ESM evaluation
+  if (existsSync(esmPath)) {
+    try {
+      const mod = await import(pathToFileURL(esmPath).href);
+      for (const sym of expected) {
+        if (sym in mod) pass(`esm exports ${sym}`);
+        else fail(`esm missing symbol: ${sym}`);
+      }
+    } catch (err) {
+      fail(`esm eval threw: ${err.message}`);
+    }
+  }
+
+  // CJS evaluation
+  if (existsSync(cjsPath)) {
+    try {
+      const mod = require(cjsPath);
+      for (const sym of expected) {
+        if (sym in mod) pass(`cjs exports ${sym}`);
+        else fail(`cjs missing symbol: ${sym}`);
+      }
+    } catch (err) {
+      fail(`cjs eval threw: ${err.message}`);
+    }
+  }
+}
+
+console.log(`Publish gate: trendcraft@${pkgJson.version}`);
+
+for (const [subpath, entry] of Object.entries(exportsMap)) {
+  if (typeof entry !== "object" || entry === null) continue;
+  await verifyEntry(subpath, entry);
+}
+
+console.log();
+if (failures.length > 0) {
+  console.error(`FAILED: ${failures.length} issue(s) found. Fix before publishing.`);
+  process.exit(1);
+}
+console.log(`OK: all ${Object.keys(exportsMap).length} entry points resolve correctly.`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1134,6 +1134,7 @@ export type { SeriesMeta, TaggedSeries } from "./types/candle";
 
 // Streaming (real-time trading pipeline)
 export * as streaming from "./streaming";
+export { createLiveCandle } from "./streaming";
 export { livePresets } from "./streaming";
 export type { LivePreset } from "./streaming";
 export { indicatorPresets } from "./streaming";
@@ -1374,8 +1375,13 @@ export {
 export type { MarginConfig, MarginState } from "./backtest";
 
 // GARCH / EWMA Volatility
-export { garch, ewmaVolatility } from "./indicators/volatility";
-export type { GarchOptions, GarchResult, EwmaVolatilityOptions } from "./indicators/volatility";
+export { garch, ewmaVolatility, ewmaVolatilityFromCandles } from "./indicators/volatility";
+export type {
+  GarchOptions,
+  GarchResult,
+  EwmaVolatilityOptions,
+  EwmaVolatilityFromCandlesOptions,
+} from "./indicators/volatility";
 
 // Meta-Strategy (Equity Curve Trading, Strategy Rotation)
 export {

--- a/packages/core/src/indicators/__tests__/garch.test.ts
+++ b/packages/core/src/indicators/__tests__/garch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { ewmaVolatility, garch, nelderMead } from "../volatility/garch";
+import type { NormalizedCandle } from "../../types";
+import { ewmaVolatility, ewmaVolatilityFromCandles, garch, nelderMead } from "../volatility/garch";
 
 // Synthetic returns: first half low vol, second half high vol (volatility clustering)
 const returns = Array.from({ length: 100 }, (_, i) => {
@@ -201,5 +202,38 @@ describe("nelderMead", () => {
     // Just verify it runs without error and produces a result
     expect(result.x).toHaveLength(2);
     expect(Number.isFinite(result.fx)).toBe(true);
+  });
+});
+
+describe("ewmaVolatilityFromCandles", () => {
+  const makeCandles = (closes: number[]): NormalizedCandle[] =>
+    closes.map((close, i) => ({
+      time: 1700000000000 + i * 86400000,
+      open: close,
+      high: close,
+      low: close,
+      close,
+      volume: 1000,
+    }));
+
+  it("returns empty for fewer than 2 candles", () => {
+    expect(ewmaVolatilityFromCandles([])).toEqual([]);
+    expect(ewmaVolatilityFromCandles(makeCandles([100]))).toEqual([]);
+  });
+
+  it("matches ewmaVolatility(returns) value-for-value", () => {
+    const closes = Array.from({ length: 60 }, (_, i) => 100 + Math.sin(i * 0.3) * 5 + i * 0.1);
+    const candles = makeCandles(closes);
+    const fromCandles = ewmaVolatilityFromCandles(candles, { lambda: 0.94 });
+
+    const returns = closes.slice(1).map((c, i) => Math.log(c / closes[i]));
+    const fromReturns = ewmaVolatility(returns, { lambda: 0.94 });
+
+    expect(fromCandles).toHaveLength(fromReturns.length);
+    for (let i = 0; i < fromCandles.length; i++) {
+      expect(fromCandles[i].value).toBeCloseTo(fromReturns[i].value, 12);
+      // Times come from the candle stream, not return-index
+      expect(fromCandles[i].time).toBe(candles[i + 1].time);
+    }
   });
 });

--- a/packages/core/src/indicators/adaptive/adaptive-bollinger.ts
+++ b/packages/core/src/indicators/adaptive/adaptive-bollinger.ts
@@ -2,9 +2,14 @@
  * Adaptive Bollinger Bands indicator
  *
  * Bollinger Bands where the standard deviation multiplier adapts based on
- * rolling kurtosis (tail risk):
- * - High kurtosis (fat tails) -> wider bands
+ * rolling excess kurtosis of log returns (fat-tail risk):
+ * - High return kurtosis (fat tails) -> wider bands
  * - Normal kurtosis -> standard bands
+ *
+ * Note: rolling kurtosis is computed on log returns (`ln(p_t / p_{t-1})`),
+ * not on raw close prices. This matches the canonical financial definition
+ * of fat-tail risk. Prior to v0.3.0 the rolling kurtosis was computed on
+ * close prices directly, which conflated trend with tail risk.
  */
 
 import { getPrice, isNormalized, normalizeCandles } from "../../core/normalize";
@@ -154,13 +159,18 @@ export function adaptiveBollinger(
     variance /= period; // population variance (same as standard BB)
     const sd = Math.sqrt(variance);
 
-    // Calculate kurtosis from a longer lookback
-    const kurtStart = Math.max(0, i - kurtosisLookback + 1);
-    const kurtValues: number[] = [];
+    // Calculate kurtosis on log returns (canonical fat-tail measure).
+    // Need at least 5 candles → 4 log returns for kurtosis to be defined.
+    const kurtStart = Math.max(1, i - kurtosisLookback + 1);
+    const kurtReturns: number[] = [];
     for (let j = kurtStart; j <= i; j++) {
-      kurtValues.push(getPrice(normalized[j], "close"));
+      const cur = getPrice(normalized[j], "close");
+      const prev = getPrice(normalized[j - 1], "close");
+      if (prev > 0 && cur > 0) {
+        kurtReturns.push(Math.log(cur / prev));
+      }
     }
-    const kurt = calculateKurtosis(kurtValues);
+    const kurt = calculateKurtosis(kurtReturns);
 
     // Determine effective multiplier
     let effectiveMultiplier = baseStdDev;

--- a/packages/core/src/indicators/incremental/momentum/trix.ts
+++ b/packages/core/src/indicators/incremental/momentum/trix.ts
@@ -2,10 +2,13 @@
  * Incremental TRIX (Triple Exponential Average)
  *
  * 1. EMA1 = EMA(close, period)
- * 2. EMA2 = EMA(EMA1, period)
- * 3. EMA3 = EMA(EMA2, period)
+ * 2. EMA2 = EMA(EMA1, period)         — null-propagating
+ * 3. EMA3 = EMA(EMA2, period)         — null-propagating
  * 4. TRIX = (EMA3 - prevEMA3) / prevEMA3 × 100
- * 5. Signal = EMA(TRIX, signalPeriod)
+ * 5. Signal = EMA(TRIX, signalPeriod) — null-propagating
+ *
+ * The non-leading EMA stages skip null inputs and seed from the first
+ * `period` consecutive non-null upstream samples (matches batch trix()).
  */
 
 import type { NormalizedCandle } from "../../../types";
@@ -19,15 +22,68 @@ export type TrixValue = {
   signal: number | null;
 };
 
+type NullEmaState = {
+  period: number;
+  prev: number | null;
+  consec: number;
+  buffer: number[];
+};
+
+function makeNullEma(period: number, fromState?: NullEmaState) {
+  const multiplier = 2 / (period + 1);
+  let prev: number | null = fromState?.prev ?? null;
+  let consec = fromState?.consec ?? 0;
+  let buffer: number[] = fromState ? [...fromState.buffer] : [];
+
+  return {
+    next(v: number | null): number | null {
+      if (v === null) {
+        prev = null;
+        consec = 0;
+        buffer = [];
+        return null;
+      }
+      if (prev === null) {
+        consec++;
+        buffer.push(v);
+        if (buffer.length > period) buffer.shift();
+        if (consec >= period) {
+          let sum = 0;
+          for (const x of buffer) sum += x;
+          prev = sum / period;
+          return prev;
+        }
+        return null;
+      }
+      prev = v * multiplier + prev * (1 - multiplier);
+      return prev;
+    },
+    peek(v: number | null): number | null {
+      if (v === null) return null;
+      if (prev === null) {
+        if (consec + 1 < period) return null;
+        const tail = [...buffer, v];
+        if (tail.length > period) tail.shift();
+        let sum = 0;
+        for (const x of tail) sum += x;
+        return sum / period;
+      }
+      return v * multiplier + prev * (1 - multiplier);
+    },
+    getState(): NullEmaState {
+      return { period, prev, consec, buffer: [...buffer] };
+    },
+  };
+}
+
 export type TrixState = {
   period: number;
   signalPeriod: number;
   ema1State: EmaState;
-  ema2State: EmaState;
-  ema3State: EmaState;
-  signalEmaState: EmaState;
+  ema2State: NullEmaState;
+  ema3State: NullEmaState;
+  signalState: NullEmaState;
   prevEma3: number | null;
-  trixCount: number;
   count: number;
 };
 
@@ -51,29 +107,26 @@ export function createTrix(
   const signalPeriod = options.signalPeriod ?? 9;
 
   let ema1: ReturnType<typeof createEma>;
-  let ema2: ReturnType<typeof createEma>;
-  let ema3: ReturnType<typeof createEma>;
-  let signalEma: ReturnType<typeof createEma>;
+  let ema2: ReturnType<typeof makeNullEma>;
+  let ema3: ReturnType<typeof makeNullEma>;
+  let signalEma: ReturnType<typeof makeNullEma>;
   let prevEma3: number | null;
-  let trixCount: number;
   let count: number;
 
   if (warmUpOptions?.fromState) {
     const s = warmUpOptions.fromState;
     ema1 = createEma({ period }, { fromState: s.ema1State });
-    ema2 = createEma({ period }, { fromState: s.ema2State });
-    ema3 = createEma({ period }, { fromState: s.ema3State });
-    signalEma = createEma({ period: signalPeriod }, { fromState: s.signalEmaState });
+    ema2 = makeNullEma(period, s.ema2State);
+    ema3 = makeNullEma(period, s.ema3State);
+    signalEma = makeNullEma(signalPeriod, s.signalState);
     prevEma3 = s.prevEma3;
-    trixCount = s.trixCount;
     count = s.count;
   } else {
     ema1 = createEma({ period });
-    ema2 = createEma({ period });
-    ema3 = createEma({ period });
-    signalEma = createEma({ period: signalPeriod });
+    ema2 = makeNullEma(period);
+    ema3 = makeNullEma(period);
+    signalEma = makeNullEma(signalPeriod);
     prevEma3 = null;
-    trixCount = 0;
     count = 0;
   }
 
@@ -81,37 +134,16 @@ export function createTrix(
     next(candle: NormalizedCandle) {
       count++;
 
-      // Pass through triple EMA (batch maps null → 0 for synthetic candles)
-      const e1 = ema1.next(candle);
-      const e1Val = e1.value;
-      const e2 = ema2.next(makeCandle(candle.time, e1Val ?? 0));
-      const e2Val = e2.value;
-      const e3 = ema3.next(makeCandle(candle.time, e2Val ?? 0));
-      const e3Val = e3.value;
+      const e1Val = ema1.next(candle).value;
+      const e2Val = ema2.next(e1Val);
+      const e3Val = ema3.next(e2Val);
 
-      // TRIX = ROC of EMA3
       let trixVal: number | null = null;
       if (e3Val !== null && prevEma3 !== null) {
-        if (prevEma3 === 0) {
-          trixVal = 0;
-        } else {
-          trixVal = ((e3Val - prevEma3) / prevEma3) * 100;
-        }
+        trixVal = prevEma3 === 0 ? 0 : ((e3Val - prevEma3) / prevEma3) * 100;
       }
 
-      // Signal line = EMA of TRIX values
-      // Batch feeds ALL candles to signal EMA (using 0 for null trix values)
-      const signalInput = trixVal ?? 0;
-      const sigResult = signalEma.next(makeCandle(candle.time, signalInput));
-
-      // Signal is only valid after firstValidTrix + signalPeriod - 1
-      let signalVal: number | null = null;
-      if (trixVal !== null) {
-        trixCount++;
-        if (trixCount >= signalPeriod) {
-          signalVal = sigResult.value;
-        }
-      }
+      const signalVal = signalEma.next(trixVal);
 
       if (e3Val !== null) {
         prevEma3 = e3Val;
@@ -122,24 +154,15 @@ export function createTrix(
 
     peek(candle: NormalizedCandle) {
       const e1Val = ema1.peek(candle).value;
-      if (e1Val === null) return { time: candle.time, value: { trix: null, signal: null } };
-
-      const e2Val = ema2.peek(makeCandle(candle.time, e1Val)).value;
-      if (e2Val === null) return { time: candle.time, value: { trix: null, signal: null } };
-
-      const e3Val = ema3.peek(makeCandle(candle.time, e2Val)).value;
-      if (e3Val === null) return { time: candle.time, value: { trix: null, signal: null } };
+      const e2Val = ema2.peek(e1Val);
+      const e3Val = ema3.peek(e2Val);
 
       let trixVal: number | null = null;
-      if (prevEma3 !== null) {
+      if (e3Val !== null && prevEma3 !== null) {
         trixVal = prevEma3 === 0 ? 0 : ((e3Val - prevEma3) / prevEma3) * 100;
       }
 
-      let signalVal: number | null = null;
-      if (trixVal !== null && trixCount >= signalPeriod - 1) {
-        signalVal = signalEma.peek(makeCandle(candle.time, trixVal)).value;
-      }
-
+      const signalVal = signalEma.peek(trixVal);
       return { time: candle.time, value: { trix: trixVal, signal: signalVal } };
     },
 
@@ -150,9 +173,8 @@ export function createTrix(
         ema1State: ema1.getState(),
         ema2State: ema2.getState(),
         ema3State: ema3.getState(),
-        signalEmaState: signalEma.getState(),
+        signalState: signalEma.getState(),
         prevEma3,
-        trixCount,
         count,
       };
     },
@@ -162,8 +184,7 @@ export function createTrix(
     },
 
     get isWarmedUp() {
-      // First valid TRIX requires 3*(period-1)+1 candles, then +1 for ROC
-      return prevEma3 !== null && ema3.isWarmedUp;
+      return prevEma3 !== null;
     },
   };
 

--- a/packages/core/src/indicators/index.ts
+++ b/packages/core/src/indicators/index.ts
@@ -120,6 +120,7 @@ export {
   garmanKlass,
   standardDeviation,
   ewmaVolatility,
+  ewmaVolatilityFromCandles,
 } from "./volatility";
 export type {
   DonchianValue,

--- a/packages/core/src/indicators/momentum/trix.ts
+++ b/packages/core/src/indicators/momentum/trix.ts
@@ -9,6 +9,11 @@
  * 2. EMA2 = EMA(EMA1, period)
  * 3. EMA3 = EMA(EMA2, period)
  * 4. TRIX = (EMA3 - prev EMA3) / prev EMA3 × 100
+ *
+ * Warmup: nulls from each EMA stage propagate; downstream stages do not
+ * begin until they have `period` consecutive non-null upstream samples.
+ * First valid TRIX therefore appears at `index = 3 * (period - 1) + 1`,
+ * matching StockCharts canonical TRIX (no zero-padding seed contamination).
  */
 
 import { isNormalized, normalizeCandles } from "../../core/normalize";
@@ -16,6 +21,39 @@ import { tagSeries, withLabelParams } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, Series } from "../../types";
 import { TRIX_META } from "../indicator-meta";
 import { ema } from "../moving-average/ema";
+
+/**
+ * EMA over a nullable input series. Nulls do not advance the running EMA;
+ * the SMA seed is taken from the first `period` consecutive non-null
+ * inputs. A null input mid-stream resets the chain.
+ */
+function emaOfNullable(values: (number | null)[], period: number): (number | null)[] {
+  const result: (number | null)[] = new Array(values.length).fill(null);
+  const multiplier = 2 / (period + 1);
+  let prev: number | null = null;
+  let consec = 0;
+  for (let i = 0; i < values.length; i++) {
+    const v = values[i];
+    if (v === null) {
+      prev = null;
+      consec = 0;
+      continue;
+    }
+    if (prev === null) {
+      consec++;
+      if (consec === period) {
+        let sum = 0;
+        for (let j = i - period + 1; j <= i; j++) sum += values[j] as number;
+        prev = sum / period;
+        result[i] = prev;
+      }
+    } else {
+      prev = v * multiplier + prev * (1 - multiplier);
+      result[i] = prev;
+    }
+  }
+  return result;
+}
 
 /**
  * TRIX options
@@ -73,76 +111,31 @@ export function trix(
 
   if (normalized.length === 0) return [];
 
-  // Triple EMA smoothing
-  const ema1 = ema(normalized, { period, source: "close" });
+  // EMA1 over close prices (already null-aware via ema())
+  const ema1Values = ema(normalized, { period, source: "close" }).map((e) => e.value);
+  // EMA2 / EMA3: null-propagating cascade
+  const ema2Values = emaOfNullable(ema1Values, period);
+  const ema3Values = emaOfNullable(ema2Values, period);
 
-  // Build synthetic candles from ema1 for second EMA pass
-  const ema1Candles: NormalizedCandle[] = ema1.map((e) => ({
-    time: e.time,
-    open: e.value ?? 0,
-    high: e.value ?? 0,
-    low: e.value ?? 0,
-    close: e.value ?? 0,
-    volume: 0,
-  }));
-  const ema2 = ema(ema1Candles, { period, source: "close" });
-
-  const ema2Candles: NormalizedCandle[] = ema2.map((e) => ({
-    time: e.time,
-    open: e.value ?? 0,
-    high: e.value ?? 0,
-    low: e.value ?? 0,
-    close: e.value ?? 0,
-    volume: 0,
-  }));
-  const ema3 = ema(ema2Candles, { period, source: "close" });
-
-  // Calculate TRIX: rate of change of ema3
-  const trixValues: (number | null)[] = [];
-  for (let i = 0; i < ema3.length; i++) {
-    if (i === 0 || ema3[i].value === null || ema3[i - 1].value === null) {
-      trixValues.push(null);
-      continue;
-    }
-    const prev = ema3[i - 1].value ?? 0;
-    if (prev === 0) {
-      trixValues.push(0);
-    } else {
-      trixValues.push((((ema3[i].value ?? 0) - prev) / prev) * 100);
-    }
+  // TRIX = 1-period ROC of EMA3
+  const trixValues: (number | null)[] = new Array(normalized.length).fill(null);
+  for (let i = 1; i < ema3Values.length; i++) {
+    const cur = ema3Values[i];
+    const prev = ema3Values[i - 1];
+    if (cur === null || prev === null) continue;
+    trixValues[i] = prev === 0 ? 0 : ((cur - prev) / prev) * 100;
   }
 
-  // Calculate signal line (EMA of TRIX)
-  const trixCandles: NormalizedCandle[] = trixValues.map((v, i) => ({
-    time: normalized[i].time,
-    open: v ?? 0,
-    high: v ?? 0,
-    low: v ?? 0,
-    close: v ?? 0,
-    volume: 0,
-  }));
-  const signalEma = ema(trixCandles, { period: signalPeriod, source: "close" });
+  // Signal = EMA(TRIX) — null-propagating so leading null TRIX bars do not
+  // contaminate the SMA seed of the signal line.
+  const signalValues = emaOfNullable(trixValues, signalPeriod);
 
-  // Find the index where TRIX first becomes valid
-  let firstValidTrix = -1;
-  for (let i = 0; i < trixValues.length; i++) {
-    if (trixValues[i] !== null) {
-      firstValidTrix = i;
-      break;
-    }
-  }
-
-  const result: Series<TrixValue> = [];
+  const result: Series<TrixValue> = new Array(normalized.length);
   for (let i = 0; i < normalized.length; i++) {
-    const trixVal = trixValues[i];
-    // Signal is only valid after firstValidTrix + signalPeriod - 1
-    const signalVal =
-      firstValidTrix >= 0 && i >= firstValidTrix + signalPeriod - 1 ? signalEma[i].value : null;
-
-    result.push({
+    result[i] = {
       time: normalized[i].time,
-      value: { trix: trixVal, signal: signalVal },
-    });
+      value: { trix: trixValues[i], signal: signalValues[i] },
+    };
   }
 
   return tagSeries(result, withLabelParams(TRIX_META, [period]));

--- a/packages/core/src/indicators/volatility/garch.ts
+++ b/packages/core/src/indicators/volatility/garch.ts
@@ -9,8 +9,9 @@
  */
 
 import { type AnnualizationOptions, annualizationFactor } from "../../calendar";
+import { getPrice, isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries } from "../../core/tag-series";
-import type { Series } from "../../types";
+import type { Candle, NormalizedCandle, PriceSource, Series } from "../../types";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -331,4 +332,53 @@ export function ewmaVolatility(returns: number[], options?: EwmaVolatilityOption
   }
 
   return tagSeries(result, { kind: "garch", overlay: false, label: "GARCH" });
+}
+
+/** Options for `ewmaVolatilityFromCandles` */
+export type EwmaVolatilityFromCandlesOptions = EwmaVolatilityOptions & {
+  /** Price source for log returns (default: "close") */
+  source?: PriceSource;
+};
+
+/**
+ * Convenience wrapper around `ewmaVolatility()` that accepts candles
+ * directly and computes log returns internally. Each output point uses
+ * the corresponding candle's `time`, so the result aligns with other
+ * candle-based indicators on the same timeline.
+ *
+ * The first candle has no preceding return and is therefore omitted
+ * from the output (matching how `ewmaVolatility(returns)` would be
+ * called with `returns.length === candles.length - 1`).
+ *
+ * @example
+ * ```ts
+ * // Same series, two equivalent forms
+ * const vol = ewmaVolatilityFromCandles(candles, { lambda: 0.94 });
+ * const returns = candles.slice(1).map((c, i) =>
+ *   Math.log(c.close / candles[i].close),
+ * );
+ * const vol2 = ewmaVolatility(returns, { lambda: 0.94 });
+ * ```
+ */
+export function ewmaVolatilityFromCandles(
+  candles: Candle[] | NormalizedCandle[],
+  options?: EwmaVolatilityFromCandlesOptions,
+): Series<number> {
+  const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
+  if (normalized.length < 2) return [];
+
+  const source = options?.source ?? "close";
+  const returns: number[] = new Array(normalized.length - 1);
+  for (let i = 1; i < normalized.length; i++) {
+    const prev = getPrice(normalized[i - 1], source);
+    const cur = getPrice(normalized[i], source);
+    returns[i - 1] = prev > 0 && cur > 0 ? Math.log(cur / prev) : 0;
+  }
+
+  const vol = ewmaVolatility(returns, options);
+  // Realign onto candle times (returns[i] corresponds to candles[i+1])
+  for (let i = 0; i < vol.length; i++) {
+    vol[i] = { time: normalized[i + 1].time, value: vol[i].value };
+  }
+  return vol;
 }

--- a/packages/core/src/indicators/volatility/historical-volatility.ts
+++ b/packages/core/src/indicators/volatility/historical-volatility.ts
@@ -28,6 +28,13 @@ export type HistoricalVolatilityOptions = {
  * 2. Calculate standard deviation of log returns over period
  * 3. Annualize: HV = StdDev × sqrt(annualFactor) × 100
  *
+ * Note: HV uses **sample** standard deviation (`/ (period - 1)`) — this is
+ * the unbiased statistical estimator and the convention used in finance
+ * for return volatility. The plain `standardDeviation()` indicator
+ * (under `volatility/standard-deviation.ts`) uses **population** stddev
+ * (`/ period`) to match TA-Lib's Bollinger Band semantics. The two
+ * conventions are intentional and not interchangeable; pick by use case.
+ *
  * @param candles - Array of candles (raw or normalized)
  * @param options - Historical Volatility options
  * @returns Series of HV values (percentage, null for insufficient data)

--- a/packages/core/src/indicators/volatility/index.ts
+++ b/packages/core/src/indicators/volatility/index.ts
@@ -45,9 +45,10 @@ export { garmanKlass } from "./garman-klass";
 export type { GarmanKlassOptions } from "./garman-klass";
 export { standardDeviation } from "./standard-deviation";
 export type { StandardDeviationOptions } from "./standard-deviation";
-export { garch, ewmaVolatility } from "./garch";
+export { garch, ewmaVolatility, ewmaVolatilityFromCandles } from "./garch";
 export type {
   GarchOptions,
   GarchResult,
   EwmaVolatilityOptions,
+  EwmaVolatilityFromCandlesOptions,
 } from "./garch";

--- a/packages/core/src/indicators/volatility/standard-deviation.ts
+++ b/packages/core/src/indicators/volatility/standard-deviation.ts
@@ -23,8 +23,13 @@ export type StandardDeviationOptions = {
  *
  * StdDev = sqrt(sum((price - mean)^2) / N)
  *
- * Uses population standard deviation (dividing by N, not N-1) to match
- * the convention used by most charting platforms and TA-Lib.
+ * Uses **population** standard deviation (dividing by N, not N-1) to match
+ * the convention used by most charting platforms, TA-Lib, and Bollinger
+ * Bands. For statistical return-volatility analysis where the unbiased
+ * **sample** estimator (`/ (N - 1)`) is required, use
+ * `historicalVolatility()` instead — it operates on log returns and
+ * returns an annualized percentage. The choice between the two
+ * conventions is intentional and not interchangeable.
  *
  * @param candles - Array of candles (raw or normalized)
  * @param options - Standard Deviation options

--- a/packages/core/src/indicators/volume/ease-of-movement.ts
+++ b/packages/core/src/indicators/volume/ease-of-movement.ts
@@ -25,6 +25,22 @@ export type EaseOfMovementOptions = {
  * EMV = ((H+L)/2 - (prevH+prevL)/2) / ((Volume/divisor) / (H-L))
  * Then smoothed with SMA.
  *
+ * Note on `volumeDivisor`: trendcraft's default is `10000`, which makes
+ * EMV values comparable across small-volume instruments. The canonical
+ * StockCharts / ChartSchool reference uses `100_000_000` (100M), which
+ * scales EMV down by ~10000× and is the value to pass when comparing
+ * directly to charting platform references:
+ *
+ * ```ts
+ * // Match StockCharts / ChartSchool reference values
+ * const emv = easeOfMovement(candles, { period: 14, volumeDivisor: 100_000_000 });
+ * ```
+ *
+ * For trading-decision use cases the **sign** and **slope** of EMV are
+ * what matters, and both are invariant to `volumeDivisor`. The default
+ * is preserved for backward compatibility through the 0.x line; a future
+ * major bump may switch to the canonical 100M.
+ *
  * @param candles - Array of candles (raw or normalized)
  * @param options - Options
  * @returns Series of EMV values


### PR DESCRIPTION
## Summary

Quality pass ahead of cutting `trendcraft@0.3.0`. No release artifacts touched (no version bump / no tag / no publish) — only the pre-release quality items called out in the plan at `~/.claude/plans/core-0-3-0-curious-rain.md`. Six commits, split for review:

- **chore(lint)** — root `biome.json` ignore now covers cached JSON, `qa-report.json`, and the gitignored `manifest/sources/` spot-check scripts. `pnpm lint` is clean from both the repo root and `packages/core` (was 574 errors).
- **fix(core/trix)** — nested EMA stages no longer substitute `0` for `null` upstream samples. Each stage waits for `period` consecutive non-null inputs before seeding, so warmup-region values now match StockCharts canonical TRIX. Same fix applied to the signal line and mirrored in `createTrix` (batch/incremental parity preserved). Late-bar values unchanged.
- **fix(core/adaptive-bollinger)** — rolling kurtosis now runs on log returns (`ln(p_t / p_{t-1})`) instead of raw close prices. Matches the canonical financial fat-tail definition; band-shape interpretation unchanged. **Breaking** for trending series.
- **feat(core)** — `ewmaVolatilityFromCandles(candles, options)` resolves the API outlier where every other indicator takes `(candles, options)` but `ewmaVolatility` took `(returns, options)`. Wrapper computes log returns internally and aligns output to candle times. Also surfaces `createLiveCandle` at the top-level `trendcraft` entry point — it had only been reachable via the `streaming.*` namespace, even though docs/CHANGELOG advertised it as top-level.
- **docs(core)** — JSDocs spell out the deliberate `historicalVolatility` (sample, `/(N-1)`) vs `standardDeviation` (population, `/N`) split with cross-references; `easeOfMovement` documents the `volumeDivisor=10000` default vs the canonical 100M and how to match it. `API.md` / `API.ja.md` / `llms.txt` gain entries for the new wrapper, the Trading Calendar presets, the session breaks/timezone fields, and the 10 newly incrementalized indicators. CHANGELOG `Unreleased` records all of the above with a `Breaking` subsection.
- **chore(core)** — new `scripts/verify-publish.mjs` mirrors the chart-side gate: loads every entry in `package.json#exports`, checks types/ESM/CJS artifacts exist, evaluates both module forms, and asserts a representative subset of advertised symbols actually resolves. Wired into `prepublishOnly` (and exposed as `pnpm verify:publish`).

## Out of scope

- Version bump, tag, and publish — handled in a separate release task per the plan.
- LivePreset typing refactor, Adaptive incremental factories, plugin live-mode integration, intraday session-gap rendering, EMV default change to canonical 100M (would be breaking — defer to 0.4.0 if at all).

## Test plan

- [x] `pnpm test` — 4827 / 4827 tests pass (incl. new `ewmaVolatilityFromCandles` parity tests, existing TRIX cross-validation, batch↔incremental TRIX parity)
- [x] `pnpm build` — all 5 entry points emit, `dist/index.cjs` 370.6 kB
- [x] `pnpm lint` — clean from both repo root and `packages/core`
- [x] `pnpm size` — under all limits (`index.js` 94.6 kB / `index.cjs` 86.9 kB brotli)
- [x] `pnpm verify:publish` — all 5 entries resolve correctly with advertised symbols
- [ ] Manual: confirm CHANGELOG `Unreleased` reads cleanly when promoted to a versioned heading at release time