### PR TITLE
feat(strategy-studio): scaffold + regime-aware preset selector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ pnpm size-check   # Check bundle size limits (esbuild, brotli-compressed)
 - Uses Wilder's smoothing method (RSI, ATR, etc.)
 - Functions should have JSDoc comments with @example
 - `@trendcraft/chart`: Bundle size limits enforced via `size-limit` + `@size-limit/esbuild` (brotli-compressed). Main ≤ 31 kB, Headless ≤ 11 kB, React/Vue ≤ 27 kB. Zero runtime dependencies; `trendcraft`, `react`, `vue` are optional peer deps
+- `@trendcraft/chart` + `indicatorPresets` integration: when wiring a chart to `connectIndicators(chart, { presets: indicatorPresets, ... })`, **also call `registerTrendCraftPresets(chart)` from `@trendcraft/chart/presets`** before adding indicators. Without it, TrendCraft-specific shapes (adaptiveRsi `{rsi, effectivePeriod, volatilityPercentile}`, connorsRsi, klinger, vsa, etc.) fall through built-in introspection rules and silently render as generic "Indicator"/"Series" with no visible line. The chart degrades silently — there is no warning. See `packages/chart/examples/indicator-showcase/src/main.ts:57` for the canonical setup
 
 ## Testing & Validation
 

--- a/packages/chart/examples/strategy-studio/README.md
+++ b/packages/chart/examples/strategy-studio/README.md
@@ -1,0 +1,60 @@
+# Strategy Studio
+
+A 1-screen React example that aims to be the **flagship integration demo** of TrendCraft — the place where you can touch every layer (indicator, chart, signal, backtest, risk, meta-strategy, portfolio, MCP) without setting up your own project.
+
+The studio runs **fully offline with no LLM key**. It uses `detectMarketRegime` and `suggestForRegime` from `trendcraft/manifest` rule-based, so anyone can launch it and see a regime-aware setup immediately.
+
+## Why a third example?
+
+| Example | Role |
+|---|---|
+| `simple-chart`, `simple-react-chart`, `simple-vue-chart` | Minimal "hello world" for each binding |
+| `indicator-showcase` | All 96+ presets in a catalog (per-preset minimal demo) |
+| `sparkline-showcase` | Sparkline subpath demo |
+| `echarts-viewer` (formerly `chart-viewer`) | **Proof that the `trendcraft` core works with any chart library** (here: ECharts). Comprehensive analysis app, but ECharts-based |
+| **Strategy Studio** (this) | **Flagship `@trendcraft/chart` dogfooding + cross-feature integration**. The place to verify TrendCraft as a fullstack toolkit |
+
+`echarts-viewer` and `indicator-showcase` are intentionally preserved — they cover different value propositions and overlap in functionality is by design.
+
+## Roadmap (PR-by-PR)
+
+| PR | Scope | Status |
+|---|---|---|
+| PR2 | scaffold + 3-pane layout + regime banner + manifest preset selector | **this PR** |
+| PR3 | StrategyBuilder (entry/exit dropdowns) + backtest + trade overlay + JSON I/O | next |
+| PR4 | ParamEditor — paramSchema-driven slider/input UI for the 96 presets | |
+| PR5 | LiveControls — Static/Live toggle, speed presets, `createLiveCandle` integration | |
+| PR6 | SignalsPanel — cross/divergence/pattern signal detection + markers | |
+| PR7 | PluginsPanel — SMC / Pitchfork / Volume Profile / Wyckoff plugin toggles | |
+| PR8 | RiskPanel — position sizing (Kelly/ATR) + VaR/CVaR/Risk Parity | |
+| PR9 | MetaStrategyPanel — equity curve trading + strategy rotation | |
+| PR10 | PortfolioPanel — `batchBacktest` + multi-symbol allocation | |
+| PR11 | ScoringPanel — signal scoring visualization | |
+| PR12 | OptimizationPanel — grid search + walk-forward UI | |
+| PR13 | StrategyDnaPanel — genome viz + sensitivity heatmap + robustness | |
+| Phase 2 | Ask AI panel via `@trendcraft/mcp` tools (LLM tool-use) | future |
+
+When the full set lands, Studio will be a true superset of `echarts-viewer`'s analysis surface, all rendered through `@trendcraft/chart`.
+
+## Architecture notes
+
+- **`registerTrendCraftPresets(chart)` is required**, not optional. Calling `connectIndicators` with `indicatorPresets` without it leaves TrendCraft-specific shapes (`adaptiveRsi`, `connorsRsi`, `klinger`, `vsa`) silently rendering as generic "Indicator"/"Series". See `src/App.tsx` and `packages/chart/docs/COOKBOOK.md` Recipe 1.
+- **Phase 2 seam**: all domain calls go through `lib/studio-api.ts`'s `StudioAPI` interface. PR2 ships `localStudioAPI` (calls trendcraft directly). A future `mcpStudioAPI` will let LLM tool-use drive the same surface unchanged.
+- **kind ↔ preset key alias**: `trendcraft/manifest` uses long names (`bollingerBands`); `indicatorPresets` uses short keys (`bb`). 13 mappings in `KIND_TO_PRESET_KEY`. Manifest entries with no preset (`hmmRegimes`, `liquiditySweep`) render as disabled.
+
+## How to run
+
+```bash
+cd packages/chart/examples/strategy-studio
+pnpm install --ignore-workspace
+pnpm dev
+```
+
+Visit the URL Vite prints (typically <http://localhost:5173>).
+
+## Current PR2 capabilities
+
+- **Regime detection**: live `detectMarketRegime` on the loaded candles → 4-bucket classification (`trending` / `ranging` / `volatile` / `low-volatility`)
+- **Regime-aware preset suggestions**: `suggestForRegime(regime)` populates the top of the left panel
+- **Full manifest browser**: all 95 manifest entries by category, with `whenToUse` / `pitfalls` / regime tags on hover
+- **Click-to-toggle**: clicking a preset adds/removes it from the chart with proper labels and colors via `connectIndicators` + `registerTrendCraftPresets`

--- a/packages/chart/examples/strategy-studio/index.html
+++ b/packages/chart/examples/strategy-studio/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>TrendCraft — Strategy Studio</title>
+  <link rel="stylesheet" href="./src/styles.css" />
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="./src/main.tsx"></script>
+</body>
+</html>

--- a/packages/chart/examples/strategy-studio/package.json
+++ b/packages/chart/examples/strategy-studio/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "trendcraft-strategy-studio",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@trendcraft/chart": "link:../..",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "trendcraft": "link:../../../core"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
+  }
+}

--- a/packages/chart/examples/strategy-studio/pnpm-lock.yaml
+++ b/packages/chart/examples/strategy-studio/pnpm-lock.yaml
@@ -1,0 +1,1139 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@trendcraft/chart':
+        specifier: link:../..
+        version: link:../..
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      trendcraft:
+        specifier: link:../../../core
+        version: link:../../../core
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.2)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.3
+        version: 6.4.2
+
+packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  baseline-browser-mapping@2.10.24:
+    resolution: {integrity: sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  caniuse-lite@1.0.30001791:
+    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  electron-to-chromium@1.5.345:
+    resolution: {integrity: sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+snapshots:
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/estree@1.0.8': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  baseline-browser-mapping@2.10.24: {}
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.24
+      caniuse-lite: 1.0.30001791
+      electron-to-chromium: 1.5.345
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  caniuse-lite@1.0.30001791: {}
+
+  convert-source-map@2.0.0: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  electron-to-chromium@1.5.345: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  escalade@3.2.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  node-releases@2.0.38: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.12:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react-refresh@0.17.0: {}
+
+  react@19.2.5: {}
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  source-map-js@1.2.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  typescript@5.9.3: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite@6.4.2:
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  yallist@3.1.1: {}

--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -1,0 +1,125 @@
+import { type IndicatorConnection, connectIndicators } from "@trendcraft/chart";
+import { registerTrendCraftPresets } from "@trendcraft/chart/presets";
+import { useTrendChart } from "@trendcraft/chart/react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { indicatorPresets } from "trendcraft";
+import { useRegime } from "./hooks/useRegime";
+import { sampleCandles } from "./lib/sample-data";
+import { KIND_TO_PRESET_KEY, localStudioAPI } from "./lib/studio-api";
+import { PresetSelector } from "./panels/PresetSelector";
+
+function resolvePresetId(kind: string): string {
+  return KIND_TO_PRESET_KEY[kind] ?? kind;
+}
+
+export function App() {
+  const candles = sampleCandles;
+  const regime = useRegime(candles);
+
+  const [activeKinds, setActiveKinds] = useState<ReadonlySet<string>>(() => new Set());
+
+  const toggleKind = useCallback((kind: string) => {
+    setActiveKinds((prev) => {
+      const next = new Set(prev);
+      if (next.has(kind)) next.delete(kind);
+      else next.add(kind);
+      return next;
+    });
+  }, []);
+
+  const { containerRef, chart } = useTrendChart({
+    candles,
+    theme: "dark",
+    options: { watermark: "STRATEGY STUDIO" },
+  });
+
+  // Manage the indicator connection imperatively so each preset gets its full
+  // SeriesMeta (label, channelColors). The `useTrendChart` `indicators` prop
+  // skips that metadata and would render BB as anonymous channels.
+  const connectionRef = useRef<IndicatorConnection | null>(null);
+  const handlesRef = useRef<Map<string, ReturnType<IndicatorConnection["add"]>>>(new Map());
+
+  useEffect(() => {
+    if (!chart) return;
+    // Register TrendCraft-specific introspection rules + presets so chart-side
+    // shapes like adaptiveRsi (`{rsi, effectivePeriod, ...}`), connorsRsi,
+    // klinger, vsa etc. are auto-detected and rendered. Without this they fall
+    // through generic introspection and end up labelled "Indicator" / "Series"
+    // with no visible series.
+    registerTrendCraftPresets(chart);
+    const conn = connectIndicators(chart, {
+      presets: indicatorPresets,
+      candles,
+    });
+    connectionRef.current = conn;
+    handlesRef.current = new Map();
+    return () => {
+      conn.disconnect();
+      connectionRef.current = null;
+      handlesRef.current.clear();
+    };
+  }, [chart, candles]);
+
+  useEffect(() => {
+    const conn = connectionRef.current;
+    if (!conn) return;
+    const handles = handlesRef.current;
+
+    // Add new
+    for (const kind of activeKinds) {
+      if (handles.has(kind)) continue;
+      const presetId = resolvePresetId(kind);
+      if (!localStudioAPI.getIndicatorPreset(kind)) continue;
+      try {
+        handles.set(kind, conn.add(presetId));
+      } catch (err) {
+        console.warn(`[strategy-studio] Failed to add ${kind} (${presetId}):`, err);
+      }
+    }
+
+    // Remove dropped
+    for (const [kind, handle] of handles) {
+      if (!activeKinds.has(kind)) {
+        handle.remove();
+        handles.delete(kind);
+      }
+    }
+  }, [activeKinds]);
+
+  const headerInfo = useMemo(
+    () => `${candles.length} bars · LLM-free · regime-aware`,
+    [candles.length],
+  );
+
+  return (
+    <div className="studio-grid">
+      <header className="studio-header">
+        <span className="studio-title">TrendCraft — Strategy Studio</span>
+        <span className="studio-tag">@trendcraft/chart</span>
+        <span style={{ marginLeft: "auto", fontSize: 11, color: "#787b86" }}>{headerInfo}</span>
+      </header>
+
+      <aside className="pane left">
+        <PresetSelector regime={regime} activeKinds={activeKinds} onToggle={toggleKind} />
+      </aside>
+
+      <main className="pane center">
+        <div ref={containerRef} style={{ width: "100%", height: "100%" }} />
+      </main>
+
+      <aside className="pane right">
+        <div className="pane-header">Strategy Builder</div>
+        <div className="placeholder-pane">
+          <p>
+            <strong>Coming in PR3.</strong> This panel will let you compose entry/exit conditions
+            from the 114 entries in <code>backtestRegistry</code>, run a backtest, and see the
+            resulting trades overlaid on the chart.
+          </p>
+          <p style={{ marginTop: 12 }}>
+            For now, click presets in the left panel to add them to the chart.
+          </p>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/hooks/useRegime.ts
+++ b/packages/chart/examples/strategy-studio/src/hooks/useRegime.ts
@@ -1,0 +1,7 @@
+import { useMemo } from "react";
+import type { StudioCandle } from "../lib/sample-data";
+import { type RegimeSummary, localStudioAPI } from "../lib/studio-api";
+
+export function useRegime(candles: StudioCandle[]): RegimeSummary {
+  return useMemo(() => localStudioAPI.detectRegime(candles), [candles]);
+}

--- a/packages/chart/examples/strategy-studio/src/lib/sample-data.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/sample-data.ts
@@ -1,0 +1,12 @@
+import data from "../../../simple-chart/data.json";
+
+export type StudioCandle = {
+  time: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+};
+
+export const sampleCandles: StudioCandle[] = data;

--- a/packages/chart/examples/strategy-studio/src/lib/studio-api.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/studio-api.ts
@@ -1,0 +1,140 @@
+import {
+  type BacktestResult,
+  type IndicatorPreset,
+  type MarketRegimeResult,
+  backtestRegistry,
+  detectMarketRegime,
+  indicatorPresets,
+  loadStrategy,
+  normalizeCandles,
+  runBacktest,
+} from "trendcraft";
+import {
+  type IndicatorCategory,
+  type IndicatorManifest,
+  type MarketRegime,
+  listManifests,
+  suggestForRegime,
+} from "trendcraft/manifest";
+import type { StudioCandle } from "./sample-data";
+
+export type RegimeSummary = {
+  /** Detected by detectMarketRegime — granular volatility + trend snapshot. */
+  raw: MarketRegimeResult;
+  /** Mapped to manifest's MarketRegime taxonomy for suggestForRegime(). */
+  manifestRegime: MarketRegime;
+  /** Human-readable bullets describing how the regime was inferred. */
+  reasons: string[];
+};
+
+/**
+ * Bridge from the granular `detectMarketRegime` result to the four-bucket
+ * `MarketRegime` taxonomy used by the manifest. Volatility extremes win over
+ * trend classification because they change which playbook applies first
+ * (widen stops / reduce size before picking a direction).
+ */
+function toManifestRegime(raw: MarketRegimeResult): {
+  regime: MarketRegime;
+  reasons: string[];
+} {
+  const reasons: string[] = [];
+  reasons.push(
+    `Volatility: ${raw.volatility} · Trend: ${raw.trend} · ADX ${raw.trendStrength.toFixed(0)}`,
+  );
+
+  if (raw.volatility === "high") {
+    reasons.push("High ATR percentile → favor volatility-aware playbook");
+    return { regime: "volatile", reasons };
+  }
+  if (raw.volatility === "low" && raw.trend === "sideways") {
+    reasons.push("Low ATR + sideways → mean-reversion / range tools shine");
+    return { regime: "low-volatility", reasons };
+  }
+  if (raw.trend !== "sideways" && raw.trendStrength >= 25) {
+    reasons.push("ADX ≥ 25 with directional bias → trending-friendly setups");
+    return { regime: "trending", reasons };
+  }
+  reasons.push("ADX < 25 / sideways → range-bound until breakout confirms");
+  return { regime: "ranging", reasons };
+}
+
+export type StrategyRunResult = {
+  result: BacktestResult;
+  trades: BacktestResult["trades"];
+};
+
+/**
+ * Domain operations Strategy Studio panels rely on. PR2 provides a `local`
+ * implementation that calls trendcraft directly (no LLM, no network). PR (Phase 2)
+ * will add an MCP-backed implementation behind the same interface so the UI
+ * stays unchanged.
+ */
+export interface StudioAPI {
+  detectRegime(candles: StudioCandle[]): RegimeSummary;
+  suggestPresets(regime: MarketRegime): IndicatorManifest[];
+  listIndicators(filter?: { category?: IndicatorCategory }): IndicatorManifest[];
+  /**
+   * Resolve a manifest `kind` to its `indicatorPresets` entry. Some manifest
+   * kinds use a different short key in the preset registry (`bollingerBands`
+   * vs `bb`, etc.) — see `KIND_TO_PRESET_KEY`. Returns `undefined` for kinds
+   * that intentionally have no series preset (e.g. `hmmRegimes`, `liquiditySweep`).
+   */
+  getIndicatorPreset(kind: string): IndicatorPreset | undefined;
+  runStrategy(json: unknown, candles: StudioCandle[]): StrategyRunResult;
+}
+
+/**
+ * Manifest `kind` → `indicatorPresets` key for entries where the two registries
+ * use different identifiers. Manifest kinds use the function name (e.g.
+ * `bollingerBands`); the preset registry uses a shorter key (`bb`).
+ *
+ * Kinds not listed here use their manifest kind as the preset key directly.
+ * Kinds with no preset entry at all (regime classifiers, smc events) resolve
+ * to `undefined` from `getIndicatorPreset`.
+ */
+export const KIND_TO_PRESET_KEY: Record<string, string> = {
+  awesomeOscillator: "ao",
+  balanceOfPower: "bop",
+  bollingerBands: "bb",
+  choppinessIndex: "choppiness",
+  coppockCurve: "coppock",
+  donchianChannel: "donchian",
+  easeOfMovement: "emv",
+  ewmaVolatility: "ewmaVol",
+  fairValueGap: "fvg",
+  historicalVolatility: "hv",
+  keltnerChannel: "keltner",
+  openingRange: "orb",
+  ulcerIndex: "ulcer",
+};
+
+export const localStudioAPI: StudioAPI = {
+  detectRegime(candles) {
+    const raw = detectMarketRegime(candles);
+    const { regime, reasons } = toManifestRegime(raw);
+    return { raw, manifestRegime: regime, reasons };
+  },
+
+  suggestPresets(regime) {
+    return suggestForRegime(regime);
+  },
+
+  listIndicators(filter) {
+    return listManifests(filter);
+  },
+
+  getIndicatorPreset(kind) {
+    return indicatorPresets[KIND_TO_PRESET_KEY[kind] ?? kind];
+  },
+
+  runStrategy(json, candles) {
+    // biome-ignore lint/suspicious/noExplicitAny: StrategyJSON typing belongs to PR3
+    const { entry, exit, backtestOptions } = loadStrategy(json as any, backtestRegistry);
+    const normalized = normalizeCandles(candles);
+    const result = runBacktest(normalized, entry, exit, {
+      capital: 100_000,
+      ...backtestOptions,
+    });
+    return { result, trades: result.trades };
+  },
+};

--- a/packages/chart/examples/strategy-studio/src/main.tsx
+++ b/packages/chart/examples/strategy-studio/src/main.tsx
@@ -1,0 +1,5 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+
+const root = createRoot(document.getElementById("root") as HTMLElement);
+root.render(<App />);

--- a/packages/chart/examples/strategy-studio/src/panels/PresetSelector.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/PresetSelector.tsx
@@ -1,0 +1,165 @@
+import { useMemo, useState } from "react";
+import type { IndicatorCategory, IndicatorManifest, MarketRegime } from "trendcraft/manifest";
+import type { RegimeSummary } from "../lib/studio-api";
+import { localStudioAPI } from "../lib/studio-api";
+
+const CATEGORIES: IndicatorCategory[] = [
+  "moving-average",
+  "momentum",
+  "volatility",
+  "trend",
+  "volume",
+  "price",
+  "session",
+  "regime",
+  "smc",
+  "wyckoff",
+];
+
+type Props = {
+  regime: RegimeSummary;
+  activeKinds: ReadonlySet<string>;
+  onToggle: (kind: string) => void;
+};
+
+export function PresetSelector({ regime, activeKinds, onToggle }: Props) {
+  const [category, setCategory] = useState<IndicatorCategory | "all">("all");
+  const [hovered, setHovered] = useState<string | null>(null);
+
+  const suggestions = useMemo(
+    () => localStudioAPI.suggestPresets(regime.manifestRegime),
+    [regime.manifestRegime],
+  );
+
+  const browse = useMemo(() => {
+    const filter = category === "all" ? undefined : { category };
+    return localStudioAPI.listIndicators(filter);
+  }, [category]);
+
+  return (
+    <>
+      <div className="pane-header">Preset Selector</div>
+
+      <div className="regime-banner">
+        <h3>Detected Regime</h3>
+        <div className="regime-row">
+          <span className={`regime-chip ${regime.manifestRegime}`}>{regime.manifestRegime}</span>
+        </div>
+        <div className="regime-detail">
+          {regime.reasons.map((r) => (
+            <div key={r}>· {r}</div>
+          ))}
+        </div>
+      </div>
+
+      <div className="section-title">Suggested for this regime</div>
+      <PresetList
+        items={suggestions}
+        activeKinds={activeKinds}
+        hovered={hovered}
+        onHover={setHovered}
+        onToggle={onToggle}
+        emptyText="No manifest entries match this regime yet."
+      />
+
+      <div className="section-title">Browse all indicators</div>
+      <select
+        className="category-select"
+        value={category}
+        onChange={(e) => setCategory(e.target.value as IndicatorCategory | "all")}
+      >
+        <option value="all">All categories</option>
+        {CATEGORIES.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
+      </select>
+      <PresetList
+        items={browse}
+        activeKinds={activeKinds}
+        hovered={hovered}
+        onHover={setHovered}
+        onToggle={onToggle}
+        emptyText="No indicators in this category."
+      />
+    </>
+  );
+}
+
+type ListProps = {
+  items: IndicatorManifest[];
+  activeKinds: ReadonlySet<string>;
+  hovered: string | null;
+  onHover: (kind: string | null) => void;
+  onToggle: (kind: string) => void;
+  emptyText: string;
+};
+
+function PresetList({ items, activeKinds, hovered, onHover, onToggle, emptyText }: ListProps) {
+  if (items.length === 0) return <div className="empty">{emptyText}</div>;
+
+  return (
+    <ul className="preset-list">
+      {items.map((m) => {
+        const active = activeKinds.has(m.kind);
+        const renderable = localStudioAPI.getIndicatorPreset(m.kind) !== undefined;
+        const className = `preset-item${active ? " active" : ""}${renderable ? "" : " disabled"}`;
+        return (
+          <li
+            key={m.kind}
+            className={className}
+            onClick={renderable ? () => onToggle(m.kind) : undefined}
+            onMouseEnter={() => onHover(m.kind)}
+            onMouseLeave={() => onHover(null)}
+            title={renderable ? undefined : "No chart preset (event-only or regime classifier)"}
+          >
+            <span className="preset-name">{m.displayName}</span>
+            <span className="preset-kind">{m.kind}</span>
+            {hovered === m.kind && <ManifestTooltip manifest={m} />}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function ManifestTooltip({ manifest }: { manifest: IndicatorManifest }) {
+  return (
+    <div className="preset-tooltip">
+      <h4>{manifest.displayName}</h4>
+      <div style={{ color: "#787b86", fontSize: 11, marginBottom: 4 }}>{manifest.oneLiner}</div>
+      {manifest.whenToUse.length > 0 && <Section label="When to use" items={manifest.whenToUse} />}
+      {manifest.pitfalls.length > 0 && <Section label="Pitfalls" items={manifest.pitfalls} />}
+      <div className="preset-tooltip-section">
+        <div className="preset-tooltip-label">Regimes</div>
+        <RegimeChips regimes={manifest.marketRegime} />
+      </div>
+    </div>
+  );
+}
+
+function Section({ label, items }: { label: string; items: string[] }) {
+  return (
+    <div className="preset-tooltip-section">
+      <div className="preset-tooltip-label">{label}</div>
+      <ul>
+        {items.map((it) => (
+          <li key={it}>{it}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function RegimeChips({ regimes }: { regimes: MarketRegime[] }) {
+  return (
+    <div className="regime-row" style={{ marginTop: 4 }}>
+      {regimes.map((r) => (
+        <span key={r} className={`regime-chip ${r}`}>
+          {r}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/styles.css
+++ b/packages/chart/examples/strategy-studio/src/styles.css
@@ -1,0 +1,245 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #0a0e17;
+  color: #d1d4dc;
+}
+
+.studio-grid {
+  display: grid;
+  grid-template-columns: 320px 1fr 360px;
+  grid-template-rows: 40px 1fr;
+  height: 100vh;
+  gap: 1px;
+  background: #2a2e39;
+}
+
+.studio-header {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 16px;
+  background: #131722;
+  border-bottom: 1px solid #2a2e39;
+}
+
+.studio-title {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.studio-tag {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: #2196f3;
+  color: #fff;
+}
+
+.pane {
+  background: #131722;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.pane.center {
+  overflow: hidden;
+}
+
+.pane-header {
+  position: sticky;
+  top: 0;
+  padding: 10px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #787b86;
+  background: #131722;
+  border-bottom: 1px solid #2a2e39;
+  z-index: 1;
+}
+
+.regime-banner {
+  margin: 12px;
+  padding: 12px;
+  border: 1px solid #2a2e39;
+  border-radius: 6px;
+  background: #0e1320;
+}
+
+.regime-banner h3 {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #787b86;
+  margin-bottom: 8px;
+}
+
+.regime-row {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+.regime-chip {
+  font-size: 11px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: #1e222d;
+  border: 1px solid #2a2e39;
+}
+
+.regime-chip.trending {
+  background: rgba(38, 166, 154, 0.18);
+  border-color: rgba(38, 166, 154, 0.4);
+}
+.regime-chip.ranging {
+  background: rgba(255, 152, 0, 0.18);
+  border-color: rgba(255, 152, 0, 0.4);
+}
+.regime-chip.volatile {
+  background: rgba(239, 83, 80, 0.18);
+  border-color: rgba(239, 83, 80, 0.4);
+}
+.regime-chip.low-volatility {
+  background: rgba(33, 150, 243, 0.18);
+  border-color: rgba(33, 150, 243, 0.4);
+}
+
+.regime-detail {
+  font-size: 11px;
+  color: #787b86;
+  line-height: 1.5;
+}
+
+.section-title {
+  padding: 12px 12px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #787b86;
+}
+
+.preset-list {
+  list-style: none;
+  padding: 0 8px 12px;
+}
+
+.preset-item {
+  position: relative;
+  padding: 8px 10px;
+  font-size: 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.preset-item:hover {
+  background: #1e222d;
+}
+
+.preset-item.active {
+  background: rgba(33, 150, 243, 0.15);
+  color: #fff;
+}
+
+.preset-item.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.preset-item.disabled:hover {
+  background: transparent;
+}
+
+.preset-name {
+  font-weight: 500;
+}
+
+.preset-kind {
+  font-size: 10px;
+  color: #787b86;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+.preset-tooltip {
+  position: absolute;
+  left: calc(100% + 8px);
+  top: 0;
+  width: 320px;
+  padding: 10px 12px;
+  background: #1e222d;
+  border: 1px solid #2a2e39;
+  border-radius: 6px;
+  font-size: 11px;
+  color: #d1d4dc;
+  z-index: 10;
+  pointer-events: none;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+}
+
+.preset-tooltip h4 {
+  font-size: 12px;
+  margin-bottom: 6px;
+  color: #fff;
+}
+
+.preset-tooltip-section {
+  margin-top: 6px;
+}
+
+.preset-tooltip-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #787b86;
+  margin-bottom: 2px;
+}
+
+.preset-tooltip ul {
+  margin: 0;
+  padding-left: 14px;
+  line-height: 1.5;
+}
+
+.category-select {
+  width: calc(100% - 24px);
+  margin: 0 12px 8px;
+  padding: 6px 8px;
+  background: #1e222d;
+  color: #d1d4dc;
+  border: 1px solid #2a2e39;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.empty {
+  padding: 12px;
+  font-size: 12px;
+  color: #787b86;
+}
+
+.placeholder-pane {
+  padding: 16px;
+  font-size: 12px;
+  color: #787b86;
+  line-height: 1.6;
+}

--- a/packages/chart/examples/strategy-studio/tsconfig.json
+++ b/packages/chart/examples/strategy-studio/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "paths": {
+      "@trendcraft/chart": ["../../src/index.ts"],
+      "@trendcraft/chart/presets": ["../../src/presets.ts"],
+      "@trendcraft/chart/react": ["../../react/TrendChart.tsx"],
+      "trendcraft": ["../../../core/src/index.ts"],
+      "trendcraft/manifest": ["../../../core/src/manifest/index.ts"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/chart/examples/strategy-studio/vite.config.ts
+++ b/packages/chart/examples/strategy-studio/vite.config.ts
@@ -1,0 +1,20 @@
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const useDist = process.env.USE_DIST === "1";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@trendcraft/chart/react": resolve(__dirname, useDist ? "../../dist/react/TrendChart.js" : "../../react/TrendChart.tsx"),
+      "@trendcraft/chart/presets": resolve(__dirname, useDist ? "../../dist/presets.js" : "../../src/presets.ts"),
+      "@trendcraft/chart": resolve(__dirname, useDist ? "../../dist/index.js" : "../../src/index.ts"),
+      "trendcraft/manifest": resolve(__dirname, useDist ? "../../../core/dist/manifest/index.js" : "../../../core/src/manifest/index.ts"),
+      "trendcraft": resolve(__dirname, useDist ? "../../../core/dist/index.js" : "../../../core/src/index.ts"),
+    },
+  },
+});


### PR DESCRIPTION
First step of the **Strategy Studio epic** (target branch: \`epic/strategy-studio\`). The epic builds a 1-screen flagship example that, when complete, lets you touch every TrendCraft layer (indicator / chart / signal / backtest / risk / meta-strategy / portfolio / MCP) without setting up a project. The 13-PR roadmap is in \`packages/chart/examples/strategy-studio/README.md\`.

## Scope of this PR

- **3-pane React layout** (\`@trendcraft/chart\` + \`useTrendChart\` + \`connectIndicators\`)
- **Regime banner** — \`detectMarketRegime\` mapped to the manifest's 4-bucket \`MarketRegime\` taxonomy with explanatory bullets (volatility extremes win over trend; ADX ≥ 25 → trending)
- **\`suggestForRegime\` + full manifest browser** with category filter and \`whenToUse\` / \`pitfalls\` / regime tooltips on hover
- **\`KIND_TO_PRESET_KEY\` alias map** — 13 manifest kinds use shorter preset registry keys (\`bollingerBands\` → \`bb\`, \`choppinessIndex\` → \`choppiness\`, etc). Manifest entries with no preset (\`hmmRegimes\`, \`liquiditySweep\`) render disabled
- **\`StudioAPI\` interface** (\`lib/studio-api.ts\`) — Phase 2 seam: \`localStudioAPI\` calls trendcraft directly. A future \`mcpStudioAPI\` will let LLM tool-use drive the same surface unchanged
- **\`registerTrendCraftPresets(chart)\`** wired into the setup so TrendCraft-specific shapes (\`adaptiveRsi\`, \`connorsRsi\`, \`klinger\`, \`vsa\`) render with proper labels and channel colors. Without this they fall through built-in introspection and silently render as generic \"Indicator\"/\"Series\"

## CLAUDE.md update

Added a project-level note flagging \`registerTrendCraftPresets\` as a required companion to \`connectIndicators(chart, { presets: indicatorPresets })\`. The chart degrades silently without it (no warning, no type error). Discovered the hard way during this PR — see \`packages/chart/docs/COOKBOOK.md\` Recipe 1 for the canonical setup.

## Why epic branch

13 PRs is a long road; merging incremental Studio states to main would expose users to an example that's intentionally a subset (e.g. PR2 alone is essentially \`indicator-showcase + regime banner\`). Building everything on \`epic/strategy-studio\` lets us land a single \`epic → main\` PR when Studio is genuinely a flagship, with \`echarts-viewer\` and \`indicator-showcase\` continuing to cover their distinct value props (ECharts proof, minimal preset catalog).

## Test plan

- [x] \`pnpm install --frozen-lockfile\`
- [x] \`pnpm -r build\` — chart bundle 31.1KB, no regression
- [x] \`pnpm -r test\` — 5698 tests pass
- [x] \`pnpm lint\` — clean
- [x] \`cd packages/chart/examples/strategy-studio && npx tsc --noEmit\` — clean
- [x] Manual: \`pnpm dev\` → 3-pane UI loads, regime detected as \`low-volatility\` with reasons, suggestion list populated, preset clicks add/remove on chart with proper labels (BB(20,2), ATR(14), HV(20), GK Vol(20), EWMA Vol, Adaptive RSI all render correctly)
- [ ] \`echarts-viewer\` still launches independently