### PR TITLE
feat(core): add createFibonacciExtension incremental indicator

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/fibonacci-extension.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/fibonacci-extension.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Parity tests for incremental Fibonacci Extension vs batch.
+ *
+ * Same shifted-parity property as Fib Retracement: batch uses look-ahead via
+ * batch `swingPoints`, live confirms swings with `rightBars` delay, so
+ * `live.next(c_t).value` matches `batch[t - rightBars].value` once both sides
+ * have warmed up.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../../types";
+import { fibonacciExtension } from "../../price/fibonacci-extension";
+import { createFibonacciExtension } from "../price/fibonacci-extension";
+
+function generateCandles(count: number): NormalizedCandle[] {
+  const candles: NormalizedCandle[] = [];
+  const MS = 86400000;
+  const base = new Date("2020-01-01").getTime();
+  let price = 100;
+  let s = 31;
+  const r = () => {
+    s = (s * 16807) % 2147483647;
+    return s / 2147483647;
+  };
+  for (let i = 0; i < count; i++) {
+    const change = (r() - 0.5) * 5;
+    const open = price;
+    const close = price * (1 + change / 100);
+    const high = Math.max(open, close) * (1 + r() * 0.015);
+    const low = Math.min(open, close) * (1 - r() * 0.015);
+    candles.push({ time: base + i * MS, open, high, low, close, volume: 1000 });
+    price = close;
+  }
+  return candles;
+}
+
+describe("createFibonacciExtension", () => {
+  const leftBars = 5;
+  const rightBars = 5;
+  const candles = generateCandles(400);
+
+  it("matches batch with rightBars shift once both have a pattern", () => {
+    const batch = fibonacciExtension(candles, { leftBars, rightBars });
+    const live = createFibonacciExtension({ leftBars, rightBars });
+    let comparedNonNull = 0;
+    for (let t = 0; t < candles.length; t++) {
+      const liveVal = live.next(candles[t]).value;
+      const batchIdx = t - rightBars;
+      if (batchIdx < 0) continue;
+      const batchVal = batch[batchIdx].value;
+      expect(liveVal.pointA).toBe(batchVal.pointA);
+      expect(liveVal.pointB).toBe(batchVal.pointB);
+      expect(liveVal.pointC).toBe(batchVal.pointC);
+      expect(liveVal.direction).toBe(batchVal.direction);
+      if (liveVal.levels !== null && batchVal.levels !== null) {
+        expect(liveVal.levels).toEqual(batchVal.levels);
+        comparedNonNull++;
+      } else {
+        expect(liveVal.levels).toBe(batchVal.levels);
+      }
+    }
+    expect(comparedNonNull).toBeGreaterThan(50);
+  });
+
+  it("eventually produces a non-null A→B→C pattern", () => {
+    const live = createFibonacciExtension({ leftBars, rightBars });
+    let sawPattern = false;
+    for (const c of candles) {
+      const { value } = live.next(c);
+      if (value.levels !== null) {
+        sawPattern = true;
+        expect(Object.keys(value.levels)).toHaveLength(7);
+        expect(value.direction === "bullish" || value.direction === "bearish").toBe(true);
+        break;
+      }
+    }
+    expect(sawPattern).toBe(true);
+  });
+
+  it("restores from snapshot without drift", () => {
+    const a = createFibonacciExtension({ leftBars, rightBars });
+    for (let i = 0; i < 200; i++) a.next(candles[i]);
+    const b = createFibonacciExtension({ leftBars, rightBars }, { fromState: a.getState() });
+    for (let i = 200; i < candles.length; i++) {
+      const va = a.next(candles[i]).value;
+      const vb = b.next(candles[i]).value;
+      expect(vb.direction).toBe(va.direction);
+      expect(vb.pointA).toBe(va.pointA);
+      expect(vb.pointB).toBe(va.pointB);
+      expect(vb.pointC).toBe(va.pointC);
+      expect(vb.levels).toEqual(va.levels);
+    }
+  });
+
+  it("preserves custom config when restored without re-passing options", () => {
+    const customLevels = [0, 1, 1.5, 2];
+    const customLeft = 7;
+    const customRight = 4;
+    const a = createFibonacciExtension({
+      leftBars: customLeft,
+      rightBars: customRight,
+      levels: customLevels,
+    });
+    for (let i = 0; i < 200; i++) a.next(candles[i]);
+    const b = createFibonacciExtension(undefined, { fromState: a.getState() });
+    for (let i = 200; i < candles.length; i++) {
+      const va = a.next(candles[i]).value;
+      const vb = b.next(candles[i]).value;
+      expect(vb.direction).toBe(va.direction);
+      expect(vb.pointA).toBe(va.pointA);
+      expect(vb.pointB).toBe(va.pointB);
+      expect(vb.pointC).toBe(va.pointC);
+      expect(vb.levels).toEqual(va.levels);
+      if (vb.levels !== null) {
+        expect(Object.keys(vb.levels).sort()).toEqual(["0", "1", "1.5", "2"]);
+      }
+    }
+    const stateB = b.getState();
+    expect(stateB.leftBars).toBe(customLeft);
+    expect(stateB.rightBars).toBe(customRight);
+    expect(stateB.levels).toEqual(customLevels);
+  });
+
+  it("peek does not mutate state", () => {
+    const live = createFibonacciExtension({ leftBars, rightBars });
+    for (let i = 0; i < 80; i++) live.next(candles[i]);
+    const before = JSON.stringify(live.getState());
+    live.peek(candles[80]);
+    expect(JSON.stringify(live.getState())).toBe(before);
+  });
+
+  it("throws on invalid options", () => {
+    expect(() => createFibonacciExtension({ leftBars: 0 })).toThrow();
+    expect(() => createFibonacciExtension({ rightBars: 0 })).toThrow();
+    expect(() => createFibonacciExtension({ levels: [] })).toThrow();
+  });
+
+  it("warms up via WarmUpOptions.warmUp", () => {
+    const warmUp = candles.slice(0, 80);
+    const live = createFibonacciExtension({ leftBars, rightBars }, { warmUp });
+    expect(live.count).toBe(80);
+    const ref = createFibonacciExtension({ leftBars, rightBars });
+    for (const c of warmUp) ref.next(c);
+    expect(JSON.stringify(live.getState())).toBe(JSON.stringify(ref.getState()));
+  });
+
+  it("respects custom levels", () => {
+    const customLevels = [0, 1, 2];
+    const live = createFibonacciExtension({ leftBars, rightBars, levels: customLevels });
+    let saw: Record<string, number> | null = null;
+    for (const c of candles) {
+      const { value } = live.next(c);
+      if (value.levels !== null) {
+        saw = value.levels;
+        break;
+      }
+    }
+    expect(saw).not.toBeNull();
+    expect(Object.keys(saw ?? {}).sort()).toEqual(["0", "1", "2"]);
+  });
+});

--- a/packages/core/src/indicators/incremental/index.ts
+++ b/packages/core/src/indicators/incremental/index.ts
@@ -236,6 +236,12 @@ export type {
   FibonacciRetracementOptions,
   FibonacciRetracementValue as IncrementalFibonacciRetracementValue,
 } from "./price/fibonacci-retracement";
+export { createFibonacciExtension } from "./price/fibonacci-extension";
+export type {
+  FibonacciExtensionState,
+  FibonacciExtensionOptions,
+  FibonacciExtensionValue as IncrementalFibonacciExtensionValue,
+} from "./price/fibonacci-extension";
 export type {
   BosState,
   ChochState,

--- a/packages/core/src/indicators/incremental/price/fibonacci-extension.ts
+++ b/packages/core/src/indicators/incremental/price/fibonacci-extension.ts
@@ -1,0 +1,260 @@
+/**
+ * Incremental Fibonacci Extension.
+ *
+ * Wraps `createSwingPoints` and maintains an alternating-swing list of the
+ * last (up to 3) confirmed swings to detect an A→B→C pattern. When the
+ * pattern is valid (C between A and B), extension level prices are computed
+ * relative to C.
+ *
+ * Output shape matches batch `fibonacciExtension`.
+ *
+ * Parity note (same as Fib Retracement): batch uses look-ahead via batch
+ * `swingPoints`, while live confirms swings with `rightBars` delay. Live
+ * therefore lags batch by `rightBars` bars; once both sides have processed
+ * the same data, the values agree (`live.next(c_t).value` matches
+ * `batch[t - rightBars].value`).
+ */
+
+import type { NormalizedCandle } from "../../../types";
+import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type SwingPointsState, createSwingPoints } from "./swing-points";
+
+export type FibonacciExtensionValue = {
+  /** Extension levels mapped by ratio string to price value, null until a valid A→B→C pattern */
+  levels: Record<string, number> | null;
+  /** Point A price (start of initial move) */
+  pointA: number | null;
+  /** Point B price (end of initial move) */
+  pointB: number | null;
+  /** Point C price (end of retracement) */
+  pointC: number | null;
+  /** Direction of the extension */
+  direction: "bullish" | "bearish" | null;
+};
+
+export type FibonacciExtensionOptions = {
+  /** Number of bars to the left for swing point confirmation (default: 10) */
+  leftBars?: number;
+  /** Number of bars to the right for swing point confirmation (default: 10) */
+  rightBars?: number;
+  /** Extension ratio levels (default: [0, 0.618, 1, 1.272, 1.618, 2, 2.618]) */
+  levels?: number[];
+};
+
+type AlternatingPoint = {
+  index: number;
+  price: number;
+  type: "high" | "low";
+};
+
+export type FibonacciExtensionState = {
+  leftBars: number;
+  rightBars: number;
+  levels: number[];
+  swings: SwingPointsState;
+  alternating: AlternatingPoint[];
+  currentLevels: Record<string, number> | null;
+  currentPointA: number | null;
+  currentPointB: number | null;
+  currentPointC: number | null;
+  currentDirection: "bullish" | "bearish" | null;
+  count: number;
+};
+
+const DEFAULT_LEVELS: readonly number[] = [0, 0.618, 1, 1.272, 1.618, 2, 2.618];
+
+export function createFibonacciExtension(
+  options: FibonacciExtensionOptions = {},
+  warmUpOptions?: WarmUpOptions<FibonacciExtensionState>,
+): IncrementalIndicator<FibonacciExtensionValue, FibonacciExtensionState> {
+  // Persisted state takes precedence over options so a stream resumed via
+  // `restoreState(savedState)` (no re-passed options) keeps its original
+  // configuration.
+  const fromState = warmUpOptions?.fromState;
+  const leftBars = fromState?.leftBars ?? options.leftBars ?? 10;
+  const rightBars = fromState?.rightBars ?? options.rightBars ?? 10;
+  const levels = (fromState?.levels ?? options.levels ?? DEFAULT_LEVELS).slice();
+
+  if (leftBars < 1) throw new Error("leftBars must be at least 1");
+  if (rightBars < 1) throw new Error("rightBars must be at least 1");
+  if (!Array.isArray(levels) || levels.length === 0) {
+    throw new Error("levels must be a non-empty array");
+  }
+
+  // Cache the level keys so the hot path skips repeated `String(ratio)` calls.
+  const ratioKeys = levels.map(String);
+
+  let swings: ReturnType<typeof createSwingPoints>;
+  // The pattern only ever needs the last 3 alternating points. Trim to that
+  // bound to keep state size constant on long streams.
+  let alternating: AlternatingPoint[];
+  let currentLevels: Record<string, number> | null;
+  let currentPointA: number | null;
+  let currentPointB: number | null;
+  let currentPointC: number | null;
+  let currentDirection: "bullish" | "bearish" | null;
+  let count: number;
+
+  if (fromState) {
+    swings = createSwingPoints({ leftBars, rightBars }, { fromState: fromState.swings });
+    alternating = fromState.alternating.map((p) => ({ ...p }));
+    currentLevels = fromState.currentLevels ? { ...fromState.currentLevels } : null;
+    currentPointA = fromState.currentPointA;
+    currentPointB = fromState.currentPointB;
+    currentPointC = fromState.currentPointC;
+    currentDirection = fromState.currentDirection;
+    count = fromState.count;
+  } else {
+    swings = createSwingPoints({ leftBars, rightBars });
+    alternating = [];
+    currentLevels = null;
+    currentPointA = null;
+    currentPointB = null;
+    currentPointC = null;
+    currentDirection = null;
+    count = 0;
+  }
+
+  // Cached output, reused across bars when no swing-driven update happened.
+  let cached: FibonacciExtensionValue | null = null;
+
+  function pushOrReplace(point: AlternatingPoint): boolean {
+    if (alternating.length === 0) {
+      alternating.push(point);
+      return true;
+    }
+    const last = alternating[alternating.length - 1];
+    if (last.type !== point.type) {
+      alternating.push(point);
+      if (alternating.length > 3) alternating.shift();
+      return true;
+    }
+    // Same type consecutive: keep the more extreme.
+    const moreExtreme = point.type === "high" ? point.price > last.price : point.price < last.price;
+    if (moreExtreme) {
+      alternating[alternating.length - 1] = point;
+      return true;
+    }
+    return false;
+  }
+
+  function reEvaluatePattern(): void {
+    if (alternating.length < 3) return;
+    const a = alternating[0];
+    const b = alternating[1];
+    const c = alternating[2];
+    let direction: "bullish" | "bearish" | null = null;
+    if (a.type === "low" && b.type === "high" && c.type === "low") {
+      direction = "bullish";
+    } else if (a.type === "high" && b.type === "low" && c.type === "high") {
+      direction = "bearish";
+    }
+    if (!direction) return;
+    const validRetracement =
+      direction === "bullish"
+        ? c.price > a.price && c.price < b.price
+        : c.price < a.price && c.price > b.price;
+    if (!validRetracement) return;
+
+    const move = Math.abs(b.price - a.price);
+    const map: Record<string, number> = {};
+    for (let i = 0; i < levels.length; i++) {
+      const ratio = levels[i];
+      map[ratioKeys[i]] = direction === "bullish" ? c.price + ratio * move : c.price - ratio * move;
+    }
+    currentLevels = map;
+    currentPointA = a.price;
+    currentPointB = b.price;
+    currentPointC = c.price;
+    currentDirection = direction;
+    cached = null; // invalidate output cache
+  }
+
+  function output(): FibonacciExtensionValue {
+    if (cached !== null) return cached;
+    const value: FibonacciExtensionValue = {
+      levels: currentLevels,
+      pointA: currentPointA,
+      pointB: currentPointB,
+      pointC: currentPointC,
+      direction: currentDirection,
+    };
+    cached = value;
+    return value;
+  }
+
+  const indicator: IncrementalIndicator<FibonacciExtensionValue, FibonacciExtensionState> = {
+    next(candle: NormalizedCandle) {
+      count++;
+      const swingResult = swings.next(candle);
+      const sv = swingResult.value;
+      const confirmedIdx = count - 1 - rightBars;
+
+      let updated = false;
+      if (sv.isSwingHigh && sv.swingHighPrice !== null && confirmedIdx >= 0) {
+        if (pushOrReplace({ index: confirmedIdx, price: sv.swingHighPrice, type: "high" })) {
+          updated = true;
+        }
+      }
+      if (sv.isSwingLow && sv.swingLowPrice !== null && confirmedIdx >= 0) {
+        if (pushOrReplace({ index: confirmedIdx, price: sv.swingLowPrice, type: "low" })) {
+          updated = true;
+        }
+      }
+
+      if (updated) reEvaluatePattern();
+
+      return {
+        time: candle.time,
+        value: output(),
+      };
+    },
+
+    peek(candle: NormalizedCandle) {
+      const saved = indicator.getState();
+      const result = indicator.next(candle);
+      swings = createSwingPoints({ leftBars, rightBars }, { fromState: saved.swings });
+      alternating = saved.alternating.map((p) => ({ ...p }));
+      currentLevels = saved.currentLevels ? { ...saved.currentLevels } : null;
+      currentPointA = saved.currentPointA;
+      currentPointB = saved.currentPointB;
+      currentPointC = saved.currentPointC;
+      currentDirection = saved.currentDirection;
+      count = saved.count;
+      cached = null;
+      return result;
+    },
+
+    getState(): FibonacciExtensionState {
+      return {
+        leftBars,
+        rightBars,
+        levels: levels.slice(),
+        swings: swings.getState(),
+        alternating: alternating.map((p) => ({ ...p })),
+        currentLevels: currentLevels ? { ...currentLevels } : null,
+        currentPointA,
+        currentPointB,
+        currentPointC,
+        currentDirection,
+        count,
+      };
+    },
+
+    get count() {
+      return count;
+    },
+
+    get isWarmedUp() {
+      return swings.isWarmedUp;
+    },
+  };
+
+  if (warmUpOptions?.warmUp) {
+    for (const candle of warmUpOptions.warmUp) {
+      indicator.next(candle);
+    }
+  }
+
+  return indicator;
+}

--- a/packages/core/src/indicators/indicator-meta.ts
+++ b/packages/core/src/indicators/indicator-meta.ts
@@ -353,6 +353,11 @@ export const FIBONACCI_RETRACEMENT_META: SeriesMeta = {
   overlay: true,
   label: "Fib Retracement",
 };
+export const FIBONACCI_EXTENSION_META: SeriesMeta = {
+  kind: "fibonacciExtension",
+  overlay: true,
+  label: "Fib Extension",
+};
 export const GAP_ANALYSIS_META: SeriesMeta = {
   kind: "gapAnalysis",
   overlay: false,

--- a/packages/core/src/streaming/live-presets.ts
+++ b/packages/core/src/streaming/live-presets.ts
@@ -43,6 +43,7 @@ import {
   createEmv,
   createEwmaVolatility,
   createFairValueGap,
+  createFibonacciExtension,
   createFibonacciRetracement,
   createFractals,
   createFrama,
@@ -125,6 +126,7 @@ import {
   EMA_RIBBON_META,
   EMV_META,
   EWMA_VOL_META,
+  FIBONACCI_EXTENSION_META,
   FIBONACCI_RETRACEMENT_META,
   FRACTALS_META,
   FRAMA_META,
@@ -986,6 +988,20 @@ export const livePresets: Record<string, LivePreset> = {
       rightBars?: number;
       levels?: number[];
     }>()(createFibonacciRetracement, (p) => ({
+      leftBars: p.leftBars ?? 10,
+      rightBars: p.rightBars ?? 10,
+      levels: p.levels,
+    })),
+  },
+  fibonacciExtension: {
+    meta: FIBONACCI_EXTENSION_META,
+    defaultParams: { leftBars: 10, rightBars: 10 },
+    snapshotName: "fibExt",
+    createFactory: factory<{
+      leftBars?: number;
+      rightBars?: number;
+      levels?: number[];
+    }>()(createFibonacciExtension, (p) => ({
       leftBars: p.leftBars ?? 10,
       rightBars: p.rightBars ?? 10,
       levels: p.levels,


### PR DESCRIPTION
Closes #107.

## Summary
- New `createFibonacciExtension` incremental factory (`packages/core/src/indicators/incremental/price/fibonacci-extension.ts`) that wraps `createSwingPoints` and maintains a 3-entry alternating-swing list to detect an A→B→C pattern. Output shape matches the batch `fibonacciExtension`.
- Same `fromState`-precedence pattern as #106: a stream resumed via `restoreState(savedState)` without re-passing options keeps its original configuration.
- Hot-path tuning: precomputed ratio keys, output object cached across bars, alternating list bounded to last 3 entries (constant state size on long streams).
- Wired into `livePresets` only — extension targets are rendered as horizontal lines on the price pane via `FibExtensionDrawing`, not as a sub-pane scalar, so no `indicatorPresets` series entry. Follow-up #114 tracks the live auto-fib-extension showcase plugin.

## Stream semantics
Same shifted-parity property as Fib Retracement: batch uses look-ahead via batch `swingPoints`, live confirms swings with `rightBars` delay. `live.next(c_t).value` matches `batch[t - rightBars].value` once both sides have warmed up.

## Test plan
- [x] Shifted parity vs batch — `live[t]` equals `batch[t - rightBars]` on pointA / pointB / pointC / direction / levels content for >50 aligned bars
- [x] Snapshot resume drift-free with default options
- [x] Snapshot resume preserves custom config (`{ leftBars: 7, rightBars: 4, levels: [0, 1, 1.5, 2] }`) when restored without re-passed options
- [x] `peek()` does not mutate state
- [x] Option validation throws on invalid inputs
- [x] `WarmUpOptions.warmUp` matches a fresh instance
- [x] Custom levels respected
- [x] `pnpm test` (4843 core + 760 chart + 59 mcp) / `pnpm lint` / `pnpm build` all green