### PR TITLE
docs(readme): drop alpaca-demo and candle-former-demo from Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ Each demo is a standalone Vite app — `cd` into it, `pnpm install --ignore-work
 - [`packages/core/examples/chart-viewer`](./packages/core/examples/chart-viewer) — comprehensive React + ECharts viewer (indicators, signals, backtest, optimization, pattern replay).
 - [`packages/core/examples/trading-simulator`](./packages/core/examples/trading-simulator) — bar-replay practice tool with order management and end-of-session review.
 - [`packages/core/examples/sp500-showcase`](./packages/core/examples/sp500-showcase) — screening across S&P 500 symbols.
-- [`packages/core/examples/alpaca-demo`](./packages/core/examples/alpaca-demo) — multi-agent paper-trading CLI on Alpaca.
-- [`packages/core/examples/candle-former-demo`](./packages/core/examples/candle-former-demo) — CandleFormer demo.
 
 ## Disclaimer
 


### PR DESCRIPTION
## Summary
\`packages/core/examples/alpaca-demo\` and \`packages/core/examples/candle-former-demo\` are both \`.gitignore\`d — they live only in the maintainer's local clone and don't ship in the repo or on npm. Listing them in the root README's "Demos" section pointed readers at code they couldn't actually find.

Same root cause as the multi-chart-sync removal in PR #125: the "Demos" section added in PR #123 was generated without filtering for tracked directories.

## Test plan
- [x] \`git ls-files packages/core/examples/{alpaca-demo,candle-former-demo}\` returns no entries
- [x] No remaining "Demos"-style references in root \`README.md\`. (Internal references in \`CLAUDE.md\`, \`packages/chart/CHANGELOG.md\`, and other examples are intentional and not user-facing demo advertisements.)