### PR TITLE
feat(core): add createFibonacciRetracement incremental indicator

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/fibonacci-retracement.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/fibonacci-retracement.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Parity tests for incremental Fibonacci Retracement vs batch.
+ *
+ * Batch `fibonacciRetracement` uses look-ahead (it consults
+ * `swings[i].isSwingHigh`, which itself peeks `rightBars` bars into the
+ * future), so live cannot match batch bar-by-bar. Tests verify:
+ *  - Shifted parity: `live.next(c_t).value` matches `batch[t - rightBars]`
+ *    once both sides have processed enough warm-up.
+ *  - Snapshot resume drift-free.
+ *  - peek() does not mutate state.
+ *  - Option validation throws.
+ *  - Warm-up via WarmUpOptions matches a fresh instance.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../../types";
+import { fibonacciRetracement } from "../../price/fibonacci-retracement";
+import { createFibonacciRetracement } from "../price/fibonacci-retracement";
+
+function generateCandles(count: number): NormalizedCandle[] {
+  const candles: NormalizedCandle[] = [];
+  const MS = 86400000;
+  const base = new Date("2020-01-01").getTime();
+  let price = 100;
+  let s = 31;
+  const r = () => {
+    s = (s * 16807) % 2147483647;
+    return s / 2147483647;
+  };
+  for (let i = 0; i < count; i++) {
+    const change = (r() - 0.5) * 5;
+    const open = price;
+    const close = price * (1 + change / 100);
+    const high = Math.max(open, close) * (1 + r() * 0.015);
+    const low = Math.min(open, close) * (1 - r() * 0.015);
+    candles.push({ time: base + i * MS, open, high, low, close, volume: 1000 });
+    price = close;
+  }
+  return candles;
+}
+
+describe("createFibonacciRetracement", () => {
+  const leftBars = 5;
+  const rightBars = 5;
+  const candles = generateCandles(400);
+
+  it("matches batch with rightBars shift once both have swings", () => {
+    const batch = fibonacciRetracement(candles, { leftBars, rightBars });
+    const live = createFibonacciRetracement({ leftBars, rightBars });
+    let comparedNonNull = 0;
+    for (let t = 0; t < candles.length; t++) {
+      const liveVal = live.next(candles[t]).value;
+      const batchIdx = t - rightBars;
+      if (batchIdx < 0) continue;
+      const batchVal = batch[batchIdx].value;
+      // Both sides should agree on tracked swings at this aligned point.
+      expect(liveVal.swingHigh).toBe(batchVal.swingHigh);
+      expect(liveVal.swingLow).toBe(batchVal.swingLow);
+      expect(liveVal.trend).toBe(batchVal.trend);
+      if (liveVal.levels !== null && batchVal.levels !== null) {
+        expect(liveVal.levels).toEqual(batchVal.levels);
+        comparedNonNull++;
+      } else {
+        expect(liveVal.levels).toBe(batchVal.levels);
+      }
+    }
+    // Sanity: across 400 random candles with leftBars=rightBars=5, plenty of
+    // bars should have produced both swings.
+    expect(comparedNonNull).toBeGreaterThan(50);
+  });
+
+  it("produces non-null levels eventually", () => {
+    const live = createFibonacciRetracement({ leftBars, rightBars });
+    let sawLevels = false;
+    for (const c of candles) {
+      const { value } = live.next(c);
+      if (value.levels !== null) {
+        sawLevels = true;
+        // Default 7 ratios.
+        expect(Object.keys(value.levels)).toHaveLength(7);
+        break;
+      }
+    }
+    expect(sawLevels).toBe(true);
+  });
+
+  it("restores from snapshot without drift", () => {
+    const a = createFibonacciRetracement({ leftBars, rightBars });
+    for (let i = 0; i < 200; i++) a.next(candles[i]);
+    const b = createFibonacciRetracement({ leftBars, rightBars }, { fromState: a.getState() });
+    for (let i = 200; i < candles.length; i++) {
+      const va = a.next(candles[i]).value;
+      const vb = b.next(candles[i]).value;
+      expect(vb.swingHigh).toBe(va.swingHigh);
+      expect(vb.swingLow).toBe(va.swingLow);
+      expect(vb.trend).toBe(va.trend);
+      expect(vb.levels).toEqual(va.levels);
+    }
+  });
+
+  it("peek does not mutate state", () => {
+    const live = createFibonacciRetracement({ leftBars, rightBars });
+    for (let i = 0; i < 50; i++) live.next(candles[i]);
+    const before = JSON.stringify(live.getState());
+    live.peek(candles[50]);
+    expect(JSON.stringify(live.getState())).toBe(before);
+  });
+
+  it("throws on invalid options", () => {
+    expect(() => createFibonacciRetracement({ leftBars: 0 })).toThrow();
+    expect(() => createFibonacciRetracement({ rightBars: 0 })).toThrow();
+    expect(() => createFibonacciRetracement({ levels: [] })).toThrow();
+  });
+
+  it("warms up via WarmUpOptions.warmUp", () => {
+    const warmUp = candles.slice(0, 50);
+    const live = createFibonacciRetracement({ leftBars, rightBars }, { warmUp });
+    expect(live.count).toBe(50);
+    const ref = createFibonacciRetracement({ leftBars, rightBars });
+    for (const c of warmUp) ref.next(c);
+    expect(JSON.stringify(live.getState())).toBe(JSON.stringify(ref.getState()));
+  });
+
+  it("preserves custom config when restored without re-passing options", () => {
+    const customLevels = [0, 0.5, 1];
+    const customLeft = 7;
+    const customRight = 4;
+    const a = createFibonacciRetracement({
+      leftBars: customLeft,
+      rightBars: customRight,
+      levels: customLevels,
+    });
+    for (let i = 0; i < 200; i++) a.next(candles[i]);
+    // Resume with ONLY the snapshot — no options re-passed. Custom config
+    // must come from state.
+    const b = createFibonacciRetracement(undefined, { fromState: a.getState() });
+    for (let i = 200; i < candles.length; i++) {
+      const va = a.next(candles[i]).value;
+      const vb = b.next(candles[i]).value;
+      expect(vb.swingHigh).toBe(va.swingHigh);
+      expect(vb.swingLow).toBe(va.swingLow);
+      expect(vb.trend).toBe(va.trend);
+      expect(vb.levels).toEqual(va.levels);
+      if (vb.levels !== null) {
+        expect(Object.keys(vb.levels).sort()).toEqual(["0", "0.5", "1"]);
+      }
+    }
+    const stateB = b.getState();
+    expect(stateB.leftBars).toBe(customLeft);
+    expect(stateB.rightBars).toBe(customRight);
+    expect(stateB.levels).toEqual(customLevels);
+  });
+
+  it("respects custom levels", () => {
+    const customLevels = [0, 0.5, 1];
+    const live = createFibonacciRetracement({
+      leftBars,
+      rightBars,
+      levels: customLevels,
+    });
+    let sawLevels: Record<string, number> | null = null;
+    for (const c of candles) {
+      const { value } = live.next(c);
+      if (value.levels !== null) {
+        sawLevels = value.levels;
+        break;
+      }
+    }
+    expect(sawLevels).not.toBeNull();
+    expect(Object.keys(sawLevels ?? {}).sort()).toEqual(["0", "0.5", "1"]);
+  });
+});

--- a/packages/core/src/indicators/incremental/index.ts
+++ b/packages/core/src/indicators/incremental/index.ts
@@ -230,6 +230,12 @@ export {
   createBreakOfStructure,
   createChangeOfCharacter,
 } from "./price/break-of-structure";
+export { createFibonacciRetracement } from "./price/fibonacci-retracement";
+export type {
+  FibonacciRetracementState,
+  FibonacciRetracementOptions,
+  FibonacciRetracementValue as IncrementalFibonacciRetracementValue,
+} from "./price/fibonacci-retracement";
 export type {
   BosState,
   ChochState,

--- a/packages/core/src/indicators/incremental/price/fibonacci-retracement.ts
+++ b/packages/core/src/indicators/incremental/price/fibonacci-retracement.ts
@@ -1,0 +1,218 @@
+/**
+ * Incremental Fibonacci Retracement.
+ *
+ * Wraps `createSwingPoints` to track the most recent confirmed swing high and
+ * swing low and computes retracement level prices on every bar. Output shape
+ * matches the batch `fibonacciRetracement` so downstream consumers
+ * (e.g. `addAutoFibRetracement` to convert anchors → `FibRetracementDrawing`)
+ * see the same fields.
+ *
+ * Parity note
+ * -----------
+ * The batch `fibonacciRetracement` uses look-ahead via batch `swingPoints` —
+ * at iteration `i` it consults `swings[i].isSwingHigh`, which itself peeks
+ * `rightBars` bars into the future. Live cannot do that: a swing at bar `j`
+ * is only confirmed at step `j + rightBars`. As a result, this implementation
+ * lags batch by `rightBars` bars in the moment a freshly-formed swing becomes
+ * visible. Once both sides have processed the same data, the tracked
+ * `swingHigh` / `swingLow` and computed `levels` agree (shifted parity:
+ * `live.next(c_t).value` matches `batch[t - rightBars].value`).
+ */
+
+import type { NormalizedCandle } from "../../../types";
+import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type SwingPointsState, createSwingPoints } from "./swing-points";
+
+export type FibonacciRetracementValue = {
+  /** Fibonacci levels mapped by ratio string to price value, null if not enough data */
+  levels: Record<string, number> | null;
+  /** Price of the swing high used for calculation */
+  swingHigh: number | null;
+  /** Price of the swing low used for calculation */
+  swingLow: number | null;
+  /** Trend direction: "up" if swing high is more recent, "down" if swing low is more recent */
+  trend: "up" | "down" | null;
+};
+
+export type FibonacciRetracementOptions = {
+  /** Number of bars to the left for swing point confirmation (default: 10) */
+  leftBars?: number;
+  /** Number of bars to the right for swing point confirmation (default: 10) */
+  rightBars?: number;
+  /** Fibonacci ratio levels to calculate (default: [0, 0.236, 0.382, 0.5, 0.618, 0.786, 1]) */
+  levels?: number[];
+};
+
+export type FibonacciRetracementState = {
+  leftBars: number;
+  rightBars: number;
+  levels: number[];
+  swings: SwingPointsState;
+  lastSwingHighPrice: number | null;
+  lastSwingHighIdx: number | null;
+  lastSwingLowPrice: number | null;
+  lastSwingLowIdx: number | null;
+  count: number;
+};
+
+const DEFAULT_LEVELS: readonly number[] = [0, 0.236, 0.382, 0.5, 0.618, 0.786, 1];
+
+export function createFibonacciRetracement(
+  options: FibonacciRetracementOptions = {},
+  warmUpOptions?: WarmUpOptions<FibonacciRetracementState>,
+): IncrementalIndicator<FibonacciRetracementValue, FibonacciRetracementState> {
+  // Persisted state's config takes precedence over `options` so a stream
+  // resumed via `restoreState(savedState)` (no re-passed options) keeps its
+  // original leftBars / rightBars / levels. Falling back to options when
+  // `fromState` is omitted preserves the normal construction path.
+  const fromState = warmUpOptions?.fromState;
+  const leftBars = fromState?.leftBars ?? options.leftBars ?? 10;
+  const rightBars = fromState?.rightBars ?? options.rightBars ?? 10;
+  const levels = (fromState?.levels ?? options.levels ?? DEFAULT_LEVELS).slice();
+
+  if (leftBars < 1) throw new Error("leftBars must be at least 1");
+  if (rightBars < 1) throw new Error("rightBars must be at least 1");
+  if (!Array.isArray(levels) || levels.length === 0) {
+    throw new Error("levels must be a non-empty array");
+  }
+
+  // Cache the level keys so the hot path skips repeated `String(ratio)` calls
+  // (default 7 ratios × every bar).
+  const ratioKeys = levels.map(String);
+
+  let swings: ReturnType<typeof createSwingPoints>;
+  let lastSwingHighPrice: number | null;
+  let lastSwingHighIdx: number | null;
+  let lastSwingLowPrice: number | null;
+  let lastSwingLowIdx: number | null;
+  let count: number;
+
+  // Cached output. Rebuilt only when the swing state changes; otherwise the
+  // same object is returned across bars to avoid allocating an identical
+  // levels record per call. The IncrementalIndicator contract returns a
+  // fresh `{ time, value }` envelope but the inner `value` may be shared.
+  let cached: FibonacciRetracementValue | null = null;
+  let cachedHighIdx: number | null = null;
+  let cachedLowIdx: number | null = null;
+
+  if (fromState) {
+    swings = createSwingPoints({ leftBars, rightBars }, { fromState: fromState.swings });
+    lastSwingHighPrice = fromState.lastSwingHighPrice;
+    lastSwingHighIdx = fromState.lastSwingHighIdx;
+    lastSwingLowPrice = fromState.lastSwingLowPrice;
+    lastSwingLowIdx = fromState.lastSwingLowIdx;
+    count = fromState.count;
+  } else {
+    swings = createSwingPoints({ leftBars, rightBars });
+    lastSwingHighPrice = null;
+    lastSwingHighIdx = null;
+    lastSwingLowPrice = null;
+    lastSwingLowIdx = null;
+    count = 0;
+  }
+
+  function computeOutput(): FibonacciRetracementValue {
+    if (cached !== null && cachedHighIdx === lastSwingHighIdx && cachedLowIdx === lastSwingLowIdx) {
+      return cached;
+    }
+    let value: FibonacciRetracementValue;
+    if (
+      lastSwingHighPrice === null ||
+      lastSwingLowPrice === null ||
+      lastSwingHighIdx === null ||
+      lastSwingLowIdx === null
+    ) {
+      value = {
+        levels: null,
+        swingHigh: lastSwingHighPrice,
+        swingLow: lastSwingLowPrice,
+        trend: null,
+      };
+    } else {
+      const trend: "up" | "down" = lastSwingHighIdx > lastSwingLowIdx ? "up" : "down";
+      const range = lastSwingHighPrice - lastSwingLowPrice;
+      const map: Record<string, number> = {};
+      for (let i = 0; i < levels.length; i++) {
+        const ratio = levels[i];
+        map[ratioKeys[i]] =
+          trend === "up" ? lastSwingHighPrice - ratio * range : lastSwingLowPrice + ratio * range;
+      }
+      value = {
+        levels: map,
+        swingHigh: lastSwingHighPrice,
+        swingLow: lastSwingLowPrice,
+        trend,
+      };
+    }
+    cached = value;
+    cachedHighIdx = lastSwingHighIdx;
+    cachedLowIdx = lastSwingLowIdx;
+    return value;
+  }
+
+  const indicator: IncrementalIndicator<FibonacciRetracementValue, FibonacciRetracementState> = {
+    next(candle: NormalizedCandle) {
+      count++;
+      const swingResult = swings.next(candle);
+      const sv = swingResult.value;
+      // A confirmed swing at this step belongs to bar (count - 1 - rightBars).
+      const confirmedIdx = count - 1 - rightBars;
+
+      if (sv.isSwingHigh && sv.swingHighPrice !== null && confirmedIdx >= 0) {
+        lastSwingHighPrice = sv.swingHighPrice;
+        lastSwingHighIdx = confirmedIdx;
+      }
+      if (sv.isSwingLow && sv.swingLowPrice !== null && confirmedIdx >= 0) {
+        lastSwingLowPrice = sv.swingLowPrice;
+        lastSwingLowIdx = confirmedIdx;
+      }
+
+      return {
+        time: candle.time,
+        value: computeOutput(),
+      };
+    },
+
+    peek(candle: NormalizedCandle) {
+      const saved = indicator.getState();
+      const result = indicator.next(candle);
+      swings = createSwingPoints({ leftBars, rightBars }, { fromState: saved.swings });
+      lastSwingHighPrice = saved.lastSwingHighPrice;
+      lastSwingHighIdx = saved.lastSwingHighIdx;
+      lastSwingLowPrice = saved.lastSwingLowPrice;
+      lastSwingLowIdx = saved.lastSwingLowIdx;
+      count = saved.count;
+      return result;
+    },
+
+    getState(): FibonacciRetracementState {
+      return {
+        leftBars,
+        rightBars,
+        levels: levels.slice(),
+        swings: swings.getState(),
+        lastSwingHighPrice,
+        lastSwingHighIdx,
+        lastSwingLowPrice,
+        lastSwingLowIdx,
+        count,
+      };
+    },
+
+    get count() {
+      return count;
+    },
+
+    get isWarmedUp() {
+      return swings.isWarmedUp;
+    },
+  };
+
+  if (warmUpOptions?.warmUp) {
+    for (const candle of warmUpOptions.warmUp) {
+      indicator.next(candle);
+    }
+  }
+
+  return indicator;
+}

--- a/packages/core/src/indicators/indicator-meta.ts
+++ b/packages/core/src/indicators/indicator-meta.ts
@@ -348,6 +348,11 @@ export const PIVOT_POINTS_META: SeriesMeta = {
   label: "Pivot",
 };
 export const FRACTALS_META: SeriesMeta = { kind: "fractals", overlay: true, label: "Fractals" };
+export const FIBONACCI_RETRACEMENT_META: SeriesMeta = {
+  kind: "fibonacciRetracement",
+  overlay: true,
+  label: "Fib Retracement",
+};
 export const GAP_ANALYSIS_META: SeriesMeta = {
   kind: "gapAnalysis",
   overlay: false,

--- a/packages/core/src/streaming/live-presets.ts
+++ b/packages/core/src/streaming/live-presets.ts
@@ -43,6 +43,7 @@ import {
   createEmv,
   createEwmaVolatility,
   createFairValueGap,
+  createFibonacciRetracement,
   createFractals,
   createFrama,
   createGapAnalysis,
@@ -124,6 +125,7 @@ import {
   EMA_RIBBON_META,
   EMV_META,
   EWMA_VOL_META,
+  FIBONACCI_RETRACEMENT_META,
   FRACTALS_META,
   FRAMA_META,
   FVG_META,
@@ -973,6 +975,20 @@ export const livePresets: Record<string, LivePreset> = {
       minGapPercent: p.minGapPercent ?? 0,
       maxActiveFvgs: p.maxActiveFvgs ?? 10,
       partialFill: p.partialFill ?? true,
+    })),
+  },
+  fibonacciRetracement: {
+    meta: FIBONACCI_RETRACEMENT_META,
+    defaultParams: { leftBars: 10, rightBars: 10 },
+    snapshotName: "fibRet",
+    createFactory: factory<{
+      leftBars?: number;
+      rightBars?: number;
+      levels?: number[];
+    }>()(createFibonacciRetracement, (p) => ({
+      leftBars: p.leftBars ?? 10,
+      rightBars: p.rightBars ?? 10,
+      levels: p.levels,
     })),
   },
 


### PR DESCRIPTION
Closes #106.

## Summary
- New `createFibonacciRetracement` incremental factory (`packages/core/src/indicators/incremental/price/fibonacci-retracement.ts`) that wraps `createSwingPoints` and emits the same `{ levels, swingHigh, swingLow, trend }` shape as the batch `fibonacciRetracement`.
- `fromState` takes precedence over `options` for `leftBars / rightBars / levels`, so a stream resumed via `restoreState(savedState)` without re-passing options keeps its original configuration (Codex review fix).
- Hot-path tuning: precomputed ratio key strings, cached `value` object reused when swing indices haven't changed (only the `{ time, value }` envelope is fresh per bar).
- Wired into `livePresets` only — Fibonacci retracement is rendered as horizontal lines on the price pane via `FibRetracementDrawing` + `addAutoFibRetracement()`, not as a sub-pane scalar, so no `indicatorPresets` series entry. Follow-up #112 tracks adding a live auto-fib showcase plugin that consumes this factory.

## Stream semantics
Batch uses look-ahead via batch `swingPoints` (at iteration `i` it consults `swings[i].isSwingHigh` which itself peeks `rightBars` bars ahead). Live cannot do that: a swing at bar `j` is confirmed at step `j + rightBars`. Live therefore lags batch by `rightBars` bars, but once both sides have processed the same data the tracked swings and computed levels agree (`live.next(c_t).value` matches `batch[t - rightBars].value`).

## Test plan
- [x] Shifted parity vs batch — `live[t]` equals `batch[t - rightBars]` on swingHigh / swingLow / trend / levels content for >50 aligned bars
- [x] Snapshot resume drift-free with default options
- [x] **Snapshot resume preserves custom config** — `createFibonacciRetracement(undefined, { fromState })` after running with `{ leftBars: 7, rightBars: 4, levels: [0, 0.5, 1] }` continues with the persisted config (regression for Codex P2)
- [x] `peek()` does not mutate state
- [x] Option validation throws on invalid inputs
- [x] `WarmUpOptions.warmUp` matches a fresh instance
- [x] Custom levels respected
- [x] `pnpm test` (4837 core + 760 chart + 59 mcp) / `pnpm lint` / `pnpm build` all green