### PR TITLE
feat(core): add createAutoTrendLine incremental indicator

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/auto-trend-line.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/auto-trend-line.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Parity tests for incremental Auto Trend Line vs batch.
+ *
+ * Same shifted-parity property as Channel Line: live confirms swings with
+ * `rightBars` delay, so the underlying slope/anchor at step `t` agree with
+ * `batch[t - rightBars]`. Raw `resistance / support` cannot be compared
+ * bar-by-bar across the shift because each side projects at a different
+ * bar (live at the current bar, batch at iteration index); tests verify
+ * "has line" parity plus standard properties.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../../types";
+import { autoTrendLine } from "../../price/auto-trend-line";
+import { createAutoTrendLine } from "../price/auto-trend-line";
+
+function generateCandles(count: number): NormalizedCandle[] {
+  const candles: NormalizedCandle[] = [];
+  const MS = 86400000;
+  const base = new Date("2020-01-01").getTime();
+  let price = 100;
+  let s = 31;
+  const r = () => {
+    s = (s * 16807) % 2147483647;
+    return s / 2147483647;
+  };
+  for (let i = 0; i < count; i++) {
+    const change = (r() - 0.5) * 5;
+    const open = price;
+    const close = price * (1 + change / 100);
+    const high = Math.max(open, close) * (1 + r() * 0.015);
+    const low = Math.min(open, close) * (1 - r() * 0.015);
+    candles.push({ time: base + i * MS, open, high, low, close, volume: 1000 });
+    price = close;
+  }
+  return candles;
+}
+
+describe("createAutoTrendLine", () => {
+  const leftBars = 5;
+  const rightBars = 5;
+  const candles = generateCandles(400);
+
+  it("matches batch on has-line state with rightBars shift", () => {
+    const batch = autoTrendLine(candles, { leftBars, rightBars });
+    const live = createAutoTrendLine({ leftBars, rightBars });
+    let comparedDefined = 0;
+    for (let t = 0; t < candles.length; t++) {
+      const liveVal = live.next(candles[t]).value;
+      const batchIdx = t - rightBars;
+      if (batchIdx < 0) continue;
+      const batchVal = batch[batchIdx].value;
+      // Both sides should agree on whether each line is defined at this
+      // aligned point. Raw values diverge because of the projection-bar gap.
+      expect(liveVal.resistance === null).toBe(batchVal.resistance === null);
+      expect(liveVal.support === null).toBe(batchVal.support === null);
+      if (liveVal.resistance !== null && liveVal.support !== null) comparedDefined++;
+    }
+    expect(comparedDefined).toBeGreaterThan(50);
+  });
+
+  it("eventually defines both resistance and support", () => {
+    const live = createAutoTrendLine({ leftBars, rightBars });
+    let sawRes = false;
+    let sawSup = false;
+    for (const c of candles) {
+      const { value } = live.next(c);
+      if (value.resistance !== null) sawRes = true;
+      if (value.support !== null) sawSup = true;
+      if (sawRes && sawSup) break;
+    }
+    expect(sawRes).toBe(true);
+    expect(sawSup).toBe(true);
+  });
+
+  it("restores from snapshot without drift", () => {
+    const a = createAutoTrendLine({ leftBars, rightBars });
+    for (let i = 0; i < 200; i++) a.next(candles[i]);
+    const b = createAutoTrendLine({ leftBars, rightBars }, { fromState: a.getState() });
+    for (let i = 200; i < candles.length; i++) {
+      const va = a.next(candles[i]).value;
+      const vb = b.next(candles[i]).value;
+      expect(vb.resistance).toBe(va.resistance);
+      expect(vb.support).toBe(va.support);
+    }
+  });
+
+  it("preserves custom config when restored without re-passing options", () => {
+    const customLeft = 7;
+    const customRight = 4;
+    const a = createAutoTrendLine({ leftBars: customLeft, rightBars: customRight });
+    for (let i = 0; i < 200; i++) a.next(candles[i]);
+    const b = createAutoTrendLine(undefined, { fromState: a.getState() });
+    for (let i = 200; i < candles.length; i++) {
+      const va = a.next(candles[i]).value;
+      const vb = b.next(candles[i]).value;
+      expect(vb.resistance).toBe(va.resistance);
+      expect(vb.support).toBe(va.support);
+    }
+    const stateB = b.getState();
+    expect(stateB.leftBars).toBe(customLeft);
+    expect(stateB.rightBars).toBe(customRight);
+  });
+
+  it("peek does not mutate state", () => {
+    const live = createAutoTrendLine({ leftBars, rightBars });
+    for (let i = 0; i < 80; i++) live.next(candles[i]);
+    const before = JSON.stringify(live.getState());
+    live.peek(candles[80]);
+    expect(JSON.stringify(live.getState())).toBe(before);
+  });
+
+  it("throws on invalid options", () => {
+    expect(() => createAutoTrendLine({ leftBars: 0 })).toThrow();
+    expect(() => createAutoTrendLine({ rightBars: 0 })).toThrow();
+  });
+
+  it("warms up via WarmUpOptions.warmUp", () => {
+    const warmUp = candles.slice(0, 80);
+    const live = createAutoTrendLine({ leftBars, rightBars }, { warmUp });
+    expect(live.count).toBe(80);
+    const ref = createAutoTrendLine({ leftBars, rightBars });
+    for (const c of warmUp) ref.next(c);
+    expect(JSON.stringify(live.getState())).toBe(JSON.stringify(ref.getState()));
+  });
+});

--- a/packages/core/src/indicators/incremental/index.ts
+++ b/packages/core/src/indicators/incremental/index.ts
@@ -248,6 +248,12 @@ export type {
   ChannelLineOptions,
   ChannelLineValue as IncrementalChannelLineValue,
 } from "./price/channel-line";
+export { createAutoTrendLine } from "./price/auto-trend-line";
+export type {
+  AutoTrendLineState,
+  AutoTrendLineOptions,
+  AutoTrendLineValue as IncrementalAutoTrendLineValue,
+} from "./price/auto-trend-line";
 export type {
   BosState,
   ChochState,

--- a/packages/core/src/indicators/incremental/price/auto-trend-line.ts
+++ b/packages/core/src/indicators/incremental/price/auto-trend-line.ts
@@ -1,0 +1,211 @@
+/**
+ * Incremental Auto Trend Line.
+ *
+ * Wraps `createSwingPoints` and tracks the last 2 confirmed swing highs +
+ * last 2 confirmed swing lows. Resistance slope/anchor are derived from the
+ * pair of swing highs, support from the pair of swing lows. Output projects
+ * each line at the current bar.
+ *
+ * Parity note (same shifted-parity property as Channel Line / Fib): batch
+ * uses look-ahead via batch `swingPoints`, while live confirms swings with
+ * `rightBars` delay. `hasResistance / hasSupport` and the underlying slope/
+ * anchor at step `t` agree with `batch[t - rightBars]`. Raw `resistance /
+ * support` cannot be compared bar-by-bar across the shift because each side
+ * projects at a different bar.
+ */
+
+import type { NormalizedCandle } from "../../../types";
+import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type SwingPointsState, createSwingPoints } from "./swing-points";
+
+export type AutoTrendLineValue = {
+  /** Resistance line value at the current bar, null before enough data */
+  resistance: number | null;
+  /** Support line value at the current bar, null before enough data */
+  support: number | null;
+};
+
+export type AutoTrendLineOptions = {
+  /** Number of bars to the left for swing point confirmation (default: 10) */
+  leftBars?: number;
+  /** Number of bars to the right for swing point confirmation (default: 10) */
+  rightBars?: number;
+};
+
+type SwingPoint = {
+  index: number;
+  price: number;
+};
+
+export type AutoTrendLineState = {
+  leftBars: number;
+  rightBars: number;
+  swings: SwingPointsState;
+  lastTwoHighs: SwingPoint[];
+  lastTwoLows: SwingPoint[];
+  hasResistance: boolean;
+  resSlope: number;
+  resAnchorIdx: number;
+  resAnchorPrice: number;
+  hasSupport: boolean;
+  supSlope: number;
+  supAnchorIdx: number;
+  supAnchorPrice: number;
+  count: number;
+};
+
+export function createAutoTrendLine(
+  options: AutoTrendLineOptions = {},
+  warmUpOptions?: WarmUpOptions<AutoTrendLineState>,
+): IncrementalIndicator<AutoTrendLineValue, AutoTrendLineState> {
+  const fromState = warmUpOptions?.fromState;
+  const leftBars = fromState?.leftBars ?? options.leftBars ?? 10;
+  const rightBars = fromState?.rightBars ?? options.rightBars ?? 10;
+
+  if (leftBars < 1) throw new Error("leftBars must be at least 1");
+  if (rightBars < 1) throw new Error("rightBars must be at least 1");
+
+  let swings: ReturnType<typeof createSwingPoints>;
+  let lastTwoHighs: SwingPoint[];
+  let lastTwoLows: SwingPoint[];
+  let hasResistance: boolean;
+  let resSlope: number;
+  let resAnchorIdx: number;
+  let resAnchorPrice: number;
+  let hasSupport: boolean;
+  let supSlope: number;
+  let supAnchorIdx: number;
+  let supAnchorPrice: number;
+  let count: number;
+
+  if (fromState) {
+    swings = createSwingPoints({ leftBars, rightBars }, { fromState: fromState.swings });
+    lastTwoHighs = fromState.lastTwoHighs.map((p) => ({ ...p }));
+    lastTwoLows = fromState.lastTwoLows.map((p) => ({ ...p }));
+    hasResistance = fromState.hasResistance;
+    resSlope = fromState.resSlope;
+    resAnchorIdx = fromState.resAnchorIdx;
+    resAnchorPrice = fromState.resAnchorPrice;
+    hasSupport = fromState.hasSupport;
+    supSlope = fromState.supSlope;
+    supAnchorIdx = fromState.supAnchorIdx;
+    supAnchorPrice = fromState.supAnchorPrice;
+    count = fromState.count;
+  } else {
+    swings = createSwingPoints({ leftBars, rightBars });
+    lastTwoHighs = [];
+    lastTwoLows = [];
+    hasResistance = false;
+    resSlope = 0;
+    resAnchorIdx = 0;
+    resAnchorPrice = 0;
+    hasSupport = false;
+    supSlope = 0;
+    supAnchorIdx = 0;
+    supAnchorPrice = 0;
+    count = 0;
+  }
+
+  const indicator: IncrementalIndicator<AutoTrendLineValue, AutoTrendLineState> = {
+    next(candle: NormalizedCandle) {
+      count++;
+      const swingResult = swings.next(candle);
+      const sv = swingResult.value;
+      const confirmedIdx = count - 1 - rightBars;
+
+      if (sv.isSwingHigh && sv.swingHighPrice !== null && confirmedIdx >= 0) {
+        lastTwoHighs.push({ index: confirmedIdx, price: sv.swingHighPrice });
+        if (lastTwoHighs.length > 2) lastTwoHighs.shift();
+        if (lastTwoHighs.length === 2) {
+          const p1 = lastTwoHighs[0];
+          const p2 = lastTwoHighs[1];
+          resSlope = (p2.price - p1.price) / (p2.index - p1.index);
+          resAnchorIdx = p1.index;
+          resAnchorPrice = p1.price;
+          hasResistance = true;
+        }
+      }
+
+      if (sv.isSwingLow && sv.swingLowPrice !== null && confirmedIdx >= 0) {
+        lastTwoLows.push({ index: confirmedIdx, price: sv.swingLowPrice });
+        if (lastTwoLows.length > 2) lastTwoLows.shift();
+        if (lastTwoLows.length === 2) {
+          const p1 = lastTwoLows[0];
+          const p2 = lastTwoLows[1];
+          supSlope = (p2.price - p1.price) / (p2.index - p1.index);
+          supAnchorIdx = p1.index;
+          supAnchorPrice = p1.price;
+          hasSupport = true;
+        }
+      }
+
+      const barIdx = count - 1;
+      const resistance =
+        hasResistance && barIdx >= resAnchorIdx
+          ? resAnchorPrice + resSlope * (barIdx - resAnchorIdx)
+          : null;
+      const support =
+        hasSupport && barIdx >= supAnchorIdx
+          ? supAnchorPrice + supSlope * (barIdx - supAnchorIdx)
+          : null;
+
+      return {
+        time: candle.time,
+        value: { resistance, support },
+      };
+    },
+
+    peek(candle: NormalizedCandle) {
+      const saved = indicator.getState();
+      const result = indicator.next(candle);
+      swings = createSwingPoints({ leftBars, rightBars }, { fromState: saved.swings });
+      lastTwoHighs = saved.lastTwoHighs.map((p) => ({ ...p }));
+      lastTwoLows = saved.lastTwoLows.map((p) => ({ ...p }));
+      hasResistance = saved.hasResistance;
+      resSlope = saved.resSlope;
+      resAnchorIdx = saved.resAnchorIdx;
+      resAnchorPrice = saved.resAnchorPrice;
+      hasSupport = saved.hasSupport;
+      supSlope = saved.supSlope;
+      supAnchorIdx = saved.supAnchorIdx;
+      supAnchorPrice = saved.supAnchorPrice;
+      count = saved.count;
+      return result;
+    },
+
+    getState(): AutoTrendLineState {
+      return {
+        leftBars,
+        rightBars,
+        swings: swings.getState(),
+        lastTwoHighs: lastTwoHighs.map((p) => ({ ...p })),
+        lastTwoLows: lastTwoLows.map((p) => ({ ...p })),
+        hasResistance,
+        resSlope,
+        resAnchorIdx,
+        resAnchorPrice,
+        hasSupport,
+        supSlope,
+        supAnchorIdx,
+        supAnchorPrice,
+        count,
+      };
+    },
+
+    get count() {
+      return count;
+    },
+
+    get isWarmedUp() {
+      return swings.isWarmedUp;
+    },
+  };
+
+  if (warmUpOptions?.warmUp) {
+    for (const candle of warmUpOptions.warmUp) {
+      indicator.next(candle);
+    }
+  }
+
+  return indicator;
+}

--- a/packages/core/src/indicators/indicator-meta.ts
+++ b/packages/core/src/indicators/indicator-meta.ts
@@ -363,6 +363,11 @@ export const CHANNEL_LINE_META: SeriesMeta = {
   overlay: true,
   label: "Channel",
 };
+export const AUTO_TREND_LINE_META: SeriesMeta = {
+  kind: "autoTrendLine",
+  overlay: true,
+  label: "Trend Lines",
+};
 export const GAP_ANALYSIS_META: SeriesMeta = {
   kind: "gapAnalysis",
   overlay: false,

--- a/packages/core/src/streaming/live-presets.ts
+++ b/packages/core/src/streaming/live-presets.ts
@@ -23,6 +23,7 @@ import {
   createAroon,
   createAtr,
   createAtrStops,
+  createAutoTrendLine,
   createAwesomeOscillator,
   createBalanceOfPower,
   createBollingerBands,
@@ -109,6 +110,7 @@ import {
   AROON_META,
   ATR_META,
   ATR_STOPS_META,
+  AUTO_TREND_LINE_META,
   BB_META,
   BOP_META,
   CCI_META,
@@ -1017,6 +1019,18 @@ export const livePresets: Record<string, LivePreset> = {
       leftBars: p.leftBars ?? 10,
       rightBars: p.rightBars ?? 10,
     })),
+  },
+  autoTrendLine: {
+    meta: AUTO_TREND_LINE_META,
+    defaultParams: { leftBars: 10, rightBars: 10 },
+    snapshotName: "atl",
+    createFactory: factory<{ leftBars?: number; rightBars?: number }>()(
+      createAutoTrendLine,
+      (p) => ({
+        leftBars: p.leftBars ?? 10,
+        rightBars: p.rightBars ?? 10,
+      }),
+    ),
   },
 
   // Wyckoff


### PR DESCRIPTION
Closes #109.

## Summary
- New `createAutoTrendLine` incremental factory (`packages/core/src/indicators/incremental/price/auto-trend-line.ts`) that wraps `createSwingPoints` and tracks last-2 swing highs (resistance) + last-2 swing lows (support). Resistance and support slope/anchor are derived from each pair; output projects each line at the current bar.
- Simplest of the four swing-derived incremental indicators added in this stream (#106 Fib Retracement, #107 Fib Extension, #108 Channel Line). Pure scalar state in the hot path — no level record, no "between" tracking, no offset calc.
- Same `fromState`-precedence pattern: snapshot resume keeps custom config without re-passing options.
- Wired into `livePresets` only — natural rendering is two lines on the price pane, not a sub-pane scalar, so no `indicatorPresets` entry.

## Stream semantics
Same shifted-parity property as the rest of the family: live confirms swings with `rightBars` delay, so `hasResistance / hasSupport` and the underlying slope/anchor at step `t` agree with `batch[t - rightBars]`. Raw `resistance / support` cannot be compared bar-by-bar across the shift because each side projects at a different bar.

## Test plan
- [x] has-line parity vs batch — `live[t]` agrees with `batch[t - rightBars]` on whether resistance/support are defined for >50 aligned bars
- [x] Eventually defines both resistance and support
- [x] Snapshot resume drift-free with default options
- [x] Snapshot resume preserves custom config (`{ leftBars: 7, rightBars: 4 }`) when restored without re-passed options
- [x] `peek()` does not mutate state
- [x] Option validation throws on invalid inputs
- [x] `WarmUpOptions.warmUp` matches a fresh instance
- [x] `pnpm test` (4866 core + 760 chart + 59 mcp) / `pnpm lint` / `pnpm build` all green

## Follow-ups
- #118 — wire `createAutoTrendLine` into the live showcase plugin
- #119 — extract the now-repeated swing-derived helper boilerplate across the four sister indicators (Fib Retracement / Fib Extension / Channel Line / Auto Trend Line)