### PR TITLE
refactor(chart): extract interaction handlers from viewport.attach() (#19)

### DIFF
--- a/packages/chart/src/__tests__/interaction-inertia.test.ts
+++ b/packages/chart/src/__tests__/interaction-inertia.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment happy-dom
+/**
+ * Unit tests for InertiaController — physics in isolation.
+ *
+ * happy-dom provides requestAnimationFrame; we drive it via vi.useFakeTimers
+ * with `toFake: ['requestAnimationFrame', 'cancelAnimationFrame']` so each
+ * `runAllTimers()` deterministically advances the loop frame-by-frame until
+ * it terminates.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { InertiaController } from "../core/interaction/inertia";
+import type { PanInertiaState, ZoomInertiaState } from "../core/interaction/types";
+import { TimeScale } from "../core/scale";
+
+function makeTs(total = 500, visible = 100, startIdx = 100): TimeScale {
+  const ts = new TimeScale();
+  ts.setWidth(800);
+  ts.setTotalCount(total);
+  ts.setVisibleRange(startIdx, startIdx + visible);
+  return ts;
+}
+
+function makePan(): PanInertiaState {
+  return { velocity: 0, raf: null, lastTouchX: 0, lastTouchMoveTime: 0 };
+}
+
+function makeZoom(): ZoomInertiaState {
+  return { velocity: 0, raf: null, lastTime: 0, anchorX: null };
+}
+
+describe("InertiaController.pan", () => {
+  let ts: TimeScale;
+  let pan: PanInertiaState;
+  let zoom: ZoomInertiaState;
+  let onUpdate: ReturnType<typeof vi.fn>;
+  let inertia: InertiaController;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["requestAnimationFrame", "cancelAnimationFrame"] });
+    ts = makeTs();
+    pan = makePan();
+    zoom = makeZoom();
+    onUpdate = vi.fn();
+    inertia = new InertiaController(ts, pan, zoom, onUpdate);
+  });
+  afterEach(() => {
+    inertia.dispose();
+    vi.useRealTimers();
+  });
+
+  it("decays velocity by 0.92 per frame and stops at <0.5", () => {
+    pan.velocity = 10;
+    inertia.startPan();
+    expect(pan.raf).not.toBe(null);
+    vi.advanceTimersToNextFrame();
+    expect(Math.abs(pan.velocity)).toBeCloseTo(10 * 0.92, 5);
+    // Run to completion
+    vi.runAllTimers();
+    expect(pan.raf).toBe(null);
+    expect(Math.abs(pan.velocity)).toBeLessThan(0.5);
+  });
+
+  it("does nothing when velocity below threshold and no overscroll", () => {
+    pan.velocity = 0.3;
+    inertia.startPan();
+    vi.advanceTimersToNextFrame();
+    expect(pan.raf).toBe(null);
+  });
+
+  it("springs back when overscrolled", () => {
+    // Force overscroll by setting startIndex past the right edge
+    ts.setStartIndexUnclamped(450); // total=500, visible=100, max=400 → overscroll=50
+    expect(Math.abs(ts.overscroll)).toBeGreaterThan(0.1);
+    pan.velocity = 0;
+    inertia.startPan();
+    vi.advanceTimersToNextFrame();
+    // After one spring frame, raw position should have moved back toward clamp
+    expect(ts.rawStartIndex).toBeLessThan(450);
+    vi.runAllTimers();
+    // Should snap to clamped edge
+    expect(Math.abs(ts.overscroll)).toBeLessThan(0.5);
+    expect(pan.raf).toBe(null);
+  });
+
+  it("stopPan cancels the loop without resetting velocity", () => {
+    pan.velocity = 10;
+    inertia.startPan();
+    inertia.stopPan();
+    expect(pan.raf).toBe(null);
+    expect(pan.velocity).toBe(10);
+  });
+});
+
+describe("InertiaController.zoom", () => {
+  let ts: TimeScale;
+  let pan: PanInertiaState;
+  let zoom: ZoomInertiaState;
+  let onUpdate: ReturnType<typeof vi.fn>;
+  let inertia: InertiaController;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["requestAnimationFrame", "cancelAnimationFrame"] });
+    ts = makeTs();
+    pan = makePan();
+    zoom = makeZoom();
+    onUpdate = vi.fn();
+    inertia = new InertiaController(ts, pan, zoom, onUpdate);
+  });
+  afterEach(() => {
+    inertia.dispose();
+    vi.useRealTimers();
+  });
+
+  it("applies zoom factor each frame and decays by 0.9", () => {
+    zoom.velocity = 0.05;
+    zoom.anchorX = 400;
+    const beforeSpacing = ts.barSpacing;
+    inertia.startZoom();
+    // Run one frame
+    vi.advanceTimersToNextFrame();
+    expect(zoom.velocity).toBeCloseTo(0.05 * 0.9, 5);
+    expect(ts.barSpacing).not.toBe(beforeSpacing);
+  });
+
+  it("terminates at |velocity| < 0.0005 and clears anchor", () => {
+    zoom.velocity = 0.001;
+    zoom.anchorX = 400;
+    inertia.startZoom();
+    vi.runAllTimers();
+    expect(zoom.raf).toBe(null);
+    expect(zoom.anchorX).toBe(null);
+  });
+
+  it("stopZoom cancels and resets velocity to 0", () => {
+    zoom.velocity = 0.05;
+    zoom.anchorX = 400;
+    inertia.startZoom();
+    inertia.stopZoom();
+    expect(zoom.raf).toBe(null);
+    expect(zoom.velocity).toBe(0);
+  });
+});
+
+describe("InertiaController.dispose", () => {
+  it("cancels both loops", () => {
+    vi.useFakeTimers({ toFake: ["requestAnimationFrame", "cancelAnimationFrame"] });
+    const ts = makeTs();
+    const pan = makePan();
+    const zoom = makeZoom();
+    const inertia = new InertiaController(ts, pan, zoom, () => {});
+    pan.velocity = 10;
+    zoom.velocity = 0.05;
+    inertia.startPan();
+    inertia.startZoom();
+    inertia.dispose();
+    expect(pan.raf).toBe(null);
+    expect(zoom.raf).toBe(null);
+    vi.useRealTimers();
+  });
+});

--- a/packages/chart/src/__tests__/viewport-attach.test.ts
+++ b/packages/chart/src/__tests__/viewport-attach.test.ts
@@ -1,0 +1,395 @@
+// @vitest-environment happy-dom
+/**
+ * Characterization tests for Viewport.attach().
+ *
+ * Locks down the observable behavior of the 9 event handlers + 2 inertia loops
+ * before the handler-extraction refactor (issue #19). Each test exercises a
+ * single interaction path and asserts effects on TimeScale, Viewport state,
+ * or callbacks.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TimeScale } from "../core/scale";
+import type { PaneRect } from "../core/types";
+import { type ScrollbarRect, Viewport } from "../core/viewport";
+
+// --- helpers -------------------------------------------------------------
+
+function makeEl(width = 800, height = 600): HTMLElement {
+  const el = document.createElement("div");
+  el.getBoundingClientRect = () =>
+    ({
+      left: 0,
+      top: 0,
+      right: width,
+      bottom: height,
+      width,
+      height,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  // happy-dom doesn't always provide focus()
+  if (typeof el.focus !== "function") el.focus = () => undefined;
+  return el;
+}
+
+function makeTimeScale(total = 500, visibleStart = 100): TimeScale {
+  const ts = new TimeScale();
+  ts.setWidth(800);
+  ts.setTotalCount(total);
+  ts.setVisibleRange(visibleStart, visibleStart + 100);
+  return ts;
+}
+
+type Setup = {
+  el: HTMLElement;
+  vp: Viewport;
+  ts: TimeScale;
+  detach: () => void;
+  resizePanes: ReturnType<typeof vi.fn>;
+  dispatch: ReturnType<typeof vi.fn>;
+  onUpdate: ReturnType<typeof vi.fn>;
+};
+
+function setup(
+  opts: {
+    panes?: PaneRect[];
+    scrollbar?: ScrollbarRect | null;
+    gapAtY?: (y: number) => number | null;
+    hotkeys?: false | undefined;
+    longPress?: boolean;
+    wheelInertia?: boolean;
+    total?: number;
+  } = {},
+): Setup {
+  const el = makeEl();
+  const vp = new Viewport();
+  const ts = makeTimeScale(opts.total);
+  const panes: PaneRect[] = opts.panes ?? [
+    { id: "main", y: 0, height: 400, flex: 1 },
+    { id: "vol", y: 400, height: 200, flex: 0.5 },
+  ];
+  const scrollbar =
+    opts.scrollbar !== undefined ? opts.scrollbar : { x: 0, y: 580, width: 800, height: 12 };
+  const resizePanes = vi.fn();
+  const dispatch = vi.fn();
+  const onUpdate = vi.fn();
+  vp.setOnUpdate(onUpdate);
+  const detach = vp.attach(
+    el,
+    ts,
+    () => panes,
+    () => scrollbar,
+    opts.gapAtY,
+    resizePanes,
+    0.3,
+    {
+      lockOnLongPress: opts.longPress ?? true,
+      wheelInertia: opts.wheelInertia ?? true,
+      hotkeys: opts.hotkeys,
+      onAction: dispatch,
+    },
+  );
+  return { el, vp, ts, detach, resizePanes, dispatch, onUpdate };
+}
+
+function fireMouse(el: HTMLElement, type: string, x: number, y: number, init: MouseEventInit = {}) {
+  el.dispatchEvent(new MouseEvent(type, { clientX: x, clientY: y, bubbles: true, ...init }));
+}
+
+function fireWheel(el: HTMLElement, init: WheelEventInit) {
+  el.dispatchEvent(new WheelEvent("wheel", { bubbles: true, cancelable: true, ...init }));
+}
+
+function fireKey(el: HTMLElement, key: string, init: KeyboardEventInit = {}) {
+  // hotkeys.ts matches on `code`; default to deriving code from key when not given.
+  const code = init.code ?? deriveCode(key);
+  el.dispatchEvent(
+    new KeyboardEvent("keydown", { key, code, bubbles: true, cancelable: true, ...init }),
+  );
+}
+
+function deriveCode(key: string): string {
+  if (key === "Escape") return "Escape";
+  if (/^[a-zA-Z]$/.test(key)) return `Key${key.toUpperCase()}`;
+  if (key === "ArrowLeft" || key === "ArrowRight" || key === "ArrowUp" || key === "ArrowDown") {
+    return key;
+  }
+  if (key === "Home" || key === "End") return key;
+  if (key === "+" || key === "=") return "Equal";
+  if (key === "-") return "Minus";
+  return key;
+}
+
+function makeTouch(clientX: number, clientY: number): Touch {
+  return { clientX, clientY, identifier: 0 } as unknown as Touch;
+}
+
+function fireTouch(el: HTMLElement, type: string, touches: Touch[]) {
+  // happy-dom may not implement TouchEvent constructor — fall back to a custom event.
+  let ev: Event;
+  try {
+    ev = new TouchEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      touches: touches as unknown as TouchList,
+    });
+  } catch {
+    ev = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(ev, "touches", { value: touches });
+  }
+  el.dispatchEvent(ev);
+}
+
+// --- tests ---------------------------------------------------------------
+
+describe("Viewport.attach() — mouse pan", () => {
+  let s: Setup;
+  beforeEach(() => {
+    s = setup();
+  });
+  afterEach(() => s.detach());
+
+  it("pans startIndex by -dx/barSpacing on drag", () => {
+    const startIdx = s.ts.startIndex;
+    const spacing = s.ts.barSpacing;
+    fireMouse(s.el, "mousedown", 400, 200);
+    expect(s.vp.state.isDragging).toBe(true);
+    fireMouse(s.el, "mousemove", 350, 200); // dx = -50
+    // expected: startIndex shifted by +50/spacing bars
+    const shifted = s.ts.startIndex - startIdx;
+    expect(shifted).toBeGreaterThan(0);
+    expect(shifted).toBeCloseTo(50 / spacing, 0);
+    fireMouse(s.el, "mouseup", 350, 200);
+    expect(s.vp.state.isDragging).toBe(false);
+  });
+
+  it("clears state on mouseleave", () => {
+    fireMouse(s.el, "mousedown", 400, 200);
+    fireMouse(s.el, "mousemove", 380, 200);
+    fireMouse(s.el, "mouseleave", 0, 0);
+    expect(s.vp.state.isDragging).toBe(false);
+    expect(s.vp.state.crosshairIndex).toBe(null);
+    expect(s.vp.state.activePaneId).toBe(null);
+  });
+
+  it("updates crosshair and activePane on move (no drag)", () => {
+    fireMouse(s.el, "mousemove", 200, 100);
+    expect(s.vp.state.activePaneId).toBe("main");
+    expect(s.vp.state.crosshairIndex).not.toBe(null);
+    fireMouse(s.el, "mousemove", 200, 500);
+    expect(s.vp.state.activePaneId).toBe("vol");
+  });
+});
+
+describe("Viewport.attach() — scrollbar drag", () => {
+  it("track click jumps visible range to center on cursor", () => {
+    const s = setup();
+    const before = s.ts.startIndex;
+    // Click far right of scrollbar track (no thumb at x=700) to trigger page jump.
+    fireMouse(s.el, "mousedown", 700, 585);
+    expect(s.ts.startIndex).not.toBe(before);
+    s.detach();
+  });
+
+  it("thumb grab preserves offset under cursor on subsequent drag", () => {
+    const s = setup();
+    // First scrollbar mousedown to start drag, then move and verify reasonable shift.
+    fireMouse(s.el, "mousedown", 200, 585);
+    fireMouse(s.el, "mousemove", 250, 585);
+    expect(s.ts.startIndex).toBeGreaterThanOrEqual(0);
+    fireMouse(s.el, "mouseup", 250, 585);
+    s.detach();
+  });
+});
+
+describe("Viewport.attach() — pane resize via gap", () => {
+  it("calls resizePanes with delta when dragging gap", () => {
+    const gapAtY = (y: number) => (y >= 398 && y <= 402 ? 0 : null);
+    const s = setup({ gapAtY });
+    fireMouse(s.el, "mousedown", 400, 400);
+    fireMouse(s.el, "mousemove", 400, 420);
+    expect(s.resizePanes).toHaveBeenCalledWith(0, 20);
+    fireMouse(s.el, "mouseup", 400, 420);
+    s.detach();
+  });
+});
+
+describe("Viewport.attach() — wheel", () => {
+  let s: Setup;
+  beforeEach(() => {
+    s = setup({ wheelInertia: false });
+  });
+  afterEach(() => s.detach());
+
+  it("horizontal deltaX triggers pan (scrollByUnclamped)", () => {
+    const before = s.ts.startIndex;
+    fireWheel(s.el, { deltaX: 50, deltaY: 0, clientX: 400, clientY: 200 });
+    expect(s.ts.startIndex).not.toBe(before);
+  });
+
+  it("vertical deltaY triggers zoom around cursor", () => {
+    const beforeSpacing = s.ts.barSpacing;
+    fireWheel(s.el, { deltaX: 0, deltaY: -50, clientX: 400, clientY: 200 });
+    expect(s.ts.barSpacing).not.toBe(beforeSpacing);
+  });
+
+  it("ctrlKey forces zoom (trackpad pinch)", () => {
+    const beforeSpacing = s.ts.barSpacing;
+    fireWheel(s.el, { deltaX: 0, deltaY: -30, ctrlKey: true, clientX: 400, clientY: 200 });
+    expect(s.ts.barSpacing).not.toBe(beforeSpacing);
+  });
+
+  it("preventDefault is called", () => {
+    const ev = new WheelEvent("wheel", {
+      deltaX: 0,
+      deltaY: 50,
+      clientX: 400,
+      clientY: 200,
+      bubbles: true,
+      cancelable: true,
+    });
+    s.el.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(true);
+  });
+});
+
+describe("Viewport.attach() — keyboard nav", () => {
+  let s: Setup;
+  beforeEach(() => {
+    s = setup();
+  });
+  afterEach(() => s.detach());
+
+  it("ArrowLeft scrolls by -1, Shift+ArrowLeft by -10", () => {
+    const before = s.ts.startIndex;
+    fireKey(s.el, "ArrowLeft");
+    expect(s.ts.startIndex).toBe(before - 1);
+    fireKey(s.el, "ArrowLeft", { shiftKey: true });
+    expect(s.ts.startIndex).toBe(before - 11);
+  });
+
+  it("ArrowRight scrolls by +1", () => {
+    const before = s.ts.startIndex;
+    fireKey(s.el, "ArrowRight");
+    expect(s.ts.startIndex).toBe(before + 1);
+  });
+
+  it("+/- adjusts barSpacing via zoom", () => {
+    const before = s.ts.barSpacing;
+    fireKey(s.el, "+");
+    expect(s.ts.barSpacing).toBeGreaterThan(before);
+    const mid = s.ts.barSpacing;
+    fireKey(s.el, "-");
+    expect(s.ts.barSpacing).toBeLessThan(mid);
+  });
+
+  it("Home scrolls to start, End scrolls to end", () => {
+    fireKey(s.el, "End");
+    expect(s.ts.startIndex).toBeGreaterThan(0);
+    fireKey(s.el, "Home");
+    expect(s.ts.startIndex).toBe(0);
+  });
+
+  it("'f' fits content", () => {
+    const beforeSpacing = s.ts.barSpacing;
+    fireKey(s.el, "f");
+    expect(s.ts.startIndex).toBe(0);
+    expect(s.ts.barSpacing).not.toBe(beforeSpacing);
+  });
+
+  it("hotkeys: false disables all keyboard interaction", () => {
+    const s2 = setup({ hotkeys: false });
+    const before = s2.ts.startIndex;
+    fireKey(s2.el, "ArrowLeft");
+    fireKey(s2.el, "f");
+    fireKey(s2.el, "Escape");
+    expect(s2.ts.startIndex).toBe(before);
+    expect(s2.dispatch).not.toHaveBeenCalled();
+    s2.detach();
+  });
+
+  it("Escape dispatches 'cancel' and clears drag state", () => {
+    fireMouse(s.el, "mousedown", 400, 200);
+    expect(s.vp.state.isDragging).toBe(true);
+    fireKey(s.el, "Escape");
+    expect(s.dispatch).toHaveBeenCalledWith("cancel");
+    expect(s.vp.state.isDragging).toBe(false);
+  });
+
+  it("default hotkey Alt+T dispatches trendline action", () => {
+    fireKey(s.el, "t", { altKey: true });
+    expect(s.dispatch).toHaveBeenCalledWith("trendline");
+  });
+});
+
+describe("Viewport.attach() — touch", () => {
+  let s: Setup;
+  beforeEach(() => {
+    vi.useFakeTimers();
+    s = setup();
+  });
+  afterEach(() => {
+    s.detach();
+    vi.useRealTimers();
+  });
+
+  it("single-touch drag pans startIndex", () => {
+    const before = s.ts.startIndex;
+    fireTouch(s.el, "touchstart", [makeTouch(400, 200)]);
+    fireTouch(s.el, "touchmove", [makeTouch(350, 200)]);
+    expect(s.ts.startIndex).not.toBe(before);
+    fireTouch(s.el, "touchend", []);
+  });
+
+  it("double-tap fits content", () => {
+    fireTouch(s.el, "touchstart", [makeTouch(400, 200)]);
+    fireTouch(s.el, "touchend", []);
+    vi.advanceTimersByTime(100);
+    fireTouch(s.el, "touchstart", [makeTouch(400, 200)]);
+    expect(s.ts.startIndex).toBe(0);
+  });
+
+  it("long-press locks crosshair after 500ms", () => {
+    fireTouch(s.el, "touchstart", [makeTouch(400, 200)]);
+    vi.advanceTimersByTime(600);
+    expect(s.vp.state.crosshairIndex).not.toBe(null);
+  });
+
+  it("longPress: false skips long-press timer", () => {
+    s.detach();
+    s = setup({ longPress: false });
+    fireTouch(s.el, "touchstart", [makeTouch(400, 200)]);
+    vi.advanceTimersByTime(600);
+    expect(s.vp.state.crosshairIndex).toBe(null);
+  });
+
+  it("two-finger pinch zooms barSpacing", () => {
+    const beforeSpacing = s.ts.barSpacing;
+    fireTouch(s.el, "touchstart", [makeTouch(300, 200), makeTouch(500, 200)]);
+    fireTouch(s.el, "touchmove", [makeTouch(200, 200), makeTouch(600, 200)]);
+    expect(s.ts.barSpacing).not.toBe(beforeSpacing);
+  });
+});
+
+describe("Viewport.attach() — cleanup", () => {
+  it("detach removes all event listeners", () => {
+    const s = setup();
+    s.detach();
+    const before = s.ts.startIndex;
+    fireMouse(s.el, "mousedown", 400, 200);
+    fireMouse(s.el, "mousemove", 350, 200);
+    fireWheel(s.el, { deltaX: 50, deltaY: 0 });
+    fireKey(s.el, "ArrowLeft");
+    // No handler should have fired.
+    expect(s.ts.startIndex).toBe(before);
+    expect(s.vp.state.isDragging).toBe(false);
+  });
+
+  it("detach is safe to call twice", () => {
+    const s = setup();
+    s.detach();
+    expect(() => s.detach()).not.toThrow();
+  });
+});

--- a/packages/chart/src/core/interaction/inertia.ts
+++ b/packages/chart/src/core/interaction/inertia.ts
@@ -1,0 +1,128 @@
+/**
+ * InertiaController — owns the pan/zoom inertia animation loops.
+ *
+ * Both loops were previously inlined into `Viewport.attach()` and shared
+ * mutable state with the event handlers. They're consolidated here so the
+ * physics (friction, bounce-back, velocity blending) is testable in isolation
+ * and the event handlers only see a small imperative API.
+ *
+ * Pan-inertia behavior (preserved from the original implementation):
+ *   - When `overscroll` exceeds 0.1 bars, the loop springs back toward
+ *     `clampedStartIndex` with a stiffness of 0.2 and snaps when within 0.5
+ *     bars of the target. Velocity is held at 0 during bounce-back.
+ *   - Otherwise the loop applies `velocity / barSpacing` per frame and decays
+ *     velocity by 0.92 each frame; it stops when |velocity| < 0.5.
+ *
+ * Zoom-inertia behavior:
+ *   - Friction 0.9 per frame; loop terminates when |velocity| < 0.0005 and
+ *     clears the anchor so the next gesture re-anchors on its first event.
+ */
+
+import type { TimeScale } from "../scale";
+import type { PanInertiaState, ZoomInertiaState } from "./types";
+
+export class InertiaController {
+  constructor(
+    private readonly timeScale: TimeScale,
+    private readonly pan: PanInertiaState,
+    private readonly zoom: ZoomInertiaState,
+    private readonly onUpdate: () => void,
+  ) {}
+
+  /** Begin pan inertia / bounce-back. Caller sets `pan.velocity` first. */
+  startPan(): void {
+    this.cancelPanFrame();
+    this.pan.raf = requestAnimationFrame(this.runPan);
+  }
+
+  /** Cancel pan inertia loop. Velocity is preserved (set explicitly to reset). */
+  stopPan(): void {
+    this.cancelPanFrame();
+  }
+
+  /**
+   * Begin zoom inertia. Caller sets `zoom.velocity` and `zoom.anchorX` first.
+   * If a previous zoom-inertia loop is running, its RAF is cancelled but the
+   * caller-supplied velocity is preserved — this is what enables velocity
+   * blending across consecutive wheel events.
+   */
+  startZoom(): void {
+    this.cancelZoomFrame();
+    this.zoom.raf = requestAnimationFrame(this.runZoom);
+  }
+
+  /** Cancel zoom inertia loop and reset velocity. */
+  stopZoom(): void {
+    this.cancelZoomFrame();
+    this.zoom.velocity = 0;
+  }
+
+  private cancelPanFrame(): void {
+    if (this.pan.raf !== null) {
+      cancelAnimationFrame(this.pan.raf);
+      this.pan.raf = null;
+    }
+  }
+
+  private cancelZoomFrame(): void {
+    if (this.zoom.raf !== null) {
+      cancelAnimationFrame(this.zoom.raf);
+      this.zoom.raf = null;
+    }
+  }
+
+  /** Cancel both loops — for use by detach() / cancel hotkey. */
+  dispose(): void {
+    this.stopPan();
+    this.stopZoom();
+  }
+
+  // --- private loops -----------------------------------------------------
+
+  private runPan = (): void => {
+    const ts = this.timeScale;
+    const over = ts.overscroll;
+
+    if (Math.abs(over) > 0.1) {
+      // Bounce-back: spring toward clamped position
+      const target = ts.clampedStartIndex;
+      const raw = ts.rawStartIndex;
+      const springForce = (target - raw) * 0.2;
+      ts.setStartIndexUnclamped(raw + springForce);
+      this.pan.velocity = 0;
+
+      if (Math.abs(ts.overscroll) < 0.5) {
+        ts.setStartIndexUnclamped(ts.clampedStartIndex);
+        this.pan.raf = null;
+        this.onUpdate();
+        return;
+      }
+      this.onUpdate();
+      this.pan.raf = requestAnimationFrame(this.runPan);
+      return;
+    }
+
+    if (Math.abs(this.pan.velocity) < 0.5) {
+      this.pan.raf = null;
+      return;
+    }
+    const deltaBars = -this.pan.velocity / ts.barSpacing;
+    ts.scrollByUnclamped(deltaBars);
+    this.pan.velocity *= 0.92;
+    this.onUpdate();
+    this.pan.raf = requestAnimationFrame(this.runPan);
+  };
+
+  private runZoom = (): void => {
+    if (Math.abs(this.zoom.velocity) < 0.0005) {
+      this.zoom.raf = null;
+      this.zoom.anchorX = null;
+      return;
+    }
+    const factor = 1 - this.zoom.velocity;
+    this.timeScale.zoom(factor, this.zoom.anchorX ?? undefined);
+    this.zoom.velocity *= 0.9;
+    this.onUpdate();
+    this.zoom.raf = requestAnimationFrame(this.runZoom);
+  };
+}

--- a/packages/chart/src/core/interaction/keyboard-handler.ts
+++ b/packages/chart/src/core/interaction/keyboard-handler.ts
@@ -1,0 +1,86 @@
+/**
+ * Keyboard interaction handler — hotkey resolution + built-in nav (arrows,
+ * +/-, Home, End, F) + cancel.
+ *
+ * `hotkeys: false` from ViewportAttachOptions disables every keyboard binding,
+ * including the built-in nav. Hosts that handle keys themselves opt out with
+ * this single flag.
+ */
+
+import { resolveHotkey } from "../hotkeys";
+import type { HotkeyAction } from "../types";
+import type { InertiaController } from "./inertia";
+import type { InteractionContext } from "./types";
+
+export function attachKeyboardHandlers(
+  ctx: InteractionContext,
+  inertia: InertiaController,
+): () => void {
+  const { el, timeScale, hotkeyMap, hotkeyDisabled, dispatch } = ctx;
+
+  const resolveAction = (e: KeyboardEvent): HotkeyAction | undefined => {
+    if (hotkeyDisabled) return undefined;
+    return resolveHotkey(e, hotkeyMap || undefined);
+  };
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (hotkeyDisabled) return;
+
+    const action = resolveAction(e);
+    if (action === "cancel") {
+      // Esc cancels every transient interaction: drag, both inertia loops,
+      // long-press crosshair lock, and any in-progress drawing tool
+      // (delegated to the host via dispatch).
+      ctx.viewState.isDragging = false;
+      ctx.drag.scrollbarDragging = false;
+      ctx.drag.scrollbarGrabOffsetFrac = null;
+      inertia.stopPan();
+      inertia.stopZoom();
+      ctx.pan.velocity = 0;
+      ctx.wheel.panVelocity = 0;
+      ctx.touch.longPressCrosshairLocked = false;
+      dispatch?.("cancel");
+      e.preventDefault();
+      ctx.onUpdate();
+      return;
+    }
+    if (action !== undefined) {
+      dispatch?.(action);
+      e.preventDefault();
+      ctx.onUpdate();
+      return;
+    }
+
+    switch (e.key) {
+      case "ArrowLeft":
+        timeScale.scrollBy(e.shiftKey ? -10 : -1);
+        break;
+      case "ArrowRight":
+        timeScale.scrollBy(e.shiftKey ? 10 : 1);
+        break;
+      case "+":
+      case "=":
+        timeScale.zoom(1.15);
+        break;
+      case "-":
+        timeScale.zoom(0.87);
+        break;
+      case "Home":
+        timeScale.setVisibleRange(0, timeScale.visibleCount);
+        break;
+      case "End":
+        timeScale.scrollToEnd();
+        break;
+      case "f":
+        timeScale.fitContent();
+        break;
+      default:
+        return; // Don't prevent default for unhandled keys
+    }
+    e.preventDefault();
+    ctx.onUpdate();
+  };
+
+  el.addEventListener("keydown", onKeyDown);
+  return () => el.removeEventListener("keydown", onKeyDown);
+}

--- a/packages/chart/src/core/interaction/mouse-handler.ts
+++ b/packages/chart/src/core/interaction/mouse-handler.ts
@@ -1,0 +1,127 @@
+/**
+ * Mouse interaction handlers — mousedown / mousemove / mouseup / mouseleave.
+ *
+ * Owns: pan drag, scrollbar drag (delegates to ctx helpers), pane-resize gap drag,
+ * crosshair tracking, active-pane detection, mouse-up bounce-back trigger.
+ */
+
+import type { InertiaController } from "./inertia";
+import type { InteractionContext } from "./types";
+import { rubberBandDampen } from "./utils";
+
+export function attachMouseHandlers(
+  ctx: InteractionContext,
+  inertia: InertiaController,
+): () => void {
+  const { el, timeScale, panes, scrollbar, gapAtY, resizePanes } = ctx;
+
+  const onMouseDown = (e: MouseEvent) => {
+    el.focus();
+    const rect = el.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+
+    if (gapAtY) {
+      const gap = gapAtY(my);
+      if (gap !== null) {
+        ctx.paneResize.gap = gap;
+        ctx.paneResize.startY = e.clientY;
+        return;
+      }
+    }
+
+    const sb = scrollbar();
+    if (sb && my >= sb.y && my <= sb.y + sb.height) {
+      ctx.beginScrollbarDrag(mx, sb);
+      ctx.onUpdate();
+      return;
+    }
+
+    ctx.viewState.isDragging = true;
+    ctx.drag.startX = e.clientX;
+    ctx.drag.startIndex = timeScale.startIndex;
+  };
+
+  const onMouseMove = (e: MouseEvent) => {
+    const rect = el.getBoundingClientRect();
+    ctx.viewState.mouseX = e.clientX - rect.left;
+    ctx.viewState.mouseY = e.clientY - rect.top;
+
+    if (ctx.paneResize.gap !== null && resizePanes) {
+      const delta = e.clientY - ctx.paneResize.startY;
+      resizePanes(ctx.paneResize.gap, delta);
+      ctx.paneResize.startY = e.clientY;
+      ctx.onUpdate();
+      return;
+    }
+
+    if (gapAtY) {
+      const gap = gapAtY(ctx.viewState.mouseY);
+      el.style.cursor = gap !== null ? "ns-resize" : "crosshair";
+    }
+
+    if (ctx.drag.scrollbarDragging) {
+      const sb = scrollbar();
+      if (sb) ctx.applyScrollbarDrag(ctx.viewState.mouseX, sb);
+      ctx.onUpdate();
+      return;
+    }
+
+    const currentPanes = panes();
+    ctx.viewState.activePaneId = null;
+    for (const pane of currentPanes) {
+      if (ctx.viewState.mouseY >= pane.y && ctx.viewState.mouseY < pane.y + pane.height) {
+        ctx.viewState.activePaneId = pane.id;
+        break;
+      }
+    }
+
+    ctx.viewState.crosshairIndex = timeScale.xToIndex(ctx.viewState.mouseX);
+
+    if (ctx.viewState.isDragging) {
+      const dx = e.clientX - ctx.drag.startX;
+      const deltaBars = -(dx / timeScale.barSpacing);
+      const rawStart = ctx.drag.startIndex + deltaBars;
+      timeScale.setStartIndexUnclamped(rawStart);
+      rubberBandDampen(timeScale);
+    }
+
+    ctx.onUpdate();
+  };
+
+  const onMouseUp = () => {
+    // Bounce-back if overscrolled via mouse drag. The inertia loop handles
+    // both spring-back-from-overscroll and velocity-driven flick; here we
+    // explicitly zero velocity because mouse drag doesn't track flick speed.
+    if (ctx.viewState.isDragging && Math.abs(timeScale.overscroll) > 0.1) {
+      inertia.stopPan();
+      ctx.pan.velocity = 0;
+      inertia.startPan();
+    }
+    ctx.viewState.isDragging = false;
+    ctx.drag.scrollbarDragging = false;
+    ctx.drag.scrollbarGrabOffsetFrac = null;
+    ctx.paneResize.gap = null;
+  };
+
+  const onMouseLeave = () => {
+    ctx.viewState.isDragging = false;
+    ctx.drag.scrollbarDragging = false;
+    ctx.drag.scrollbarGrabOffsetFrac = null;
+    ctx.viewState.crosshairIndex = null;
+    ctx.viewState.activePaneId = null;
+    ctx.onUpdate();
+  };
+
+  el.addEventListener("mousedown", onMouseDown);
+  el.addEventListener("mousemove", onMouseMove);
+  el.addEventListener("mouseup", onMouseUp);
+  el.addEventListener("mouseleave", onMouseLeave);
+
+  return () => {
+    el.removeEventListener("mousedown", onMouseDown);
+    el.removeEventListener("mousemove", onMouseMove);
+    el.removeEventListener("mouseup", onMouseUp);
+    el.removeEventListener("mouseleave", onMouseLeave);
+  };
+}

--- a/packages/chart/src/core/interaction/touch-handler.ts
+++ b/packages/chart/src/core/interaction/touch-handler.ts
@@ -1,0 +1,162 @@
+/**
+ * Touch interaction handlers — single-touch pan, double-tap, long-press
+ * crosshair lock, two-finger pinch zoom.
+ */
+
+import type { InertiaController } from "./inertia";
+import type { InteractionContext } from "./types";
+import { rubberBandDampen } from "./utils";
+
+export function attachTouchHandlers(
+  ctx: InteractionContext,
+  inertia: InertiaController,
+): () => void {
+  const { el, timeScale, scrollbar, sens, longPressEnabled } = ctx;
+
+  const onTouchStart = (e: TouchEvent) => {
+    inertia.stopPan();
+    if (e.touches.length === 1) {
+      const now = Date.now();
+      const touch = e.touches[0];
+
+      // Scrollbar hit on touch
+      const rect = el.getBoundingClientRect();
+      const touchLocalX = touch.clientX - rect.left;
+      const touchLocalY = touch.clientY - rect.top;
+      const sb = scrollbar();
+      if (sb && touchLocalY >= sb.y && touchLocalY <= sb.y + sb.height) {
+        ctx.beginScrollbarDrag(touchLocalX, sb);
+        ctx.onUpdate();
+        return;
+      }
+
+      // Double-tap detection
+      if (now - ctx.touch.lastTapTime < 300) {
+        timeScale.fitContent();
+        ctx.onUpdate();
+        ctx.touch.lastTapTime = 0;
+        return;
+      }
+      ctx.touch.lastTapTime = now;
+
+      // Long-press detection (disabled when option is off)
+      if (longPressEnabled) {
+        ctx.touch.longPressTimer = setTimeout(() => {
+          ctx.touch.longPressCrosshairLocked = true;
+          const r = el.getBoundingClientRect();
+          ctx.viewState.crosshairIndex = timeScale.xToIndex(touch.clientX - r.left);
+          ctx.onUpdate();
+        }, 500);
+      }
+
+      ctx.viewState.isDragging = true;
+      ctx.pan.lastTouchX = touch.clientX;
+      ctx.pan.lastTouchMoveTime = now;
+      ctx.pan.velocity = 0;
+      ctx.drag.startX = ctx.pan.lastTouchX;
+      ctx.drag.startIndex = timeScale.startIndex;
+    } else if (e.touches.length === 2) {
+      // Switch from pan to pinch: cancel drag state
+      if (ctx.touch.longPressTimer) {
+        clearTimeout(ctx.touch.longPressTimer);
+        ctx.touch.longPressTimer = null;
+      }
+      ctx.viewState.isDragging = false;
+      ctx.touch.longPressCrosshairLocked = false;
+      const dx = e.touches[0].clientX - e.touches[1].clientX;
+      const dy = e.touches[0].clientY - e.touches[1].clientY;
+      ctx.touch.lastDist = Math.sqrt(dx * dx + dy * dy);
+    }
+  };
+
+  const onTouchMove = (e: TouchEvent) => {
+    e.preventDefault();
+    if (ctx.touch.longPressTimer) {
+      clearTimeout(ctx.touch.longPressTimer);
+      ctx.touch.longPressTimer = null;
+    }
+
+    // Scrollbar drag (touch)
+    if (ctx.drag.scrollbarDragging && e.touches.length === 1) {
+      const sbTouch = e.touches[0];
+      const rect = el.getBoundingClientRect();
+      const localX = sbTouch.clientX - rect.left;
+      const sb = scrollbar();
+      if (sb) ctx.applyScrollbarDrag(localX, sb);
+      ctx.onUpdate();
+      return;
+    }
+
+    if (e.touches.length === 1 && ctx.viewState.isDragging) {
+      const now = Date.now();
+      const currentX = e.touches[0].clientX;
+
+      const dt = now - ctx.pan.lastTouchMoveTime;
+      if (dt > 0) {
+        ctx.pan.velocity = ((currentX - ctx.pan.lastTouchX) / dt) * 16 * sens;
+      }
+      ctx.pan.lastTouchX = currentX;
+      ctx.pan.lastTouchMoveTime = now;
+
+      if (ctx.touch.longPressCrosshairLocked) {
+        const rect = el.getBoundingClientRect();
+        ctx.viewState.crosshairIndex = timeScale.xToIndex(currentX - rect.left);
+        ctx.onUpdate();
+        return;
+      }
+
+      const dx = currentX - ctx.drag.startX;
+      const deltaBars = -(dx / timeScale.barSpacing);
+      const rawStart = ctx.drag.startIndex + deltaBars;
+      timeScale.setStartIndexUnclamped(rawStart);
+      rubberBandDampen(timeScale);
+      ctx.onUpdate();
+    } else if (e.touches.length === 2) {
+      const tdx = e.touches[0].clientX - e.touches[1].clientX;
+      const tdy = e.touches[0].clientY - e.touches[1].clientY;
+      const dist = Math.sqrt(tdx * tdx + tdy * tdy);
+      if (ctx.touch.lastDist > 0 && dist > 0) {
+        // Amplify pinch: double the zoom delta for responsive feel
+        const rawFactor = dist / ctx.touch.lastDist;
+        const amplified = 1 + (rawFactor - 1) * 2.5;
+        const midX = (e.touches[0].clientX + e.touches[1].clientX) / 2;
+        const rect = el.getBoundingClientRect();
+        timeScale.zoom(amplified, midX - rect.left);
+        ctx.onUpdate();
+      }
+      ctx.touch.lastDist = dist;
+    }
+  };
+
+  const onTouchEnd = () => {
+    if (ctx.touch.longPressTimer) {
+      clearTimeout(ctx.touch.longPressTimer);
+      ctx.touch.longPressTimer = null;
+    }
+
+    // Start inertia if swiped fast enough, or bounce-back if overscrolled
+    if (ctx.viewState.isDragging && !ctx.touch.longPressCrosshairLocked) {
+      if (Math.abs(ctx.pan.velocity) > 3 || Math.abs(timeScale.overscroll) > 0.1) {
+        inertia.startPan();
+      }
+    }
+
+    ctx.viewState.isDragging = false;
+    ctx.touch.longPressCrosshairLocked = false;
+    ctx.touch.lastDist = 0;
+  };
+
+  el.addEventListener("touchstart", onTouchStart, { passive: false });
+  el.addEventListener("touchmove", onTouchMove, { passive: false });
+  el.addEventListener("touchend", onTouchEnd);
+
+  return () => {
+    if (ctx.touch.longPressTimer) {
+      clearTimeout(ctx.touch.longPressTimer);
+      ctx.touch.longPressTimer = null;
+    }
+    el.removeEventListener("touchstart", onTouchStart);
+    el.removeEventListener("touchmove", onTouchMove);
+    el.removeEventListener("touchend", onTouchEnd);
+  };
+}

--- a/packages/chart/src/core/interaction/types.ts
+++ b/packages/chart/src/core/interaction/types.ts
@@ -1,0 +1,113 @@
+/**
+ * Shared types for the interaction module.
+ *
+ * The `attach()` method on `Viewport` used to be a 537-line closure that owned
+ * 9 event handlers, 2 inertia loops, and ~15 mutable variables. The handlers
+ * were tightly coupled through shared mutable state. To split them into
+ * testable units we externalize the shared state here so each handler file
+ * can take a typed reference instead of capturing local variables from the
+ * same enclosing scope.
+ */
+
+import type { HotkeyMap } from "../hotkeys";
+import type { TimeScale } from "../scale";
+import type { HotkeyAction, PaneRect } from "../types";
+
+export type ScrollbarRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+/** Public read-only viewport state (cursor, drag flag, crosshair). */
+export type ViewportState = {
+  isDragging: boolean;
+  mouseX: number;
+  mouseY: number;
+  activePaneId: string | null;
+  crosshairIndex: number | null;
+};
+
+/** Drag-related instance state shared across mouse / touch / keyboard handlers. */
+export type DragState = {
+  startX: number;
+  startIndex: number;
+  scrollbarDragging: boolean;
+  /** See Viewport._scrollbarGrabOffsetFrac for semantics. */
+  scrollbarGrabOffsetFrac: number | null;
+};
+
+/** Pane-resize gap drag state — only used by mouse handlers. */
+export type PaneResizeState = {
+  gap: number | null;
+  startY: number;
+};
+
+/** Pan inertia (touch flick + wheel handoff + bounce-back). */
+export type PanInertiaState = {
+  velocity: number;
+  raf: number | null;
+  lastTouchX: number;
+  lastTouchMoveTime: number;
+};
+
+/** Zoom inertia (trackpad pinch + wheel zoom continuation). */
+export type ZoomInertiaState = {
+  velocity: number;
+  raf: number | null;
+  lastTime: number;
+  anchorX: number | null;
+};
+
+/** Wheel-specific gesture lock + velocity tracking. */
+export type WheelGestureState = {
+  /** "pan" | "zoom" | null — locks the active gesture for ~150ms */
+  dir: "pan" | "zoom" | null;
+  timer: ReturnType<typeof setTimeout> | null;
+  panVelocity: number;
+  lastPanTime: number;
+};
+
+/** Touch-specific shared state (pinch baseline + double-tap + long-press). */
+export type TouchHandlerState = {
+  lastDist: number;
+  lastTapTime: number;
+  longPressTimer: ReturnType<typeof setTimeout> | null;
+  longPressCrosshairLocked: boolean;
+};
+
+/**
+ * Bundle handed to each interaction handler. References are shared — handlers
+ * mutate the contained state objects directly so changes are visible to other
+ * handlers and to the inertia loops.
+ */
+export type InteractionContext = {
+  // Stable dependencies (set once at attach time)
+  el: HTMLElement;
+  timeScale: TimeScale;
+  panes: () => PaneRect[];
+  scrollbar: () => ScrollbarRect | null;
+  gapAtY?: (y: number) => number | null;
+  resizePanes?: (gap: number, dy: number) => void;
+  sens: number;
+  longPressEnabled: boolean;
+  wheelInertiaEnabled: boolean;
+  hotkeyMap: HotkeyMap | undefined;
+  hotkeyDisabled: boolean;
+  dispatch?: (action: HotkeyAction) => void;
+  onUpdate: () => void;
+
+  // Mutable shared state (owned by Viewport; handed by reference)
+  viewState: ViewportState;
+  drag: DragState;
+  paneResize: PaneResizeState;
+  pan: PanInertiaState;
+  zoom: ZoomInertiaState;
+  wheel: WheelGestureState;
+  touch: TouchHandlerState;
+
+  // Scrollbar-press helpers (kept on Viewport to preserve their docstrings).
+  applyScrollbarDrag: (mouseX: number, sb: ScrollbarRect) => void;
+  beginScrollbarDrag: (mouseX: number, sb: ScrollbarRect) => void;
+};

--- a/packages/chart/src/core/interaction/utils.ts
+++ b/packages/chart/src/core/interaction/utils.ts
@@ -1,0 +1,11 @@
+import type { TimeScale } from "../scale";
+
+/** Apply rubber-band dampening: diminishing returns past the edge. */
+export function rubberBandDampen(timeScale: TimeScale): void {
+  const over = timeScale.overscroll;
+  if (over === 0) return;
+  const maxStretch = timeScale.visibleCount * 0.15;
+  const sign = over > 0 ? 1 : -1;
+  const dampened = maxStretch * (1 - 1 / (1 + Math.abs(over) / maxStretch));
+  timeScale.setStartIndexUnclamped(timeScale.clampedStartIndex + sign * dampened);
+}

--- a/packages/chart/src/core/interaction/wheel-handler.ts
+++ b/packages/chart/src/core/interaction/wheel-handler.ts
@@ -1,0 +1,116 @@
+/**
+ * Wheel interaction handler — pan / zoom + gesture direction lock + inertia handoff.
+ *
+ * Direction lock: holds "pan" or "zoom" for ~150ms after the last wheel event,
+ * but re-evaluates when the dominant axis flips so users can quickly switch.
+ *
+ * Inertia handoff: when the gesture lock expires, residual horizontal pan
+ * velocity is fed into the shared pan-inertia loop so trackpad flicks
+ * decelerate naturally instead of stopping dead. Zoom inertia is started on
+ * each frame and cancelled by the next wheel event if the gesture continues.
+ */
+
+import type { InertiaController } from "./inertia";
+import type { InteractionContext } from "./types";
+
+export function attachWheelHandlers(
+  ctx: InteractionContext,
+  inertia: InertiaController,
+): () => void {
+  const { el, timeScale, sens, wheelInertiaEnabled } = ctx;
+
+  const onWheel = (e: WheelEvent) => {
+    e.preventDefault();
+    // ctrlKey indicates trackpad pinch — always treat as zoom
+    const eventDir: "pan" | "zoom" = e.ctrlKey
+      ? "zoom"
+      : Math.abs(e.deltaX) > Math.abs(e.deltaY)
+        ? "pan"
+        : "zoom";
+
+    // Reset lock immediately if direction flipped
+    if (ctx.wheel.dir !== null && ctx.wheel.dir !== eventDir) {
+      ctx.wheel.dir = null;
+      ctx.zoom.anchorX = null;
+      inertia.stopZoom();
+    }
+
+    if (ctx.wheel.dir === null) ctx.wheel.dir = eventDir;
+
+    if (ctx.wheel.timer) clearTimeout(ctx.wheel.timer);
+    ctx.wheel.timer = setTimeout(() => {
+      ctx.wheel.dir = null;
+      // Hand residual wheel velocity to the pan-inertia loop. Falls back to
+      // bounce-back when overscrolled but not actively flicking.
+      const flick = wheelInertiaEnabled && Math.abs(ctx.wheel.panVelocity) > 3;
+      if (flick || Math.abs(timeScale.overscroll) > 0.1) {
+        inertia.stopPan();
+        ctx.pan.velocity = flick ? ctx.wheel.panVelocity : 0;
+        inertia.startPan();
+      }
+      ctx.wheel.panVelocity = 0;
+    }, 150);
+
+    if (ctx.wheel.dir === "pan") {
+      const deltaBars = e.deltaX / timeScale.barSpacing;
+      timeScale.scrollByUnclamped(deltaBars);
+      const now = performance.now();
+      const dt = now - ctx.wheel.lastPanTime;
+      // pan.velocity convention: positive = reveal past (content moves right),
+      // so invert deltaX which is positive when scrolling forward in time.
+      const sample = dt > 0 && dt < 100 ? (-e.deltaX / dt) * 16 * sens : 0;
+      if (dt > 0 && dt < 100) {
+        ctx.wheel.panVelocity = ctx.wheel.panVelocity * 0.5 + sample * 0.5;
+      } else {
+        ctx.wheel.panVelocity = sample;
+      }
+      ctx.wheel.lastPanTime = now;
+    } else {
+      // Zoom: proportional to deltaY magnitude for smooth trackpad support
+      const clampedDelta = Math.max(-50, Math.min(50, e.deltaY));
+      const zoomDelta = e.ctrlKey ? clampedDelta * 0.01 : (clampedDelta / 500) * sens;
+      const factor = 1 - zoomDelta;
+
+      const rect = el.getBoundingClientRect();
+      const mouseX = e.clientX - rect.left;
+
+      // Lock anchor on first zoom event
+      if (ctx.zoom.anchorX === null) ctx.zoom.anchorX = mouseX;
+
+      const now = performance.now();
+
+      // If inertia is running, absorb its velocity and stop it
+      if (ctx.zoom.raf !== null) {
+        cancelAnimationFrame(ctx.zoom.raf);
+        ctx.zoom.raf = null;
+      }
+
+      timeScale.zoom(factor, ctx.zoom.anchorX);
+
+      const dt = now - ctx.zoom.lastTime;
+      if (dt < 50) {
+        ctx.zoom.velocity = ctx.zoom.velocity * 0.3 + zoomDelta * 0.7;
+      } else {
+        ctx.zoom.velocity = zoomDelta;
+      }
+      ctx.zoom.lastTime = now;
+
+      // Skipped entirely when wheelInertia is off so the zoom stops the moment
+      // the user lifts their fingers.
+      if (wheelInertiaEnabled) {
+        inertia.startZoom();
+      }
+    }
+    ctx.onUpdate();
+  };
+
+  el.addEventListener("wheel", onWheel, { passive: false });
+
+  return () => {
+    if (ctx.wheel.timer) {
+      clearTimeout(ctx.wheel.timer);
+      ctx.wheel.timer = null;
+    }
+    el.removeEventListener("wheel", onWheel);
+  };
+}

--- a/packages/chart/src/core/viewport.ts
+++ b/packages/chart/src/core/viewport.ts
@@ -1,18 +1,34 @@
 /**
  * Viewport — Manages user interaction state (pan, zoom, crosshair).
  * Translates DOM events into TimeScale/PriceScale operations.
+ *
+ * The DOM event handling is delegated to the `core/interaction/` module:
+ * each input device (mouse, wheel, keyboard, touch) has its own handler file
+ * and the `attach()` method below is just the orchestrator that wires them
+ * together with a shared `InteractionContext` and `InertiaController`.
  */
 
-import { type HotkeyMap, resolveHotkey } from "./hotkeys";
+import type { HotkeyMap } from "./hotkeys";
+import { InertiaController } from "./interaction/inertia";
+import { attachKeyboardHandlers } from "./interaction/keyboard-handler";
+import { attachMouseHandlers } from "./interaction/mouse-handler";
+import { attachTouchHandlers } from "./interaction/touch-handler";
+import type {
+  DragState,
+  InteractionContext,
+  PanInertiaState,
+  PaneResizeState,
+  ScrollbarRect,
+  TouchHandlerState,
+  ViewportState,
+  WheelGestureState,
+  ZoomInertiaState,
+} from "./interaction/types";
+import { attachWheelHandlers } from "./interaction/wheel-handler";
 import type { TimeScale } from "./scale";
 import type { HotkeyAction, PaneRect } from "./types";
 
-export type ScrollbarRect = {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-};
+export type { ScrollbarRect, ViewportState } from "./interaction/types";
 
 export type ViewportAttachOptions = {
   /** Enable long-press crosshair lock on touch devices (default: true) */
@@ -25,28 +41,6 @@ export type ViewportAttachOptions = {
   onAction?: (action: HotkeyAction) => void;
 };
 
-export type ViewportState = {
-  /** Is user currently dragging */
-  isDragging: boolean;
-  /** Last mouse position in chart coordinates */
-  mouseX: number;
-  mouseY: number;
-  /** Current pane under cursor */
-  activePaneId: string | null;
-  /** Crosshair snapped index */
-  crosshairIndex: number | null;
-};
-
-/** Apply rubber-band dampening: diminishing returns past the edge. */
-function rubberBandDampen(timeScale: TimeScale): void {
-  const over = timeScale.overscroll;
-  if (over === 0) return;
-  const maxStretch = timeScale.visibleCount * 0.15;
-  const sign = over > 0 ? 1 : -1;
-  const dampened = maxStretch * (1 - 1 / (1 + Math.abs(over) / maxStretch));
-  timeScale.setStartIndexUnclamped(timeScale.clampedStartIndex + sign * dampened);
-}
-
 export class Viewport {
   private _state: ViewportState = {
     isDragging: false,
@@ -56,17 +50,20 @@ export class Viewport {
     crosshairIndex: null,
   };
 
-  private _dragStartX = 0;
-  private _dragStartIndex = 0;
-  private _scrollbarDragging = false;
-  /**
-   * When grabbing the scrollbar thumb, this holds the fraction (of scrollbar
-   * width) between the pointer and the thumb's left edge at press-time — so
-   * subsequent drag positions preserve that offset instead of centering the
-   * visible range on the pointer. `null` when the press was on the track
-   * (outside the thumb); in that case we page-jump to center on the cursor.
-   */
-  private _scrollbarGrabOffsetFrac: number | null = null;
+  private _drag: DragState = {
+    startX: 0,
+    startIndex: 0,
+    scrollbarDragging: false,
+    /**
+     * When grabbing the scrollbar thumb, this holds the fraction (of scrollbar
+     * width) between the pointer and the thumb's left edge at press-time — so
+     * subsequent drag positions preserve that offset instead of centering the
+     * visible range on the pointer. `null` when the press was on the track
+     * (outside the thumb); in that case we page-jump to center on the cursor.
+     */
+    scrollbarGrabOffsetFrac: null,
+  };
+
   private _onUpdate: (() => void) | null = null;
 
   get state(): Readonly<ViewportState> {
@@ -91,8 +88,8 @@ export class Viewport {
     const pointerFrac = (mouseX - sb.x) / sb.width;
 
     let newStart: number;
-    if (this._scrollbarGrabOffsetFrac !== null) {
-      const startFrac = pointerFrac - this._scrollbarGrabOffsetFrac;
+    if (this._drag.scrollbarGrabOffsetFrac !== null) {
+      const startFrac = pointerFrac - this._drag.scrollbarGrabOffsetFrac;
       newStart = Math.round(startFrac * total);
     } else {
       const targetCenter = Math.round(pointerFrac * total);
@@ -109,10 +106,10 @@ export class Viewport {
    * page-to-cursor (the legacy behavior).
    */
   private _beginScrollbarDrag(mouseX: number, sb: ScrollbarRect, timeScale: TimeScale): void {
-    this._scrollbarDragging = true;
+    this._drag.scrollbarDragging = true;
     const total = timeScale.totalCount;
     if (sb.width <= 0 || total <= 0) {
-      this._scrollbarGrabOffsetFrac = null;
+      this._drag.scrollbarGrabOffsetFrac = null;
       return;
     }
     const startFrac = Math.max(0, timeScale.startIndex / total);
@@ -120,9 +117,9 @@ export class Viewport {
     const thumbX = sb.x + startFrac * sb.width;
     const thumbW = Math.max(8, (endFrac - startFrac) * sb.width);
     if (mouseX >= thumbX && mouseX <= thumbX + thumbW) {
-      this._scrollbarGrabOffsetFrac = (mouseX - sb.x) / sb.width - startFrac;
+      this._drag.scrollbarGrabOffsetFrac = (mouseX - sb.x) / sb.width - startFrac;
     } else {
-      this._scrollbarGrabOffsetFrac = null;
+      this._drag.scrollbarGrabOffsetFrac = null;
       this._applyScrollbarDrag(mouseX, sb, timeScale);
     }
   }
@@ -141,7 +138,7 @@ export class Viewport {
     this._state.crosshairIndex = index;
   }
 
-  /** Attach DOM event listeners to the canvas container */
+  /** Attach DOM event listeners to the canvas container. */
   attach(
     el: HTMLElement,
     timeScale: TimeScale,
@@ -152,531 +149,65 @@ export class Viewport {
     scrollSensitivity = 0.3,
     opts?: ViewportAttachOptions,
   ): () => void {
-    const sens = Math.max(0.1, scrollSensitivity);
-    const longPressEnabled = opts?.lockOnLongPress ?? true;
-    const wheelInertiaEnabled = opts?.wheelInertia ?? true;
-    const hotkeyMap = opts?.hotkeys;
-    const hotkeyDisabled = hotkeyMap === false;
-    const resolveAction = (e: KeyboardEvent): HotkeyAction | undefined => {
-      if (hotkeyDisabled) return undefined;
-      return resolveHotkey(e, hotkeyMap || undefined);
-    };
-    const dispatch = opts?.onAction;
     // Make focusable for keyboard events
     el.tabIndex = 0;
     el.style.outline = "none";
 
-    let paneResizeGap: number | null = null;
-    let paneResizeStartY = 0;
-
-    const onMouseDown = (e: MouseEvent) => {
-      el.focus();
-      const rect = el.getBoundingClientRect();
-      const mx = e.clientX - rect.left;
-      const my = e.clientY - rect.top;
-
-      // Check pane gap hit (resize)
-      if (gapAtY) {
-        const gap = gapAtY(my);
-        if (gap !== null) {
-          paneResizeGap = gap;
-          paneResizeStartY = e.clientY;
-          return;
-        }
-      }
-
-      // Check scrollbar hit
-      const sb = scrollbar();
-      if (sb && my >= sb.y && my <= sb.y + sb.height) {
-        this._beginScrollbarDrag(mx, sb, timeScale);
-        this._onUpdate?.();
-        return;
-      }
-
-      this._state.isDragging = true;
-      this._dragStartX = e.clientX;
-      this._dragStartIndex = timeScale.startIndex;
+    const hotkeyMap = opts?.hotkeys;
+    const ctx: InteractionContext = {
+      el,
+      timeScale,
+      panes,
+      scrollbar,
+      gapAtY,
+      resizePanes,
+      sens: Math.max(0.1, scrollSensitivity),
+      longPressEnabled: opts?.lockOnLongPress ?? true,
+      wheelInertiaEnabled: opts?.wheelInertia ?? true,
+      hotkeyMap: hotkeyMap === false ? undefined : hotkeyMap,
+      hotkeyDisabled: hotkeyMap === false,
+      dispatch: opts?.onAction,
+      onUpdate: () => this._onUpdate?.(),
+      viewState: this._state,
+      drag: this._drag,
+      paneResize: { gap: null, startY: 0 },
+      pan: { velocity: 0, raf: null, lastTouchX: 0, lastTouchMoveTime: 0 },
+      zoom: { velocity: 0, raf: null, lastTime: 0, anchorX: null },
+      wheel: { dir: null, timer: null, panVelocity: 0, lastPanTime: 0 },
+      touch: {
+        lastDist: 0,
+        lastTapTime: 0,
+        longPressTimer: null,
+        longPressCrosshairLocked: false,
+      },
+      applyScrollbarDrag: (mouseX, sb) => this._applyScrollbarDrag(mouseX, sb, timeScale),
+      beginScrollbarDrag: (mouseX, sb) => this._beginScrollbarDrag(mouseX, sb, timeScale),
     };
 
-    const onMouseMove = (e: MouseEvent) => {
-      const rect = el.getBoundingClientRect();
-      this._state.mouseX = e.clientX - rect.left;
-      this._state.mouseY = e.clientY - rect.top;
+    const inertia = new InertiaController(timeScale, ctx.pan, ctx.zoom, ctx.onUpdate);
 
-      // Pane resize drag
-      if (paneResizeGap !== null && resizePanes) {
-        const delta = e.clientY - paneResizeStartY;
-        resizePanes(paneResizeGap, delta);
-        paneResizeStartY = e.clientY;
-        this._onUpdate?.();
-        return;
-      }
-
-      // Cursor style for gap hover
-      if (gapAtY) {
-        const gap = gapAtY(this._state.mouseY);
-        el.style.cursor = gap !== null ? "ns-resize" : "crosshair";
-      }
-
-      // Scrollbar drag
-      if (this._scrollbarDragging) {
-        const sb = scrollbar();
-        if (sb) this._applyScrollbarDrag(this._state.mouseX, sb, timeScale);
-        this._onUpdate?.();
-        return;
-      }
-
-      // Find active pane
-      const currentPanes = panes();
-      this._state.activePaneId = null;
-      for (const pane of currentPanes) {
-        if (this._state.mouseY >= pane.y && this._state.mouseY < pane.y + pane.height) {
-          this._state.activePaneId = pane.id;
-          break;
-        }
-      }
-
-      // Snap crosshair to nearest candle
-      this._state.crosshairIndex = timeScale.xToIndex(this._state.mouseX);
-
-      if (this._state.isDragging) {
-        const dx = e.clientX - this._dragStartX;
-        const deltaBars = -(dx / timeScale.barSpacing);
-        const rawStart = this._dragStartIndex + deltaBars;
-        timeScale.setStartIndexUnclamped(rawStart);
-        rubberBandDampen(timeScale);
-      }
-
-      this._onUpdate?.();
-    };
-
-    const onMouseUp = () => {
-      // Bounce-back if overscrolled via mouse drag
-      if (this._state.isDragging && Math.abs(timeScale.overscroll) > 0.1) {
-        stopInertia();
-        touchVelocity = 0;
-        inertiaRaf = requestAnimationFrame(runInertia);
-      }
-      this._state.isDragging = false;
-      this._scrollbarDragging = false;
-      this._scrollbarGrabOffsetFrac = null;
-      paneResizeGap = null;
-    };
-
-    const onMouseLeave = () => {
-      this._state.isDragging = false;
-      this._scrollbarDragging = false;
-      this._scrollbarGrabOffsetFrac = null;
-      this._state.crosshairIndex = null;
-      this._state.activePaneId = null;
-      this._onUpdate?.();
-    };
-
-    // Gesture direction lock: holds current direction, but re-evaluates
-    // when the dominant axis changes (allows quick pan↔zoom switching)
-    let gestureDir: "pan" | "zoom" | null = null;
-    let gestureTimer: ReturnType<typeof setTimeout> | null = null;
-    let zoomAnchorX: number | null = null;
-
-    // Zoom inertia state
-    let zoomVelocity = 0;
-    let zoomInertiaRaf: number | null = null;
-    let lastZoomTime = 0;
-
-    // Wheel pan velocity — fed into the shared touchVelocity inertia loop when
-    // the wheel gesture ends, so trackpad flicks decelerate instead of stopping dead.
-    let wheelPanVelocity = 0;
-    let lastWheelPanTime = 0;
-
-    const stopZoomInertia = () => {
-      if (zoomInertiaRaf !== null) {
-        cancelAnimationFrame(zoomInertiaRaf);
-        zoomInertiaRaf = null;
-      }
-      zoomVelocity = 0;
-    };
-
-    const runZoomInertia = () => {
-      if (Math.abs(zoomVelocity) < 0.0005) {
-        zoomInertiaRaf = null;
-        zoomAnchorX = null;
-        return;
-      }
-      const factor = 1 - zoomVelocity;
-      timeScale.zoom(factor, zoomAnchorX ?? undefined);
-      zoomVelocity *= 0.9; // Friction
-      this._onUpdate?.();
-      zoomInertiaRaf = requestAnimationFrame(runZoomInertia);
-    };
-
-    const onWheel = (e: WheelEvent) => {
-      e.preventDefault();
-      // Determine direction from this event
-      // ctrlKey indicates trackpad pinch — always treat as zoom
-      const eventDir: "pan" | "zoom" = e.ctrlKey
-        ? "zoom"
-        : Math.abs(e.deltaX) > Math.abs(e.deltaY)
-          ? "pan"
-          : "zoom";
-
-      // If direction changed, reset lock immediately
-      if (gestureDir !== null && gestureDir !== eventDir) {
-        gestureDir = null;
-        zoomAnchorX = null;
-        stopZoomInertia();
-      }
-
-      if (gestureDir === null) gestureDir = eventDir;
-
-      // Reset lock after 150ms of no wheel events (gesture ended)
-      if (gestureTimer) clearTimeout(gestureTimer);
-      gestureTimer = setTimeout(() => {
-        gestureDir = null;
-        // Hand off residual wheel velocity to the shared inertia loop.
-        // Falls back to bounce-back when overscrolled but not flicking.
-        const flick = wheelInertiaEnabled && Math.abs(wheelPanVelocity) > 3;
-        if (flick || Math.abs(timeScale.overscroll) > 0.1) {
-          stopInertia();
-          touchVelocity = flick ? wheelPanVelocity : 0;
-          inertiaRaf = requestAnimationFrame(runInertia);
-        }
-        wheelPanVelocity = 0;
-      }, 150);
-
-      if (gestureDir === "pan") {
-        // Horizontal scroll (pan) with rubber-band at edges
-        const deltaBars = e.deltaX / timeScale.barSpacing;
-        timeScale.scrollByUnclamped(deltaBars);
-        // Track velocity for inertia handoff when the gesture ends.
-        const now = performance.now();
-        const dt = now - lastWheelPanTime;
-        // touchVelocity convention: positive = reveal past (finger/content moves right),
-        // so invert deltaX which is positive when scrolling forward in time.
-        const sample = dt > 0 && dt < 100 ? (-e.deltaX / dt) * 16 * sens : 0;
-        if (dt > 0 && dt < 100) {
-          wheelPanVelocity = wheelPanVelocity * 0.5 + sample * 0.5;
-        } else {
-          wheelPanVelocity = sample;
-        }
-        lastWheelPanTime = now;
-      } else {
-        // Zoom: proportional to deltaY magnitude for smooth trackpad support
-        const clampedDelta = Math.max(-50, Math.min(50, e.deltaY));
-        const zoomDelta = e.ctrlKey ? clampedDelta * 0.01 : (clampedDelta / 500) * sens;
-        const factor = 1 - zoomDelta;
-
-        const rect = el.getBoundingClientRect();
-        const mouseX = e.clientX - rect.left;
-
-        // Lock anchor on first zoom event
-        if (zoomAnchorX === null) zoomAnchorX = mouseX;
-
-        const now = performance.now();
-
-        // If inertia is running, absorb its velocity and stop it
-        if (zoomInertiaRaf !== null) {
-          cancelAnimationFrame(zoomInertiaRaf);
-          zoomInertiaRaf = null;
-        }
-
-        timeScale.zoom(factor, zoomAnchorX);
-
-        // Blend velocity: smooth transition between active zoom and inertia
-        const dt = now - lastZoomTime;
-        if (dt < 50) {
-          // Events arriving quickly — blend with previous velocity
-          zoomVelocity = zoomVelocity * 0.3 + zoomDelta * 0.7;
-        } else {
-          zoomVelocity = zoomDelta;
-        }
-        lastZoomTime = now;
-
-        // Start inertia immediately on each frame — it will be cancelled
-        // by the next wheel event if the gesture is still active. Skipped
-        // entirely when `wheelInertia` is opted out so the zoom stops the
-        // moment the user lifts their fingers.
-        if (wheelInertiaEnabled) {
-          zoomInertiaRaf = requestAnimationFrame(runZoomInertia);
-        }
-      }
-      this._onUpdate?.();
-    };
-
-    // Keyboard shortcuts
-    const onKeyDown = (e: KeyboardEvent) => {
-      // `hotkeys: false` disables every keyboard interaction — including the
-      // built-in viewport nav (arrows, +/-, Home/End, F) and the v0.2.0
-      // drawing-tool bindings. Hosts that take over key handling themselves
-      // opt out with this single flag.
-      if (hotkeyDisabled) return;
-
-      // Configurable hotkeys (drawing tools, cancel, toggleOverlays).
-      // Resolved first so users can override the built-in Escape/Alt bindings.
-      const action = resolveAction(e);
-      if (action === "cancel") {
-        // Esc cancels every transient interaction: drag, both inertia loops,
-        // the long-press crosshair lock, and any in-progress drawing tool
-        // (delegated to the host via `dispatch`).
-        this._state.isDragging = false;
-        this._scrollbarDragging = false;
-        this._scrollbarGrabOffsetFrac = null;
-        stopInertia();
-        stopZoomInertia();
-        touchVelocity = 0;
-        wheelPanVelocity = 0;
-        longPressCrosshairLocked = false;
-        dispatch?.("cancel");
-        e.preventDefault();
-        this._onUpdate?.();
-        return;
-      }
-      if (action !== undefined) {
-        dispatch?.(action);
-        e.preventDefault();
-        this._onUpdate?.();
-        return;
-      }
-
-      switch (e.key) {
-        case "ArrowLeft":
-          timeScale.scrollBy(e.shiftKey ? -10 : -1);
-          break;
-        case "ArrowRight":
-          timeScale.scrollBy(e.shiftKey ? 10 : 1);
-          break;
-        case "+":
-        case "=":
-          timeScale.zoom(1.15);
-          break;
-        case "-":
-          timeScale.zoom(0.87);
-          break;
-        case "Home":
-          timeScale.setVisibleRange(0, timeScale.visibleCount);
-          break;
-        case "End":
-          timeScale.scrollToEnd();
-          break;
-        case "f":
-          timeScale.fitContent();
-          break;
-        default:
-          return; // Don't prevent default for unhandled keys
-      }
-      e.preventDefault();
-      this._onUpdate?.();
-    };
-
-    el.addEventListener("mousedown", onMouseDown);
-    el.addEventListener("mousemove", onMouseMove);
-    el.addEventListener("mouseup", onMouseUp);
-    el.addEventListener("mouseleave", onMouseLeave);
-    el.addEventListener("wheel", onWheel, { passive: false });
-    el.addEventListener("keydown", onKeyDown);
-
-    // Touch support with inertia, double-tap, and long-press
-    let lastTouchX = 0;
-    let lastTouchDist = 0;
-    let touchVelocity = 0;
-    let lastTouchMoveTime = 0;
-    let inertiaRaf: number | null = null;
-    let lastTapTime = 0;
-    let longPressTimer: ReturnType<typeof setTimeout> | null = null;
-    let longPressCrosshairLocked = false;
-
-    const stopInertia = () => {
-      if (inertiaRaf !== null) {
-        cancelAnimationFrame(inertiaRaf);
-        inertiaRaf = null;
-      }
-    };
-
-    const runInertia = () => {
-      const over = timeScale.overscroll;
-
-      if (Math.abs(over) > 0.1) {
-        // Bounce-back: spring toward clamped position (use raw float index)
-        const target = timeScale.clampedStartIndex;
-        const raw = timeScale.rawStartIndex;
-        const springForce = (target - raw) * 0.2;
-        timeScale.setStartIndexUnclamped(raw + springForce);
-        touchVelocity = 0;
-
-        if (Math.abs(timeScale.overscroll) < 0.5) {
-          // Close enough — snap exactly to clamped position
-          timeScale.setStartIndexUnclamped(timeScale.clampedStartIndex);
-          inertiaRaf = null;
-          this._onUpdate?.();
-          return;
-        }
-        this._onUpdate?.();
-        inertiaRaf = requestAnimationFrame(runInertia);
-        return;
-      }
-
-      if (Math.abs(touchVelocity) < 0.5) {
-        inertiaRaf = null;
-        return;
-      }
-      const deltaBars = -touchVelocity / timeScale.barSpacing;
-      timeScale.scrollByUnclamped(deltaBars);
-      touchVelocity *= 0.92;
-      this._onUpdate?.();
-      inertiaRaf = requestAnimationFrame(runInertia);
-    };
-
-    const onTouchStart = (e: TouchEvent) => {
-      stopInertia();
-      if (e.touches.length === 1) {
-        const now = Date.now();
-        const touch = e.touches[0];
-
-        // Check scrollbar hit on touch
-        const rect = el.getBoundingClientRect();
-        const touchLocalX = touch.clientX - rect.left;
-        const touchLocalY = touch.clientY - rect.top;
-        const sb = scrollbar();
-        if (sb && touchLocalY >= sb.y && touchLocalY <= sb.y + sb.height) {
-          this._beginScrollbarDrag(touchLocalX, sb, timeScale);
-          this._onUpdate?.();
-          return;
-        }
-
-        // Double-tap detection
-        if (now - lastTapTime < 300) {
-          timeScale.fitContent();
-          this._onUpdate?.();
-          lastTapTime = 0;
-          return;
-        }
-        lastTapTime = now;
-
-        // Long-press detection (disabled when option is off)
-        if (longPressEnabled) {
-          longPressTimer = setTimeout(() => {
-            longPressCrosshairLocked = true;
-            const rect = el.getBoundingClientRect();
-            this._state.crosshairIndex = timeScale.xToIndex(touch.clientX - rect.left);
-            this._onUpdate?.();
-          }, 500);
-        }
-
-        this._state.isDragging = true;
-        lastTouchX = touch.clientX;
-        lastTouchMoveTime = now;
-        touchVelocity = 0;
-        this._dragStartX = lastTouchX;
-        this._dragStartIndex = timeScale.startIndex;
-      } else if (e.touches.length === 2) {
-        // Switch from pan to pinch: cancel drag state
-        if (longPressTimer) clearTimeout(longPressTimer);
-        this._state.isDragging = false;
-        longPressCrosshairLocked = false;
-        const dx = e.touches[0].clientX - e.touches[1].clientX;
-        const dy = e.touches[0].clientY - e.touches[1].clientY;
-        lastTouchDist = Math.sqrt(dx * dx + dy * dy);
-      }
-    };
-
-    const onTouchMove = (e: TouchEvent) => {
-      e.preventDefault();
-      if (longPressTimer) {
-        clearTimeout(longPressTimer);
-        longPressTimer = null;
-      }
-
-      // Scrollbar drag (touch)
-      if (this._scrollbarDragging && e.touches.length === 1) {
-        const sbTouch = e.touches[0];
-        const rect = el.getBoundingClientRect();
-        const localX = sbTouch.clientX - rect.left;
-        const sb = scrollbar();
-        if (sb) this._applyScrollbarDrag(localX, sb, timeScale);
-        this._onUpdate?.();
-        return;
-      }
-
-      if (e.touches.length === 1 && this._state.isDragging) {
-        const now = Date.now();
-        const currentX = e.touches[0].clientX;
-
-        // Track velocity for inertia
-        const dt = now - lastTouchMoveTime;
-        if (dt > 0) {
-          touchVelocity = ((currentX - lastTouchX) / dt) * 16 * sens; // Normalize to ~60fps + sensitivity
-        }
-        lastTouchX = currentX;
-        lastTouchMoveTime = now;
-
-        // Long-press crosshair tracking
-        if (longPressCrosshairLocked) {
-          const rect = el.getBoundingClientRect();
-          this._state.crosshairIndex = timeScale.xToIndex(currentX - rect.left);
-          this._onUpdate?.();
-          return;
-        }
-
-        const dx = currentX - this._dragStartX;
-        const deltaBars = -(dx / timeScale.barSpacing);
-        const rawStart = this._dragStartIndex + deltaBars;
-        timeScale.setStartIndexUnclamped(rawStart);
-        rubberBandDampen(timeScale);
-        this._onUpdate?.();
-      } else if (e.touches.length === 2) {
-        const tdx = e.touches[0].clientX - e.touches[1].clientX;
-        const tdy = e.touches[0].clientY - e.touches[1].clientY;
-        const dist = Math.sqrt(tdx * tdx + tdy * tdy);
-        if (lastTouchDist > 0 && dist > 0) {
-          // Amplify pinch: double the zoom delta for responsive feel
-          const rawFactor = dist / lastTouchDist;
-          const amplified = 1 + (rawFactor - 1) * 2.5;
-          const midX = (e.touches[0].clientX + e.touches[1].clientX) / 2;
-          const rect = el.getBoundingClientRect();
-          timeScale.zoom(amplified, midX - rect.left);
-          this._onUpdate?.();
-        }
-        lastTouchDist = dist;
-      }
-    };
-
-    const onTouchEnd = () => {
-      if (longPressTimer) {
-        clearTimeout(longPressTimer);
-        longPressTimer = null;
-      }
-
-      // Start inertia if swiped fast enough, or bounce-back if overscrolled
-      if (this._state.isDragging && !longPressCrosshairLocked) {
-        if (Math.abs(touchVelocity) > 3 || Math.abs(timeScale.overscroll) > 0.1) {
-          inertiaRaf = requestAnimationFrame(runInertia);
-        }
-      }
-
-      this._state.isDragging = false;
-      longPressCrosshairLocked = false;
-      lastTouchDist = 0;
-    };
-
-    el.addEventListener("touchstart", onTouchStart, { passive: false });
-    el.addEventListener("touchmove", onTouchMove, { passive: false });
-    el.addEventListener("touchend", onTouchEnd);
+    const detachers = [
+      attachMouseHandlers(ctx, inertia),
+      attachWheelHandlers(ctx, inertia),
+      attachKeyboardHandlers(ctx, inertia),
+      attachTouchHandlers(ctx, inertia),
+    ];
 
     return () => {
-      // Cancel pending animations and timers to prevent memory leaks
-      stopInertia();
-      stopZoomInertia();
-      if (gestureTimer) clearTimeout(gestureTimer);
-      if (longPressTimer) clearTimeout(longPressTimer);
-
-      el.removeEventListener("mousedown", onMouseDown);
-      el.removeEventListener("mousemove", onMouseMove);
-      el.removeEventListener("mouseup", onMouseUp);
-      el.removeEventListener("mouseleave", onMouseLeave);
-      el.removeEventListener("wheel", onWheel);
-      el.removeEventListener("keydown", onKeyDown);
-      el.removeEventListener("touchstart", onTouchStart);
-      el.removeEventListener("touchmove", onTouchMove);
-      el.removeEventListener("touchend", onTouchEnd);
+      inertia.dispose();
+      for (const detach of detachers) detach();
     };
   }
 }
+
+// Re-export internal types not used here but referenced by external consumers
+// of the interaction module (tests, future plugins).
+export type {
+  DragState,
+  InteractionContext,
+  PaneResizeState,
+  PanInertiaState,
+  TouchHandlerState,
+  WheelGestureState,
+  ZoomInertiaState,
+};


### PR DESCRIPTION
## Summary
- Splits `Viewport.attach()` from a 537-line closure into per-device handler modules under `packages/chart/src/core/interaction/` (mouse / wheel / keyboard / touch).
- Consolidates pan and zoom inertia loops into a single `InertiaController` with explicit `startPan` / `stopPan` / `startZoom` / `stopZoom` / `dispose` API.
- Moves the ~15 closure-local mutable variables into typed shared state objects (`DragState`, `PanInertiaState`, `ZoomInertiaState`, `WheelGestureState`, `TouchHandlerState`, `PaneResizeState`) bundled into an `InteractionContext` that handlers receive by reference.
- `Viewport.attach()` becomes a ~50-line orchestrator. Public API is unchanged. `viewport.ts` shrinks from 683 to 211 lines.

## Why
Issue #19 — the original `attach()` had 9 nested event handlers, 2 inertia animation loops, and ~15 shared mutable variables in a single closure, making each interaction (pan / zoom / inertia / pinch / long-press) untestable in isolation. Bug surface area was high because handler ↔ handler coupling was implicit.

## Test plan
- [x] `pnpm test` (chart): 70 files / 733 tests green (was 725, +8 inertia unit tests; the 25 new characterization tests run against both pre- and post-refactor code paths).
- [x] `pnpm build` (chart): green, no type errors.
- [x] `pnpm size-check`: all entries within limits (Main 35.69/36 kB · Headless 10.66/11 kB · React 29.68/30 kB · Vue 29.91/30 kB).
- [x] `pnpm lint` (root): clean.
- [x] Manual smoke via `examples/indicator-showcase`: mouse drag pan / wheel zoom / horizontal scroll / scrollbar drag / pane resize / hotkeys / touch emulation pinch + long-press all behave identically.

## New files
- `core/interaction/types.ts` — shared types
- `core/interaction/utils.ts` — `rubberBandDampen`
- `core/interaction/inertia.ts` — `InertiaController`
- `core/interaction/{mouse,wheel,keyboard,touch}-handler.ts`
- `__tests__/viewport-attach.test.ts` — 25 characterization tests
- `__tests__/interaction-inertia.test.ts` — 8 inertia physics tests

Closes #19