### PR TITLE
docs(readme): drop multi-chart-sync demo entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Each demo is a standalone Vite app — `cd` into it, `pnpm install --ignore-work
 **Charting (`@trendcraft/chart`)**
 - [`packages/chart/examples/simple-chart`](./packages/chart/examples/simple-chart) — start here. Vanilla TS, one chart, a handful of indicators.
 - [`packages/chart/examples/simple-react-chart`](./packages/chart/examples/simple-react-chart) / [`simple-vue-chart`](./packages/chart/examples/simple-vue-chart) — framework binding minimal demos.
-- [`packages/chart/examples/multi-chart-sync`](./packages/chart/examples/multi-chart-sync) — `syncCharts()` between two charts.
 - [`packages/chart/examples/indicator-showcase`](./packages/chart/examples/indicator-showcase) — every preset (96+) with live-replay, signal panel, plugin panel.
 - [`packages/chart/examples/sparkline-showcase`](./packages/chart/examples/sparkline-showcase) — the `@trendcraft/chart/sparkline` subpath on a 200-row ticker dashboard.
 


### PR DESCRIPTION
## Summary
\`syncCharts()\` is intentionally not exported from \`@trendcraft/chart\` (see commit \`844f09d\`) — cross-timeframe viewport sync still has UX issues (jitter, animation tween conflicts, oscillating bar spacing) that would misrepresent the API.

The \`multi-chart-sync\` example directory is also \`.gitignore\`d, so it never ships in the repo or on npm.

PR #123 inadvertently added it to the root README's "Demos" section. This drops that line so readers aren't pointed at an API they cannot import.

## Test plan
- [x] Repo-wide grep for \`multi-chart-sync\` / \`syncCharts\` in \`*.md\` / \`*.txt\` returns no matches