### PR TITLE
feat(chart): add connectLivePrimitives for live mode plugin support (#21)

### DIFF
--- a/packages/chart/src/__tests__/connect-live-primitives.test.ts
+++ b/packages/chart/src/__tests__/connect-live-primitives.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LiveSource } from "../integration/connect-indicators";
+import { connectLivePrimitives } from "../integration/connect-live-primitives";
+import type { SourceCandle } from "../integration/helpers";
+
+// Minimal mock LiveSource — same shape as the one in connect-indicators.test.ts
+// but only the bits that connectLivePrimitives uses (on / completedCandles).
+function createMockLiveSource(initial: SourceCandle[] = []) {
+  const completedCandles: SourceCandle[] = [...initial];
+  const tickCbs: Array<
+    (p: { candle: SourceCandle; snapshot: Record<string, unknown>; isNewCandle: boolean }) => void
+  > = [];
+  const completeCbs: Array<
+    (p: { candle: SourceCandle; snapshot: Record<string, unknown> }) => void
+  > = [];
+
+  const source: LiveSource = {
+    get completedCandles() {
+      return completedCandles;
+    },
+    candle: null,
+    snapshot: {},
+    on: ((event: "tick" | "candleComplete", cb: (...args: unknown[]) => void) => {
+      if (event === "tick") {
+        tickCbs.push(cb as (typeof tickCbs)[0]);
+        return () => {
+          const i = tickCbs.indexOf(cb as (typeof tickCbs)[0]);
+          if (i >= 0) tickCbs.splice(i, 1);
+        };
+      }
+      completeCbs.push(cb as (typeof completeCbs)[0]);
+      return () => {
+        const i = completeCbs.indexOf(cb as (typeof completeCbs)[0]);
+        if (i >= 0) completeCbs.splice(i, 1);
+      };
+    }) as LiveSource["on"],
+  };
+
+  return {
+    source,
+    pushCompleted(c: SourceCandle) {
+      completedCandles.push(c);
+    },
+    emitComplete(c: SourceCandle) {
+      for (const cb of [...completeCbs]) cb({ candle: c, snapshot: {} });
+    },
+    emitTick(c: SourceCandle) {
+      for (const cb of [...tickCbs]) cb({ candle: c, snapshot: {}, isNewCandle: false });
+    },
+    completeCbCount: () => completeCbs.length,
+  };
+}
+
+const candle = (time: number, close = 100): SourceCandle =>
+  ({ time, open: close, high: close, low: close, close, volume: 1000 }) as SourceCandle;
+
+describe("connectLivePrimitives", () => {
+  it("recomputes and updates on candleComplete", () => {
+    const mock = createMockLiveSource([candle(1)]);
+    const handle = { update: vi.fn() };
+    const recompute = vi.fn((cs: readonly SourceCandle[]) => ({ count: cs.length }));
+
+    connectLivePrimitives(mock.source, [{ recompute, handle }]);
+
+    mock.pushCompleted(candle(2));
+    mock.emitComplete(candle(2));
+
+    expect(recompute).toHaveBeenCalledTimes(1);
+    expect(recompute.mock.calls[0][0]).toHaveLength(2);
+    expect(handle.update).toHaveBeenCalledWith({ count: 2 });
+  });
+
+  it("handles multiple specs independently", () => {
+    const mock = createMockLiveSource();
+    const h1 = { update: vi.fn() };
+    const h2 = { update: vi.fn() };
+    const h3 = { update: vi.fn() };
+    const r1 = vi.fn(() => "a");
+    const r2 = vi.fn(() => "b");
+    const r3 = vi.fn(() => "c");
+
+    connectLivePrimitives(mock.source, [
+      { recompute: r1, handle: h1 },
+      { recompute: r2, handle: h2 },
+      { recompute: r3, handle: h3 },
+    ]);
+
+    mock.emitComplete(candle(1));
+
+    expect(h1.update).toHaveBeenCalledWith("a");
+    expect(h2.update).toHaveBeenCalledWith("b");
+    expect(h3.update).toHaveBeenCalledWith("c");
+  });
+
+  it("does not trigger on tick events", () => {
+    const mock = createMockLiveSource();
+    const handle = { update: vi.fn() };
+    const recompute = vi.fn(() => null);
+
+    connectLivePrimitives(mock.source, [{ recompute, handle }]);
+
+    mock.emitTick(candle(1));
+
+    expect(recompute).not.toHaveBeenCalled();
+    expect(handle.update).not.toHaveBeenCalled();
+  });
+
+  it("isolates errors — one failing spec does not block others", () => {
+    const mock = createMockLiveSource();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const goodHandle = { update: vi.fn() };
+    const badRecompute = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const goodRecompute = vi.fn(() => "ok");
+
+    connectLivePrimitives(mock.source, [
+      { recompute: badRecompute, handle: { update: vi.fn() }, name: "bad" },
+      { recompute: goodRecompute, handle: goodHandle },
+    ]);
+
+    expect(() => mock.emitComplete(candle(1))).not.toThrow();
+    expect(goodHandle.update).toHaveBeenCalledWith("ok");
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("isolates errors thrown by handle.update", () => {
+    const mock = createMockLiveSource();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const goodHandle = { update: vi.fn() };
+    const badHandle = {
+      update: vi.fn(() => {
+        throw new Error("update boom");
+      }),
+    };
+
+    connectLivePrimitives(mock.source, [
+      { recompute: () => "x", handle: badHandle },
+      { recompute: () => "y", handle: goodHandle },
+    ]);
+
+    expect(() => mock.emitComplete(candle(1))).not.toThrow();
+    expect(goodHandle.update).toHaveBeenCalledWith("y");
+    errorSpy.mockRestore();
+  });
+
+  it("disconnect stops further updates and is idempotent", () => {
+    const mock = createMockLiveSource();
+    const handle = { update: vi.fn() };
+    const recompute = vi.fn(() => null);
+
+    const conn = connectLivePrimitives(mock.source, [{ recompute, handle }]);
+    expect(mock.completeCbCount()).toBe(1);
+
+    conn.disconnect();
+    expect(mock.completeCbCount()).toBe(0);
+
+    mock.emitComplete(candle(1));
+    expect(recompute).not.toHaveBeenCalled();
+
+    expect(() => conn.disconnect()).not.toThrow();
+  });
+
+  it("recomputeAll triggers all specs synchronously", () => {
+    const mock = createMockLiveSource([candle(1), candle(2)]);
+    const h1 = { update: vi.fn() };
+    const h2 = { update: vi.fn() };
+
+    const conn = connectLivePrimitives(mock.source, [
+      { recompute: (cs) => cs.length, handle: h1 },
+      { recompute: () => "fixed", handle: h2 },
+    ]);
+
+    conn.recomputeAll();
+
+    expect(h1.update).toHaveBeenCalledWith(2);
+    expect(h2.update).toHaveBeenCalledWith("fixed");
+  });
+
+  it("accepts mixed specs with different T (compile-time check)", () => {
+    // Regression for codex review P1: the `specs` parameter must preserve
+    // per-element generic so strongly-typed plugin handles type-check.
+    const mock = createMockLiveSource();
+    const numHandle: { update: (n: number) => void } = { update: vi.fn() };
+    const arrHandle: { update: (a: string[]) => void } = { update: vi.fn() };
+    const objHandle: { update: (o: { count: number }) => void } = { update: vi.fn() };
+
+    // If this compiles, the public signature accepts heterogeneous specs.
+    connectLivePrimitives(mock.source, [
+      { recompute: () => 42, handle: numHandle },
+      { recompute: () => ["a", "b"], handle: arrHandle },
+      { recompute: (cs) => ({ count: cs.length }), handle: objHandle },
+    ]);
+
+    mock.emitComplete(candle(1));
+    expect(numHandle.update).toHaveBeenCalledWith(42);
+    expect(arrHandle.update).toHaveBeenCalledWith(["a", "b"]);
+    expect(objHandle.update).toHaveBeenCalledWith({ count: 0 });
+  });
+
+  it("recomputeAll after disconnect is a no-op", () => {
+    const mock = createMockLiveSource([candle(1)]);
+    const handle = { update: vi.fn() };
+    const conn = connectLivePrimitives(mock.source, [{ recompute: () => null, handle }]);
+    conn.disconnect();
+    conn.recomputeAll();
+    expect(handle.update).not.toHaveBeenCalled();
+  });
+});

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -123,6 +123,15 @@ export { DrawHelper, type StrokeStyle, type FillStyle } from "./core/draw-helper
 // Unified indicator connection
 export { connectIndicators, defineIndicator } from "./integration/connect-indicators";
 
+// Live mode for primitive plugins (S/R Zones, SMC, Wyckoff, Kill Zones, Regime
+// Heatmap, etc.) — recompute on candleComplete and push to handle.update().
+export { connectLivePrimitives } from "./integration/connect-live-primitives";
+export type {
+  LivePrimitiveSpec,
+  LivePrimitiveHandle,
+  LivePrimitivesConnection,
+} from "./integration/connect-live-primitives";
+
 // Drawing auto-injection helpers — convert indicator output (fibs / trendlines / channels)
 // into built-in Drawing objects without needing a dedicated primitive plugin.
 export {

--- a/packages/chart/src/integration/connect-live-primitives.ts
+++ b/packages/chart/src/integration/connect-live-primitives.ts
@@ -1,0 +1,113 @@
+/**
+ * connectLivePrimitives — drive primitive plugins (S/R Zones, SMC, Wyckoff,
+ * Kill Zones, Regime Heatmap, etc.) from a LiveSource by recomputing their
+ * data on `candleComplete` and pushing the result to the plugin handle's
+ * `update()` method.
+ *
+ * Primitives use `chart.registerPrimitive()` instead of `chart.addIndicator()`,
+ * so they're invisible to {@link connectIndicators}'s live event loop. Until
+ * each primitive grows an incremental factory, this helper provides a simple
+ * batch-recompute fallback: O(N) per candle, but plugins only fire on
+ * candleComplete so the cost is bounded.
+ *
+ * @example
+ * ```ts
+ * import { connectIndicators, connectLivePrimitives, connectSrConfluence, srZones } from "@trendcraft/chart";
+ *
+ * const conn = connectIndicators(chart, { presets, candles, live: source });
+ * const sr = connectSrConfluence(chart, srZones(source.completedCandles));
+ *
+ * const live = connectLivePrimitives(source, [
+ *   { recompute: (candles) => srZones(candles), handle: sr, name: "sr" },
+ * ]);
+ *
+ * // later
+ * live.disconnect();
+ * conn.disconnect();
+ * ```
+ */
+
+import type { LiveSource } from "./connect-indicators";
+import type { SourceCandle } from "./helpers";
+
+/**
+ * One primitive plugin to keep in sync with a {@link LiveSource}. The handle's
+ * {@link LivePrimitiveHandle.update} method is called with the result of
+ * `recompute(source.completedCandles)` on every candleComplete event.
+ */
+export type LivePrimitiveSpec<T = unknown> = {
+  /** Recompute the primitive's data from the current candle history. */
+  recompute: (candles: readonly SourceCandle[]) => T;
+  /** Plugin handle whose `update(data)` will be called with the recomputed result. */
+  handle: LivePrimitiveHandle<T>;
+  /** Optional name used in error logs to help identify which spec failed. */
+  name?: string;
+};
+
+/** Minimal duck-typed shape of a primitive plugin handle (e.g. from `connectSrConfluence`). */
+export type LivePrimitiveHandle<T> = {
+  update: (data: T) => void;
+};
+
+export type LivePrimitivesConnection = {
+  /** Disconnect from candleComplete events. Idempotent. */
+  disconnect(): void;
+  /**
+   * Manually trigger a recompute of all specs. Useful right after construction
+   * to seed handles with the current history, or after host code has mutated
+   * `source.completedCandles` outside the live event flow.
+   * No-op once `disconnect()` has been called.
+   */
+  recomputeAll(): void;
+};
+
+export function connectLivePrimitives(
+  source: LiveSource,
+  // Per-spec T must vary across the array; `unknown` would force every
+  // handle.update to accept unknown and break strongly-typed plugin handles
+  // (e.g. `connectSrConfluence().update`).
+  // biome-ignore lint/suspicious/noExplicitAny: see comment above
+  specs: readonly LivePrimitiveSpec<any>[],
+): LivePrimitivesConnection {
+  let connected = true;
+
+  const runSpecs = (candles: readonly SourceCandle[]): void => {
+    for (const spec of specs) {
+      let value: unknown;
+      try {
+        value = spec.recompute(candles);
+      } catch (e) {
+        console.error(
+          `[@trendcraft/chart] connectLivePrimitives recompute error${spec.name ? ` (${spec.name})` : ""}:`,
+          e,
+        );
+        continue;
+      }
+      try {
+        spec.handle.update(value);
+      } catch (e) {
+        console.error(
+          `[@trendcraft/chart] connectLivePrimitives handle.update error${spec.name ? ` (${spec.name})` : ""}:`,
+          e,
+        );
+      }
+    }
+  };
+
+  const unsub = source.on("candleComplete", () => {
+    if (!connected) return;
+    runSpecs(source.completedCandles);
+  });
+
+  return {
+    disconnect(): void {
+      if (!connected) return;
+      connected = false;
+      unsub();
+    },
+    recomputeAll(): void {
+      if (!connected) return;
+      runSpecs(source.completedCandles);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a generic helper `connectLivePrimitives(source, specs)` that drives primitive plugins (S/R Zones, SMC, Wyckoff Phases, Kill Zones, Regime Heatmap, etc.) from a `LiveSource` by recomputing their data on `candleComplete` and pushing the result to each plugin handle's `update()` method.
- Each spec pairs a `recompute(candles)` function with a `LivePrimitiveHandle<T>`. Errors in one spec's recompute or update are isolated via try/catch so they don't break sibling specs.
- Tick events are intentionally ignored — these plugins all visualize completed-candle structure, so per-tick recomputation would just burn CPU. Future tick support can be added as an opt-in option.
- The signature uses `LivePrimitiveSpec<any>[]` for the array parameter to preserve each spec's per-element generic; widening to `LivePrimitiveSpec<unknown>[]` would break strongly-typed plugin handles like `connectSrConfluence().update(zones: SrZoneData[])` under TypeScript strict mode.

## Why
Issue #21 — the 9 differentiation primitive plugins (`killZones`, `wyckoffPhases`, `vsa`, `srZones`, `orderBlock`, `fairValueGap`, `liquiditySweep`, `breakOfStructure`, `hmmRegimes`) currently only work in static/batch mode. `connectIndicators({ live })` only updates series, not primitives. This is the short-term batch-recompute approach; long-term incremental factories remain a separate roadmap item.

## Scope notes
- **No plugin files were modified.** Each `connectXxx()` already exposes a `.update(newData)` handle that this helper drives. New ergonomic surface only.
- Adds `connectLivePrimitives` + `LivePrimitiveSpec` + `LivePrimitiveHandle` + `LivePrimitivesConnection` to the public API (`src/index.ts`).
- Visual verification (running differentiation plugins against a live-simulated candle stream in `indicator-showcase`) is tracked separately and will land as a follow-up PR; this PR is API + unit tests only.

## Test plan
- [x] `pnpm test` (chart): 71 files / 742 tests green (was 733, +9 new tests).
- [x] `pnpm build` (chart): green, no type errors.
- [x] `pnpm size-check`: all entries within limits (Main 35.76/36 kB · Headless 10.66/11 kB · React 29.71/30 kB · Vue 29.91/30 kB).
- [x] `pnpm lint` (root): clean.
- [x] Codex review: P1 (generic erasure on `specs`) caught and fixed in this PR; regression test included.

Closes #21