### PR TITLE
feat(showcase): add Live Simulate mode to indicator-showcase

### DIFF
--- a/packages/chart/examples/indicator-showcase/src/live-panel.ts
+++ b/packages/chart/examples/indicator-showcase/src/live-panel.ts
@@ -1,0 +1,225 @@
+/**
+ * Live Panel — sidebar dock UI for the showcase Live Mode.
+ *
+ * Layout (top to bottom):
+ *   - Mode pill: [Static] | [Live]    (mutually exclusive)
+ *   - When Live is active:
+ *       Play/Pause toggle
+ *       Speed presets [1x] [4x] [16x]
+ *       Progress bar
+ *       Reset button
+ *
+ * The panel doesn't own a simulator — `bindSimulator(sim)` wires the controls
+ * to a live `SimulatorHandle`, and is called by `main.ts` after instantiating
+ * the simulator on mode change.
+ */
+
+import type { SimulatorHandle, SimulatorState } from "./live-simulator";
+
+export type Mode = "static" | "live";
+
+export type LivePanelHandle = {
+  destroy(): void;
+  /** Wire the panel's controls to a simulator. Pass `null` to detach. */
+  bindSimulator(sim: SimulatorHandle | null): void;
+  /** Programmatically set the mode (e.g. on initial mount). */
+  setMode(mode: Mode): void;
+};
+
+const SPEED_PRESETS: { label: string; ms: number }[] = [
+  { label: "1×", ms: 250 },
+  { label: "4×", ms: 63 },
+  { label: "16×", ms: 16 },
+];
+
+export function createLivePanel(
+  container: HTMLElement,
+  opts: {
+    onModeChange: (mode: Mode) => void;
+    /**
+     * Called when the user clicks Reset. The host should rebuild the live
+     * pipeline (dispose simulator + chart + connections, then re-mount in
+     * Live mode) — resetting just the simulator strands the chart and the
+     * existing connectIndicators / connectLivePrimitives subscriptions on
+     * the disposed LiveCandle.
+     */
+    onReset?: () => void;
+  },
+): LivePanelHandle {
+  let mode: Mode = "static";
+  let sim: SimulatorHandle | null = null;
+  let unsubChange: (() => void) | null = null;
+  let activeSpeedIdx = 0;
+
+  // Root
+  const root = document.createElement("div");
+  root.style.cssText =
+    "padding:10px 12px;border-bottom:1px solid #2a2e39;background:#1a1d28;flex-shrink:0;";
+
+  // Header label
+  const header = document.createElement("div");
+  header.style.cssText =
+    "font-size:11px;font-weight:700;color:#787b86;letter-spacing:0.5px;text-transform:uppercase;margin-bottom:8px;";
+  header.textContent = "Mode";
+  root.appendChild(header);
+
+  // Mode pill
+  const pill = document.createElement("div");
+  pill.style.cssText =
+    "display:flex;background:#131722;border:1px solid #2a2e39;border-radius:6px;overflow:hidden;margin-bottom:10px;";
+  const staticBtn = makeSegBtn("Static", true);
+  const liveBtn = makeSegBtn("Live", false);
+  pill.appendChild(staticBtn);
+  pill.appendChild(liveBtn);
+  root.appendChild(pill);
+
+  staticBtn.addEventListener("click", () => setMode("static"));
+  liveBtn.addEventListener("click", () => setMode("live"));
+
+  // Live controls (hidden when mode = static)
+  const controls = document.createElement("div");
+  controls.style.cssText = "display:none;flex-direction:column;gap:8px;";
+  root.appendChild(controls);
+
+  // Play/Pause row
+  const playPauseBtn = document.createElement("button");
+  playPauseBtn.textContent = "▶ Play";
+  playPauseBtn.style.cssText = controlBtnCss();
+  controls.appendChild(playPauseBtn);
+  playPauseBtn.addEventListener("click", () => {
+    if (!sim) return;
+    if (sim.getState() === "playing") sim.pause();
+    else sim.play();
+  });
+
+  // Speed row
+  const speedRow = document.createElement("div");
+  speedRow.style.cssText = "display:flex;gap:4px;align-items:center;";
+  const speedLabel = document.createElement("span");
+  speedLabel.textContent = "Speed";
+  speedLabel.style.cssText = "font-size:11px;color:#787b86;flex-shrink:0;width:42px;";
+  speedRow.appendChild(speedLabel);
+  const speedBtns: HTMLButtonElement[] = SPEED_PRESETS.map((preset, idx) => {
+    const b = document.createElement("button");
+    b.textContent = preset.label;
+    b.style.cssText = segBtnCss(idx === 0);
+    b.addEventListener("click", () => {
+      activeSpeedIdx = idx;
+      speedBtns.forEach((sb, i) => {
+        sb.style.cssText = segBtnCss(i === idx);
+      });
+      sim?.setIntervalMs(preset.ms);
+    });
+    speedRow.appendChild(b);
+    return b;
+  });
+  controls.appendChild(speedRow);
+
+  // Progress bar
+  const progressWrap = document.createElement("div");
+  progressWrap.style.cssText =
+    "height:6px;background:#131722;border:1px solid #2a2e39;border-radius:3px;overflow:hidden;position:relative;";
+  const progressFill = document.createElement("div");
+  progressFill.style.cssText =
+    "height:100%;width:0;background:linear-gradient(90deg,#2196F3,#26a69a);transition:width 0.05s linear;";
+  progressWrap.appendChild(progressFill);
+  controls.appendChild(progressWrap);
+
+  // State label
+  const stateLabel = document.createElement("div");
+  stateLabel.style.cssText = "font-size:10px;color:#787b86;text-align:center;";
+  stateLabel.textContent = "idle";
+  controls.appendChild(stateLabel);
+
+  // Reset
+  const resetBtn = document.createElement("button");
+  resetBtn.textContent = "↺ Reset";
+  resetBtn.style.cssText = controlBtnCss();
+  controls.appendChild(resetBtn);
+  resetBtn.addEventListener("click", () => {
+    if (opts.onReset) opts.onReset();
+    else sim?.reset();
+  });
+
+  container.appendChild(root);
+
+  function setMode(next: Mode): void {
+    if (mode === next) return;
+    mode = next;
+    staticBtn.style.cssText = segBtnCss(mode === "static");
+    liveBtn.style.cssText = segBtnCss(mode === "live");
+    controls.style.display = mode === "live" ? "flex" : "none";
+    opts.onModeChange(mode);
+  }
+
+  function refreshFromSim(state: SimulatorState, progress: number): void {
+    progressFill.style.width = `${(progress * 100).toFixed(1)}%`;
+    stateLabel.textContent = state;
+    if (state === "playing") {
+      playPauseBtn.textContent = "⏸ Pause";
+      playPauseBtn.disabled = false;
+    } else if (state === "complete") {
+      playPauseBtn.textContent = "▶ Play";
+      playPauseBtn.disabled = true;
+      playPauseBtn.style.opacity = "0.5";
+    } else {
+      playPauseBtn.textContent = "▶ Play";
+      playPauseBtn.disabled = false;
+      playPauseBtn.style.opacity = "1";
+    }
+  }
+
+  return {
+    destroy(): void {
+      unsubChange?.();
+      unsubChange = null;
+      sim = null;
+      root.remove();
+    },
+    bindSimulator(next): void {
+      unsubChange?.();
+      unsubChange = null;
+      sim = next;
+      if (sim) {
+        // sync initial speed to currently selected preset
+        sim.setIntervalMs(SPEED_PRESETS[activeSpeedIdx].ms);
+        unsubChange = sim.onChange(refreshFromSim);
+        refreshFromSim(sim.getState(), sim.getProgress());
+      } else {
+        progressFill.style.width = "0%";
+        stateLabel.textContent = "idle";
+        playPauseBtn.textContent = "▶ Play";
+        playPauseBtn.disabled = false;
+        playPauseBtn.style.opacity = "1";
+      }
+    },
+    setMode,
+  };
+}
+
+// --- styling helpers ---
+
+function makeSegBtn(label: string, active: boolean): HTMLButtonElement {
+  const b = document.createElement("button");
+  b.textContent = label;
+  b.style.cssText = segBtnCss(active);
+  return b;
+}
+
+function segBtnCss(active: boolean): string {
+  return `
+    flex:1;padding:6px 12px;font-size:12px;font-weight:600;
+    border:none;cursor:pointer;
+    background:${active ? "#2196F3" : "transparent"};
+    color:${active ? "#fff" : "#d1d4dc"};
+    transition:background 0.15s;
+  `;
+}
+
+function controlBtnCss(): string {
+  return `
+    width:100%;padding:6px 12px;font-size:12px;
+    background:#2a2e39;border:1px solid #363a45;border-radius:4px;
+    color:#d1d4dc;cursor:pointer;
+  `;
+}

--- a/packages/chart/examples/indicator-showcase/src/live-simulator.ts
+++ b/packages/chart/examples/indicator-showcase/src/live-simulator.ts
@@ -1,0 +1,195 @@
+/**
+ * Live Simulator — drives a `createLiveCandle` instance from a static candle
+ * array on a timer, splitting each pending candle into N intra-candle ticks
+ * before the final candleComplete.
+ *
+ * Used by the showcase Live Mode to demonstrate `connectIndicators({ live })`
+ * (series indicators) and `connectLivePrimitives` (primitive plugins) against
+ * a deterministic, replayable stream.
+ */
+
+import { type NormalizedCandle, createLiveCandle } from "trendcraft";
+
+type LiveCandle = ReturnType<typeof createLiveCandle>;
+
+/** Duck-typed LiveSource — same shape `connectIndicators` and `connectLivePrimitives` expect. */
+export type LiveSource = Pick<
+  LiveCandle,
+  "completedCandles" | "candle" | "snapshot" | "on" | "addIndicator" | "removeIndicator"
+>;
+
+export type SimulatorState = "idle" | "playing" | "paused" | "complete";
+
+export type SimulatorHandle = {
+  /** Pass to `connectIndicators({ live })` and `connectLivePrimitives`. */
+  readonly live: LiveSource;
+  /** Initial seed history loaded into the LiveCandle. */
+  readonly seedCandles: readonly NormalizedCandle[];
+  getState(): SimulatorState;
+  /** 0..1 progress across the queued (= post-seed) candles. */
+  getProgress(): number;
+  play(): void;
+  pause(): void;
+  /** Inter-frame interval in ms. Default 250 (= 1x). */
+  setIntervalMs(ms: number): void;
+  /** Rewind to seed-only. Cancels playback. Note: replaces the LiveCandle
+   * instance — callers that captured `live` directly should re-read it. */
+  reset(): void;
+  /** Subscribe to state/progress changes. Returns unsubscribe. */
+  onChange(cb: (state: SimulatorState, progress: number) => void): () => void;
+  dispose(): void;
+};
+
+export type SimulatorOptions = {
+  candles: readonly NormalizedCandle[];
+  /** Fraction of `candles` to load as seed before playback starts. Default 0.6. */
+  seedRatio?: number;
+  /** Number of partial ticks emitted before each candleComplete. Default 5. */
+  ticksPerCandle?: number;
+  /** Initial inter-frame interval in ms. Default 250. */
+  intervalMs?: number;
+};
+
+export function createLiveSimulator(opts: SimulatorOptions): SimulatorHandle {
+  const candles = opts.candles;
+  const seedRatio = clamp(opts.seedRatio ?? 0.6, 0.05, 0.95);
+  const ticksPerCandle = Math.max(1, opts.ticksPerCandle ?? 5);
+  let intervalMs = Math.max(8, opts.intervalMs ?? 250);
+
+  const seedEnd = Math.max(1, Math.floor(candles.length * seedRatio));
+  const seedCandles = candles.slice(0, seedEnd);
+  const queue = candles.slice(seedEnd);
+
+  let live: LiveCandle = makeLive(seedCandles);
+  let nextIdx = 0;
+  let tickIdx = 0;
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let state: SimulatorState = queue.length === 0 ? "complete" : "idle";
+  const listeners = new Set<(s: SimulatorState, p: number) => void>();
+
+  function makeLive(seed: readonly NormalizedCandle[]): LiveCandle {
+    // Note: pass an empty `history` and populate `completedCandles` via
+    // addCandle() instead. That way indicators registered AFTER construction
+    // (via connect-indicators' factory path) warm up exactly once from
+    // _completedCandles. Passing both `history: seed` AND addCandle(seed)
+    // would double-count seed bars in warmUpIndicator.
+    const lc = createLiveCandle({});
+    for (const c of seed) lc.addCandle(c);
+    return lc;
+  }
+
+  function getProgress(): number {
+    if (queue.length === 0) return 1;
+    const partial = tickIdx / ticksPerCandle;
+    return Math.min(1, (nextIdx + partial) / queue.length);
+  }
+
+  function notify(): void {
+    const p = getProgress();
+    for (const cb of listeners) cb(state, p);
+  }
+
+  function step(): void {
+    if (state !== "playing") return;
+    if (nextIdx >= queue.length) {
+      state = "complete";
+      stopTimer();
+      notify();
+      return;
+    }
+    const target = queue[nextIdx];
+
+    if (tickIdx < ticksPerCandle - 1) {
+      live.addCandle(buildPartial(target, tickIdx + 1, ticksPerCandle), { partial: true });
+      tickIdx++;
+    } else {
+      live.addCandle(target);
+      nextIdx++;
+      tickIdx = 0;
+    }
+    notify();
+  }
+
+  function startTimer(): void {
+    stopTimer();
+    timer = setInterval(step, intervalMs);
+  }
+
+  function stopTimer(): void {
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  const handle: SimulatorHandle = {
+    get live(): LiveSource {
+      return live;
+    },
+    seedCandles,
+    getState: () => state,
+    getProgress,
+    play(): void {
+      if (state === "complete" || state === "playing") return;
+      state = "playing";
+      startTimer();
+      notify();
+    },
+    pause(): void {
+      if (state !== "playing") return;
+      state = "paused";
+      stopTimer();
+      notify();
+    },
+    setIntervalMs(ms: number): void {
+      intervalMs = Math.max(8, ms);
+      if (state === "playing") startTimer();
+    },
+    reset(): void {
+      stopTimer();
+      live.dispose();
+      live = makeLive(seedCandles);
+      nextIdx = 0;
+      tickIdx = 0;
+      state = queue.length === 0 ? "complete" : "idle";
+      notify();
+    },
+    onChange(cb): () => void {
+      listeners.add(cb);
+      return () => {
+        listeners.delete(cb);
+      };
+    },
+    dispose(): void {
+      stopTimer();
+      live.dispose();
+      listeners.clear();
+    },
+  };
+
+  return handle;
+}
+
+/** Build the i-th synthetic intra-candle snapshot toward `target` (i in 1..N-1). */
+function buildPartial(target: NormalizedCandle, i: number, N: number): NormalizedCandle {
+  const frac = i / N;
+  const close = target.open + (target.close - target.open) * frac;
+  const partialHigh = Math.max(
+    target.open,
+    close,
+    target.open + (target.high - target.open) * frac,
+  );
+  const partialLow = Math.min(target.open, close, target.open + (target.low - target.open) * frac);
+  return {
+    time: target.time,
+    open: target.open,
+    high: partialHigh,
+    low: partialLow,
+    close,
+    volume: target.volume * frac,
+  };
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}

--- a/packages/chart/examples/indicator-showcase/src/main.ts
+++ b/packages/chart/examples/indicator-showcase/src/main.ts
@@ -17,6 +17,8 @@ import { indicatorPresets } from "trendcraft";
 import type { NormalizedCandle } from "trendcraft";
 import dailySampleData from "../../simple-chart/data.json";
 import { generateIntradayCandles } from "./data-intraday";
+import { type LivePanelHandle, type Mode, createLivePanel } from "./live-panel";
+import { type SimulatorHandle, createLiveSimulator } from "./live-simulator";
 import { type PluginsPanelHandle, createPluginsPanel } from "./plugins-panel";
 import type { SidebarEntry } from "./sidebar";
 import { createSidebar } from "./sidebar";
@@ -59,17 +61,32 @@ registerTrendCraftPresets(chart);
 // ============================================
 
 let currentTimeframe: Timeframe = "daily";
+let currentMode: Mode = "static";
 let currentCandles: NormalizedCandle[] = dailyCandles;
 let conn: IndicatorConnection;
 let pluginsPanel: PluginsPanelHandle;
 let signalsPanel: SignalsPanelHandle;
+let livePanel: LivePanelHandle | null = null;
+let simulator: SimulatorHandle | null = null;
 
-function mount(timeframe: Timeframe): void {
+function mount(timeframe: Timeframe, mode: Mode): void {
   currentTimeframe = timeframe;
+  currentMode = mode;
   currentCandles = timeframe === "daily" ? dailyCandles : intradayCandles;
 
-  chart.setCandles(currentCandles);
-  conn = connectIndicators(chart, { presets: indicatorPresets, candles: currentCandles });
+  if (mode === "live") {
+    simulator = createLiveSimulator({ candles: currentCandles });
+    chart.setCandles(simulator.seedCandles as NormalizedCandle[]);
+    conn = connectIndicators(chart, {
+      presets: indicatorPresets,
+      candles: simulator.seedCandles,
+      live: simulator.live,
+    });
+  } else {
+    simulator = null;
+    chart.setCandles(currentCandles);
+    conn = connectIndicators(chart, { presets: indicatorPresets, candles: currentCandles });
+  }
 
   // Sidebar is rebuilt from scratch — its DOM/state are reset by createSidebar.
   // We still need to wipe the container because the plugins panel is a sibling
@@ -116,15 +133,50 @@ function mount(timeframe: Timeframe): void {
   });
 
   const scrollSlot = sidebarAPI.getScrollSlot();
-  pluginsPanel = createPluginsPanel(scrollSlot, currentCandles, chart);
+  // Live panel goes ABOVE the indicator list and other panels (mounted before
+  // the scroll slot's existing children so it's always visible at the top).
+  livePanel = createLivePanel(scrollSlot, {
+    onModeChange(next) {
+      if (next === currentMode) return;
+      const tf = currentTimeframe;
+      unmount();
+      mount(tf, next);
+    },
+    onReset() {
+      // Rebuild the entire live pipeline. simulator.reset() alone would strand
+      // the chart at its streamed state and leave conn/livePrimsConn subscribed
+      // to the disposed LiveCandle.
+      const tf = currentTimeframe;
+      unmount();
+      mount(tf, "live");
+    },
+  });
+  livePanel.setMode(currentMode);
+  // Re-attach the live panel root as the first child of scrollSlot so it sits
+  // above the (later-appended) plugins / signals panels and the indicator list.
+  // (The list itself was inserted before the panel was created, so prepending
+  // here puts the live panel at the top of the scroll viewport.)
+  if (scrollSlot.firstChild && scrollSlot.firstChild !== scrollSlot.lastChild) {
+    scrollSlot.prepend(scrollSlot.lastChild as Node);
+  }
+  pluginsPanel = createPluginsPanel(scrollSlot, currentCandles, chart, {
+    live: simulator?.live,
+  });
   signalsPanel = createSignalsPanel(scrollSlot, currentCandles, chart);
+  if (mode === "live" && simulator) {
+    livePanel.bindSimulator(simulator);
+  }
   chart.fitContent();
 }
 
 function unmount(): void {
   signalsPanel?.destroy();
   pluginsPanel?.destroy();
+  livePanel?.destroy();
+  livePanel = null;
   conn?.disconnect();
+  simulator?.dispose();
+  simulator = null;
 }
 
 /** Resolve special-case params for specific indicators */
@@ -135,7 +187,7 @@ function resolveParams(id: string, params: Record<string, unknown>): Record<stri
   return params;
 }
 
-mount("daily");
+mount("daily", "static");
 
 // ============================================
 // Toolbar Controls
@@ -145,8 +197,9 @@ mount("daily");
 const timeframeBtn = document.getElementById("btn-timeframe") as HTMLElement;
 timeframeBtn.addEventListener("click", () => {
   const next: Timeframe = currentTimeframe === "daily" ? "intraday" : "daily";
+  const mode = currentMode;
   unmount();
-  mount(next);
+  mount(next, mode);
   timeframeBtn.textContent = next === "daily" ? "Daily" : "1H";
 });
 

--- a/packages/chart/examples/indicator-showcase/src/plugins-panel.ts
+++ b/packages/chart/examples/indicator-showcase/src/plugins-panel.ts
@@ -6,11 +6,16 @@
  * Each entry computes its data from the current candles on toggle and
  * connects the plugin. The panel can be rebuilt against a new candle set
  * (e.g. daily ↔ intraday switch) via `destroy()` + re-create.
+ *
+ * Live mode: when `opts.live` is provided, every active plugin is also
+ * driven by `connectLivePrimitives` so it recomputes on every candleComplete
+ * event from the live source.
  */
 
-import type { ChartInstance } from "@trendcraft/chart";
+import type { ChartInstance, LivePrimitivesConnection } from "@trendcraft/chart";
 import {
   connectAndrewsPitchfork,
+  connectLivePrimitives,
   connectMarketProfile,
   connectRegimeHeatmap,
   connectSessionZones,
@@ -33,14 +38,30 @@ import {
   vsa,
   wyckoffPhases,
 } from "trendcraft";
+import type { LiveSource } from "./live-simulator";
 
-type PluginHandle = { remove: () => void };
+// Per-plugin update signatures vary (zones[], smc sources, regime data, etc.).
+// Each spec pairs the matching `recompute` shape with its own handle, so
+// widening here is safe.
+type PluginHandle = {
+  remove: () => void;
+  // biome-ignore lint/suspicious/noExplicitAny: see comment above
+  update: (data: any) => void;
+};
 
+/**
+ * One plugin spec — produces both a handle and the recompute closure that
+ * the live wiring can call on every candleComplete.
+ */
 type PluginSpec = {
   id: string;
   label: string;
   description: string;
-  connect: (candles: NormalizedCandle[]) => PluginHandle | null;
+  /** Returns null when the candle history can't satisfy the plugin (e.g. <3 swings). */
+  build: (candles: NormalizedCandle[]) => {
+    handle: PluginHandle;
+    recompute: (cs: readonly NormalizedCandle[]) => unknown;
+  } | null;
 };
 
 export type PluginsPanelHandle = {
@@ -53,9 +74,12 @@ const SPECS: PluginSpec[] = [
     id: "srConfluence",
     label: "S/R Confluence",
     description: "Multi-source support/resistance zones",
-    connect: (candles) => {
-      const { zones } = srZones(candles);
-      return connectSrConfluence(chartRef, zones);
+    build: (candles) => {
+      const handle = connectSrConfluence(chartRef, srZones(candles).zones);
+      return {
+        handle: handle as PluginHandle,
+        recompute: (cs) => srZones(cs as NormalizedCandle[]).zones,
+      };
     },
   },
   {
@@ -63,63 +87,122 @@ const SPECS: PluginSpec[] = [
     label: "SMC Layer (bundle)",
     description:
       "OB + FVG + Sweeps in one pass — use the individual SMC presets for per-indicator params",
-    connect: (candles) =>
-      connectSmcLayer(chartRef, {
+    build: (candles) => {
+      const sources = {
         orderBlocks: orderBlock(candles),
         fvgs: fairValueGap(candles),
         sweeps: liquiditySweep(candles),
-      }),
+      };
+      const handle = connectSmcLayer(chartRef, sources);
+      return {
+        handle: handle as PluginHandle,
+        recompute: (cs) => {
+          const arr = cs as NormalizedCandle[];
+          return {
+            orderBlocks: orderBlock(arr),
+            fvgs: fairValueGap(arr),
+            sweeps: liquiditySweep(arr),
+          };
+        },
+      };
+    },
   },
   {
     id: "regimeHeatmap",
     label: "Regime Heatmap",
     description: "HMM-classified market regime background",
-    connect: (candles) => connectRegimeHeatmap(chartRef, hmmRegimes(candles)),
+    build: (candles) => {
+      const handle = connectRegimeHeatmap(chartRef, hmmRegimes(candles));
+      return {
+        handle: handle as PluginHandle,
+        recompute: (cs) => hmmRegimes(cs as NormalizedCandle[]),
+      };
+    },
   },
   {
     id: "wyckoffPhase",
     label: "Wyckoff Phase",
     description: "Range boxes + PS/SC/SOS/... event labels + phase badge",
-    connect: (candles) =>
-      connectWyckoffPhase(chartRef, {
+    build: (candles) => {
+      const handle = connectWyckoffPhase(chartRef, {
         phases: wyckoffPhases(candles),
         vsa: vsa(candles),
         candles,
-      }),
+      });
+      return {
+        handle: handle as PluginHandle,
+        recompute: (cs) => {
+          const arr = cs as NormalizedCandle[];
+          return {
+            phases: wyckoffPhases(arr),
+            vsa: vsa(arr),
+            candles: arr,
+          };
+        },
+      };
+    },
   },
   {
     id: "sessionZones",
     label: "Session Zones",
     description: "ICT kill-zone backgrounds (needs intraday data)",
-    connect: (candles) => connectSessionZones(chartRef, killZones(candles)),
+    build: (candles) => {
+      const handle = connectSessionZones(chartRef, killZones(candles));
+      return {
+        handle: handle as PluginHandle,
+        recompute: (cs) => killZones(cs as NormalizedCandle[]),
+      };
+    },
   },
   {
     id: "andrewsPitchfork",
     label: "Andrew's Pitchfork",
     description: "Median + handles from the last 3 swing anchors",
-    connect: (candles) => {
-      const last3 = getAlternatingSwingPoints(candles, 3, { leftBars: 10, rightBars: 10 });
-      if (last3.length < 3) return null;
-      return connectAndrewsPitchfork(chartRef, {
-        p0: { index: last3[0].index, price: last3[0].price },
-        p1: { index: last3[1].index, price: last3[1].price },
-        p2: { index: last3[2].index, price: last3[2].price },
-      });
+    build: (candles) => {
+      const points = pitchforkPoints(candles);
+      if (!points) return null;
+      const handle = connectAndrewsPitchfork(chartRef, points);
+      return {
+        handle: handle as PluginHandle,
+        recompute: (cs) => pitchforkPoints(cs as NormalizedCandle[]) ?? points,
+      };
     },
   },
   {
     id: "volumeProfile",
     label: "Volume Profile",
     description: "Horizontal volume-by-price histogram + POC",
-    connect: (candles) => connectVolumeProfile(chartRef, volumeProfile(candles, { levels: 30 })),
+    build: (candles) => {
+      const handle = connectVolumeProfile(chartRef, volumeProfile(candles, { levels: 30 }));
+      return {
+        handle: handle as PluginHandle,
+        recompute: (cs) => volumeProfile(cs as NormalizedCandle[], { levels: 30 }),
+      };
+    },
   },
   {
     id: "marketProfile",
     label: "Market Profile",
     description: "TPO-based time-at-price + POC / VAH / VAL",
-    connect: (candles) => connectMarketProfile(chartRef, marketProfile(candles)),
+    build: (candles) => {
+      const handle = connectMarketProfile(chartRef, marketProfile(candles));
+      return {
+        handle: handle as PluginHandle,
+        recompute: (cs) => marketProfile(cs as NormalizedCandle[]),
+      };
+    },
   },
 ];
+
+function pitchforkPoints(candles: NormalizedCandle[]) {
+  const last3 = getAlternatingSwingPoints(candles, 3, { leftBars: 10, rightBars: 10 });
+  if (last3.length < 3) return null;
+  return {
+    p0: { index: last3[0].index, price: last3[0].price },
+    p1: { index: last3[1].index, price: last3[1].price },
+    p2: { index: last3[2].index, price: last3[2].price },
+  };
+}
 
 // The specs above close over a mutable `chartRef`. The panel factory sets it
 // on every mount so SPECS can stay a single module-level list.
@@ -129,9 +212,11 @@ export function createPluginsPanel(
   container: HTMLElement,
   candles: NormalizedCandle[],
   chart: ChartInstance,
+  opts: { live?: LiveSource } = {},
 ): PluginsPanelHandle {
   chartRef = chart;
   const active = new Map<string, PluginHandle>();
+  const liveConns = new Map<string, LivePrimitivesConnection>();
   const panelRoot = document.createElement("div");
   panelRoot.dataset.role = "plugins-panel";
   container.appendChild(panelRoot);
@@ -140,7 +225,7 @@ export function createPluginsPanel(
   const header = document.createElement("div");
   header.style.cssText =
     "padding:10px 12px;background:#181c27;border-top:1px solid #2a2e39;border-bottom:1px solid #1e222d;font-weight:600;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;";
-  header.textContent = "\u25BC Plugins";
+  header.textContent = "▼ Plugins";
   panelRoot.appendChild(header);
 
   for (const spec of SPECS) {
@@ -182,23 +267,33 @@ export function createPluginsPanel(
     row.addEventListener("click", () => {
       const existing = active.get(spec.id);
       if (existing) {
+        liveConns.get(spec.id)?.disconnect();
+        liveConns.delete(spec.id);
         existing.remove();
         active.delete(spec.id);
         applyActive(false);
       } else {
-        const handle = spec.connect(candles);
-        if (!handle) {
+        const built = spec.build(candles);
+        if (!built) {
           console.warn(`Plugin ${spec.id} could not be connected (insufficient data)`);
           return;
         }
-        active.set(spec.id, handle);
+        active.set(spec.id, built.handle);
         applyActive(true);
+        if (opts.live) {
+          const conn = connectLivePrimitives(opts.live, [
+            { recompute: built.recompute, handle: built.handle, name: spec.id },
+          ]);
+          liveConns.set(spec.id, conn);
+        }
       }
     });
   }
 
   return {
     destroy() {
+      for (const conn of liveConns.values()) conn.disconnect();
+      liveConns.clear();
       for (const h of active.values()) h.remove();
       active.clear();
       panelRoot.remove();


### PR DESCRIPTION
## Summary
- Adds a sidebar dock in `indicator-showcase` for replaying any timeframe (daily / 1H) as a live stream, so consumers can see how `connectIndicators({ live })` and `connectLivePrimitives` (PR #100) actually behave on a chart — not just in unit tests.
- New `live-simulator.ts` wraps `createLiveCandle` and emits **intra-candle partial ticks** (5 per candle by default) before each `candleComplete`. The forming bar grows naturally and series indicators (RSI / SMA / MACD / etc.) update in real time on every tick.
- New `live-panel.ts` is the sidebar dock: Static/Live pill, Play/Pause toggle, speed presets (1× / 4× / 16×), progress bar, Reset.
- `main.ts` becomes `mount(timeframe, mode)`. Reset rebuilds the entire pipeline (chart + `connectIndicators` + `plugins-panel`) because resetting the simulator alone would strand existing subscriptions on the disposed `LiveCandle` and leave the chart at its streamed state.
- `plugins-panel.ts` accepts `opts.live`. Each spec is restructured into `build(candles)` returning both the chart handle and a `recompute` closure; on toggle-on with live, the panel starts a per-plugin `connectLivePrimitives` connection so primitives recompute on every `candleComplete`.

## Why
PR #100 added `connectLivePrimitives` with API + unit tests, but visual verification was tracked separately (memory note `project_showcase_live_simulate.md`). This PR delivers that verification surface and doubles as a demo for series indicator live mode (`connectIndicators({ live })`).

## Scope
- **No changes** to `packages/chart/src/` or `packages/core/src/`. All new code is under `packages/chart/examples/indicator-showcase/src/`.
- `signals-panel.ts` is left static; live-driven signals are out of scope for this PR.

## Implementation notes
- Seed candles are loaded via `addCandle()` rather than `createLiveCandle({ history: seed })` because passing `history` alongside would cause `warmUpIndicator()` to double-process every seed bar when `connectIndicators` later registers factories via `addIndicator()`.
- Reset behavior: clicking Reset triggers a full re-mount in Live mode. The user's previously-toggled indicators and plugins are NOT preserved through Reset — re-toggling is required. This is intentional MVP scope; full state preservation can be a follow-up.
- Tick timing: `setInterval` with configurable `intervalMs`. Default 250ms (= 1×). At 16× (16ms) the chart still renders smoothly.

## Test plan
- [x] `pnpm test` (chart): 71 files / 742 tests still green (no source changes, just verifying no regression).
- [x] `pnpm build` (chart): green.
- [x] Manual: `cd packages/chart/examples/indicator-showcase && pnpm dev`
  - Static mode: existing behavior unchanged (timeframe / theme / chart-type / fit / indicator add+remove / plugin toggle / signals panel)
  - Live mode: Static→Live toggles correctly; Play streams candles + intra-candle ticks; SMA/EMA/RSI/MACD update in real time; S/R Confluence / SMC Layer / Regime Heatmap / Wyckoff Phase / Session Zones recompute on every candleComplete; Pause/Resume; speed switch; Reset rebuilds; queue end → state="complete" + Play disabled