### PR TITLE
feat(core): add createChannelLine incremental indicator

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/channel-line.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/channel-line.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Parity tests for incremental Channel Line vs batch.
+ *
+ * Batch uses look-ahead via batch `swingPoints`, while live confirms swings
+ * with `rightBars` delay. Live's channel parameters (direction, slope,
+ * anchor, offset) at step `t` agree with `batch[t - rightBars]`. Raw
+ * `upper / lower / middle` cannot be compared bar-by-bar across the shift
+ * because each side projects at a different bar (live at the current bar,
+ * batch at its own iteration index); tests verify direction parity plus
+ * standard snapshot / peek / warmup properties.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../../types";
+import { channelLine } from "../../price/channel-line";
+import { createChannelLine } from "../price/channel-line";
+
+function generateCandles(count: number): NormalizedCandle[] {
+  const candles: NormalizedCandle[] = [];
+  const MS = 86400000;
+  const base = new Date("2020-01-01").getTime();
+  let price = 100;
+  let s = 31;
+  const r = () => {
+    s = (s * 16807) % 2147483647;
+    return s / 2147483647;
+  };
+  for (let i = 0; i < count; i++) {
+    const change = (r() - 0.5) * 5;
+    const open = price;
+    const close = price * (1 + change / 100);
+    const high = Math.max(open, close) * (1 + r() * 0.015);
+    const low = Math.min(open, close) * (1 - r() * 0.015);
+    candles.push({ time: base + i * MS, open, high, low, close, volume: 1000 });
+    price = close;
+  }
+  return candles;
+}
+
+describe("createChannelLine", () => {
+  const leftBars = 5;
+  const rightBars = 5;
+  const candles = generateCandles(400);
+
+  it("matches batch direction with rightBars shift once channel is defined", () => {
+    const batch = channelLine(candles, { leftBars, rightBars });
+    const live = createChannelLine({ leftBars, rightBars });
+    let comparedDefined = 0;
+    for (let t = 0; t < candles.length; t++) {
+      const liveVal = live.next(candles[t]).value;
+      const batchIdx = t - rightBars;
+      if (batchIdx < 0) continue;
+      const batchVal = batch[batchIdx].value;
+      expect(liveVal.direction).toBe(batchVal.direction);
+      if (liveVal.direction !== null) {
+        // Both sides should report a defined channel; live also emits
+        // upper/lower/middle but they project at different bars from batch
+        // so we only check structural consistency here.
+        expect(liveVal.upper).not.toBeNull();
+        expect(liveVal.lower).not.toBeNull();
+        expect(liveVal.middle).not.toBeNull();
+        expect(liveVal.upper).toBeGreaterThanOrEqual(liveVal.lower as number);
+        comparedDefined++;
+      }
+    }
+    expect(comparedDefined).toBeGreaterThan(50);
+  });
+
+  it("eventually defines a channel", () => {
+    const live = createChannelLine({ leftBars, rightBars });
+    let saw = false;
+    for (const c of candles) {
+      const { value } = live.next(c);
+      if (value.direction !== null) {
+        saw = true;
+        expect(value.upper).not.toBeNull();
+        expect(value.lower).not.toBeNull();
+        expect(value.middle).toBe(((value.upper as number) + (value.lower as number)) / 2);
+        break;
+      }
+    }
+    expect(saw).toBe(true);
+  });
+
+  it("restores from snapshot without drift", () => {
+    const a = createChannelLine({ leftBars, rightBars });
+    for (let i = 0; i < 200; i++) a.next(candles[i]);
+    const b = createChannelLine({ leftBars, rightBars }, { fromState: a.getState() });
+    for (let i = 200; i < candles.length; i++) {
+      const va = a.next(candles[i]).value;
+      const vb = b.next(candles[i]).value;
+      expect(vb.direction).toBe(va.direction);
+      expect(vb.upper).toBe(va.upper);
+      expect(vb.lower).toBe(va.lower);
+      expect(vb.middle).toBe(va.middle);
+    }
+  });
+
+  it("preserves custom config when restored without re-passing options", () => {
+    const customLeft = 7;
+    const customRight = 4;
+    const a = createChannelLine({ leftBars: customLeft, rightBars: customRight });
+    for (let i = 0; i < 200; i++) a.next(candles[i]);
+    const b = createChannelLine(undefined, { fromState: a.getState() });
+    for (let i = 200; i < candles.length; i++) {
+      const va = a.next(candles[i]).value;
+      const vb = b.next(candles[i]).value;
+      expect(vb.direction).toBe(va.direction);
+      expect(vb.upper).toBe(va.upper);
+      expect(vb.lower).toBe(va.lower);
+    }
+    const stateB = b.getState();
+    expect(stateB.leftBars).toBe(customLeft);
+    expect(stateB.rightBars).toBe(customRight);
+  });
+
+  it("peek does not mutate state", () => {
+    const live = createChannelLine({ leftBars, rightBars });
+    for (let i = 0; i < 80; i++) live.next(candles[i]);
+    const before = JSON.stringify(live.getState());
+    live.peek(candles[80]);
+    expect(JSON.stringify(live.getState())).toBe(before);
+  });
+
+  it("throws on invalid options", () => {
+    expect(() => createChannelLine({ leftBars: 0 })).toThrow();
+    expect(() => createChannelLine({ rightBars: 0 })).toThrow();
+  });
+
+  it("warms up via WarmUpOptions.warmUp", () => {
+    const warmUp = candles.slice(0, 80);
+    const live = createChannelLine({ leftBars, rightBars }, { warmUp });
+    expect(live.count).toBe(80);
+    const ref = createChannelLine({ leftBars, rightBars });
+    for (const c of warmUp) ref.next(c);
+    expect(JSON.stringify(live.getState())).toBe(JSON.stringify(ref.getState()));
+  });
+});

--- a/packages/core/src/indicators/incremental/index.ts
+++ b/packages/core/src/indicators/incremental/index.ts
@@ -242,6 +242,12 @@ export type {
   FibonacciExtensionOptions,
   FibonacciExtensionValue as IncrementalFibonacciExtensionValue,
 } from "./price/fibonacci-extension";
+export { createChannelLine } from "./price/channel-line";
+export type {
+  ChannelLineState,
+  ChannelLineOptions,
+  ChannelLineValue as IncrementalChannelLineValue,
+} from "./price/channel-line";
 export type {
   BosState,
   ChochState,

--- a/packages/core/src/indicators/incremental/price/channel-line.ts
+++ b/packages/core/src/indicators/incremental/price/channel-line.ts
@@ -1,0 +1,343 @@
+/**
+ * Incremental Channel Line.
+ *
+ * Wraps `createSwingPoints` and tracks the last 2 confirmed swing highs +
+ * the last 2 confirmed swing lows. From those:
+ *   - up-channel candidate connects the last two swing lows when rising;
+ *     the parallel line passes through the highest swing high between them.
+ *   - down-channel candidate connects the last two swing highs when falling;
+ *     the parallel line passes through the lowest swing low between them.
+ *   - if both candidates are valid, the more recent one (by anchor index)
+ *     wins.
+ *
+ * Output projects the primary line at the current bar (`count - 1`) and the
+ * parallel offset is added/subtracted to produce upper/lower/middle.
+ *
+ * Parity note (same shifted-parity property as Fib Retracement): batch uses
+ * look-ahead via batch `swingPoints`, while live confirms swings with
+ * `rightBars` delay. Live's `direction` and channel parameters at step `t`
+ * agree with `batch[t - rightBars]`. Raw `upper / lower / middle` cannot be
+ * compared bar-by-bar across the shift because each side projects at a
+ * different bar (live at the current bar, batch at its own iteration index);
+ * tests verify direction parity plus standard snapshot / peek / warmup
+ * properties.
+ */
+
+import type { NormalizedCandle } from "../../../types";
+import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type SwingPointsState, createSwingPoints } from "./swing-points";
+
+export type ChannelLineValue = {
+  /** Upper channel line value */
+  upper: number | null;
+  /** Lower channel line value */
+  lower: number | null;
+  /** Middle channel line value (average of upper and lower) */
+  middle: number | null;
+  /** Channel direction: "up" or "down" */
+  direction: "up" | "down" | null;
+};
+
+export type ChannelLineOptions = {
+  /** Number of bars to the left for swing point confirmation (default: 10) */
+  leftBars?: number;
+  /** Number of bars to the right for swing point confirmation (default: 10) */
+  rightBars?: number;
+};
+
+type SwingPoint = {
+  index: number;
+  price: number;
+};
+
+export type ChannelLineState = {
+  leftBars: number;
+  rightBars: number;
+  swings: SwingPointsState;
+  lastTwoHighs: SwingPoint[];
+  lastTwoLows: SwingPoint[];
+  highsSinceLastSwingLow: SwingPoint[];
+  lowsSinceLastSwingHigh: SwingPoint[];
+  highsBetweenLastTwoLows: SwingPoint[];
+  lowsBetweenLastTwoHighs: SwingPoint[];
+  channelDefined: boolean;
+  channelDir: "up" | "down";
+  primarySlope: number;
+  primaryAnchorIdx: number;
+  primaryAnchorPrice: number;
+  parallelOffset: number;
+  count: number;
+};
+
+export function createChannelLine(
+  options: ChannelLineOptions = {},
+  warmUpOptions?: WarmUpOptions<ChannelLineState>,
+): IncrementalIndicator<ChannelLineValue, ChannelLineState> {
+  // Persisted state takes precedence over options.
+  const fromState = warmUpOptions?.fromState;
+  const leftBars = fromState?.leftBars ?? options.leftBars ?? 10;
+  const rightBars = fromState?.rightBars ?? options.rightBars ?? 10;
+
+  if (leftBars < 1) throw new Error("leftBars must be at least 1");
+  if (rightBars < 1) throw new Error("rightBars must be at least 1");
+
+  let swings: ReturnType<typeof createSwingPoints>;
+  let lastTwoHighs: SwingPoint[];
+  let lastTwoLows: SwingPoint[];
+  let highsSinceLastSwingLow: SwingPoint[];
+  let lowsSinceLastSwingHigh: SwingPoint[];
+  let highsBetweenLastTwoLows: SwingPoint[];
+  let lowsBetweenLastTwoHighs: SwingPoint[];
+  let channelDefined: boolean;
+  let channelDir: "up" | "down";
+  let primarySlope: number;
+  let primaryAnchorIdx: number;
+  let primaryAnchorPrice: number;
+  let parallelOffset: number;
+  let count: number;
+
+  if (fromState) {
+    swings = createSwingPoints({ leftBars, rightBars }, { fromState: fromState.swings });
+    lastTwoHighs = fromState.lastTwoHighs.map((p) => ({ ...p }));
+    lastTwoLows = fromState.lastTwoLows.map((p) => ({ ...p }));
+    highsSinceLastSwingLow = fromState.highsSinceLastSwingLow.map((p) => ({ ...p }));
+    lowsSinceLastSwingHigh = fromState.lowsSinceLastSwingHigh.map((p) => ({ ...p }));
+    highsBetweenLastTwoLows = fromState.highsBetweenLastTwoLows.map((p) => ({ ...p }));
+    lowsBetweenLastTwoHighs = fromState.lowsBetweenLastTwoHighs.map((p) => ({ ...p }));
+    channelDefined = fromState.channelDefined;
+    channelDir = fromState.channelDir;
+    primarySlope = fromState.primarySlope;
+    primaryAnchorIdx = fromState.primaryAnchorIdx;
+    primaryAnchorPrice = fromState.primaryAnchorPrice;
+    parallelOffset = fromState.parallelOffset;
+    count = fromState.count;
+  } else {
+    swings = createSwingPoints({ leftBars, rightBars });
+    lastTwoHighs = [];
+    lastTwoLows = [];
+    highsSinceLastSwingLow = [];
+    lowsSinceLastSwingHigh = [];
+    highsBetweenLastTwoLows = [];
+    lowsBetweenLastTwoHighs = [];
+    channelDefined = false;
+    channelDir = "up";
+    primarySlope = 0;
+    primaryAnchorIdx = 0;
+    primaryAnchorPrice = 0;
+    parallelOffset = 0;
+    count = 0;
+  }
+
+  function pushBounded(arr: SwingPoint[], p: SwingPoint, max: number): void {
+    arr.push(p);
+    if (arr.length > max) arr.shift();
+  }
+
+  /**
+   * Re-evaluate channel candidates from the current `lastTwoLows` /
+   * `lastTwoHighs` and the corresponding "between" lists. Mirrors the batch
+   * decision: prefer the candidate with the more recent defining point when
+   * both are valid.
+   */
+  function reEvaluateChannel(): void {
+    let upValid = false;
+    let upSlope = 0;
+    let upAnchorIdx = 0;
+    let upAnchorPrice = 0;
+    let upOffset = 0;
+    let upLastIdx = 0;
+
+    if (lastTwoLows.length === 2) {
+      const sl1 = lastTwoLows[0];
+      const sl2 = lastTwoLows[1];
+      if (sl2.price > sl1.price) {
+        upValid = true;
+        upSlope = (sl2.price - sl1.price) / (sl2.index - sl1.index);
+        upAnchorIdx = sl1.index;
+        upAnchorPrice = sl1.price;
+        upLastIdx = sl2.index;
+        let maxOffset = 0;
+        for (const sh of highsBetweenLastTwoLows) {
+          if (sh.index >= sl1.index && sh.index <= sl2.index) {
+            const onPrimary = upAnchorPrice + upSlope * (sh.index - upAnchorIdx);
+            const offset = sh.price - onPrimary;
+            if (offset > maxOffset) maxOffset = offset;
+          }
+        }
+        upOffset = maxOffset;
+      }
+    }
+
+    let downValid = false;
+    let downSlope = 0;
+    let downAnchorIdx = 0;
+    let downAnchorPrice = 0;
+    let downOffset = 0;
+    let downLastIdx = 0;
+
+    if (lastTwoHighs.length === 2) {
+      const sh1 = lastTwoHighs[0];
+      const sh2 = lastTwoHighs[1];
+      if (sh2.price < sh1.price) {
+        downValid = true;
+        downSlope = (sh2.price - sh1.price) / (sh2.index - sh1.index);
+        downAnchorIdx = sh1.index;
+        downAnchorPrice = sh1.price;
+        downLastIdx = sh2.index;
+        let maxOffset = 0;
+        for (const sl of lowsBetweenLastTwoHighs) {
+          if (sl.index >= sh1.index && sl.index <= sh2.index) {
+            const onPrimary = downAnchorPrice + downSlope * (sl.index - downAnchorIdx);
+            const offset = onPrimary - sl.price;
+            if (offset > maxOffset) maxOffset = offset;
+          }
+        }
+        downOffset = maxOffset;
+      }
+    }
+
+    if (upValid && downValid) {
+      if (upLastIdx >= downLastIdx) {
+        channelDir = "up";
+        primarySlope = upSlope;
+        primaryAnchorIdx = upAnchorIdx;
+        primaryAnchorPrice = upAnchorPrice;
+        parallelOffset = upOffset;
+      } else {
+        channelDir = "down";
+        primarySlope = downSlope;
+        primaryAnchorIdx = downAnchorIdx;
+        primaryAnchorPrice = downAnchorPrice;
+        parallelOffset = downOffset;
+      }
+      channelDefined = true;
+    } else if (upValid) {
+      channelDir = "up";
+      primarySlope = upSlope;
+      primaryAnchorIdx = upAnchorIdx;
+      primaryAnchorPrice = upAnchorPrice;
+      parallelOffset = upOffset;
+      channelDefined = true;
+    } else if (downValid) {
+      channelDir = "down";
+      primarySlope = downSlope;
+      primaryAnchorIdx = downAnchorIdx;
+      primaryAnchorPrice = downAnchorPrice;
+      parallelOffset = downOffset;
+      channelDefined = true;
+    }
+    // If neither is valid, leave existing state untouched (matches batch:
+    // batch only writes channel state inside a valid branch).
+  }
+
+  function project(barIdx: number): ChannelLineValue {
+    if (!channelDefined || barIdx < primaryAnchorIdx) {
+      return { upper: null, lower: null, middle: null, direction: null };
+    }
+    const primary = primaryAnchorPrice + primarySlope * (barIdx - primaryAnchorIdx);
+    const upper = channelDir === "up" ? primary + parallelOffset : primary;
+    const lower = channelDir === "up" ? primary : primary - parallelOffset;
+    return {
+      upper,
+      lower,
+      middle: (upper + lower) / 2,
+      direction: channelDir,
+    };
+  }
+
+  const indicator: IncrementalIndicator<ChannelLineValue, ChannelLineState> = {
+    next(candle: NormalizedCandle) {
+      count++;
+      const swingResult = swings.next(candle);
+      const sv = swingResult.value;
+      const confirmedIdx = count - 1 - rightBars;
+
+      let updated = false;
+
+      if (sv.isSwingHigh && sv.swingHighPrice !== null && confirmedIdx >= 0) {
+        const point: SwingPoint = { index: confirmedIdx, price: sv.swingHighPrice };
+        // Capture lows-since-last-swing-high as the new "between last two
+        // highs" set, then reset; finally update lastTwoHighs.
+        lowsBetweenLastTwoHighs = lowsSinceLastSwingHigh;
+        lowsSinceLastSwingHigh = [];
+        pushBounded(lastTwoHighs, point, 2);
+        // The new high also belongs to "highs since last swing low".
+        highsSinceLastSwingLow.push(point);
+        updated = true;
+      }
+
+      if (sv.isSwingLow && sv.swingLowPrice !== null && confirmedIdx >= 0) {
+        const point: SwingPoint = { index: confirmedIdx, price: sv.swingLowPrice };
+        highsBetweenLastTwoLows = highsSinceLastSwingLow;
+        highsSinceLastSwingLow = [];
+        pushBounded(lastTwoLows, point, 2);
+        lowsSinceLastSwingHigh.push(point);
+        updated = true;
+      }
+
+      if (updated) reEvaluateChannel();
+
+      return {
+        time: candle.time,
+        value: project(count - 1),
+      };
+    },
+
+    peek(candle: NormalizedCandle) {
+      const saved = indicator.getState();
+      const result = indicator.next(candle);
+      swings = createSwingPoints({ leftBars, rightBars }, { fromState: saved.swings });
+      lastTwoHighs = saved.lastTwoHighs.map((p) => ({ ...p }));
+      lastTwoLows = saved.lastTwoLows.map((p) => ({ ...p }));
+      highsSinceLastSwingLow = saved.highsSinceLastSwingLow.map((p) => ({ ...p }));
+      lowsSinceLastSwingHigh = saved.lowsSinceLastSwingHigh.map((p) => ({ ...p }));
+      highsBetweenLastTwoLows = saved.highsBetweenLastTwoLows.map((p) => ({ ...p }));
+      lowsBetweenLastTwoHighs = saved.lowsBetweenLastTwoHighs.map((p) => ({ ...p }));
+      channelDefined = saved.channelDefined;
+      channelDir = saved.channelDir;
+      primarySlope = saved.primarySlope;
+      primaryAnchorIdx = saved.primaryAnchorIdx;
+      primaryAnchorPrice = saved.primaryAnchorPrice;
+      parallelOffset = saved.parallelOffset;
+      count = saved.count;
+      return result;
+    },
+
+    getState(): ChannelLineState {
+      return {
+        leftBars,
+        rightBars,
+        swings: swings.getState(),
+        lastTwoHighs: lastTwoHighs.map((p) => ({ ...p })),
+        lastTwoLows: lastTwoLows.map((p) => ({ ...p })),
+        highsSinceLastSwingLow: highsSinceLastSwingLow.map((p) => ({ ...p })),
+        lowsSinceLastSwingHigh: lowsSinceLastSwingHigh.map((p) => ({ ...p })),
+        highsBetweenLastTwoLows: highsBetweenLastTwoLows.map((p) => ({ ...p })),
+        lowsBetweenLastTwoHighs: lowsBetweenLastTwoHighs.map((p) => ({ ...p })),
+        channelDefined,
+        channelDir,
+        primarySlope,
+        primaryAnchorIdx,
+        primaryAnchorPrice,
+        parallelOffset,
+        count,
+      };
+    },
+
+    get count() {
+      return count;
+    },
+
+    get isWarmedUp() {
+      return swings.isWarmedUp;
+    },
+  };
+
+  if (warmUpOptions?.warmUp) {
+    for (const candle of warmUpOptions.warmUp) {
+      indicator.next(candle);
+    }
+  }
+
+  return indicator;
+}

--- a/packages/core/src/indicators/indicator-meta.ts
+++ b/packages/core/src/indicators/indicator-meta.ts
@@ -358,6 +358,11 @@ export const FIBONACCI_EXTENSION_META: SeriesMeta = {
   overlay: true,
   label: "Fib Extension",
 };
+export const CHANNEL_LINE_META: SeriesMeta = {
+  kind: "channelLine",
+  overlay: true,
+  label: "Channel",
+};
 export const GAP_ANALYSIS_META: SeriesMeta = {
   kind: "gapAnalysis",
   overlay: false,

--- a/packages/core/src/streaming/live-presets.ts
+++ b/packages/core/src/streaming/live-presets.ts
@@ -28,6 +28,7 @@ import {
   createBollingerBands,
   createCci,
   createChandelierExit,
+  createChannelLine,
   createChoppinessIndex,
   createCmf,
   createCmo,
@@ -112,6 +113,7 @@ import {
   BOP_META,
   CCI_META,
   CHANDELIER_EXIT_META,
+  CHANNEL_LINE_META,
   CHOPPINESS_META,
   CMF_META,
   CMO_META,
@@ -1005,6 +1007,15 @@ export const livePresets: Record<string, LivePreset> = {
       leftBars: p.leftBars ?? 10,
       rightBars: p.rightBars ?? 10,
       levels: p.levels,
+    })),
+  },
+  channelLine: {
+    meta: CHANNEL_LINE_META,
+    defaultParams: { leftBars: 10, rightBars: 10 },
+    snapshotName: "channel",
+    createFactory: factory<{ leftBars?: number; rightBars?: number }>()(createChannelLine, (p) => ({
+      leftBars: p.leftBars ?? 10,
+      rightBars: p.rightBars ?? 10,
     })),
   },
 


### PR DESCRIPTION
Closes #108.

## Summary
- New `createChannelLine` incremental factory (`packages/core/src/indicators/incremental/price/channel-line.ts`) that wraps `createSwingPoints` and tracks last-2 swing highs / lows plus the swings that fall between them. Up-channel connects rising swing lows with a parallel line through the highest swing high between; down-channel mirrors with falling swing highs. When both candidates are valid the more recent one wins (matches batch).
- `fromState`-precedence pattern (snapshot resume keeps custom config without re-passing options).
- State growth bounded: the two "since last opposite swing" lists are capped by reset on the next opposite-type confirmation; `lastTwoHighs` / `lastTwoLows` are bounded to length 2.
- Wired into `livePresets` only — channel is rendered as 3 parallel lines on the price pane natively (no `indicatorPresets` series entry). Follow-up #116 tracks the live channel showcase plugin.

## Stream semantics
Same shifted-parity property as Fib Retracement: live confirms swings with `rightBars` delay, so `direction` at step `t` agrees with `batch[t - rightBars]`. Raw `upper / lower / middle` cannot be compared bar-by-bar across the shift because each side projects at a different bar (live at the current bar, batch at iteration index); tests verify direction parity plus standard properties.

## Test plan
- [x] Direction parity vs batch — `live[t].direction` equals `batch[t - rightBars].direction` for >50 aligned bars
- [x] Eventually defines a channel; structural consistency (upper >= lower, middle = mean)
- [x] Snapshot resume drift-free with default options
- [x] Snapshot resume preserves custom config (`{ leftBars: 7, rightBars: 4 }`) when restored without re-passed options
- [x] `peek()` does not mutate state
- [x] Option validation throws on invalid inputs
- [x] `WarmUpOptions.warmUp` matches a fresh instance
- [x] `pnpm test` (4854 core + 760 chart + 59 mcp) / `pnpm lint` / `pnpm build` all green