### PR TITLE
feat(strategy-studio): strategy builder + backtest + JSON I/O

### DIFF
--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -1,12 +1,16 @@
 import { type IndicatorConnection, connectIndicators } from "@trendcraft/chart";
 import { registerTrendCraftPresets } from "@trendcraft/chart/presets";
 import { useTrendChart } from "@trendcraft/chart/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { indicatorPresets } from "trendcraft";
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
+import { indicatorPresets, parseStrategy, validateStrategyJSON } from "trendcraft";
+import { useBacktestRunner } from "./hooks/useBacktestRunner";
 import { useRegime } from "./hooks/useRegime";
 import { sampleCandles } from "./lib/sample-data";
+import { builderReducer, initialBuilderState, strategyJSONToState } from "./lib/strategy-state";
 import { KIND_TO_PRESET_KEY, localStudioAPI } from "./lib/studio-api";
 import { PresetSelector } from "./panels/PresetSelector";
+import { ResultsSummary } from "./panels/ResultsSummary";
+import { StrategyBuilder } from "./panels/StrategyBuilder";
 
 function resolvePresetId(kind: string): string {
   return KIND_TO_PRESET_KEY[kind] ?? kind;
@@ -91,6 +95,38 @@ export function App() {
     [candles.length],
   );
 
+  // ---- PR3: strategy builder + backtest runner ----
+  const [builderState, builderDispatch] = useReducer(
+    builderReducer,
+    undefined,
+    initialBuilderState,
+  );
+  const [jsonText, setJsonText] = useState<string>("");
+  const [importError, setImportError] = useState<string | null>(null);
+  const runner = useBacktestRunner(chart, candles);
+
+  const handleImport = useCallback((raw: string) => {
+    if (!raw.trim()) {
+      setImportError(null);
+      return;
+    }
+    try {
+      // parseStrategy: JSON.parse + $schema/version checks. validateStrategyJSON:
+      // deep field/condition validation against backtestRegistry. Both run in
+      // sequence — parse first to get an object, then deep-validate that object.
+      const json = parseStrategy(raw);
+      const validation = validateStrategyJSON(json);
+      if (!validation.valid) {
+        setImportError(validation.errors.join("; "));
+        return;
+      }
+      builderDispatch({ type: "replace", state: strategyJSONToState(json) });
+      setImportError(null);
+    } catch (err) {
+      setImportError(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
+
   return (
     <div className="studio-grid">
       <header className="studio-header">
@@ -108,17 +144,18 @@ export function App() {
       </main>
 
       <aside className="pane right">
-        <div className="pane-header">Strategy Builder</div>
-        <div className="placeholder-pane">
-          <p>
-            <strong>Coming in PR3.</strong> This panel will let you compose entry/exit conditions
-            from the 114 entries in <code>backtestRegistry</code>, run a backtest, and see the
-            resulting trades overlaid on the chart.
-          </p>
-          <p style={{ marginTop: 12 }}>
-            For now, click presets in the left panel to add them to the chart.
-          </p>
-        </div>
+        <StrategyBuilder
+          state={builderState}
+          dispatch={builderDispatch}
+          onRun={runner.run}
+          onImport={handleImport}
+          jsonText={jsonText}
+          onJsonTextChange={setJsonText}
+          importError={importError}
+          runError={runner.state.status === "error" ? runner.state.lastError : null}
+        />
+        <div className="pane-divider" />
+        <ResultsSummary result={runner.state.lastResult?.result} />
       </aside>
     </div>
   );

--- a/packages/chart/examples/strategy-studio/src/hooks/useBacktestRunner.ts
+++ b/packages/chart/examples/strategy-studio/src/hooks/useBacktestRunner.ts
@@ -1,0 +1,57 @@
+import type { ChartInstance } from "@trendcraft/chart";
+import { useCallback, useState } from "react";
+import type { StrategyJSON } from "trendcraft";
+import type { StudioCandle } from "../lib/sample-data";
+import { type StrategyRunResult, localStudioAPI } from "../lib/studio-api";
+
+export type BacktestRunnerState =
+  | { status: "idle"; lastError?: undefined; lastResult?: StrategyRunResult }
+  | { status: "running"; lastError?: undefined; lastResult?: StrategyRunResult }
+  | { status: "error"; lastError: string; lastResult?: StrategyRunResult }
+  | { status: "ready"; lastError?: undefined; lastResult: StrategyRunResult };
+
+/**
+ * Runs a `StrategyJSON` through `runBacktest` and applies the result to the
+ * chart. Returns a `run()` callback plus reactive state so the right pane can
+ * show summary / trades / errors. The caller is responsible for clearing the
+ * chart's previous trade overlay before calling `run()` for a fresh strategy.
+ */
+export function useBacktestRunner(
+  chart: ChartInstance | null,
+  candles: StudioCandle[],
+): {
+  state: BacktestRunnerState;
+  run(json: StrategyJSON): StrategyRunResult | null;
+  reset(): void;
+} {
+  const [state, setState] = useState<BacktestRunnerState>({ status: "idle" });
+
+  const run = useCallback(
+    (json: StrategyJSON): StrategyRunResult | null => {
+      if (!chart) {
+        setState({ status: "error", lastError: "Chart not ready" });
+        return null;
+      }
+      setState({ status: "running" });
+      try {
+        const out = localStudioAPI.runStrategy(json, candles);
+        // `addBacktest` already paints the trade markers + holding-period
+        // shading from `result.trades`; calling `addTrades` on top of it
+        // would double-render every overlay. The equity-curve subchart and
+        // marker overlay are both produced by `addBacktest` alone.
+        chart.addBacktest(out.result);
+        setState({ status: "ready", lastResult: out });
+        return out;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ status: "error", lastError: message });
+        return null;
+      }
+    },
+    [chart, candles],
+  );
+
+  const reset = useCallback(() => setState({ status: "idle" }), []);
+
+  return { state, run, reset };
+}

--- a/packages/chart/examples/strategy-studio/src/lib/strategy-state.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/strategy-state.ts
@@ -1,0 +1,170 @@
+import type { ConditionSpec, StrategyJSON } from "trendcraft";
+
+/**
+ * One row in the entry/exit list. Stored locally in the builder; serialised
+ * into a `ConditionSpec` when the user runs the backtest.
+ */
+export type ConditionRow = {
+  /** Stable id within the builder (so React keys are stable). */
+  id: string;
+  /** Registered condition name, e.g. "goldenCross". */
+  name: string;
+  /** User-overridden parameter values; merged with the registry's defaults at hydrate time. */
+  params: Record<string, unknown>;
+};
+
+export type BuilderState = {
+  /** Strategy id (used as the JSON `id` field). */
+  id: string;
+  /** Display name. */
+  name: string;
+  /** Entry rows joined with AND. */
+  entry: ConditionRow[];
+  /** Exit rows joined with AND. */
+  exit: ConditionRow[];
+  /** Backtest options exposed to the user. */
+  capital: number;
+  stopLoss?: number;
+  takeProfit?: number;
+};
+
+export type BuilderAction =
+  | { type: "set-name"; value: string }
+  | { type: "set-id"; value: string }
+  | { type: "set-capital"; value: number }
+  | { type: "set-stop-loss"; value: number | undefined }
+  | { type: "set-take-profit"; value: number | undefined }
+  | { type: "add-row"; bucket: "entry" | "exit"; conditionName: string }
+  | { type: "remove-row"; bucket: "entry" | "exit"; id: string }
+  | { type: "set-row-name"; bucket: "entry" | "exit"; id: string; conditionName: string }
+  | {
+      type: "set-row-param";
+      bucket: "entry" | "exit";
+      id: string;
+      key: string;
+      value: unknown;
+    }
+  | { type: "replace"; state: BuilderState };
+
+let nextId = 1;
+const newRowId = (): string => `row-${nextId++}`;
+
+export function initialBuilderState(): BuilderState {
+  return {
+    id: "studio-strategy",
+    name: "Studio Strategy",
+    entry: [{ id: newRowId(), name: "goldenCross", params: {} }],
+    exit: [{ id: newRowId(), name: "deadCross", params: {} }],
+    capital: 100_000,
+  };
+}
+
+export function builderReducer(state: BuilderState, action: BuilderAction): BuilderState {
+  switch (action.type) {
+    case "set-name":
+      return { ...state, name: action.value };
+    case "set-id":
+      return { ...state, id: action.value };
+    case "set-capital":
+      return { ...state, capital: action.value };
+    case "set-stop-loss":
+      return { ...state, stopLoss: action.value };
+    case "set-take-profit":
+      return { ...state, takeProfit: action.value };
+    case "add-row":
+      return {
+        ...state,
+        [action.bucket]: [
+          ...state[action.bucket],
+          { id: newRowId(), name: action.conditionName, params: {} },
+        ],
+      };
+    case "remove-row":
+      return {
+        ...state,
+        [action.bucket]: state[action.bucket].filter((r) => r.id !== action.id),
+      };
+    case "set-row-name":
+      return {
+        ...state,
+        [action.bucket]: state[action.bucket].map((r) =>
+          r.id === action.id ? { ...r, name: action.conditionName, params: {} } : r,
+        ),
+      };
+    case "set-row-param":
+      return {
+        ...state,
+        [action.bucket]: state[action.bucket].map((r) =>
+          r.id === action.id ? { ...r, params: { ...r.params, [action.key]: action.value } } : r,
+        ),
+      };
+    case "replace":
+      return action.state;
+  }
+}
+
+/**
+ * Convert a list of rows into a `ConditionSpec`. Single rows are emitted as
+ * leaves; multiple rows are wrapped in an `and` combinator. Empty input throws
+ * because the backtest engine requires both entry and exit conditions.
+ */
+function rowsToSpec(rows: ConditionRow[], bucket: "entry" | "exit"): ConditionSpec {
+  if (rows.length === 0) {
+    throw new Error(`No ${bucket} conditions specified`);
+  }
+  const specs = rows.map((r): ConditionSpec => ({ name: r.name, params: { ...r.params } }));
+  if (specs.length === 1) return specs[0];
+  return { op: "and", conditions: specs };
+}
+
+export function buildStrategyJSON(state: BuilderState): StrategyJSON {
+  const json: StrategyJSON = {
+    $schema: "trendcraft/strategy",
+    version: 1,
+    id: state.id,
+    name: state.name,
+    entry: rowsToSpec(state.entry, "entry"),
+    exit: rowsToSpec(state.exit, "exit"),
+    backtest: {
+      capital: state.capital,
+    },
+  };
+  if (state.stopLoss !== undefined && json.backtest) json.backtest.stopLoss = state.stopLoss;
+  if (state.takeProfit !== undefined && json.backtest) json.backtest.takeProfit = state.takeProfit;
+  return json;
+}
+
+export class UnsupportedSpecError extends Error {
+  constructor(op: "or" | "not") {
+    super(
+      `Strategy uses '${op}' combinator, which Studio's PR3 builder UI doesn't yet expose. Run the JSON directly without importing into the builder, or rewrite using only AND.`,
+    );
+    this.name = "UnsupportedSpecError";
+  }
+}
+
+/**
+ * Convert a parsed `StrategyJSON` back into builder state. The PR3 builder UI
+ * only models AND-of-leaves, so importing a strategy that uses OR / NOT
+ * combinators throws `UnsupportedSpecError` rather than silently breaking the
+ * round-trip. The caller surfaces the error in the import banner.
+ */
+export function strategyJSONToState(json: StrategyJSON): BuilderState {
+  return {
+    id: json.id,
+    name: json.name,
+    entry: specToRows(json.entry),
+    exit: specToRows(json.exit),
+    capital: json.backtest?.capital ?? 100_000,
+    stopLoss: json.backtest?.stopLoss,
+    takeProfit: json.backtest?.takeProfit,
+  };
+}
+
+function specToRows(spec: ConditionSpec): ConditionRow[] {
+  if ("op" in spec) {
+    if (spec.op === "and") return spec.conditions.flatMap(specToRows);
+    throw new UnsupportedSpecError(spec.op);
+  }
+  return [{ id: newRowId(), name: spec.name, params: { ...(spec.params ?? {}) } }];
+}

--- a/packages/chart/examples/strategy-studio/src/lib/studio-api.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/studio-api.ts
@@ -1,7 +1,11 @@
 import {
   type BacktestResult,
+  type Condition,
+  type ConditionCategory,
+  type ConditionRegistryEntry,
   type IndicatorPreset,
   type MarketRegimeResult,
+  type StrategyJSON,
   backtestRegistry,
   detectMarketRegime,
   indicatorPresets,
@@ -80,7 +84,9 @@ export interface StudioAPI {
    * that intentionally have no series preset (e.g. `hmmRegimes`, `liquiditySweep`).
    */
   getIndicatorPreset(kind: string): IndicatorPreset | undefined;
-  runStrategy(json: unknown, candles: StudioCandle[]): StrategyRunResult;
+  /** All registered backtest conditions, optionally filtered by category. */
+  listConditions(category?: ConditionCategory): ConditionRegistryEntry<Condition>[];
+  runStrategy(json: StrategyJSON, candles: StudioCandle[]): StrategyRunResult;
 }
 
 /**
@@ -127,9 +133,12 @@ export const localStudioAPI: StudioAPI = {
     return indicatorPresets[KIND_TO_PRESET_KEY[kind] ?? kind];
   },
 
+  listConditions(category) {
+    return backtestRegistry.list(category);
+  },
+
   runStrategy(json, candles) {
-    // biome-ignore lint/suspicious/noExplicitAny: StrategyJSON typing belongs to PR3
-    const { entry, exit, backtestOptions } = loadStrategy(json as any, backtestRegistry);
+    const { entry, exit, backtestOptions } = loadStrategy(json, backtestRegistry);
     const normalized = normalizeCandles(candles);
     const result = runBacktest(normalized, entry, exit, {
       capital: 100_000,

--- a/packages/chart/examples/strategy-studio/src/panels/ResultsSummary.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/ResultsSummary.tsx
@@ -1,0 +1,95 @@
+import type { BacktestResult } from "trendcraft";
+
+type Props = {
+  result: BacktestResult | undefined;
+};
+
+export function ResultsSummary({ result }: Props) {
+  if (!result) {
+    return (
+      <div className="results-summary empty">Run a backtest to see metrics and trades here.</div>
+    );
+  }
+
+  const cards: Array<{ label: string; value: string; tone?: "good" | "bad" }> = [
+    {
+      label: "Total return",
+      value: `${formatPercent(result.totalReturnPercent)} (${formatMoney(result.totalReturn)})`,
+      tone: result.totalReturn >= 0 ? "good" : "bad",
+    },
+    { label: "Trades", value: String(result.tradeCount) },
+    {
+      label: "Win rate",
+      value: formatPercent(result.winRate),
+      tone: result.winRate >= 50 ? "good" : "bad",
+    },
+    {
+      label: "Max DD",
+      value: formatPercent(-Math.abs(result.maxDrawdown)),
+      tone: "bad",
+    },
+    { label: "Sharpe", value: result.sharpeRatio.toFixed(2) },
+    {
+      label: "PF",
+      value: Number.isFinite(result.profitFactor) ? result.profitFactor.toFixed(2) : "∞",
+    },
+    { label: "Avg hold", value: `${result.avgHoldingDays.toFixed(1)}d` },
+  ];
+
+  return (
+    <div className="results-summary">
+      <div className="metrics-grid">
+        {cards.map((c) => (
+          <div key={c.label} className={`metric${c.tone ? ` ${c.tone}` : ""}`}>
+            <div className="metric-label">{c.label}</div>
+            <div className="metric-value">{c.value}</div>
+          </div>
+        ))}
+      </div>
+
+      <div className="trades-header">Trades ({result.trades.length})</div>
+      <div className="trades-table-wrap">
+        <table className="trades-table">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Entry</th>
+              <th>Exit</th>
+              <th className="num">Return</th>
+              <th>Reason</th>
+            </tr>
+          </thead>
+          <tbody>
+            {result.trades.slice(-50).map((t, i) => (
+              <tr key={`${t.entryTime}-${i}`} className={t.return >= 0 ? "win" : "loss"}>
+                <td>{i + 1}</td>
+                <td>{formatDate(t.entryTime)}</td>
+                <td>{formatDate(t.exitTime)}</td>
+                <td className="num">{formatPercent(t.returnPercent)}</td>
+                <td>{t.exitReason ?? "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {result.trades.length > 50 && (
+          <div className="trades-footer">Showing last 50 of {result.trades.length}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatPercent(v: number): string {
+  if (!Number.isFinite(v)) return "—";
+  const sign = v > 0 ? "+" : "";
+  return `${sign}${v.toFixed(2)}%`;
+}
+
+function formatMoney(v: number): string {
+  const sign = v >= 0 ? "+" : "-";
+  return `${sign}$${Math.abs(v).toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+}
+
+function formatDate(t: number): string {
+  return new Date(t).toISOString().slice(0, 10);
+}

--- a/packages/chart/examples/strategy-studio/src/panels/StrategyBuilder.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/StrategyBuilder.tsx
@@ -1,0 +1,288 @@
+import { useMemo } from "react";
+import {
+  type Condition,
+  type ConditionCategory,
+  type ConditionRegistryEntry,
+  type StrategyJSON,
+  serializeStrategy,
+} from "trendcraft";
+import {
+  type BuilderAction,
+  type BuilderState,
+  type ConditionRow,
+  buildStrategyJSON,
+} from "../lib/strategy-state";
+import { localStudioAPI } from "../lib/studio-api";
+
+const CATEGORY_ORDER: ConditionCategory[] = [
+  "trend",
+  "momentum",
+  "volatility",
+  "volume",
+  "pattern",
+  "smc",
+  "range",
+  "fundamental",
+];
+
+type Props = {
+  state: BuilderState;
+  dispatch: (action: BuilderAction) => void;
+  onRun: (json: StrategyJSON) => void;
+  onImport: (text: string) => void;
+  jsonText: string;
+  onJsonTextChange: (text: string) => void;
+  importError: string | null;
+  runError: string | null;
+};
+
+export function StrategyBuilder({
+  state,
+  dispatch,
+  onRun,
+  onImport,
+  jsonText,
+  onJsonTextChange,
+  importError,
+  runError,
+}: Props) {
+  const { conditionsByCategory, conditionMap } = useMemo(() => {
+    const byCategory = new Map<string, ConditionRegistryEntry<Condition>[]>();
+    const map = new Map<string, ConditionRegistryEntry<Condition>>();
+    for (const entry of localStudioAPI.listConditions()) {
+      map.set(entry.name, entry);
+      const cat = entry.category ?? "uncategorized";
+      const list = byCategory.get(cat) ?? [];
+      list.push(entry);
+      byCategory.set(cat, list);
+    }
+    return { conditionsByCategory: byCategory, conditionMap: map };
+  }, []);
+
+  const canRun = state.entry.length > 0 && state.exit.length > 0;
+
+  function handleRun() {
+    if (!canRun) return;
+    const json = buildStrategyJSON(state);
+    onJsonTextChange(serializeStrategy(json));
+    onRun(json);
+  }
+
+  return (
+    <>
+      <div className="pane-header">Strategy Builder</div>
+
+      <div className="builder-meta">
+        <label className="builder-field">
+          <span>Name</span>
+          <input
+            type="text"
+            value={state.name}
+            onChange={(e) => dispatch({ type: "set-name", value: e.target.value })}
+          />
+        </label>
+        <label className="builder-field">
+          <span>Capital</span>
+          <input
+            type="number"
+            value={state.capital}
+            onChange={(e) => dispatch({ type: "set-capital", value: Number(e.target.value) || 0 })}
+          />
+        </label>
+        <div className="builder-field-pair">
+          <label className="builder-field">
+            <span>Stop %</span>
+            <input
+              type="number"
+              value={state.stopLoss ?? ""}
+              placeholder="—"
+              onChange={(e) =>
+                dispatch({
+                  type: "set-stop-loss",
+                  value: e.target.value === "" ? undefined : Number(e.target.value),
+                })
+              }
+            />
+          </label>
+          <label className="builder-field">
+            <span>TP %</span>
+            <input
+              type="number"
+              value={state.takeProfit ?? ""}
+              placeholder="—"
+              onChange={(e) =>
+                dispatch({
+                  type: "set-take-profit",
+                  value: e.target.value === "" ? undefined : Number(e.target.value),
+                })
+              }
+            />
+          </label>
+        </div>
+      </div>
+
+      <BucketEditor
+        bucket="entry"
+        rows={state.entry}
+        dispatch={dispatch}
+        conditionsByCategory={conditionsByCategory}
+        conditionMap={conditionMap}
+      />
+      <BucketEditor
+        bucket="exit"
+        rows={state.exit}
+        dispatch={dispatch}
+        conditionsByCategory={conditionsByCategory}
+        conditionMap={conditionMap}
+      />
+
+      <div className="builder-actions">
+        <button type="button" className="primary" onClick={handleRun} disabled={!canRun}>
+          Run backtest
+        </button>
+      </div>
+      {runError && <div className="error-banner">Backtest error: {runError}</div>}
+
+      <details className="json-io">
+        <summary>Strategy JSON</summary>
+        <textarea
+          value={jsonText}
+          onChange={(e) => onJsonTextChange(e.target.value)}
+          rows={8}
+          spellCheck={false}
+        />
+        <div className="builder-actions">
+          <button
+            type="button"
+            disabled={!canRun}
+            onClick={() => onJsonTextChange(serializeStrategy(buildStrategyJSON(state)))}
+          >
+            Export current
+          </button>
+          <button type="button" onClick={() => onImport(jsonText)}>
+            Import to builder
+          </button>
+        </div>
+        {importError && <div className="error-banner">Import error: {importError}</div>}
+      </details>
+    </>
+  );
+}
+
+type BucketProps = {
+  bucket: "entry" | "exit";
+  rows: ConditionRow[];
+  dispatch: (action: BuilderAction) => void;
+  conditionsByCategory: Map<string, ConditionRegistryEntry<Condition>[]>;
+  conditionMap: Map<string, ConditionRegistryEntry<Condition>>;
+};
+
+function BucketEditor({ bucket, rows, dispatch, conditionsByCategory, conditionMap }: BucketProps) {
+  return (
+    <div className="bucket">
+      <div className="bucket-header">
+        <span>{bucket === "entry" ? "Entry conditions" : "Exit conditions"}</span>
+        <button
+          type="button"
+          className="ghost"
+          onClick={() =>
+            dispatch({
+              type: "add-row",
+              bucket,
+              conditionName: bucket === "entry" ? "goldenCross" : "deadCross",
+            })
+          }
+        >
+          + add
+        </button>
+      </div>
+      {rows.length === 0 && <div className="empty">No conditions — backtest disabled.</div>}
+      {rows.map((row) => {
+        const entry = conditionMap.get(row.name);
+        return (
+          <div key={row.id} className="row">
+            <select
+              value={row.name}
+              onChange={(e) =>
+                dispatch({
+                  type: "set-row-name",
+                  bucket,
+                  id: row.id,
+                  conditionName: e.target.value,
+                })
+              }
+            >
+              {CATEGORY_ORDER.map((cat) => {
+                const items = conditionsByCategory.get(cat);
+                if (!items?.length) return null;
+                return (
+                  <optgroup key={cat} label={cat}>
+                    {items.map((c) => (
+                      <option key={c.name} value={c.name}>
+                        {c.displayName}
+                      </option>
+                    ))}
+                  </optgroup>
+                );
+              })}
+            </select>
+            <button
+              type="button"
+              className="ghost danger"
+              onClick={() => dispatch({ type: "remove-row", bucket, id: row.id })}
+              aria-label="Remove condition"
+            >
+              ×
+            </button>
+            {entry && (
+              <ParamInputs
+                bucket={bucket}
+                rowId={row.id}
+                row={row}
+                entry={entry}
+                dispatch={dispatch}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+type ParamInputsProps = {
+  bucket: "entry" | "exit";
+  rowId: string;
+  row: ConditionRow;
+  entry: ConditionRegistryEntry<Condition>;
+  dispatch: (action: BuilderAction) => void;
+};
+
+function ParamInputs({ bucket, rowId, row, entry, dispatch }: ParamInputsProps) {
+  const keys = Object.keys(entry.params);
+  if (keys.length === 0) return null;
+  return (
+    <div className="param-grid">
+      {keys.map((key) => {
+        const def = entry.params[key];
+        const current = row.params[key] ?? def.default;
+        return (
+          <label key={key} className="param-field" title={def.description ?? key}>
+            <span>{key}</span>
+            <input
+              type={def.type === "number" ? "number" : "text"}
+              value={current === undefined ? "" : String(current)}
+              min={def.min}
+              max={def.max}
+              onChange={(e) => {
+                const raw = e.target.value;
+                const value = def.type === "number" ? (raw === "" ? undefined : Number(raw)) : raw;
+                dispatch({ type: "set-row-param", bucket, id: rowId, key, value });
+              }}
+            />
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/styles.css
+++ b/packages/chart/examples/strategy-studio/src/styles.css
@@ -243,3 +243,309 @@ body,
   color: #787b86;
   line-height: 1.6;
 }
+
+/* ============================================
+ * Strategy Builder (right pane)
+ * ============================================ */
+
+.builder-meta {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+  padding: 12px;
+  border-bottom: 1px solid #2a2e39;
+}
+
+.builder-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+  color: #787b86;
+}
+
+.builder-field input,
+.row select,
+.param-field input {
+  background: #1e222d;
+  border: 1px solid #2a2e39;
+  border-radius: 3px;
+  color: #d1d4dc;
+  padding: 4px 6px;
+  font-size: 12px;
+  font-family: inherit;
+}
+
+.builder-field input:focus,
+.row select:focus,
+.param-field input:focus {
+  outline: none;
+  border-color: #2196f3;
+}
+
+.builder-field-pair {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.bucket {
+  padding: 8px 12px 12px;
+  border-bottom: 1px solid #2a2e39;
+}
+
+.bucket-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #787b86;
+  padding: 6px 0;
+}
+
+.row {
+  background: #0e1320;
+  border: 1px solid #2a2e39;
+  border-radius: 4px;
+  padding: 6px 8px;
+  margin-bottom: 6px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 6px;
+}
+
+.row > select {
+  width: 100%;
+}
+
+.param-grid {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  padding-top: 4px;
+}
+
+.param-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 10px;
+  color: #787b86;
+}
+
+.param-field input {
+  font-size: 11px;
+  padding: 3px 5px;
+}
+
+.builder-actions {
+  display: flex;
+  gap: 8px;
+  padding: 12px;
+  flex-wrap: wrap;
+}
+
+.builder-actions button {
+  background: #1e222d;
+  color: #d1d4dc;
+  border: 1px solid #2a2e39;
+  border-radius: 3px;
+  padding: 6px 12px;
+  font-size: 12px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.builder-actions button:hover {
+  background: #2a2e39;
+}
+
+.builder-actions button.primary {
+  background: #2196f3;
+  border-color: #2196f3;
+  color: #fff;
+  font-weight: 600;
+}
+
+.builder-actions button.primary:hover {
+  background: #1976d2;
+}
+
+button.ghost {
+  background: transparent;
+  border: 1px solid #2a2e39;
+  color: #787b86;
+  border-radius: 3px;
+  padding: 2px 8px;
+  font-size: 11px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+button.ghost:hover {
+  background: #1e222d;
+  color: #d1d4dc;
+}
+
+button.ghost.danger:hover {
+  background: rgba(239, 83, 80, 0.18);
+  color: #ef5350;
+  border-color: rgba(239, 83, 80, 0.4);
+}
+
+.error-banner {
+  margin: 0 12px 12px;
+  padding: 8px 10px;
+  background: rgba(239, 83, 80, 0.12);
+  border: 1px solid rgba(239, 83, 80, 0.4);
+  border-radius: 3px;
+  color: #ef5350;
+  font-size: 11px;
+}
+
+.json-io {
+  padding: 0 12px 12px;
+}
+
+.json-io summary {
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #787b86;
+  padding: 8px 0;
+}
+
+.json-io textarea {
+  width: 100%;
+  background: #0e1320;
+  color: #d1d4dc;
+  border: 1px solid #2a2e39;
+  border-radius: 3px;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 11px;
+  padding: 6px 8px;
+  resize: vertical;
+}
+
+.pane-divider {
+  border-top: 1px solid #2a2e39;
+  margin: 0;
+}
+
+/* ============================================
+ * Results Summary
+ * ============================================ */
+
+.results-summary {
+  padding: 12px;
+}
+
+.results-summary.empty {
+  color: #787b86;
+  font-size: 12px;
+  font-style: italic;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.metric {
+  background: #0e1320;
+  border: 1px solid #2a2e39;
+  border-radius: 4px;
+  padding: 6px 8px;
+}
+
+.metric-label {
+  font-size: 10px;
+  color: #787b86;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.metric-value {
+  font-size: 13px;
+  font-weight: 600;
+  margin-top: 2px;
+  font-variant-numeric: tabular-nums;
+}
+
+.metric.good .metric-value {
+  color: #26a69a;
+}
+
+.metric.bad .metric-value {
+  color: #ef5350;
+}
+
+.trades-header {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #787b86;
+  margin: 8px 0 4px;
+}
+
+.trades-table-wrap {
+  border: 1px solid #2a2e39;
+  border-radius: 4px;
+  overflow-x: auto;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.trades-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.trades-table th,
+.trades-table td {
+  padding: 4px 6px;
+  border-bottom: 1px solid #1e222d;
+  text-align: left;
+}
+
+.trades-table th {
+  background: #131722;
+  position: sticky;
+  top: 0;
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: #787b86;
+}
+
+.trades-table .num {
+  text-align: right;
+}
+
+.trades-table tr.win .num {
+  color: #26a69a;
+}
+
+.trades-table tr.loss .num {
+  color: #ef5350;
+}
+
+.trades-footer {
+  padding: 6px 8px;
+  font-size: 10px;
+  color: #787b86;
+  text-align: center;
+  border-top: 1px solid #2a2e39;
+}


### PR DESCRIPTION
PR3 of the Strategy Studio epic. Adds the right pane: a backtestRegistry-driven entry/exit builder, run-backtest action with chart overlays, summary metrics + trade table, and StrategyJSON import/export.

## Scope

**UI / hooks**
- \`StrategyBuilder.tsx\` — category-grouped (\`<optgroup>\`) condition dropdowns over all 114 backtestRegistry entries, per-row param inputs derived from each entry's \`params\` schema, capital + stop/TP fields, JSON details panel
- \`ResultsSummary.tsx\` — 7 KPI cards (return / trades / win rate / max DD / sharpe / PF / avg hold) with good/bad colouring + last-50 trades table
- \`useBacktestRunner.ts\` — thin wrapper around \`localStudioAPI.runStrategy\` that applies the result to the chart
- \`strategy-state.ts\` — \`BuilderState\` reducer + \`buildStrategyJSON\` / \`strategyJSONToState\` round-trip helpers. Top-level OR/NOT in imported JSON throws \`UnsupportedSpecError\` because the PR3 builder UI only models AND-of-leaves

**\`studio-api.ts\`**
- \`listConditions(category?)\` exposes \`backtestRegistry.list\` to the panels
- \`runStrategy\` is now typed against \`StrategyJSON\` instead of \`unknown\`

**\`App.tsx\`**
- Wires the builder reducer + json textarea + runner into the right pane
- \`handleImport\` order corrected: \`parseStrategy(raw)\` first, then \`validateStrategyJSON(json)\`. Previously it passed the raw string to \`validateStrategyJSON\` which always failed with \`Strategy must be an object\`

## Notable correctness fixes from review

- **\`addBacktest\` paints trade markers itself.** The first revision called \`addTrades(trades)\` *and* \`addBacktest({...trades})\` — Codex flagged that this doubles every overlay. Removed the \`addTrades\` call; \`addBacktest\` alone now drives both the marker overlay and the equity-curve subchart
- **OR/NOT imports used to silently break.** \`specToRows\` originally created synthetic rows named \`or-block\` / \`not-block\` that were not registered in \`backtestRegistry\`. Now throws \`UnsupportedSpecError\`, surfaced via the import banner
- **\`validateStrategyJSON\` was being called on a string.** Re-ordered so we parse first, then validate the resulting object

## Test plan

- [x] \`pnpm install --frozen-lockfile\`
- [x] \`pnpm -r build\` — chart bundle 31.1 kB, no regression
- [x] \`pnpm -r test\` — 5698 tests pass
- [x] \`pnpm lint\` — clean
- [x] \`cd packages/chart/examples/strategy-studio && npx tsc --noEmit\` — clean
- [x] Manual via \`agent-browser\` against a running dev server:
  - Run backtest yields 23 trades / -3.93% on the bundled sample, single (non-duplicated) marker overlay, full KPI grid populated
  - Importing a strategy with top-level AND round-trips name + capital + rows
  - Importing one with top-level OR surfaces the \`UnsupportedSpecError\` message instead of silently breaking the next Run