### PR TITLE
docs(examples): add READMEs for showcase + simulator examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ See each package's README for full documentation:
 
 Release and versioning conventions for the monorepo are documented in [CLAUDE.md](./CLAUDE.md#release-workflow).
 
+## Demos
+
+Each demo is a standalone Vite app — `cd` into it, `pnpm install --ignore-workspace`, `pnpm dev`.
+
+**Charting (`@trendcraft/chart`)**
+- [`packages/chart/examples/simple-chart`](./packages/chart/examples/simple-chart) — start here. Vanilla TS, one chart, a handful of indicators.
+- [`packages/chart/examples/simple-react-chart`](./packages/chart/examples/simple-react-chart) / [`simple-vue-chart`](./packages/chart/examples/simple-vue-chart) — framework binding minimal demos.
+- [`packages/chart/examples/multi-chart-sync`](./packages/chart/examples/multi-chart-sync) — `syncCharts()` between two charts.
+- [`packages/chart/examples/indicator-showcase`](./packages/chart/examples/indicator-showcase) — every preset (96+) with live-replay, signal panel, plugin panel.
+- [`packages/chart/examples/sparkline-showcase`](./packages/chart/examples/sparkline-showcase) — the `@trendcraft/chart/sparkline` subpath on a 200-row ticker dashboard.
+
+**Core (`trendcraft`)**
+- [`packages/core/examples/quick-start`](./packages/core/examples/quick-start) — the smallest "import and call an indicator" example.
+- [`packages/core/examples/chart-viewer`](./packages/core/examples/chart-viewer) — comprehensive React + ECharts viewer (indicators, signals, backtest, optimization, pattern replay).
+- [`packages/core/examples/trading-simulator`](./packages/core/examples/trading-simulator) — bar-replay practice tool with order management and end-of-session review.
+- [`packages/core/examples/sp500-showcase`](./packages/core/examples/sp500-showcase) — screening across S&P 500 symbols.
+- [`packages/core/examples/alpaca-demo`](./packages/core/examples/alpaca-demo) — multi-agent paper-trading CLI on Alpaca.
+- [`packages/core/examples/candle-former-demo`](./packages/core/examples/candle-former-demo) — CandleFormer demo.
+
 ## Disclaimer
 
 TrendCraft is a technical analysis toolkit for informational and educational purposes only. Outputs — including indicator values, signals, backtest results, and chart visualizations — are not investment advice and do not constitute a recommendation to buy, sell, or hold any financial instrument. You are solely responsible for any trading decisions made using this software.

--- a/packages/chart/examples/indicator-showcase/README.md
+++ b/packages/chart/examples/indicator-showcase/README.md
@@ -1,0 +1,41 @@
+# indicator-showcase
+
+Catalog demo for `@trendcraft/chart`. Every preset registered with
+`registerTrendCraftPresets` (96+ entries) is exposed via a categorized sidebar
+with parameter controls, live mode, signal panel, and plugin panel.
+
+## Setup
+
+```bash
+cd packages/chart/examples/indicator-showcase
+pnpm install --ignore-workspace
+pnpm dev
+```
+
+## What you can do
+
+- **Browse all presets** — sidebar is auto-generated from `indicatorPresets`
+  metadata, grouped by category (moving-average, momentum, volatility, …).
+- **Tweak parameters** — each entry exposes `paramSchema` controls.
+- **Daily / Intraday toggle** — the bundled daily sample data, or a synthetic
+  1-minute dataset (see `src/data-intraday.ts`) so intraday-only plugins like
+  Session Zones or ICT Kill Zones can be demo'd.
+- **Static / Live Simulate toggle** — replays the dataset bar-by-bar through
+  `connectIndicators({ live })`, exercising the same code path that production
+  live feeds use.
+- **Signals panel** — overlay detected signals (crosses, divergences, …).
+- **Plugins panel** — toggle Regime Heatmap, SMC Layer, Wyckoff Phase, etc.
+- **Last-value badges** — `Badges` and `Mode` toolbar buttons exercise
+  `showSeriesBadges` / `seriesBadgeMode` (absolute vs visible).
+- **Theme + PNG export** — light/dark and `chart.exportPng()`.
+
+## When to read this code
+
+- Looking for a worked example of `connectIndicators` (bulk preset hookup) — see
+  `src/main.ts`.
+- Looking for a live-replay pattern — see `src/live-simulator.ts` +
+  `src/live-panel.ts`.
+- Looking for plugin wiring (`createRegimeHeatmap`, `createSmcLayer`, etc.) —
+  see `src/plugins-panel.ts`.
+
+For a smaller "one indicator at a time" demo, see [`../simple-chart`](../simple-chart).

--- a/packages/chart/examples/sparkline-showcase/README.md
+++ b/packages/chart/examples/sparkline-showcase/README.md
@@ -1,0 +1,42 @@
+# sparkline-showcase
+
+Catalog demo for the `@trendcraft/chart/sparkline` subpath — small inline
+canvases (≈120 × 32 px) for ticker tables and dashboards.
+
+## Setup
+
+```bash
+cd packages/chart/examples/sparkline-showcase
+pnpm install --ignore-workspace
+pnpm dev
+```
+
+## What you can do
+
+- **Modes**: `line + fill` and `candle`.
+- **Color presets**: `auto`, `period` (single color), `baseline` (split at a
+  reference value), `fixed`.
+- **Count**: 50 / 200 / 500 sparklines on one page — exercises the rendering
+  budget on dense dashboards.
+- **Session controls**:
+  - `Full` — data fills the width.
+  - `Mid-session` / `Late-session` — uses `totalSlots` to reserve space for
+    bars that have not arrived yet (right side stays blank).
+  - `JPX session w/ lunch break` — time-based `session` definition with a
+    `breaks` window; the lunch gap renders as a visible break.
+- **Shared hover** — all sparklines in the group share a hover index via
+  `createSparklineGroup({ hover: true })`.
+- **Regenerate** — reseeds the synthetic price series.
+
+## When to read this code
+
+- Looking for `createSparklineGroup` usage and per-row `SparklineOptions` — see
+  `src/main.ts`.
+- Looking for the smallest possible sparkline call site — see the README of
+  the main [`@trendcraft/chart`](../../README.md#sparkline) package.
+
+## Bundle reference
+
+Sparkline is its own subpath; see `packages/chart/.size-limit.json` for the
+current brotli budget. Importing from `@trendcraft/chart/sparkline` does not
+pull in the main chart code.

--- a/packages/core/examples/trading-simulator/README.md
+++ b/packages/core/examples/trading-simulator/README.md
@@ -1,0 +1,52 @@
+# trading-simulator
+
+Browser-based **bar-replay practice tool** built on `trendcraft`. Drop a CSV
+(or pull intraday bars from Alpaca), step bars forward one at a time, and
+practice entries / exits with the same indicators and incremental engine you
+would use in a backtest.
+
+This is a learning / journaling tool, not a backtest harness — for that, see
+the `backtest()` API in `trendcraft` and the `chart-viewer` example.
+
+## Setup
+
+```bash
+cd packages/core/examples/trading-simulator
+pnpm install --ignore-workspace
+pnpm dev
+```
+
+## What you can do
+
+- **Load data**: drop a CSV, paste a symbol for Alpaca pull, or use the bundled
+  quick-start dataset.
+- **Replay**: play / pause / step / speed control via `playbackSlice`.
+- **Trade**: market / limit / stop orders, position panel, partial close,
+  break-even stop.
+- **Indicators**: standard set (SMA, EMA, RSI, MACD, BB, ATR, …) with the
+  incremental implementations under `src/store/slices/incrementalIndicatorSlice.ts`.
+- **Drawings**: trend lines, H-lines, Fibonacci on a separate drawing layer.
+- **Coaching panel**: rule-based hints (volume spikes, divergences, MTF
+  alignment) — see `src/store/slices/coachingSlice.ts`.
+- **Trade analysis**: MFE / MAE, holding period, streaks, exit reason — see
+  `src/components/TradeAnalysis.tsx`.
+- **Session persistence**: open positions, drawings, settings survive reloads
+  via `useSessionPersistence`.
+- **Performance review**: end-of-session report covering equity curve, win
+  rate, expectancy, and per-trade breakdowns.
+- **Keyboard shortcuts**: see `useKeyboardShortcuts` and the in-app help panel.
+
+## When to read this code
+
+- For an end-to-end consumer of incremental indicators, see
+  `src/store/slices/incrementalIndicatorSlice.ts`.
+- For a Zustand-with-slices pattern, see `src/store/`.
+- For a non-trivial `trendcraft` UI integration that isn't `@trendcraft/chart`,
+  this is the largest example in the repo.
+
+## Notes
+
+- This example renders with **ECharts**, not `@trendcraft/chart`. It predates
+  the chart package and has not been migrated yet.
+- The Alpaca client expects `VITE_ALPACA_API_KEY` / `VITE_ALPACA_API_SECRET`
+  in `.env.local` if you want live data; otherwise CSV / quick-start works.


### PR DESCRIPTION
## Summary
- New READMEs for `indicator-showcase`, `sparkline-showcase`, and `trading-simulator` so each example explains what it covers and how to start it.
- Adds a **Demos** section to the root README mapping every demo under `packages/{chart,core}/examples/` so new readers have a single index.

Part of P1 of the UX/quality + differentiation roadmap (docs-only, no runtime change).

## Test plan
- [x] \`pnpm lint\` (biome) clean
- [x] All four files render correctly as Markdown on GitHub