### PR TITLE
refactor(core): extract swing-derived incremental helpers

### DIFF
--- a/packages/core/src/indicators/incremental/price/auto-trend-line.ts
+++ b/packages/core/src/indicators/incremental/price/auto-trend-line.ts
@@ -16,6 +16,7 @@
 
 import type { NormalizedCandle } from "../../../types";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { cloneShallow, pushBounded, resolveSwingConfig } from "./swing-helpers";
 import { type SwingPointsState, createSwingPoints } from "./swing-points";
 
 export type AutoTrendLineValue = {
@@ -59,11 +60,7 @@ export function createAutoTrendLine(
   warmUpOptions?: WarmUpOptions<AutoTrendLineState>,
 ): IncrementalIndicator<AutoTrendLineValue, AutoTrendLineState> {
   const fromState = warmUpOptions?.fromState;
-  const leftBars = fromState?.leftBars ?? options.leftBars ?? 10;
-  const rightBars = fromState?.rightBars ?? options.rightBars ?? 10;
-
-  if (leftBars < 1) throw new Error("leftBars must be at least 1");
-  if (rightBars < 1) throw new Error("rightBars must be at least 1");
+  const { leftBars, rightBars } = resolveSwingConfig(options, fromState);
 
   let swings: ReturnType<typeof createSwingPoints>;
   let lastTwoHighs: SwingPoint[];
@@ -80,8 +77,8 @@ export function createAutoTrendLine(
 
   if (fromState) {
     swings = createSwingPoints({ leftBars, rightBars }, { fromState: fromState.swings });
-    lastTwoHighs = fromState.lastTwoHighs.map((p) => ({ ...p }));
-    lastTwoLows = fromState.lastTwoLows.map((p) => ({ ...p }));
+    lastTwoHighs = cloneShallow(fromState.lastTwoHighs);
+    lastTwoLows = cloneShallow(fromState.lastTwoLows);
     hasResistance = fromState.hasResistance;
     resSlope = fromState.resSlope;
     resAnchorIdx = fromState.resAnchorIdx;
@@ -114,8 +111,7 @@ export function createAutoTrendLine(
       const confirmedIdx = count - 1 - rightBars;
 
       if (sv.isSwingHigh && sv.swingHighPrice !== null && confirmedIdx >= 0) {
-        lastTwoHighs.push({ index: confirmedIdx, price: sv.swingHighPrice });
-        if (lastTwoHighs.length > 2) lastTwoHighs.shift();
+        pushBounded(lastTwoHighs, { index: confirmedIdx, price: sv.swingHighPrice }, 2);
         if (lastTwoHighs.length === 2) {
           const p1 = lastTwoHighs[0];
           const p2 = lastTwoHighs[1];
@@ -127,8 +123,7 @@ export function createAutoTrendLine(
       }
 
       if (sv.isSwingLow && sv.swingLowPrice !== null && confirmedIdx >= 0) {
-        lastTwoLows.push({ index: confirmedIdx, price: sv.swingLowPrice });
-        if (lastTwoLows.length > 2) lastTwoLows.shift();
+        pushBounded(lastTwoLows, { index: confirmedIdx, price: sv.swingLowPrice }, 2);
         if (lastTwoLows.length === 2) {
           const p1 = lastTwoLows[0];
           const p2 = lastTwoLows[1];
@@ -159,8 +154,8 @@ export function createAutoTrendLine(
       const saved = indicator.getState();
       const result = indicator.next(candle);
       swings = createSwingPoints({ leftBars, rightBars }, { fromState: saved.swings });
-      lastTwoHighs = saved.lastTwoHighs.map((p) => ({ ...p }));
-      lastTwoLows = saved.lastTwoLows.map((p) => ({ ...p }));
+      lastTwoHighs = cloneShallow(saved.lastTwoHighs);
+      lastTwoLows = cloneShallow(saved.lastTwoLows);
       hasResistance = saved.hasResistance;
       resSlope = saved.resSlope;
       resAnchorIdx = saved.resAnchorIdx;
@@ -178,8 +173,8 @@ export function createAutoTrendLine(
         leftBars,
         rightBars,
         swings: swings.getState(),
-        lastTwoHighs: lastTwoHighs.map((p) => ({ ...p })),
-        lastTwoLows: lastTwoLows.map((p) => ({ ...p })),
+        lastTwoHighs: cloneShallow(lastTwoHighs),
+        lastTwoLows: cloneShallow(lastTwoLows),
         hasResistance,
         resSlope,
         resAnchorIdx,

--- a/packages/core/src/indicators/incremental/price/channel-line.ts
+++ b/packages/core/src/indicators/incremental/price/channel-line.ts
@@ -25,6 +25,7 @@
 
 import type { NormalizedCandle } from "../../../types";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { cloneShallow, pushBounded, resolveSwingConfig } from "./swing-helpers";
 import { type SwingPointsState, createSwingPoints } from "./swing-points";
 
 export type ChannelLineValue = {
@@ -73,13 +74,8 @@ export function createChannelLine(
   options: ChannelLineOptions = {},
   warmUpOptions?: WarmUpOptions<ChannelLineState>,
 ): IncrementalIndicator<ChannelLineValue, ChannelLineState> {
-  // Persisted state takes precedence over options.
   const fromState = warmUpOptions?.fromState;
-  const leftBars = fromState?.leftBars ?? options.leftBars ?? 10;
-  const rightBars = fromState?.rightBars ?? options.rightBars ?? 10;
-
-  if (leftBars < 1) throw new Error("leftBars must be at least 1");
-  if (rightBars < 1) throw new Error("rightBars must be at least 1");
+  const { leftBars, rightBars } = resolveSwingConfig(options, fromState);
 
   let swings: ReturnType<typeof createSwingPoints>;
   let lastTwoHighs: SwingPoint[];
@@ -98,12 +94,12 @@ export function createChannelLine(
 
   if (fromState) {
     swings = createSwingPoints({ leftBars, rightBars }, { fromState: fromState.swings });
-    lastTwoHighs = fromState.lastTwoHighs.map((p) => ({ ...p }));
-    lastTwoLows = fromState.lastTwoLows.map((p) => ({ ...p }));
-    highsSinceLastSwingLow = fromState.highsSinceLastSwingLow.map((p) => ({ ...p }));
-    lowsSinceLastSwingHigh = fromState.lowsSinceLastSwingHigh.map((p) => ({ ...p }));
-    highsBetweenLastTwoLows = fromState.highsBetweenLastTwoLows.map((p) => ({ ...p }));
-    lowsBetweenLastTwoHighs = fromState.lowsBetweenLastTwoHighs.map((p) => ({ ...p }));
+    lastTwoHighs = cloneShallow(fromState.lastTwoHighs);
+    lastTwoLows = cloneShallow(fromState.lastTwoLows);
+    highsSinceLastSwingLow = cloneShallow(fromState.highsSinceLastSwingLow);
+    lowsSinceLastSwingHigh = cloneShallow(fromState.lowsSinceLastSwingHigh);
+    highsBetweenLastTwoLows = cloneShallow(fromState.highsBetweenLastTwoLows);
+    lowsBetweenLastTwoHighs = cloneShallow(fromState.lowsBetweenLastTwoHighs);
     channelDefined = fromState.channelDefined;
     channelDir = fromState.channelDir;
     primarySlope = fromState.primarySlope;
@@ -126,11 +122,6 @@ export function createChannelLine(
     primaryAnchorPrice = 0;
     parallelOffset = 0;
     count = 0;
-  }
-
-  function pushBounded(arr: SwingPoint[], p: SwingPoint, max: number): void {
-    arr.push(p);
-    if (arr.length > max) arr.shift();
   }
 
   /**
@@ -287,12 +278,12 @@ export function createChannelLine(
       const saved = indicator.getState();
       const result = indicator.next(candle);
       swings = createSwingPoints({ leftBars, rightBars }, { fromState: saved.swings });
-      lastTwoHighs = saved.lastTwoHighs.map((p) => ({ ...p }));
-      lastTwoLows = saved.lastTwoLows.map((p) => ({ ...p }));
-      highsSinceLastSwingLow = saved.highsSinceLastSwingLow.map((p) => ({ ...p }));
-      lowsSinceLastSwingHigh = saved.lowsSinceLastSwingHigh.map((p) => ({ ...p }));
-      highsBetweenLastTwoLows = saved.highsBetweenLastTwoLows.map((p) => ({ ...p }));
-      lowsBetweenLastTwoHighs = saved.lowsBetweenLastTwoHighs.map((p) => ({ ...p }));
+      lastTwoHighs = cloneShallow(saved.lastTwoHighs);
+      lastTwoLows = cloneShallow(saved.lastTwoLows);
+      highsSinceLastSwingLow = cloneShallow(saved.highsSinceLastSwingLow);
+      lowsSinceLastSwingHigh = cloneShallow(saved.lowsSinceLastSwingHigh);
+      highsBetweenLastTwoLows = cloneShallow(saved.highsBetweenLastTwoLows);
+      lowsBetweenLastTwoHighs = cloneShallow(saved.lowsBetweenLastTwoHighs);
       channelDefined = saved.channelDefined;
       channelDir = saved.channelDir;
       primarySlope = saved.primarySlope;
@@ -308,12 +299,12 @@ export function createChannelLine(
         leftBars,
         rightBars,
         swings: swings.getState(),
-        lastTwoHighs: lastTwoHighs.map((p) => ({ ...p })),
-        lastTwoLows: lastTwoLows.map((p) => ({ ...p })),
-        highsSinceLastSwingLow: highsSinceLastSwingLow.map((p) => ({ ...p })),
-        lowsSinceLastSwingHigh: lowsSinceLastSwingHigh.map((p) => ({ ...p })),
-        highsBetweenLastTwoLows: highsBetweenLastTwoLows.map((p) => ({ ...p })),
-        lowsBetweenLastTwoHighs: lowsBetweenLastTwoHighs.map((p) => ({ ...p })),
+        lastTwoHighs: cloneShallow(lastTwoHighs),
+        lastTwoLows: cloneShallow(lastTwoLows),
+        highsSinceLastSwingLow: cloneShallow(highsSinceLastSwingLow),
+        lowsSinceLastSwingHigh: cloneShallow(lowsSinceLastSwingHigh),
+        highsBetweenLastTwoLows: cloneShallow(highsBetweenLastTwoLows),
+        lowsBetweenLastTwoHighs: cloneShallow(lowsBetweenLastTwoHighs),
         channelDefined,
         channelDir,
         primarySlope,

--- a/packages/core/src/indicators/incremental/price/fibonacci-extension.ts
+++ b/packages/core/src/indicators/incremental/price/fibonacci-extension.ts
@@ -17,6 +17,12 @@
 
 import type { NormalizedCandle } from "../../../types";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  cloneShallow,
+  pushBounded,
+  resolveLevelsConfig,
+  resolveSwingConfig,
+} from "./swing-helpers";
 import { type SwingPointsState, createSwingPoints } from "./swing-points";
 
 export type FibonacciExtensionValue = {
@@ -67,22 +73,9 @@ export function createFibonacciExtension(
   options: FibonacciExtensionOptions = {},
   warmUpOptions?: WarmUpOptions<FibonacciExtensionState>,
 ): IncrementalIndicator<FibonacciExtensionValue, FibonacciExtensionState> {
-  // Persisted state takes precedence over options so a stream resumed via
-  // `restoreState(savedState)` (no re-passed options) keeps its original
-  // configuration.
   const fromState = warmUpOptions?.fromState;
-  const leftBars = fromState?.leftBars ?? options.leftBars ?? 10;
-  const rightBars = fromState?.rightBars ?? options.rightBars ?? 10;
-  const levels = (fromState?.levels ?? options.levels ?? DEFAULT_LEVELS).slice();
-
-  if (leftBars < 1) throw new Error("leftBars must be at least 1");
-  if (rightBars < 1) throw new Error("rightBars must be at least 1");
-  if (!Array.isArray(levels) || levels.length === 0) {
-    throw new Error("levels must be a non-empty array");
-  }
-
-  // Cache the level keys so the hot path skips repeated `String(ratio)` calls.
-  const ratioKeys = levels.map(String);
+  const { leftBars, rightBars } = resolveSwingConfig(options, fromState);
+  const { levels, ratioKeys } = resolveLevelsConfig(options, fromState, DEFAULT_LEVELS);
 
   let swings: ReturnType<typeof createSwingPoints>;
   // The pattern only ever needs the last 3 alternating points. Trim to that
@@ -97,7 +90,7 @@ export function createFibonacciExtension(
 
   if (fromState) {
     swings = createSwingPoints({ leftBars, rightBars }, { fromState: fromState.swings });
-    alternating = fromState.alternating.map((p) => ({ ...p }));
+    alternating = cloneShallow(fromState.alternating);
     currentLevels = fromState.currentLevels ? { ...fromState.currentLevels } : null;
     currentPointA = fromState.currentPointA;
     currentPointB = fromState.currentPointB;
@@ -125,8 +118,7 @@ export function createFibonacciExtension(
     }
     const last = alternating[alternating.length - 1];
     if (last.type !== point.type) {
-      alternating.push(point);
-      if (alternating.length > 3) alternating.shift();
+      pushBounded(alternating, point, 3);
       return true;
     }
     // Same type consecutive: keep the more extreme.
@@ -214,7 +206,7 @@ export function createFibonacciExtension(
       const saved = indicator.getState();
       const result = indicator.next(candle);
       swings = createSwingPoints({ leftBars, rightBars }, { fromState: saved.swings });
-      alternating = saved.alternating.map((p) => ({ ...p }));
+      alternating = cloneShallow(saved.alternating);
       currentLevels = saved.currentLevels ? { ...saved.currentLevels } : null;
       currentPointA = saved.currentPointA;
       currentPointB = saved.currentPointB;
@@ -231,7 +223,7 @@ export function createFibonacciExtension(
         rightBars,
         levels: levels.slice(),
         swings: swings.getState(),
-        alternating: alternating.map((p) => ({ ...p })),
+        alternating: cloneShallow(alternating),
         currentLevels: currentLevels ? { ...currentLevels } : null,
         currentPointA,
         currentPointB,

--- a/packages/core/src/indicators/incremental/price/fibonacci-retracement.ts
+++ b/packages/core/src/indicators/incremental/price/fibonacci-retracement.ts
@@ -21,6 +21,7 @@
 
 import type { NormalizedCandle } from "../../../types";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { resolveLevelsConfig, resolveSwingConfig } from "./swing-helpers";
 import { type SwingPointsState, createSwingPoints } from "./swing-points";
 
 export type FibonacciRetracementValue = {
@@ -61,24 +62,9 @@ export function createFibonacciRetracement(
   options: FibonacciRetracementOptions = {},
   warmUpOptions?: WarmUpOptions<FibonacciRetracementState>,
 ): IncrementalIndicator<FibonacciRetracementValue, FibonacciRetracementState> {
-  // Persisted state's config takes precedence over `options` so a stream
-  // resumed via `restoreState(savedState)` (no re-passed options) keeps its
-  // original leftBars / rightBars / levels. Falling back to options when
-  // `fromState` is omitted preserves the normal construction path.
   const fromState = warmUpOptions?.fromState;
-  const leftBars = fromState?.leftBars ?? options.leftBars ?? 10;
-  const rightBars = fromState?.rightBars ?? options.rightBars ?? 10;
-  const levels = (fromState?.levels ?? options.levels ?? DEFAULT_LEVELS).slice();
-
-  if (leftBars < 1) throw new Error("leftBars must be at least 1");
-  if (rightBars < 1) throw new Error("rightBars must be at least 1");
-  if (!Array.isArray(levels) || levels.length === 0) {
-    throw new Error("levels must be a non-empty array");
-  }
-
-  // Cache the level keys so the hot path skips repeated `String(ratio)` calls
-  // (default 7 ratios × every bar).
-  const ratioKeys = levels.map(String);
+  const { leftBars, rightBars } = resolveSwingConfig(options, fromState);
+  const { levels, ratioKeys } = resolveLevelsConfig(options, fromState, DEFAULT_LEVELS);
 
   let swings: ReturnType<typeof createSwingPoints>;
   let lastSwingHighPrice: number | null;

--- a/packages/core/src/indicators/incremental/price/swing-helpers.ts
+++ b/packages/core/src/indicators/incremental/price/swing-helpers.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared helpers for swing-derived incremental indicators.
+ *
+ * The four indicators that wrap `createSwingPoints` (Fibonacci Retracement /
+ * Extension, Channel Line, Auto Trend Line) all repeat the same patterns:
+ * resolving `leftBars` / `rightBars` with snapshot-precedence over options,
+ * validating `< 1` errors, levels-array handling for Fibonacci variants, and
+ * bookkeeping helpers like a bounded push and a shallow array clone.
+ *
+ * These helpers exist purely to remove duplication. They do not change the
+ * runtime behavior of any indicator — every parity / snapshot / peek test
+ * across the four sister files passes unchanged after this refactor.
+ */
+
+/**
+ * Resolve `leftBars` / `rightBars` with the canonical precedence:
+ *   snapshot state → constructor options → defaults (10).
+ *
+ * Validates that both values are `>= 1`.
+ */
+export function resolveSwingConfig(
+  options: { leftBars?: number; rightBars?: number } | undefined,
+  fromState: { leftBars: number; rightBars: number } | undefined,
+): { leftBars: number; rightBars: number } {
+  const leftBars = fromState?.leftBars ?? options?.leftBars ?? 10;
+  const rightBars = fromState?.rightBars ?? options?.rightBars ?? 10;
+  if (leftBars < 1) throw new Error("leftBars must be at least 1");
+  if (rightBars < 1) throw new Error("rightBars must be at least 1");
+  return { leftBars, rightBars };
+}
+
+/**
+ * Resolve a Fibonacci-style `levels: number[]` with the same precedence and
+ * return both the (defensively copied) levels array and a pre-computed array
+ * of `String(ratio)` keys so the hot path can skip per-bar coercion.
+ */
+export function resolveLevelsConfig(
+  options: { levels?: number[] } | undefined,
+  fromState: { levels: number[] } | undefined,
+  defaults: readonly number[],
+): { levels: number[]; ratioKeys: string[] } {
+  const source = fromState?.levels ?? options?.levels ?? defaults;
+  if (!Array.isArray(source) || source.length === 0) {
+    throw new Error("levels must be a non-empty array");
+  }
+  const levels = source.slice();
+  return { levels, ratioKeys: levels.map(String) };
+}
+
+/**
+ * Push `item` and drop the oldest entries until the array length is at most
+ * `maxLen`. Used to keep "last N" trackers bounded (e.g., last 2 swing highs).
+ */
+export function pushBounded<T>(arr: T[], item: T, maxLen: number): void {
+  arr.push(item);
+  while (arr.length > maxLen) arr.shift();
+}
+
+/**
+ * Shallow-clone an array of plain objects. Equivalent to
+ * `arr.map((p) => ({ ...p }))` but reads more clearly when used 6+ times in
+ * a single file.
+ */
+export function cloneShallow<T extends object>(arr: readonly T[]): T[] {
+  return arr.map((p) => ({ ...p }));
+}


### PR DESCRIPTION
Closes #119.

## Summary
Centralizes the duplicated boilerplate that accumulated across the four swing-derived incremental indicators added in #106–#109 (Fib Retracement, Fib Extension, Channel Line, Auto Trend Line) into a new `packages/core/src/indicators/incremental/price/swing-helpers.ts`.

## Helpers extracted
- **`resolveSwingConfig(options, fromState)`** — canonical `fromState ?? options ?? default(10)` precedence for `leftBars / rightBars` with `< 1` validation
- **`resolveLevelsConfig(options, fromState, defaults)`** — same precedence for Fibonacci-style level arrays; surfaces the precomputed `String(ratio)` keys for the hot path
- **`pushBounded(arr, item, maxLen)`** — replaces the inline `push + while length > N: shift` pattern (used by channel-line, auto-trend-line, fib-extension)
- **`cloneShallow(arr)`** — readability shim for the 18+ `arr.map((p) => ({ ...p }))` sites (mostly in channel-line)

## Behavior preservation
- No public API change.
- Every existing parity / snapshot / peek / warmup test across the four sister files passes **unchanged** (no test edits in this PR).
- The four indicator bodies shrink by 36 lines combined; the helper file adds 66 lines of mostly JSDoc. Net LoC is roughly flat. The win is centralization: a 5th swing-derived indicator can drop the boilerplate entirely, and any change to the resolution rules only has to land in one place.

## Test plan
- [x] All 4 sister test files (Fib Retracement / Fib Extension / Channel Line / Auto Trend Line) pass with no modifications — 51 tests
- [x] `pnpm test` (4866 core + 760 chart + 59 mcp) / `pnpm lint` / `pnpm build` all green