### PR TITLE
feat(mcp): v0.2.0 — candle handle, compact tuple input, response polish

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`load_candles` tool + `candlesRef` input** — cache OHLCV candles in the
+  session and pass an opaque `handle` as `candlesRef` on subsequent
+  `calc_indicator` / `detect_signal` calls. Designed for multi-tool screens:
+  five parallel indicator calls against the same 124-bar series transmit the
+  bars **once** instead of five times. Handles are session-ephemeral (live
+  only for the stdio process), capacity 50, oldest evicted silently. Reload
+  is cheap.
+- **Compact tuple input via `candlesArray`** — `calc_indicator`,
+  `detect_signal`, and `load_candles` now accept
+  `[[time, open, high, low, close, volume?], ...]` as an alternative to the
+  canonical object-per-bar form. ~40% smaller payload because field names
+  are not repeated per row.
+- **`paramHints` inlined in `calc_indicator` `INVALID_PARAMETER` errors** — when
+  a missing-params destructure error fires, the message now embeds the
+  manifest's `paramHints` directly (e.g.
+  `paramHints: period: 20 for short-term, 50 for medium, 200 for primary trend`)
+  instead of pointing to `get_indicator_manifest`. Matches the parity that
+  `detect_signal` already had.
+- **`INVALID_HANDLE` canonical error** — surfaced when a `candlesRef` is
+  unknown / evicted / never loaded; the message instructs the caller to
+  re-run `load_candles`.
+
+### Changed
+
+- `calc_indicator` and `detect_signal` candle input is now exactly-one-of
+  `candles` / `candlesArray` / `candlesRef`. Existing inline `candles`
+  callers are unaffected.
+- Bumped the advertised server version to `0.2.0`.
+
 ## 0.1.0 (2026-04-26)
 
 ### Added

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -25,6 +25,19 @@
 - **`INVALID_HANDLE` canonical error** — surfaced when a `candlesRef` is
   unknown / evicted / never loaded; the message instructs the caller to
   re-run `load_candles`.
+- **`processedBars` on `detect_signal` output** — number of input candle bars
+  the signal was evaluated against. Resolves the ambiguity on `events`-shape
+  results between *"no events fired"* and *"no data was processed"* (the
+  existing `totalLength` field counts events for events-shape outputs, not
+  bars).
+- **`symbol` echoed on `calc_indicator` / `detect_signal` output** — when the
+  caller used `candlesRef`, the `symbol` recorded on the handle at
+  `load_candles` time is included on the response so the LLM can correlate
+  handle → symbol without keeping a side-table. Omitted when no symbol was
+  set or when inline `candles` / `candlesArray` was used.
+- **`storeSize` and `capacity` on `load_candles` output** — number of handles
+  currently held by the session-scoped store and its LRU capacity. Lets the
+  caller spot impending eviction without trial-and-error.
 
 ### Changed
 

--- a/packages/mcp/EXAMPLES.md
+++ b/packages/mcp/EXAMPLES.md
@@ -1,6 +1,6 @@
 # @trendcraft/mcp — Recipes
 
-Concrete patterns for using the seven tools together. Examples assume an MCP client (Claude Desktop, Claude Code, Cursor, ...) with `trendcraft` configured per the [README](./README.md). Candles are illustrative — supply real OHLCV from your data source.
+Concrete patterns for using the eight tools together. Examples assume an MCP client (Claude Desktop, Claude Code, Cursor, ...) with `trendcraft` configured per the [README](./README.md). Candles are illustrative — supply real OHLCV from your data source.
 
 ## Conventions
 
@@ -208,6 +208,45 @@ detect_signal({ kind: "volumeAccumulation", candles, lastN: 10 })
 
 ---
 
+## 6.5. Multi-indicator screen with `load_candles` (v0.2.0+)
+
+When you fan out 5+ tools against the same candles, sending the bars inline on every call dominates token cost. `load_candles` caches the array in the session and returns an opaque `handle`; subsequent calls reference it via `candlesRef`.
+
+```ts
+// 1. Cache once.
+const { handle } = load_candles({ candles, symbol: "BTC" })
+// → { handle: "cdl_1_a8f2c1", count: 124, span: { from: ..., to: ... } }
+
+// 2. Fan out — bars are transmitted exactly once total.
+calc_indicator  ({ kind: "rsi",          candlesRef: handle, params: { period: 14 } })
+calc_indicator  ({ kind: "atr",          candlesRef: handle, params: { period: 14 } })
+calc_indicator  ({ kind: "macd",         candlesRef: handle, params: { fast: 12, slow: 26, signal: 9 } })
+detect_signal   ({ kind: "goldenCross",  candlesRef: handle, params: { short: 5, long: 25 } })
+detect_signal   ({ kind: "bollingerSqueeze", candlesRef: handle })
+```
+
+**Lifetime & limits.** Handles live for the duration of the stdio MCP process only — they are not persisted across restarts and not shared across sessions. Capacity is 50 handles per process; the oldest is silently evicted. If a `candlesRef` is stale you'll see `INVALID_HANDLE`; just call `load_candles` again — reload is cheap.
+
+### Compact tuple form
+
+When you'd rather inline the candles but want a smaller payload, use `candlesArray` (~40% smaller than the canonical object form because field names are not repeated per row):
+
+```ts
+calc_indicator({
+  kind: "rsi",
+  candlesArray: [
+    [1714000000000, 100,   101, 99,  100.5, 1200],
+    [1714003600000, 100.5, 102, 100, 101.5, 1300],
+    // [time, open, high, low, close, volume?]
+  ],
+  params: { period: 14 },
+})
+```
+
+`candlesArray` works on `load_candles`, `calc_indicator`, and `detect_signal`. You can also feed it into `load_candles` to obtain a handle without paying the object-form overhead first.
+
+---
+
 ## 7. Token budgets
 
 `detect_signal` and `calc_indicator` both default to `lastN: 200`. Tune by use case:
@@ -230,7 +269,8 @@ Every tool returns canonical `<CODE>: <message>` strings on failure. Common reco
 | Error | Action |
 |---|---|
 | `INVALID_INPUT: candles must contain at least 1 entry` | Verify the data source returned candles. |
-| `INVALID_PARAMETER: indicator "sma" requires a params object` | Always pass `params: { period: ... }`. Use `get_indicator_manifest` for `paramHints`. |
+| `INVALID_PARAMETER: indicator "sma" requires a params object — paramHints: ...` | Always pass `params: { period: ... }`. The error message inlines the manifest's `paramHints` in v0.2.0+; older clients can still call `get_indicator_manifest` for the same content. |
+| `INVALID_HANDLE: candlesRef "cdl_..." is not in the session cache` | The handle was evicted (capacity 50, LRU) or the process restarted. Call `load_candles` again — it's cheap. |
 | `INSUFFICIENT_DATA` | Increase the candles window — typical minimum is 2× the indicator's longest lookback. |
 | `UNSUPPORTED_KIND` (calc) | The kind is documented but no calc wrapper yet. Use `list_indicators({ calcSupported: true })` to enumerate the calc-ready set. |
 | `UNSUPPORTED_SIGNAL` (detect_signal) | Call `list_signals({})` to see registered kinds — the set is smaller than `calc_indicator`'s. |

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -88,6 +88,12 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
 
 A stale or evicted `candlesRef` returns `INVALID_HANDLE`; just call `load_candles` again.
 
+### Response envelope additions (v0.2.0+)
+
+- `load_candles` returns `storeSize` (handles currently held) and `capacity` (LRU max). Watch `storeSize` approach `capacity` to anticipate eviction.
+- `detect_signal` returns `processedBars` — the number of input bars the signal was evaluated against. Use this to distinguish *"no events fired"* from *"no data processed"* on `events`-shape outputs (where `totalLength` counts events, not bars).
+- `calc_indicator` and `detect_signal` echo `symbol` when the caller used `candlesRef` and the handle was loaded with a `symbol`. Omitted otherwise — handy for fan-out screens to correlate handle → symbol without a side-table.
+
 ## Designed for screening
 
 The output shape is tuned for two LLM-driven workflows: **single-symbol analysis** (call a few indicators + signals on one symbol's candles) and **multi-symbol screening** (loop over many symbols, ask one yes/no per signal). For screening, `detect_signal` returns a `firedAt: number[]` summary so the caller doesn't have to scan the full series — typically 100x cheaper on tokens than reading the boolean output array.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -56,7 +56,7 @@ Or edit `~/.claude.json` directly under the `mcpServers` key with the same confi
 
 ### Verify
 
-After connecting, the seven tools below should appear in the client's tool picker. To smoke-test the binary directly without an MCP client:
+After connecting, the eight tools below should appear in the client's tool picker. To smoke-test the binary directly without an MCP client:
 
 ```bash
 echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
@@ -74,6 +74,19 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
 | `calc_indicator` | Compute one indicator on caller-supplied OHLCV candles. ~60 kinds have safe-calc wrappers. `lastN` (default 200) trims response size. |
 | `list_signals` | Discover signal kinds supported by `detect_signal`. Returns `kind`, `shape` (`series` or `events`), `oneLiner`, and `paramsHint`. Optional `shape` filter. |
 | `detect_signal` | Detect a trading signal — crossovers, MA alignment, candlestick patterns, divergences, squeeze, and volume signals. Returns `{ output, firedAt, ... }` where `firedAt` is a sparse list of trigger times — designed for cheap screening (*"did the signal fire in the last N bars?"*). |
+| `load_candles` | Cache OHLCV candles in the session and return an opaque `handle`. Pass that handle as `candlesRef` on subsequent `calc_indicator` / `detect_signal` calls instead of re-sending the array. Designed for multi-tool screens. Session-ephemeral, capacity 50, oldest evicted silently. |
+
+### Candle input forms (v0.2.0+)
+
+`calc_indicator` and `detect_signal` accept exactly one of:
+
+| Form | Shape | Use when |
+|---|---|---|
+| `candles` | `[{time, open, high, low, close, volume?}, ...]` | Single-call, simplest. The canonical form. |
+| `candlesArray` | `[[time, open, high, low, close, volume?], ...]` | ~40% smaller payload — field names not repeated per row. |
+| `candlesRef` | string handle from `load_candles` | Cheapest for multi-tool calls — bars transmitted once total. |
+
+A stale or evicted `candlesRef` returns `INVALID_HANDLE`; just call `load_candles` again.
 
 ## Designed for screening
 
@@ -128,13 +141,46 @@ detect_signal({
 // → { firedAt: [...timestamps], output: [...] }
 ```
 
+### Multi-indicator screen with `load_candles`
+
+When you want to fan out 5+ tools against the same candle series, send the bars
+once and reuse the handle:
+
+```ts
+// 1. Cache the candles in the session.
+const { handle } = load_candles({ candles, symbol: "BTC" })
+// → { handle: "cdl_3_8a2c1f", count: 124, span: { from, to } }
+
+// 2. Fan out — `candlesRef` replaces `candles` on every subsequent call.
+calc_indicator  ({ kind: "rsi",         candlesRef: handle, params: { period: 14 } })
+calc_indicator  ({ kind: "atr",         candlesRef: handle, params: { period: 14 } })
+calc_indicator  ({ kind: "macd",        candlesRef: handle, params: { fast: 12, slow: 26, signal: 9 } })
+detect_signal   ({ kind: "goldenCross", candlesRef: handle, params: { short: 5, long: 25 } })
+detect_signal   ({ kind: "bollingerSqueeze", candlesRef: handle })
+```
+
+Or send the bars in compact tuple form once-shot to a single tool:
+
+```ts
+calc_indicator({
+  kind: "rsi",
+  candlesArray: [
+    [1714000000000, 100, 101, 99, 100.5, 1200],
+    [1714003600000, 100.5, 102, 100, 101.5, 1300],
+    // ...
+  ],
+  params: { period: 14 },
+})
+```
+
 ## Errors
 
 All tool errors return `isError: true` with the message body in the form `<CODE>: <message>`. Codes:
 
 | Code | Meaning | Surface |
 |---|---|---|
-| `INVALID_INPUT` | Empty / malformed candles array | calc, detect_signal |
+| `INVALID_INPUT` | Empty / malformed candles array, or zero/multiple of `candles` / `candlesArray` / `candlesRef` provided | calc, detect_signal, load_candles |
+| `INVALID_HANDLE` | `candlesRef` is unknown / evicted / never loaded — call `load_candles` again | calc, detect_signal |
 | `INVALID_PARAMETER` | Missing or invalid params (negative period, missing required `params` object, etc.) | calc, detect_signal |
 | `INSUFFICIENT_DATA` | Candles count below the indicator/signal's minimum required window | calc, detect_signal |
 | `INDICATOR_ERROR` | Underlying indicator raised an unclassified runtime error | calc |

--- a/packages/mcp/src/__tests__/calc.test.ts
+++ b/packages/mcp/src/__tests__/calc.test.ts
@@ -60,8 +60,9 @@ describe("calcIndicatorHandler", () => {
     const candles = makeCandles(50);
     // sma() destructures `period` from options — calling without params crashes
     // with a TypeError that previously surfaced as opaque INDICATOR_ERROR.
+    // v0.2.0: the manifest's paramHints are inlined in the error message.
     expect(() => calcIndicatorHandler({ kind: "sma", candles })).toThrow(
-      /INVALID_PARAMETER.*requires a params object.*get_indicator_manifest/s,
+      /INVALID_PARAMETER.*requires a params object.*paramHints:.*period/s,
     );
   });
 

--- a/packages/mcp/src/__tests__/candle-input.test.ts
+++ b/packages/mcp/src/__tests__/candle-input.test.ts
@@ -136,3 +136,72 @@ describe("detect_signal with new candle input forms", () => {
     ).toThrow(/INVALID_HANDLE/);
   });
 });
+
+describe("response envelope additions (v0.2.0+)", () => {
+  function makeCandles(n: number): Candle[] {
+    const out: Candle[] = [];
+    for (let i = 0; i < n; i++) {
+      const close = 100 + i * 0.3;
+      out.push({
+        time: i * 86_400_000,
+        open: close - 0.4,
+        high: close + 0.6,
+        low: close - 0.6,
+        close,
+        volume: 1000 + i,
+      });
+    }
+    return out;
+  }
+
+  it("calc_indicator echoes `symbol` only when candlesRef was used and the handle had one", () => {
+    const store = new CandleStore();
+    const candles = makeCandles(40);
+    const { handle } = loadCandlesHandler({ candles, symbol: "AAPL" }, store);
+
+    const viaRef = calcIndicatorHandler(
+      { kind: "rsi", candlesRef: handle, params: { period: 14 } },
+      store,
+    );
+    expect(viaRef.symbol).toBe("AAPL");
+
+    const inline = calcIndicatorHandler({ kind: "rsi", candles, params: { period: 14 } }, store);
+    expect(inline.symbol).toBeUndefined();
+  });
+
+  it("calc_indicator omits `symbol` when handle was loaded without one", () => {
+    const store = new CandleStore();
+    const candles = makeCandles(40);
+    const { handle } = loadCandlesHandler({ candles }, store);
+    const result = calcIndicatorHandler(
+      { kind: "rsi", candlesRef: handle, params: { period: 14 } },
+      store,
+    );
+    expect(result.symbol).toBeUndefined();
+  });
+
+  it("detect_signal exposes processedBars and echoes symbol via candlesRef", () => {
+    const store = new CandleStore();
+    const candles = makeCandles(80);
+    const { handle } = loadCandlesHandler({ candles, symbol: "BTC" }, store);
+
+    const viaRef = detectSignalHandler({ kind: "bollingerSqueeze", candlesRef: handle }, store);
+    expect(viaRef.processedBars).toBe(80);
+    expect(viaRef.symbol).toBe("BTC");
+
+    const inline = detectSignalHandler({ kind: "bollingerSqueeze", candles }, store);
+    expect(inline.processedBars).toBe(80);
+    expect(inline.symbol).toBeUndefined();
+  });
+
+  it("detect_signal processedBars distinguishes 'no events' from 'no data'", () => {
+    const store = new CandleStore();
+    // 80 bars in, 0 events out — the ambiguity #1 was supposed to fix.
+    const result = detectSignalHandler(
+      { kind: "bollingerSqueeze", candles: makeCandles(80) },
+      store,
+    );
+    expect(result.totalLength).toBe(0);
+    expect(result.processedBars).toBe(80);
+  });
+});

--- a/packages/mcp/src/__tests__/candle-input.test.ts
+++ b/packages/mcp/src/__tests__/candle-input.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { CandleStore } from "../dispatcher/candle-store";
+import type { Candle } from "../schemas/candle";
+import { calcIndicatorHandler } from "../tools/calc";
+import { detectSignalHandler } from "../tools/detect-signal";
+import { loadCandlesHandler } from "../tools/load-candles";
+
+function makeCandles(n: number, start = 100): Candle[] {
+  const out: Candle[] = [];
+  for (let i = 0; i < n; i++) {
+    const close = start + Math.sin(i / 4) * 5 + i * 0.1;
+    out.push({
+      time: i * 60_000,
+      open: close - 0.5,
+      high: close + 1,
+      low: close - 1,
+      close,
+      volume: 1000 + i * 10,
+    });
+  }
+  return out;
+}
+
+function tuplesFromCandles(candles: Candle[]): [number, number, number, number, number, number][] {
+  return candles.map((c) => [c.time, c.open, c.high, c.low, c.close, c.volume ?? 0]);
+}
+
+describe("calc_indicator with new candle input forms", () => {
+  it("accepts candlesRef and produces the same result as inline candles", () => {
+    const store = new CandleStore();
+    const candles = makeCandles(80);
+    const { handle } = loadCandlesHandler({ candles }, store);
+
+    const inline = calcIndicatorHandler({ kind: "rsi", candles, params: { period: 14 } }, store);
+    const viaRef = calcIndicatorHandler(
+      { kind: "rsi", candlesRef: handle, params: { period: 14 } },
+      store,
+    );
+
+    expect(viaRef.totalLength).toBe(inline.totalLength);
+    expect(viaRef.count).toBe(inline.count);
+    expect(viaRef.series).toEqual(inline.series);
+  });
+
+  it("accepts candlesArray (compact tuple form) and matches canonical result", () => {
+    const store = new CandleStore();
+    const candles = makeCandles(60);
+    const tuples = tuplesFromCandles(candles);
+
+    const inline = calcIndicatorHandler({ kind: "sma", candles, params: { period: 5 } }, store);
+    const viaArray = calcIndicatorHandler(
+      { kind: "sma", candlesArray: tuples, params: { period: 5 } },
+      store,
+    );
+
+    expect(viaArray.series).toEqual(inline.series);
+  });
+
+  it("returns INVALID_HANDLE for evicted/missing candlesRef", () => {
+    const store = new CandleStore();
+    expect(() =>
+      calcIndicatorHandler({ kind: "rsi", candlesRef: "cdl_nope", params: { period: 14 } }, store),
+    ).toThrow(/INVALID_HANDLE.*load_candles/);
+  });
+
+  it("rejects when caller provides no candle input", () => {
+    const store = new CandleStore();
+    expect(() => calcIndicatorHandler({ kind: "rsi", params: { period: 14 } }, store)).toThrow(
+      /INVALID_INPUT.*one of/,
+    );
+  });
+
+  it("rejects when caller provides multiple candle inputs", () => {
+    const store = new CandleStore();
+    const candles = makeCandles(20);
+    const { handle } = loadCandlesHandler({ candles }, store);
+    expect(() =>
+      calcIndicatorHandler(
+        { kind: "rsi", candles, candlesRef: handle, params: { period: 14 } },
+        store,
+      ),
+    ).toThrow(/INVALID_INPUT.*exactly one/);
+  });
+
+  it("INVALID_PARAMETER message embeds manifest paramHints (B4)", () => {
+    const store = new CandleStore();
+    const candles = makeCandles(50);
+    // sma's manifest paramHints includes the word "period"; we only assert the
+    // error mentions "paramHints:" so the test stays robust if hint text
+    // wording shifts.
+    expect(() => calcIndicatorHandler({ kind: "sma", candles }, store)).toThrow(
+      /INVALID_PARAMETER.*paramHints:/,
+    );
+  });
+});
+
+describe("detect_signal with new candle input forms", () => {
+  function trending(n: number): Candle[] {
+    const out: Candle[] = [];
+    for (let i = 0; i < n; i++) {
+      const close = 100 + i * 0.3 + Math.sin(i / 5) * 2;
+      out.push({
+        time: i * 86_400_000,
+        open: close - 0.4,
+        high: close + 0.6,
+        low: close - 0.6,
+        close,
+        volume: 1000 + (i % 7) * 250,
+      });
+    }
+    return out;
+  }
+
+  it("accepts candlesRef and matches inline result", () => {
+    const store = new CandleStore();
+    const candles = trending(80);
+    const { handle } = loadCandlesHandler({ candles }, store);
+
+    const inline = detectSignalHandler(
+      { kind: "goldenCross", candles, params: { short: 5, long: 25 }, lastN: 0 },
+      store,
+    );
+    const viaRef = detectSignalHandler(
+      { kind: "goldenCross", candlesRef: handle, params: { short: 5, long: 25 }, lastN: 0 },
+      store,
+    );
+
+    expect(viaRef.firedAt).toEqual(inline.firedAt);
+    expect(viaRef.totalLength).toBe(inline.totalLength);
+  });
+
+  it("returns INVALID_HANDLE for stale candlesRef", () => {
+    const store = new CandleStore();
+    expect(() =>
+      detectSignalHandler({ kind: "goldenCross", candlesRef: "cdl_gone" }, store),
+    ).toThrow(/INVALID_HANDLE/);
+  });
+});

--- a/packages/mcp/src/__tests__/candle-store.test.ts
+++ b/packages/mcp/src/__tests__/candle-store.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { CandleStore } from "../dispatcher/candle-store";
+import type { Candle } from "../schemas/candle";
+
+function makeCandles(n: number, start = 100): Candle[] {
+  const out: Candle[] = [];
+  for (let i = 0; i < n; i++) {
+    const close = start + i;
+    out.push({
+      time: i * 60_000,
+      open: close - 0.5,
+      high: close + 1,
+      low: close - 1,
+      close,
+      volume: 1000 + i,
+    });
+  }
+  return out;
+}
+
+describe("CandleStore", () => {
+  it("stores and retrieves candles by handle, exposing count + span metadata", () => {
+    const store = new CandleStore();
+    const candles = makeCandles(124);
+    const meta = store.put(candles, { symbol: "AAPL" });
+
+    expect(meta.handle).toMatch(/^cdl_/);
+    expect(meta.count).toBe(124);
+    expect(meta.span.from).toBe(0);
+    expect(meta.span.to).toBe(123 * 60_000);
+    expect(meta.symbol).toBe("AAPL");
+
+    const retrieved = store.get(meta.handle);
+    expect(retrieved).toBe(candles);
+  });
+
+  it("returns undefined for unknown handles", () => {
+    const store = new CandleStore();
+    expect(store.get("cdl_nope")).toBeUndefined();
+  });
+
+  it("rejects empty candle arrays at put-time", () => {
+    const store = new CandleStore();
+    expect(() => store.put([])).toThrow(/INVALID_INPUT/);
+  });
+
+  it("evicts oldest entry when capacity is exceeded (LRU by insertion)", () => {
+    const store = new CandleStore(3);
+    const a = store.put(makeCandles(2));
+    const b = store.put(makeCandles(2));
+    const c = store.put(makeCandles(2));
+    const d = store.put(makeCandles(2));
+
+    // a should have been evicted
+    expect(store.get(a.handle)).toBeUndefined();
+    expect(store.get(b.handle)).not.toBeUndefined();
+    expect(store.get(c.handle)).not.toBeUndefined();
+    expect(store.get(d.handle)).not.toBeUndefined();
+    expect(store.size()).toBe(3);
+  });
+
+  it("get() touches the entry so it is not the oldest anymore", () => {
+    const store = new CandleStore(3);
+    const a = store.put(makeCandles(2));
+    const b = store.put(makeCandles(2));
+    const c = store.put(makeCandles(2));
+
+    // Touch a so b becomes oldest
+    store.get(a.handle);
+
+    const d = store.put(makeCandles(2));
+
+    expect(store.get(a.handle)).not.toBeUndefined();
+    expect(store.get(b.handle)).toBeUndefined();
+    expect(store.get(c.handle)).not.toBeUndefined();
+    expect(store.get(d.handle)).not.toBeUndefined();
+  });
+
+  it("generates unique handles across rapid puts", () => {
+    const store = new CandleStore(100);
+    const handles = new Set<string>();
+    for (let i = 0; i < 50; i++) {
+      handles.add(store.put(makeCandles(1)).handle);
+    }
+    expect(handles.size).toBe(50);
+  });
+});

--- a/packages/mcp/src/__tests__/load-candles.test.ts
+++ b/packages/mcp/src/__tests__/load-candles.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { CandleStore } from "../dispatcher/candle-store";
+import type { Candle } from "../schemas/candle";
+import { loadCandlesHandler } from "../tools/load-candles";
+
+function makeCandles(n: number): Candle[] {
+  const out: Candle[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push({
+      time: i * 60_000,
+      open: 100 + i,
+      high: 101 + i,
+      low: 99 + i,
+      close: 100 + i,
+      volume: 1000 + i,
+    });
+  }
+  return out;
+}
+
+describe("loadCandlesHandler", () => {
+  it("accepts canonical candles and returns a usable handle", () => {
+    const store = new CandleStore();
+    const candles = makeCandles(50);
+
+    const result = loadCandlesHandler({ candles, symbol: "BTC", hint: "1Hour" }, store);
+
+    expect(result.handle).toMatch(/^cdl_/);
+    expect(result.count).toBe(50);
+    expect(result.span.from).toBe(0);
+    expect(result.span.to).toBe(49 * 60_000);
+    expect(result.symbol).toBe("BTC");
+    expect(result.hint).toBe("1Hour");
+    expect(store.get(result.handle)?.length).toBe(50);
+  });
+
+  it("accepts compact tuple form via candlesArray", () => {
+    const store = new CandleStore();
+    const tuples: [number, number, number, number, number, number][] = [
+      [0, 100, 101, 99, 100.5, 1000],
+      [60_000, 100.5, 102, 100, 101.5, 1100],
+      [120_000, 101.5, 103, 101, 102.5, 1200],
+    ];
+
+    const result = loadCandlesHandler({ candlesArray: tuples }, store);
+    expect(result.count).toBe(3);
+
+    const stored = store.get(result.handle);
+    expect(stored).toEqual([
+      { time: 0, open: 100, high: 101, low: 99, close: 100.5, volume: 1000 },
+      { time: 60_000, open: 100.5, high: 102, low: 100, close: 101.5, volume: 1100 },
+      { time: 120_000, open: 101.5, high: 103, low: 101, close: 102.5, volume: 1200 },
+    ]);
+  });
+
+  it("accepts tuples without volume (5-element form)", () => {
+    const store = new CandleStore();
+    const tuples: [number, number, number, number, number][] = [[0, 100, 101, 99, 100]];
+    const result = loadCandlesHandler({ candlesArray: tuples }, store);
+    const stored = store.get(result.handle);
+    expect(stored).toEqual([{ time: 0, open: 100, high: 101, low: 99, close: 100 }]);
+  });
+
+  it("rejects when neither candles nor candlesArray is provided", () => {
+    const store = new CandleStore();
+    expect(() => loadCandlesHandler({}, store)).toThrow(/INVALID_INPUT.*one of/);
+  });
+
+  it("rejects when both candles and candlesArray are provided", () => {
+    const store = new CandleStore();
+    expect(() =>
+      loadCandlesHandler({ candles: makeCandles(2), candlesArray: [[0, 1, 1, 1, 1]] }, store),
+    ).toThrow(/INVALID_INPUT.*exactly one/);
+  });
+
+  it("rejects empty arrays with canonical INVALID_INPUT", () => {
+    const store = new CandleStore();
+    expect(() => loadCandlesHandler({ candles: [] }, store)).toThrow(/INVALID_INPUT.*at least 1/);
+  });
+});

--- a/packages/mcp/src/__tests__/load-candles.test.ts
+++ b/packages/mcp/src/__tests__/load-candles.test.ts
@@ -77,4 +77,20 @@ describe("loadCandlesHandler", () => {
     const store = new CandleStore();
     expect(() => loadCandlesHandler({ candles: [] }, store)).toThrow(/INVALID_INPUT.*at least 1/);
   });
+
+  it("reports storeSize and capacity so the caller can spot eviction risk", () => {
+    const store = new CandleStore(3);
+    const a = loadCandlesHandler({ candles: makeCandles(2) }, store);
+    expect(a.storeSize).toBe(1);
+    expect(a.capacity).toBe(3);
+
+    const b = loadCandlesHandler({ candles: makeCandles(2) }, store);
+    expect(b.storeSize).toBe(2);
+
+    loadCandlesHandler({ candles: makeCandles(2) }, store);
+    const d = loadCandlesHandler({ candles: makeCandles(2) }, store);
+    // capacity 3, four puts → storeSize stays at 3 (oldest evicted)
+    expect(d.storeSize).toBe(3);
+    expect(d.capacity).toBe(3);
+  });
 });

--- a/packages/mcp/src/dispatcher/candle-store.ts
+++ b/packages/mcp/src/dispatcher/candle-store.ts
@@ -1,0 +1,103 @@
+import type { Candle } from "../schemas/candle";
+
+export interface CandleHandle {
+  handle: string;
+  count: number;
+  span: { from: number; to: number };
+  symbol?: string;
+  hint?: string;
+}
+
+interface Entry extends CandleHandle {
+  candles: Candle[];
+}
+
+const DEFAULT_CAPACITY = 50;
+
+/**
+ * Session-scoped candle store. Lifetime = the stdio MCP process; not persisted.
+ * LRU eviction (oldest dropped silently when capacity is exceeded). Reload is
+ * cheap because the caller already has the candles in hand.
+ *
+ * Insertion order in a Map is preserved by spec. We exploit that for LRU:
+ * `get()` re-inserts the entry to move it to the end, `keys().next().value`
+ * gives the oldest entry to evict.
+ */
+export class CandleStore {
+  private readonly entries = new Map<string, Entry>();
+  private readonly capacity: number;
+  private counter = 0;
+
+  constructor(capacity = DEFAULT_CAPACITY) {
+    this.capacity = capacity;
+  }
+
+  put(candles: Candle[], meta: { symbol?: string; hint?: string } = {}): CandleHandle {
+    if (candles.length === 0) {
+      throw new Error("INVALID_INPUT: candles must contain at least 1 entry");
+    }
+    const handle = this.nextHandle();
+    const entry: Entry = {
+      handle,
+      candles,
+      count: candles.length,
+      span: {
+        from: candles[0].time,
+        to: candles[candles.length - 1].time,
+      },
+      symbol: meta.symbol,
+      hint: meta.hint,
+    };
+    this.entries.set(handle, entry);
+    this.evictIfNeeded();
+    return this.toMeta(entry);
+  }
+
+  get(handle: string): Candle[] | undefined {
+    const entry = this.entries.get(handle);
+    if (!entry) return undefined;
+    // Touch: move to most-recently-used position
+    this.entries.delete(handle);
+    this.entries.set(handle, entry);
+    return entry.candles;
+  }
+
+  has(handle: string): boolean {
+    return this.entries.has(handle);
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  private nextHandle(): string {
+    this.counter += 1;
+    const rand = Math.random().toString(36).slice(2, 8);
+    return `cdl_${this.counter.toString(36)}_${rand}`;
+  }
+
+  private evictIfNeeded(): void {
+    while (this.entries.size > this.capacity) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+    }
+  }
+
+  private toMeta(entry: Entry): CandleHandle {
+    return {
+      handle: entry.handle,
+      count: entry.count,
+      span: entry.span,
+      symbol: entry.symbol,
+      hint: entry.hint,
+    };
+  }
+}
+
+/** Singleton store shared across tool handlers in the same process. */
+export const defaultCandleStore = new CandleStore();

--- a/packages/mcp/src/dispatcher/candle-store.ts
+++ b/packages/mcp/src/dispatcher/candle-store.ts
@@ -54,12 +54,21 @@ export class CandleStore {
   }
 
   get(handle: string): Candle[] | undefined {
+    return this.getEntry(handle)?.candles;
+  }
+
+  /**
+   * Like `get`, but also exposes the metadata stored at `put` time. Used when
+   * callers want to echo `symbol` / `hint` back in their own response so the
+   * LLM can correlate handle → symbol without keeping a side-table.
+   */
+  getEntry(handle: string): Entry | undefined {
     const entry = this.entries.get(handle);
     if (!entry) return undefined;
     // Touch: move to most-recently-used position
     this.entries.delete(handle);
     this.entries.set(handle, entry);
-    return entry.candles;
+    return entry;
   }
 
   has(handle: string): boolean {
@@ -68,6 +77,10 @@ export class CandleStore {
 
   size(): number {
     return this.entries.size;
+  }
+
+  getCapacity(): number {
+    return this.capacity;
   }
 
   clear(): void {

--- a/packages/mcp/src/schemas/candle.ts
+++ b/packages/mcp/src/schemas/candle.ts
@@ -52,6 +52,16 @@ export interface CandlesInput {
   candlesRef?: string;
 }
 
+export interface ResolvedCandles {
+  candles: Candle[];
+  /** Source the candles came from. `ref` means a `candlesRef` handle was used. */
+  source: "inline" | "tuple" | "ref";
+  /** Stored on the handle at `load_candles` time. Only ever set when `source === "ref"`. */
+  symbol?: string;
+  /** Stored on the handle at `load_candles` time. Only ever set when `source === "ref"`. */
+  hint?: string;
+}
+
 function tupleToCandle(t: CandleTuple): Candle {
   const [time, open, high, low, close, volume] = t;
   return volume === undefined
@@ -61,9 +71,14 @@ function tupleToCandle(t: CandleTuple): Candle {
 
 /**
  * Resolve the three accepted candle input forms to a single canonical
- * `Candle[]`. Throws canonical INVALID_INPUT / INVALID_HANDLE on disagreement.
+ * `Candle[]` plus source metadata. Throws canonical INVALID_INPUT /
+ * INVALID_HANDLE on disagreement.
+ *
+ * When the caller supplies `candlesRef`, the handle's `symbol` / `hint` are
+ * surfaced on the result so tool handlers can echo them back into their own
+ * response (helps the LLM correlate handle → symbol without a side-table).
  */
-export function resolveCandlesInput(input: CandlesInput, store: CandleStore): Candle[] {
+export function resolveCandlesInput(input: CandlesInput, store: CandleStore): ResolvedCandles {
   const provided = [input.candles, input.candlesArray, input.candlesRef].filter(
     (v) => v !== undefined,
   ).length;
@@ -80,22 +95,31 @@ export function resolveCandlesInput(input: CandlesInput, store: CandleStore): Ca
   }
 
   let candles: Candle[];
+  let source: ResolvedCandles["source"];
+  let symbol: string | undefined;
+  let hint: string | undefined;
+
   if (input.candlesRef !== undefined) {
-    const cached = store.get(input.candlesRef);
-    if (!cached) {
+    const entry = store.getEntry(input.candlesRef);
+    if (!entry) {
       throw new Error(
         `INVALID_HANDLE: candlesRef "${input.candlesRef}" is not in the session cache (evicted, expired, or never loaded). Call load_candles to obtain a fresh handle.`,
       );
     }
-    candles = cached;
+    candles = entry.candles;
+    source = "ref";
+    symbol = entry.symbol;
+    hint = entry.hint;
   } else if (input.candlesArray !== undefined) {
     candles = input.candlesArray.map(tupleToCandle);
+    source = "tuple";
   } else {
     candles = input.candles as Candle[];
+    source = "inline";
   }
 
   if (candles.length === 0) {
     throw new Error("INVALID_INPUT: candles must contain at least 1 entry");
   }
-  return candles;
+  return { candles, source, ...(symbol ? { symbol } : {}), ...(hint ? { hint } : {}) };
 }

--- a/packages/mcp/src/schemas/candle.ts
+++ b/packages/mcp/src/schemas/candle.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { CandleStore } from "../dispatcher/candle-store";
 
 export const candleSchema = z.object({
   time: z.number(),
@@ -9,8 +10,92 @@ export const candleSchema = z.object({
   volume: z.number().optional(),
 });
 
-// Length validation is handled by calcIndicatorHandler so that the surfaced
+// Length validation is handled by the tool handler so that the surfaced
 // error follows the canonical INVALID_INPUT envelope instead of a raw zod blob.
 export const candlesArraySchema = z.array(candleSchema);
 
 export type Candle = z.infer<typeof candleSchema>;
+
+/**
+ * Compact tuple form: `[time, open, high, low, close, volume?]`.
+ *
+ * ~40% smaller than the canonical object-per-bar shape because field names
+ * are not repeated per row. Use on `load_candles` / `calc_indicator` /
+ * `detect_signal` via the `candlesArray` parameter.
+ */
+export const candleTupleSchema = z.union([
+  z.tuple([z.number(), z.number(), z.number(), z.number(), z.number()]),
+  z.tuple([z.number(), z.number(), z.number(), z.number(), z.number(), z.number()]),
+]);
+
+export const candlesTupleArraySchema = z.array(candleTupleSchema);
+
+export type CandleTuple = z.infer<typeof candleTupleSchema>;
+
+/**
+ * Tool input fragments accepting any of:
+ *   - `candles` — canonical object-per-bar array
+ *   - `candlesArray` — compact tuple form
+ *   - `candlesRef` — handle returned from `load_candles`
+ *
+ * Spread into a tool's `inputSchema` and resolve via `resolveCandlesInput`.
+ */
+export const candlesInputShape = {
+  candles: candlesArraySchema.optional(),
+  candlesArray: candlesTupleArraySchema.optional(),
+  candlesRef: z.string().min(1).optional(),
+};
+
+export interface CandlesInput {
+  candles?: Candle[];
+  candlesArray?: CandleTuple[];
+  candlesRef?: string;
+}
+
+function tupleToCandle(t: CandleTuple): Candle {
+  const [time, open, high, low, close, volume] = t;
+  return volume === undefined
+    ? { time, open, high, low, close }
+    : { time, open, high, low, close, volume };
+}
+
+/**
+ * Resolve the three accepted candle input forms to a single canonical
+ * `Candle[]`. Throws canonical INVALID_INPUT / INVALID_HANDLE on disagreement.
+ */
+export function resolveCandlesInput(input: CandlesInput, store: CandleStore): Candle[] {
+  const provided = [input.candles, input.candlesArray, input.candlesRef].filter(
+    (v) => v !== undefined,
+  ).length;
+
+  if (provided === 0) {
+    throw new Error(
+      "INVALID_INPUT: must provide one of `candles`, `candlesArray`, or `candlesRef`",
+    );
+  }
+  if (provided > 1) {
+    throw new Error(
+      "INVALID_INPUT: provide exactly one of `candles`, `candlesArray`, or `candlesRef` (not multiple)",
+    );
+  }
+
+  let candles: Candle[];
+  if (input.candlesRef !== undefined) {
+    const cached = store.get(input.candlesRef);
+    if (!cached) {
+      throw new Error(
+        `INVALID_HANDLE: candlesRef "${input.candlesRef}" is not in the session cache (evicted, expired, or never loaded). Call load_candles to obtain a fresh handle.`,
+      );
+    }
+    candles = cached;
+  } else if (input.candlesArray !== undefined) {
+    candles = input.candlesArray.map(tupleToCandle);
+  } else {
+    candles = input.candles as Candle[];
+  }
+
+  if (candles.length === 0) {
+    throw new Error("INVALID_INPUT: candles must contain at least 1 entry");
+  }
+  return candles;
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { calcIndicatorHandler, calcIndicatorInputShape } from "./tools/calc";
 import { detectSignalHandler, detectSignalInputShape } from "./tools/detect-signal";
 import { listSignalsHandler, listSignalsInputShape } from "./tools/list-signals";
+import { loadCandlesHandler, loadCandlesInputShape } from "./tools/load-candles";
 import {
   formatMarkdownHandler,
   formatMarkdownInputShape,
@@ -14,7 +15,7 @@ import {
 } from "./tools/manifest";
 
 export const SERVER_NAME = "trendcraft-mcp";
-export const SERVER_VERSION = "0.1.0";
+export const SERVER_VERSION = "0.2.0";
 
 function jsonResult(data: unknown) {
   return {
@@ -129,12 +130,33 @@ export function createServer(): McpServer {
   );
 
   server.registerTool(
+    "load_candles",
+    {
+      description:
+        "Cache OHLCV candles in the session and return an opaque `handle`. Pass that handle as `candlesRef` on subsequent `calc_indicator` / `detect_signal` calls instead of re-sending the candle array. " +
+        "Designed for multi-tool screens: 5 parallel indicator calls against the same 124-bar series transmits the bars 1× total instead of 5×. " +
+        "Inputs: provide either `candles` (canonical `[{time,open,high,low,close,volume?}]`) or `candlesArray` (compact tuple form `[[time,open,high,low,close,volume?], ...]`, ~40% smaller). Optional `symbol` and `hint` are stored as metadata for your own bookkeeping. " +
+        "Output: `{ handle, count, span: { from, to }, symbol?, hint? }`. " +
+        "Lifetime: handles live for the duration of the stdio MCP process only — no persistence, no cross-session sharing. Capacity is 50 handles; oldest is silently evicted. Reload is cheap.",
+      inputSchema: loadCandlesInputShape,
+    },
+    async (args) => {
+      try {
+        return jsonResult(loadCandlesHandler(args as Parameters<typeof loadCandlesHandler>[0]));
+      } catch (err) {
+        return errorResult(err);
+      }
+    },
+  );
+
+  server.registerTool(
     "detect_signal",
     {
       description:
         "Detect a trading signal from caller-supplied OHLCV candles. Single-tool dispatcher across crossovers (goldenCross, deadCross), multi-MA alignment (perfectOrder), divergence (rsiDivergence, macdDivergence, obvDivergence), volatility squeeze (bollingerSqueeze), and volume signals (volumeBreakout, volumeAccumulation, volumeMaCross, volumeAboveAverage). " +
+        "Candle input: provide exactly one of `candles` (canonical), `candlesArray` (compact tuple form), or `candlesRef` (handle from `load_candles` — cheapest for repeated calls). " +
         'Output envelope: `{ kind, shape, output, firedAt, count, totalLength, truncated }`. `firedAt` is a token-cheap list of times where the signal triggered — ideal for screening ("did goldenCross fire in the last 5 bars on this symbol?"). `shape` is `series` (boolean per bar) or `events` (sparse event objects). ' +
-        "Errors: INVALID_INPUT, INVALID_PARAMETER, INSUFFICIENT_DATA, UNSUPPORTED_SIGNAL, SIGNAL_ERROR. " +
+        "Errors: INVALID_INPUT, INVALID_HANDLE, INVALID_PARAMETER, INSUFFICIENT_DATA, UNSUPPORTED_SIGNAL, SIGNAL_ERROR. " +
         "Note: signal kinds are NOT the same set as calc_indicator kinds — call detect_signal with an unknown kind to see the supported list.",
       inputSchema: detectSignalInputShape,
     },
@@ -152,8 +174,8 @@ export function createServer(): McpServer {
     {
       description:
         "Compute a single indicator on caller-supplied OHLCV candles. " +
-        "Inputs: kind (e.g. 'rsi', 'ema', 'ichimoku'), candles ([{time,open,high,low,close,volume?}], must be non-empty), optional params, optional lastN (default 200, 0 = full series). " +
-        "Returns Result envelope. Errors use canonical codes: INVALID_INPUT (bad candles), INVALID_PARAMETER (bad/missing params — most indicators require a params object; consult get_indicator_manifest for paramHints), INSUFFICIENT_DATA, UNSUPPORTED_KIND (no calc wrapper for this kind). " +
+        "Inputs: kind (e.g. 'rsi', 'ema', 'ichimoku'); candle input via exactly one of `candles` (canonical `[{time,open,high,low,close,volume?}]`), `candlesArray` (compact tuple form `[[time,open,high,low,close,volume?], ...]`, ~40% smaller), or `candlesRef` (handle from `load_candles` — cheapest for repeated calls); optional params; optional lastN (default 200, 0 = full series). " +
+        "Returns Result envelope. Errors use canonical codes: INVALID_INPUT (bad candles), INVALID_HANDLE (stale `candlesRef`), INVALID_PARAMETER (bad/missing params — error message embeds the manifest's paramHints), INSUFFICIENT_DATA, UNSUPPORTED_KIND (no calc wrapper for this kind). " +
         "Discover computable kinds via list_indicators({ calcSupported: true }).",
       inputSchema: calcIndicatorInputShape,
     },

--- a/packages/mcp/src/tools/calc.ts
+++ b/packages/mcp/src/tools/calc.ts
@@ -27,6 +27,8 @@ export interface CalcResult {
   truncated: boolean;
   totalLength: number;
   series: unknown[];
+  /** Echoed from the handle when the caller used `candlesRef`. Omitted otherwise. */
+  symbol?: string;
 }
 
 const DEFAULT_LAST_N = 200;
@@ -58,7 +60,8 @@ export function calcIndicatorHandler(
   },
   store: CandleStore = defaultCandleStore,
 ): CalcResult {
-  const candles = resolveCandlesInput(input, store);
+  const resolved = resolveCandlesInput(input, store);
+  const { candles } = resolved;
 
   const fn = getSafeIndicator(input.kind);
   if (!fn) {
@@ -100,6 +103,7 @@ export function calcIndicatorHandler(
     totalLength,
     truncated: sliced.length < totalLength,
     series: sliced,
+    ...(resolved.symbol !== undefined ? { symbol: resolved.symbol } : {}),
   };
 }
 

--- a/packages/mcp/src/tools/calc.ts
+++ b/packages/mcp/src/tools/calc.ts
@@ -1,10 +1,17 @@
+import { getManifest } from "trendcraft/manifest";
 import { z } from "zod";
+import { type CandleStore, defaultCandleStore } from "../dispatcher/candle-store";
 import { getSafeIndicator, listSupportedKinds } from "../dispatcher/safe-map";
-import { type Candle, candlesArraySchema } from "../schemas/candle";
+import {
+  type Candle,
+  type CandlesInput,
+  candlesInputShape,
+  resolveCandlesInput,
+} from "../schemas/candle";
 
 export const calcIndicatorInputShape = {
   kind: z.string().min(1),
-  candles: candlesArraySchema,
+  ...candlesInputShape,
   params: z.record(z.string(), z.unknown()).optional(),
   /**
    * Slice the trailing N entries of the result series. Defaults to 200 to
@@ -43,15 +50,15 @@ function isResultLike(x: unknown): x is ResultLike {
  */
 const MISSING_PARAMS_RE = /Cannot (destructure property|read propert(?:y|ies))/i;
 
-export function calcIndicatorHandler(input: {
-  kind: string;
-  candles: Candle[];
-  params?: Record<string, unknown>;
-  lastN?: number;
-}): CalcResult {
-  if (!input.candles || input.candles.length === 0) {
-    throw new Error("INVALID_INPUT: candles must contain at least 1 entry");
-  }
+export function calcIndicatorHandler(
+  input: CandlesInput & {
+    kind: string;
+    params?: Record<string, unknown>;
+    lastN?: number;
+  },
+  store: CandleStore = defaultCandleStore,
+): CalcResult {
+  const candles = resolveCandlesInput(input, store);
 
   const fn = getSafeIndicator(input.kind);
   if (!fn) {
@@ -61,7 +68,7 @@ export function calcIndicatorHandler(input: {
     );
   }
 
-  const raw = (fn as (c: Candle[], p?: unknown) => unknown)(input.candles, input.params);
+  const raw = (fn as (c: Candle[], p?: unknown) => unknown)(candles, input.params);
 
   if (!isResultLike(raw)) {
     throw new Error(`INTERNAL_ERROR: indicator "${input.kind}" did not return a Result envelope`);
@@ -73,7 +80,10 @@ export function calcIndicatorHandler(input: {
 
     if (code === "INDICATOR_ERROR" && MISSING_PARAMS_RE.test(message)) {
       code = "INVALID_PARAMETER";
-      message = `indicator "${input.kind}" requires a params object — call get_indicator_manifest("${input.kind}") for the paramHints. (underlying: ${message})`;
+      const hint = paramHintFor(input.kind);
+      message = hint
+        ? `indicator "${input.kind}" requires a params object — paramHints: ${hint}. (underlying: ${message})`
+        : `indicator "${input.kind}" requires a params object — call get_indicator_manifest("${input.kind}") for paramHints. (underlying: ${message})`;
     }
 
     throw new Error(`${code}: ${message}`);
@@ -91,4 +101,18 @@ export function calcIndicatorHandler(input: {
     truncated: sliced.length < totalLength,
     series: sliced,
   };
+}
+
+function paramHintFor(kind: string): string | undefined {
+  try {
+    const m = getManifest(kind);
+    const hints = m?.paramHints;
+    if (!hints) return undefined;
+    const parts = Object.entries(hints)
+      .filter(([, v]) => typeof v === "string" && v.length > 0)
+      .map(([k, v]) => `${k}: ${v}`);
+    return parts.length > 0 ? parts.join("; ") : undefined;
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/mcp/src/tools/detect-signal.ts
+++ b/packages/mcp/src/tools/detect-signal.ts
@@ -1,14 +1,15 @@
 import { z } from "zod";
+import { type CandleStore, defaultCandleStore } from "../dispatcher/candle-store";
 import {
   defaultFiresAt,
   getSignalDescriptor,
   listSupportedSignals,
 } from "../dispatcher/signal-map";
-import { type Candle, candlesArraySchema } from "../schemas/candle";
+import { type CandlesInput, candlesInputShape, resolveCandlesInput } from "../schemas/candle";
 
 export const detectSignalInputShape = {
   kind: z.string().min(1),
-  candles: candlesArraySchema,
+  ...candlesInputShape,
   params: z.record(z.string(), z.unknown()).optional(),
   /**
    * Slice the trailing N entries of the output. Defaults to 200 to stay
@@ -36,15 +37,15 @@ const DEFAULT_LAST_N = 200;
 
 const MISSING_PARAMS_RE = /Cannot (destructure property|read propert(?:y|ies))/i;
 
-export function detectSignalHandler(input: {
-  kind: string;
-  candles: Candle[];
-  params?: Record<string, unknown>;
-  lastN?: number;
-}): DetectSignalResult {
-  if (!input.candles || input.candles.length === 0) {
-    throw new Error("INVALID_INPUT: candles must contain at least 1 entry");
-  }
+export function detectSignalHandler(
+  input: CandlesInput & {
+    kind: string;
+    params?: Record<string, unknown>;
+    lastN?: number;
+  },
+  store: CandleStore = defaultCandleStore,
+): DetectSignalResult {
+  const candles = resolveCandlesInput(input, store);
 
   const desc = getSignalDescriptor(input.kind);
   if (!desc) {
@@ -56,7 +57,7 @@ export function detectSignalHandler(input: {
 
   let raw: unknown;
   try {
-    raw = desc.fn(input.candles, input.params);
+    raw = desc.fn(candles, input.params);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (MISSING_PARAMS_RE.test(message)) {

--- a/packages/mcp/src/tools/detect-signal.ts
+++ b/packages/mcp/src/tools/detect-signal.ts
@@ -31,6 +31,15 @@ export interface DetectSignalResult {
    * Provided as a token-cheap screening summary.
    */
   firedAt: number[];
+  /**
+   * Number of input candle bars the signal was evaluated against. Lets the
+   * caller distinguish "no events fired" from "no data was processed" — the
+   * two are indistinguishable on `events`-shape outputs from `totalLength`
+   * alone (which counts events, not bars).
+   */
+  processedBars: number;
+  /** Echoed from the handle when the caller used `candlesRef`. Omitted otherwise. */
+  symbol?: string;
 }
 
 const DEFAULT_LAST_N = 200;
@@ -45,7 +54,8 @@ export function detectSignalHandler(
   },
   store: CandleStore = defaultCandleStore,
 ): DetectSignalResult {
-  const candles = resolveCandlesInput(input, store);
+  const resolved = resolveCandlesInput(input, store);
+  const { candles } = resolved;
 
   const desc = getSignalDescriptor(input.kind);
   if (!desc) {
@@ -107,5 +117,7 @@ export function detectSignalHandler(
     truncated: sliced.length < totalLength,
     output: sliced,
     firedAt,
+    processedBars: candles.length,
+    ...(resolved.symbol !== undefined ? { symbol: resolved.symbol } : {}),
   };
 }

--- a/packages/mcp/src/tools/load-candles.ts
+++ b/packages/mcp/src/tools/load-candles.ts
@@ -20,6 +20,10 @@ export interface LoadCandlesResult {
   span: { from: number; to: number };
   symbol?: string;
   hint?: string;
+  /** Number of handles currently held by the session-scoped store, including this one. */
+  storeSize: number;
+  /** LRU capacity — when storeSize would exceed this, the oldest handle is silently evicted. */
+  capacity: number;
 }
 
 function tupleToCandle(t: CandleTuple): Candle {
@@ -62,5 +66,7 @@ export function loadCandlesHandler(
     span: meta.span,
     ...(meta.symbol !== undefined ? { symbol: meta.symbol } : {}),
     ...(meta.hint !== undefined ? { hint: meta.hint } : {}),
+    storeSize: store.size(),
+    capacity: store.getCapacity(),
   };
 }

--- a/packages/mcp/src/tools/load-candles.ts
+++ b/packages/mcp/src/tools/load-candles.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import { type CandleStore, defaultCandleStore } from "../dispatcher/candle-store";
+import {
+  type Candle,
+  type CandleTuple,
+  candlesArraySchema,
+  candlesTupleArraySchema,
+} from "../schemas/candle";
+
+export const loadCandlesInputShape = {
+  candles: candlesArraySchema.optional(),
+  candlesArray: candlesTupleArraySchema.optional(),
+  symbol: z.string().min(1).optional(),
+  hint: z.string().min(1).optional(),
+};
+
+export interface LoadCandlesResult {
+  handle: string;
+  count: number;
+  span: { from: number; to: number };
+  symbol?: string;
+  hint?: string;
+}
+
+function tupleToCandle(t: CandleTuple): Candle {
+  const [time, open, high, low, close, volume] = t;
+  return volume === undefined
+    ? { time, open, high, low, close }
+    : { time, open, high, low, close, volume };
+}
+
+export function loadCandlesHandler(
+  input: {
+    candles?: Candle[];
+    candlesArray?: CandleTuple[];
+    symbol?: string;
+    hint?: string;
+  },
+  store: CandleStore = defaultCandleStore,
+): LoadCandlesResult {
+  const provided = [input.candles, input.candlesArray].filter((v) => v !== undefined).length;
+  if (provided === 0) {
+    throw new Error("INVALID_INPUT: must provide one of `candles` or `candlesArray`");
+  }
+  if (provided > 1) {
+    throw new Error("INVALID_INPUT: provide exactly one of `candles` or `candlesArray`");
+  }
+
+  const candles: Candle[] =
+    input.candlesArray !== undefined
+      ? input.candlesArray.map(tupleToCandle)
+      : (input.candles as Candle[]);
+
+  if (candles.length === 0) {
+    throw new Error("INVALID_INPUT: candles must contain at least 1 entry");
+  }
+
+  const meta = store.put(candles, { symbol: input.symbol, hint: input.hint });
+  return {
+    handle: meta.handle,
+    count: meta.count,
+    span: meta.span,
+    ...(meta.symbol !== undefined ? { symbol: meta.symbol } : {}),
+    ...(meta.hint !== undefined ? { hint: meta.hint } : {}),
+  };
+}


### PR DESCRIPTION
## Summary

Closes the v0.2.0 ship slice agreed in [`project_mcp_0_2_0_backlog`](../../blob/main/.) — addresses the two pain points surfaced by external user feedback (2026-04-27): repeated candle payload cost across multi-tool screens, and trial-and-error first calls into `calc_indicator` because params differ per kind.

### What changed

- **`load_candles` tool + `candlesRef` input** (A0). Cache OHLCV candles in the session, get back an opaque handle, pass it to `calc_indicator` / `detect_signal` instead of re-sending the array. Five parallel tool calls against the same 124-bar series now transmit the bars once total. In-memory LRU, capacity 50, oldest evicted silently. Lifetime = stdio process; no persistence.
- **Compact tuple input via `candlesArray`** (A2 subset). Accept `[[time, open, high, low, close, volume?], ...]` everywhere candles are taken. ~40% smaller payload than the canonical object-per-bar form.
- **`paramHints` inlined in `calc_indicator` `INVALID_PARAMETER` errors** (B4). Match the parity `detect_signal` already had — the manifest's `paramHints` are embedded directly in the error message so the LLM doesn't need a `get_indicator_manifest` round-trip.
- **Response polish** surfaced during real-MCP testing of the slice:
  - `detect_signal.processedBars` — input candle count, distinguishes "no events fired" from "no data processed" on events-shape outputs.
  - `calc_indicator.symbol` / `detect_signal.symbol` — echoed when the caller used `candlesRef` and the handle was loaded with a symbol; lets the LLM correlate handle → symbol on fan-out screens without a side-table.
  - `load_candles.storeSize` / `capacity` — anticipate LRU eviction without trial-and-error.

New canonical error `INVALID_HANDLE` for stale/evicted `candlesRef`.

### Out of scope (deferred)

- A1 `candlesPath` (file disk read) — A0 covers the bigger pattern; revisit if demand surfaces.
- A2 CSV / Markdown ingest — ship in 0.2.x once A0 lands and we see real upstream usage.
- B1 `detect_current_regime` — owner decision is to add the classifier API to `trendcraft/core` first, then wrap in MCP.
- B2 `backtest`, B3 events normalization, A3 README data MCP list, C1-C4 polish.

### Plan of record

`~/.claude/plans/mcp-0-2-0-noble-cupcake.md`.

## Test plan

- [x] `pnpm --filter @trendcraft/mcp test` — 59 passing (was 34).
- [x] `pnpm --filter @trendcraft/mcp build` — green; bundle 28.92 → 30.04 kB ESM.
- [x] `pnpm lint` — clean on changed files.
- [x] Real-MCP smoke: `load_candles` (canonical + tuple), `candlesRef` fan-out into `calc_indicator` × 3 and `detect_signal` × 2, error paths (`INVALID_HANDLE`, `INVALID_INPUT` zero/multi, `INVALID_PARAMETER` with embedded paramHints), `processedBars` / `symbol` / `storeSize` / `capacity` envelope fields all observed in live responses.

## Release note

`SERVER_VERSION` bumped to `0.2.0` in source. `package.json` version + tag `mcp-v0.2.0` left for the explicit release step (CHANGELOG entry is in the `Unreleased` section pending a date).