### PR TITLE
feat(strategy-studio): legend-anchored param editor (PR4)

### DIFF
--- a/packages/chart/examples/strategy-studio/README.md
+++ b/packages/chart/examples/strategy-studio/README.md
@@ -20,9 +20,9 @@ The studio runs **fully offline with no LLM key**. It uses `detectMarketRegime` 
 
 | PR | Scope | Status |
 |---|---|---|
-| PR2 | scaffold + 3-pane layout + regime banner + manifest preset selector | **this PR** |
-| PR3 | StrategyBuilder (entry/exit dropdowns) + backtest + trade overlay + JSON I/O | next |
-| PR4 | ParamEditor — paramSchema-driven slider/input UI for the 96 presets | |
+| PR2 | scaffold + 3-pane layout + regime banner + manifest preset selector | done |
+| PR3 | StrategyBuilder (entry/exit dropdowns) + backtest + trade overlay + JSON I/O | done |
+| PR4 | ParamEditor — paramSchema-driven slider/input UI for the 96 presets | **this PR** |
 | PR5 | LiveControls — Static/Live toggle, speed presets, `createLiveCandle` integration | |
 | PR6 | SignalsPanel — cross/divergence/pattern signal detection + markers | |
 | PR7 | PluginsPanel — SMC / Pitchfork / Volume Profile / Wyckoff plugin toggles | |

--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -8,6 +8,7 @@ import { useRegime } from "./hooks/useRegime";
 import { sampleCandles } from "./lib/sample-data";
 import { builderReducer, initialBuilderState, strategyJSONToState } from "./lib/strategy-state";
 import { KIND_TO_PRESET_KEY, localStudioAPI } from "./lib/studio-api";
+import { ParamPopover } from "./panels/ParamPopover";
 import { PresetSelector } from "./panels/PresetSelector";
 import { ResultsSummary } from "./panels/ResultsSummary";
 import { StrategyBuilder } from "./panels/StrategyBuilder";
@@ -16,20 +17,82 @@ function resolvePresetId(kind: string): string {
   return KIND_TO_PRESET_KEY[kind] ?? kind;
 }
 
+/**
+ * One mounted indicator on the chart. Multiple instances of the same `kind`
+ * are supported (e.g. SMA(5), SMA(20), SMA(60)); `id` is the stable identity.
+ */
+export type IndicatorInstance = {
+  id: string;
+  kind: string;
+  params: Record<string, number>;
+};
+
 export function App() {
   const candles = sampleCandles;
   const regime = useRegime(candles);
 
-  const [activeKinds, setActiveKinds] = useState<ReadonlySet<string>>(() => new Set());
+  const [instances, setInstances] = useState<IndicatorInstance[]>([]);
+  const [popoverState, setPopoverState] = useState<{
+    instanceId: string;
+    anchorEl: HTMLElement;
+  } | null>(null);
+  // Mirror of popoverState read by the mount effect so it doesn't have to add
+  // popoverState to its deps (which would re-run the whole add/remove sweep
+  // on every popover open/close).
+  const popoverStateRef = useRef(popoverState);
+  popoverStateRef.current = popoverState;
+  const nextIdRef = useRef(1);
 
-  const toggleKind = useCallback((kind: string) => {
-    setActiveKinds((prev) => {
-      const next = new Set(prev);
-      if (next.has(kind)) next.delete(kind);
-      else next.add(kind);
-      return next;
-    });
+  const newInstance = useCallback(
+    (kind: string): IndicatorInstance => ({
+      id: `inst-${nextIdRef.current++}`,
+      kind,
+      params: {},
+    }),
+    [],
+  );
+
+  // Empty kind → add one; non-empty → clear all of that kind. Per-row +N chip
+  // is the path to stack more (SMA(5)+SMA(20)+SMA(60)).
+  const toggleKind = useCallback(
+    (kind: string) => {
+      if (!localStudioAPI.getIndicatorPreset(kind)) return;
+      setInstances((prev) =>
+        prev.some((i) => i.kind === kind)
+          ? prev.filter((i) => i.kind !== kind)
+          : [...prev, newInstance(kind)],
+      );
+    },
+    [newInstance],
+  );
+
+  const addInstanceOfKind = useCallback(
+    (kind: string) => {
+      if (!localStudioAPI.getIndicatorPreset(kind)) return;
+      setInstances((prev) => [...prev, newInstance(kind)]);
+    },
+    [newInstance],
+  );
+
+  const removeInstance = useCallback((id: string) => {
+    setInstances((prev) => prev.filter((i) => i.id !== id));
   }, []);
+
+  const updateInstanceParam = useCallback((id: string, key: string, value: number) => {
+    setInstances((prev) =>
+      prev.map((i) => (i.id === id ? { ...i, params: { ...i.params, [key]: value } } : i)),
+    );
+  }, []);
+
+  const resetInstanceParams = useCallback((id: string) => {
+    setInstances((prev) => prev.map((i) => (i.id === id ? { ...i, params: {} } : i)));
+  }, []);
+
+  const instanceCountsByKind = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const i of instances) counts[i.kind] = (counts[i.kind] ?? 0) + 1;
+    return counts;
+  }, [instances]);
 
   const { containerRef, chart } = useTrendChart({
     candles,
@@ -42,6 +105,11 @@ export function App() {
   // skips that metadata and would render BB as anonymous channels.
   const connectionRef = useRef<IndicatorConnection | null>(null);
   const handlesRef = useRef<Map<string, ReturnType<IndicatorConnection["add"]>>>(new Map());
+  // The chart has no live `update(params)` API, so a param edit triggers
+  // remove+add. The signature memo lets us skip that round-trip when the
+  // user hasn't actually changed anything.
+  const paramSigRef = useRef<Map<string, string>>(new Map());
+  const seriesIdToInstanceIdRef = useRef<Map<string, string>>(new Map());
 
   useEffect(() => {
     if (!chart) return;
@@ -61,6 +129,7 @@ export function App() {
       conn.disconnect();
       connectionRef.current = null;
       handlesRef.current.clear();
+      paramSigRef.current.clear();
     };
   }, [chart, candles]);
 
@@ -68,27 +137,95 @@ export function App() {
     const conn = connectionRef.current;
     if (!conn) return;
     const handles = handlesRef.current;
+    const sigs = paramSigRef.current;
+    const liveIds = new Set(instances.map((i) => i.id));
 
-    // Add new
-    for (const kind of activeKinds) {
-      if (handles.has(kind)) continue;
-      const presetId = resolvePresetId(kind);
-      if (!localStudioAPI.getIndicatorPreset(kind)) continue;
+    const idMap = seriesIdToInstanceIdRef.current;
+
+    const unmount = (instId: string): void => {
+      const handle = handles.get(instId);
+      if (!handle) return;
+      if (handle.series.id) idMap.delete(handle.series.id);
+      handle.remove();
+      handles.delete(instId);
+      sigs.delete(instId);
+    };
+
+    const mount = (instance: IndicatorInstance): void => {
+      const presetId = resolvePresetId(instance.kind);
+      if (!localStudioAPI.getIndicatorPreset(instance.kind)) return;
       try {
-        handles.set(kind, conn.add(presetId));
+        // snapshotName override — most presets derive a unique snapshot from
+        // params (SMA(5)/SMA(20) collide-free), but a few use a static string
+        // (e.g. emaRibbon) and would clobber duplicates without this.
+        const handle = conn.add(presetId, {
+          ...instance.params,
+          snapshotName: `${presetId}-${instance.id}`,
+        });
+        handles.set(instance.id, handle);
+        sigs.set(instance.id, JSON.stringify(instance.params));
+        if (handle.series.id) idMap.set(handle.series.id, instance.id);
       } catch (err) {
-        console.warn(`[strategy-studio] Failed to add ${kind} (${presetId}):`, err);
+        console.warn(`[strategy-studio] Failed to add ${instance.kind} (${presetId}):`, err);
+      }
+    };
+
+    // Add or remount on param-signature change
+    for (const instance of instances) {
+      const desiredSig = JSON.stringify(instance.params);
+      const existing = handles.get(instance.id);
+      if (!existing) {
+        mount(instance);
+        continue;
+      }
+      if (sigs.get(instance.id) !== desiredSig) {
+        unmount(instance.id);
+        mount(instance);
+        // The popover's anchor element was just detached by the legend rebuild.
+        // Re-resolve it from the chart so the popover stays attached to the new
+        // row instead of floating against a dead DOM node.
+        if (chart && popoverStateRef.current?.instanceId === instance.id) {
+          const newSeriesId = handles.get(instance.id)?.series.id;
+          const newAnchor = newSeriesId ? chart.getLegendRow(newSeriesId) : null;
+          if (newAnchor) setPopoverState({ instanceId: instance.id, anchorEl: newAnchor });
+        }
       }
     }
 
-    // Remove dropped
-    for (const [kind, handle] of handles) {
-      if (!activeKinds.has(kind)) {
-        handle.remove();
-        handles.delete(kind);
-      }
+    for (const id of [...handles.keys()]) {
+      if (!liveIds.has(id)) unmount(id);
     }
-  }, [activeKinds]);
+  }, [instances, chart]);
+
+  // The chart announces lifecycle intent (⚙/✕ on legend rows) but never acts
+  // on it — the host owns indicator lifecycle.
+  useEffect(() => {
+    if (!chart) return;
+    const onEdit = (data: unknown) => {
+      const payload = data as { seriesId?: string; anchorEl?: HTMLElement } | null;
+      if (!payload?.seriesId || !payload.anchorEl) return;
+      const instId = seriesIdToInstanceIdRef.current.get(payload.seriesId);
+      if (instId) setPopoverState({ instanceId: instId, anchorEl: payload.anchorEl });
+    };
+    const onRemove = (data: unknown) => {
+      const seriesId = (data as { seriesId?: string } | null)?.seriesId;
+      if (!seriesId) return;
+      const instId = seriesIdToInstanceIdRef.current.get(seriesId);
+      if (instId) setInstances((prev) => prev.filter((i) => i.id !== instId));
+    };
+    chart.on("seriesEditRequest", onEdit);
+    chart.on("seriesRemoveRequest", onRemove);
+    return () => {
+      chart.off("seriesEditRequest", onEdit);
+      chart.off("seriesRemoveRequest", onRemove);
+    };
+  }, [chart]);
+
+  // Close the popover if its instance was removed (or never existed).
+  const popoverInstance = useMemo(() => {
+    if (!popoverState) return null;
+    return instances.find((i) => i.id === popoverState.instanceId) ?? null;
+  }, [popoverState, instances]);
 
   const headerInfo = useMemo(
     () => `${candles.length} bars · LLM-free · regime-aware`,
@@ -136,7 +273,12 @@ export function App() {
       </header>
 
       <aside className="pane left">
-        <PresetSelector regime={regime} activeKinds={activeKinds} onToggle={toggleKind} />
+        <PresetSelector
+          regime={regime}
+          instanceCountsByKind={instanceCountsByKind}
+          onToggle={toggleKind}
+          onAdd={addInstanceOfKind}
+        />
       </aside>
 
       <main className="pane center">
@@ -157,6 +299,17 @@ export function App() {
         <div className="pane-divider" />
         <ResultsSummary result={runner.state.lastResult?.result} />
       </aside>
+
+      {popoverState && popoverInstance && (
+        <ParamPopover
+          instance={popoverInstance}
+          anchorEl={popoverState.anchorEl}
+          onParamChange={updateInstanceParam}
+          onReset={resetInstanceParams}
+          onRemove={removeInstance}
+          onClose={() => setPopoverState(null)}
+        />
+      )}
     </div>
   );
 }

--- a/packages/chart/examples/strategy-studio/src/panels/ParamCardBody.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/ParamCardBody.tsx
@@ -1,0 +1,148 @@
+import { useMemo } from "react";
+import type { IndicatorPreset, ParamSchema } from "trendcraft";
+import type { IndicatorInstance } from "../App";
+
+type Props = {
+  instance: IndicatorInstance;
+  preset: IndicatorPreset;
+  onChange: (key: string, value: number) => void;
+  onReset: () => void;
+  onRemove?: () => void;
+  /** Adds a Remove button to the action row (popover uses it). */
+  showRemoveButton?: boolean;
+};
+
+/**
+ * The slider/input form for one indicator instance. Pure rendering — owners
+ * supply state, callbacks, and chrome (header, container). Reused by the
+ * legend popover and (historically) by an inline card list.
+ */
+export function ParamCardBody({
+  instance,
+  preset,
+  onChange,
+  onReset,
+  onRemove,
+  showRemoveButton,
+}: Props) {
+  const fields = useMemo(() => buildFields(preset), [preset]);
+  const hasOverrides = Object.keys(instance.params).length > 0;
+
+  if (fields.length === 0) {
+    return <div className="empty">No tunable parameters.</div>;
+  }
+
+  return (
+    <div className="param-card-body">
+      {fields.map((f) => {
+        const current = instance.params[f.key] ?? f.default;
+        return (
+          <div key={f.key} className="param-row">
+            <div className="param-row-head">
+              <label htmlFor={`${instance.id}-${f.key}`} className="param-row-label">
+                {f.label}
+              </label>
+              <span className="param-row-value">{current}</span>
+            </div>
+            {f.min !== undefined && f.max !== undefined ? (
+              <input
+                id={`${instance.id}-${f.key}`}
+                type="range"
+                min={f.min}
+                max={f.max}
+                step={f.step ?? 1}
+                value={current}
+                onChange={(e) => onChange(f.key, Number(e.target.value))}
+              />
+            ) : (
+              <input
+                id={`${instance.id}-${f.key}`}
+                type="number"
+                min={f.min}
+                max={f.max}
+                step={f.step ?? 1}
+                value={current}
+                onChange={(e) => {
+                  const raw = e.target.value;
+                  if (raw === "") return;
+                  const n = Number(raw);
+                  if (Number.isFinite(n)) onChange(f.key, n);
+                }}
+              />
+            )}
+          </div>
+        );
+      })}
+      <div className="param-card-actions">
+        <button
+          type="button"
+          className="ghost"
+          onClick={onReset}
+          disabled={!hasOverrides}
+          aria-label="Reset to defaults"
+        >
+          Reset
+        </button>
+        {showRemoveButton && onRemove && (
+          <button
+            type="button"
+            className="ghost danger"
+            onClick={onRemove}
+            aria-label="Remove instance"
+          >
+            Remove
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+type Field = {
+  key: string;
+  label: string;
+  default: number;
+  min?: number;
+  max?: number;
+  step?: number;
+};
+
+function buildFields(preset: IndicatorPreset): Field[] {
+  if (preset.paramSchema && preset.paramSchema.length > 0) {
+    return preset.paramSchema.map(toField);
+  }
+  const out: Field[] = [];
+  for (const [key, val] of Object.entries(preset.defaultParams)) {
+    if (typeof val === "number" && Number.isFinite(val)) {
+      out.push({ key, label: key, default: val });
+    }
+  }
+  return out;
+}
+
+function toField(s: ParamSchema): Field {
+  return {
+    key: s.key,
+    label: s.label,
+    default: s.default,
+    min: s.min,
+    max: s.max,
+    step: s.step,
+  };
+}
+
+/**
+ * One-line param summary for compact listings — `Period 5` or `Period 20 · k 2.5`.
+ * Useful when showing many instances in legends / quick lists.
+ */
+export function formatParamSummary(
+  preset: IndicatorPreset,
+  overrides: Record<string, number>,
+): string {
+  const fields = buildFields(preset);
+  if (fields.length === 0) return "";
+  return fields
+    .slice(0, 2)
+    .map((f) => `${f.label} ${overrides[f.key] ?? f.default}`)
+    .join(" · ");
+}

--- a/packages/chart/examples/strategy-studio/src/panels/ParamPopover.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/ParamPopover.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import type { IndicatorInstance } from "../App";
+import { localStudioAPI } from "../lib/studio-api";
+import { ParamCardBody } from "./ParamCardBody";
+
+type Props = {
+  instance: IndicatorInstance;
+  /** DOM element the popover is positioned relative to (the legend row). */
+  anchorEl: HTMLElement;
+  onParamChange: (id: string, key: string, value: number) => void;
+  onReset: (id: string) => void;
+  onRemove: (id: string) => void;
+  onClose: () => void;
+};
+
+const POPOVER_WIDTH = 260;
+const GAP = 6;
+const MARGIN = 8;
+/** Used for the first-frame placement before ResizeObserver measures real height. */
+const FALLBACK_HEIGHT = 240;
+
+/**
+ * Floating editor anchored to a chart legend row. Closes on outside click,
+ * Escape, or scroll. Position is recomputed on window resize so the popover
+ * stays attached even as the chart relayouts.
+ */
+export function ParamPopover({
+  instance,
+  anchorEl,
+  onParamChange,
+  onReset,
+  onRemove,
+  onClose,
+}: Props) {
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  // Always read the latest anchor for outside-click + window-resize re-anchor,
+  // but keep position frozen otherwise — re-anchoring on every slider step
+  // (the legend reflows each remount) made the popover jitter.
+  const anchorRef = useRef(anchorEl);
+  anchorRef.current = anchorEl;
+
+  const { preset, displayName } = useMemo(() => {
+    const p = localStudioAPI.getIndicatorPreset(instance.kind);
+    const name =
+      localStudioAPI.listIndicators().find((m) => m.kind === instance.kind)?.displayName ??
+      p?.name ??
+      instance.kind;
+    return { preset: p, displayName: name };
+  }, [instance.kind]);
+
+  // Position is recomputed when the user switches to a different instance's
+  // editor, when the popover's own dimensions change (ResizeObserver), or on
+  // window resize. It is *not* recomputed when `anchorEl` is swapped for the
+  // same instance — that happens on every slider step (legend reflows after
+  // each param remount) and would make the popover jitter. Trade-off: the
+  // popover doesn't follow scroll once opened.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: instance.id is the trigger key — effect reads anchorEl via anchorRef so that swap doesn't reposition.
+  useLayoutEffect(() => {
+    let frame = 0;
+    function compute(): void {
+      const a = anchorRef.current;
+      if (!a) return;
+      const rect = a.getBoundingClientRect();
+      const popH = popoverRef.current?.offsetHeight ?? FALLBACK_HEIGHT;
+      const vh = window.innerHeight;
+      const vw = window.innerWidth;
+      const left = Math.min(Math.max(rect.left, MARGIN), vw - POPOVER_WIDTH - MARGIN);
+      const spaceBelow = vh - rect.bottom - MARGIN;
+      const spaceAbove = rect.top - MARGIN;
+      let top: number;
+      if (popH + GAP <= spaceBelow) {
+        top = rect.bottom + GAP;
+      } else if (popH + GAP <= spaceAbove) {
+        top = rect.top - GAP - popH;
+      } else {
+        top = Math.max(MARGIN, Math.min(rect.bottom + GAP, vh - MARGIN - popH));
+      }
+      setPos({ top, left });
+    }
+    function schedule(): void {
+      if (frame) return;
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        compute();
+      });
+    }
+    compute();
+    const ro = popoverRef.current ? new ResizeObserver(schedule) : null;
+    if (popoverRef.current) ro?.observe(popoverRef.current);
+    window.addEventListener("resize", schedule);
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      ro?.disconnect();
+      window.removeEventListener("resize", schedule);
+    };
+  }, [instance.id]);
+
+  useEffect(() => {
+    function onPointerDown(e: PointerEvent): void {
+      const target = e.target as Node;
+      if (popoverRef.current?.contains(target)) return;
+      // Re-clicking the same ⚙ that opened us shouldn't close+reopen.
+      if (anchorRef.current?.contains(target)) return;
+      onClose();
+    }
+    function onKey(e: KeyboardEvent): void {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [onClose]);
+
+  if (!preset) return null;
+
+  return (
+    <div
+      ref={popoverRef}
+      className="param-popover"
+      role="dialog"
+      aria-label={`${displayName} parameters`}
+      style={{
+        position: "fixed",
+        top: pos?.top ?? -9999,
+        left: pos?.left ?? -9999,
+        width: POPOVER_WIDTH,
+        visibility: pos ? "visible" : "hidden",
+      }}
+    >
+      <div className="param-popover-header">
+        <div className="param-popover-titles">
+          <span className="param-card-title">{displayName}</span>
+          <span className="param-card-kind">{instance.kind}</span>
+        </div>
+        <button type="button" className="ghost" onClick={onClose} aria-label="Close" title="Close">
+          ✕
+        </button>
+      </div>
+      <ParamCardBody
+        instance={instance}
+        preset={preset}
+        onChange={(key, value) => onParamChange(instance.id, key, value)}
+        onReset={() => onReset(instance.id)}
+        onRemove={() => {
+          onRemove(instance.id);
+          onClose();
+        }}
+        showRemoveButton
+      />
+    </div>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/panels/PresetSelector.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/PresetSelector.tsx
@@ -18,11 +18,15 @@ const CATEGORIES: IndicatorCategory[] = [
 
 type Props = {
   regime: RegimeSummary;
-  activeKinds: ReadonlySet<string>;
+  /** How many instances of each kind are currently mounted. */
+  instanceCountsByKind: Record<string, number>;
+  /** Row click — empty kind adds one, non-empty kind clears all. */
   onToggle: (kind: string) => void;
+  /** +N chip click — append another instance of the same kind. */
+  onAdd: (kind: string) => void;
 };
 
-export function PresetSelector({ regime, activeKinds, onToggle }: Props) {
+export function PresetSelector({ regime, instanceCountsByKind, onToggle, onAdd }: Props) {
   const [category, setCategory] = useState<IndicatorCategory | "all">("all");
   const [hovered, setHovered] = useState<string | null>(null);
 
@@ -55,10 +59,11 @@ export function PresetSelector({ regime, activeKinds, onToggle }: Props) {
       <div className="section-title">Suggested for this regime</div>
       <PresetList
         items={suggestions}
-        activeKinds={activeKinds}
+        instanceCountsByKind={instanceCountsByKind}
         hovered={hovered}
         onHover={setHovered}
         onToggle={onToggle}
+        onAdd={onAdd}
         emptyText="No manifest entries match this regime yet."
       />
 
@@ -77,10 +82,11 @@ export function PresetSelector({ regime, activeKinds, onToggle }: Props) {
       </select>
       <PresetList
         items={browse}
-        activeKinds={activeKinds}
+        instanceCountsByKind={instanceCountsByKind}
         hovered={hovered}
         onHover={setHovered}
         onToggle={onToggle}
+        onAdd={onAdd}
         emptyText="No indicators in this category."
       />
     </>
@@ -89,33 +95,65 @@ export function PresetSelector({ regime, activeKinds, onToggle }: Props) {
 
 type ListProps = {
   items: IndicatorManifest[];
-  activeKinds: ReadonlySet<string>;
+  instanceCountsByKind: Record<string, number>;
   hovered: string | null;
   onHover: (kind: string | null) => void;
   onToggle: (kind: string) => void;
+  onAdd: (kind: string) => void;
   emptyText: string;
 };
 
-function PresetList({ items, activeKinds, hovered, onHover, onToggle, emptyText }: ListProps) {
+function PresetList({
+  items,
+  instanceCountsByKind,
+  hovered,
+  onHover,
+  onToggle,
+  onAdd,
+  emptyText,
+}: ListProps) {
   if (items.length === 0) return <div className="empty">{emptyText}</div>;
 
   return (
     <ul className="preset-list">
       {items.map((m) => {
-        const active = activeKinds.has(m.kind);
+        const count = instanceCountsByKind[m.kind] ?? 0;
         const renderable = localStudioAPI.getIndicatorPreset(m.kind) !== undefined;
-        const className = `preset-item${active ? " active" : ""}${renderable ? "" : " disabled"}`;
+        const className = `preset-item${count > 0 ? " active" : ""}${renderable ? "" : " disabled"}`;
+        const tip = !renderable
+          ? "No chart preset (event-only or regime classifier)"
+          : count > 0
+            ? `Click to remove all ${m.displayName}; use +N to add another`
+            : `Click to add ${m.displayName}`;
         return (
           <li
             key={m.kind}
             className={className}
-            onClick={renderable ? () => onToggle(m.kind) : undefined}
             onMouseEnter={() => onHover(m.kind)}
             onMouseLeave={() => onHover(null)}
-            title={renderable ? undefined : "No chart preset (event-only or regime classifier)"}
           >
-            <span className="preset-name">{m.displayName}</span>
-            <span className="preset-kind">{m.kind}</span>
+            <button
+              type="button"
+              className="preset-toggle"
+              onClick={renderable ? () => onToggle(m.kind) : undefined}
+              disabled={!renderable}
+              aria-pressed={count > 0}
+              title={tip}
+            >
+              <span className="preset-name">{m.displayName}</span>
+              <span className="preset-kind">{m.kind}</span>
+            </button>
+            {renderable && count > 0 && (
+              <button
+                type="button"
+                className="preset-count"
+                onClick={() => onAdd(m.kind)}
+                aria-label={`Add another ${m.displayName}`}
+                title={`Add another ${m.displayName} instance`}
+              >
+                +{count}
+              </button>
+            )}
             {hovered === m.kind && <ManifestTooltip manifest={m} />}
           </li>
         );

--- a/packages/chart/examples/strategy-studio/src/styles.css
+++ b/packages/chart/examples/strategy-studio/src/styles.css
@@ -142,14 +142,10 @@ body,
 
 .preset-item {
   position: relative;
-  padding: 8px 10px;
-  font-size: 12px;
   border-radius: 4px;
-  cursor: pointer;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+  align-items: stretch;
+  gap: 4px;
 }
 
 .preset-item:hover {
@@ -158,16 +154,37 @@ body,
 
 .preset-item.active {
   background: rgba(33, 150, 243, 0.15);
-  color: #fff;
 }
 
-.preset-item.disabled {
+.preset-toggle {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.preset-toggle:focus-visible {
+  outline: 2px solid #2196f3;
+  outline-offset: -2px;
+}
+
+.preset-toggle:disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
 
-.preset-item.disabled:hover {
-  background: transparent;
+.preset-item.active .preset-toggle {
+  color: #fff;
 }
 
 .preset-name {
@@ -178,6 +195,27 @@ body,
   font-size: 10px;
   color: #787b86;
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+.preset-count {
+  align-self: center;
+  margin-right: 6px;
+  padding: 2px 8px;
+  font-size: 10px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  background: rgba(33, 150, 243, 0.35);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.preset-count:hover,
+.preset-count:focus-visible {
+  background: #2196f3;
+  outline: none;
 }
 
 .preset-tooltip {
@@ -436,6 +474,152 @@ button.ghost.danger:hover {
 .pane-divider {
   border-top: 1px solid #2a2e39;
   margin: 0;
+}
+
+/* ============================================
+ * Parameter Editor (left pane)
+ * ============================================ */
+
+.param-card {
+  margin: 8px 12px;
+  border: 1px solid #2a2e39;
+  border-radius: 4px;
+  background: #0e1320;
+  transition: box-shadow 200ms ease, border-color 200ms ease;
+}
+
+.param-card--flash {
+  border-color: #2196f3;
+  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.35);
+}
+
+.param-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid #2a2e39;
+}
+
+.param-card-titles {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.param-card-title {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.param-card-summary {
+  font-weight: 400;
+  color: #787b86;
+  font-variant-numeric: tabular-nums;
+}
+
+.param-card-kind {
+  font-size: 10px;
+  color: #787b86;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+.param-card-body {
+  padding: 8px 10px;
+}
+
+.param-row {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin-bottom: 8px;
+}
+
+.param-row-head {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: #787b86;
+}
+
+.param-row-value {
+  font-variant-numeric: tabular-nums;
+  color: #d1d4dc;
+}
+
+.param-row input[type="range"] {
+  width: 100%;
+  accent-color: #2196f3;
+}
+
+.param-row input[type="number"] {
+  width: 100%;
+  background: #1e222d;
+  border: 1px solid #2a2e39;
+  border-radius: 3px;
+  color: #d1d4dc;
+  padding: 4px 6px;
+  font-size: 12px;
+  font-family: inherit;
+}
+
+.param-row input[type="number"]:focus {
+  outline: none;
+  border-color: #2196f3;
+}
+
+.param-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+.param-card-actions button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ============================================
+ * Param Popover (chart-anchored editor)
+ * ============================================ */
+
+.param-popover {
+  z-index: 100;
+  background: #131722;
+  border: 1px solid #2a2e39;
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.6);
+  font-family: inherit;
+  color: #d1d4dc;
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.param-popover-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 10px;
+  background: #131722;
+  border-bottom: 1px solid #2a2e39;
+}
+
+.param-popover-titles {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.param-popover .param-card-body {
+  padding: 8px 10px;
 }
 
 /* ============================================

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -114,7 +114,7 @@
     {
       "name": "Main (createChart + all exports)",
       "path": "dist/index.js",
-      "limit": "37 kB"
+      "limit": "38 kB"
     },
     {
       "name": "Headless API",
@@ -139,12 +139,12 @@
     {
       "name": "React wrapper",
       "path": "dist/react/TrendChart.js",
-      "limit": "31 kB"
+      "limit": "32 kB"
     },
     {
       "name": "Vue wrapper",
       "path": "dist/vue/TrendChart.js",
-      "limit": "31 kB"
+      "limit": "32 kB"
     }
   ],
   "devDependencies": {

--- a/packages/chart/src/__tests__/decimation.test.ts
+++ b/packages/chart/src/__tests__/decimation.test.ts
@@ -106,6 +106,22 @@ describe("decimateCandles", () => {
     expect(result.candles[0].volume).toBe(firstBucketVolume);
   });
 
+  it("clamps out-of-range indices instead of throwing on undefined candle", () => {
+    // The viewport can lag a setCandles call by a frame, leaving the renderer
+    // requesting a range past the data. Reading `candles[bStart].open` would
+    // crash without the clamp.
+    const candles = makeCandles(50);
+    expect(() => decimateCandles(candles, 0, 200, 20)).not.toThrow();
+    const past = decimateCandles(candles, 60, 200, 20);
+    expect(past.candles).toEqual([]);
+    expect(past.originalIndices.length).toBe(0);
+    const overshoot = decimateCandles(candles, 0, 200, 20);
+    expect(overshoot.candles.length).toBe(20);
+    for (let i = 0; i < overshoot.originalIndices.length; i++) {
+      expect(overshoot.originalIndices[i]).toBeLessThan(50);
+    }
+  });
+
   it("originalIndices are monotonic, in-range, and land inside each bucket", () => {
     const candles = makeCandles(100);
     const result = decimateCandles(candles, 10, 90, 8);

--- a/packages/chart/src/__tests__/legend-actions.test.ts
+++ b/packages/chart/src/__tests__/legend-actions.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+/**
+ * Legend per-row actions (⚙ edit / ✕ remove) — only render when the host has
+ * subscribed to the matching event. A bare chart must not show affordances
+ * that go nowhere when clicked.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createChart } from "../index";
+
+beforeAll(() => {
+  const noop = () => {};
+  const ctx = new Proxy(
+    {},
+    {
+      get: (_t, prop) => {
+        if (prop === "canvas") return null;
+        if (prop === "measureText") return () => ({ width: 0 }) as TextMetrics;
+        return noop;
+      },
+      set: () => true,
+    },
+  ) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as { getContext: () => unknown }).getContext = () => ctx;
+});
+
+function makeContainer(): HTMLElement {
+  const el = document.createElement("div");
+  el.style.width = "800px";
+  el.style.height = "400px";
+  document.body.appendChild(el);
+  return el;
+}
+
+const sampleSeries = [
+  { time: 1000, value: 1 },
+  { time: 2000, value: 2 },
+  { time: 3000, value: 3 },
+];
+
+describe("Legend per-row actions", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders only the toggle button by default", () => {
+    const container = makeContainer();
+    const chart = createChart(container, { legend: true });
+    chart.addIndicator(sampleSeries, { label: "Test" });
+    const actions = container.querySelectorAll(".tc-legend-action");
+    expect(actions.length).toBe(0);
+    const toggles = container.querySelectorAll('.tc-legend-btn[data-action="toggle"]');
+    expect(toggles.length).toBe(1);
+    chart.destroy();
+  });
+
+  it("renders ⚙ once a seriesEditRequest listener is attached", () => {
+    const container = makeContainer();
+    const chart = createChart(container, { legend: true });
+    chart.on("seriesEditRequest", () => {});
+    chart.addIndicator(sampleSeries, { label: "Test" });
+    const editButtons = container.querySelectorAll('.tc-legend-action[data-action="edit"]');
+    expect(editButtons.length).toBe(1);
+    const removeButtons = container.querySelectorAll('.tc-legend-action[data-action="remove"]');
+    expect(removeButtons.length).toBe(0);
+    chart.destroy();
+  });
+
+  it("renders ✕ once a seriesRemoveRequest listener is attached", () => {
+    const container = makeContainer();
+    const chart = createChart(container, { legend: true });
+    chart.on("seriesRemoveRequest", () => {});
+    chart.addIndicator(sampleSeries, { label: "Test" });
+    const removeButtons = container.querySelectorAll('.tc-legend-action[data-action="remove"]');
+    expect(removeButtons.length).toBe(1);
+    chart.destroy();
+  });
+});

--- a/packages/chart/src/core/decimation.ts
+++ b/packages/chart/src/core/decimation.ts
@@ -141,11 +141,19 @@ export function decimateCandles(
   endIndex: number,
   maxBars: number,
 ): DecimatedCandles {
-  const count = endIndex - startIndex;
+  // Clamp the requested range to the actual data length. The viewport can lag
+  // a setCandles call by a frame (or be set programmatically past the data),
+  // and reading `candles[bStart].open` blindly would crash on an undefined.
+  const safeStart = Math.max(0, Math.min(startIndex, candles.length));
+  const safeEnd = Math.max(safeStart, Math.min(endIndex, candles.length));
+  const count = safeEnd - safeStart;
+  if (count === 0) {
+    return { candles: [], originalIndices: new Int32Array(0) };
+  }
   if (count <= maxBars || maxBars <= 0) {
-    const result = candles.slice(startIndex, endIndex) as CandleData[];
+    const result = candles.slice(safeStart, safeEnd) as CandleData[];
     const originalIndices = new Int32Array(result.length);
-    for (let i = 0; i < result.length; i++) originalIndices[i] = startIndex + i;
+    for (let i = 0; i < result.length; i++) originalIndices[i] = safeStart + i;
     return { candles: result, originalIndices };
   }
 
@@ -154,8 +162,8 @@ export function decimateCandles(
   const originalIndices = new Int32Array(maxBars);
 
   for (let b = 0; b < maxBars; b++) {
-    const bStart = startIndex + Math.floor(b * bucketSize);
-    const bEnd = Math.min(startIndex + Math.floor((b + 1) * bucketSize), endIndex);
+    const bStart = safeStart + Math.floor(b * bucketSize);
+    const bEnd = Math.min(safeStart + Math.floor((b + 1) * bucketSize), safeEnd);
 
     const open = candles[bStart].open;
     let high = Number.NEGATIVE_INFINITY;

--- a/packages/chart/src/core/html.ts
+++ b/packages/chart/src/core/html.ts
@@ -1,0 +1,13 @@
+/** Prevent XSS from user-supplied labels / colors / locale strings. */
+export function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => {
+    const map: Record<string, string> = {
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;",
+    };
+    return map[c] ?? c;
+  });
+}

--- a/packages/chart/src/core/i18n.ts
+++ b/packages/chart/src/core/i18n.ts
@@ -31,6 +31,10 @@ export type ChartLocale = {
   indicator: string;
   indicators: string;
   toggleVisibility: (label: string) => string;
+  /** Optional — falls back to `Edit ${label}` if not provided. */
+  editSeries?: (label: string) => string;
+  /** Optional — falls back to `Remove ${label}` if not provided. */
+  removeSeries?: (label: string) => string;
 
   // Drawing
   defaultLabel: string;
@@ -60,6 +64,8 @@ export const DEFAULT_LOCALE: ChartLocale = {
   indicator: "indicator",
   indicators: "indicators",
   toggleVisibility: (label: string) => `Toggle ${label} visibility`,
+  editSeries: (label: string) => `Edit ${label}`,
+  removeSeries: (label: string) => `Remove ${label}`,
 
   defaultLabel: "Label",
 };

--- a/packages/chart/src/core/types/chart-instance.ts
+++ b/packages/chart/src/core/types/chart-instance.ts
@@ -33,6 +33,14 @@ export type ChartInstance = {
   // Series query
   getAllSeries(): SeriesInfo[];
   getVisibleRange(): VisibleRangeChangeData | null;
+  /**
+   * Returns the legend row element for `seriesId`, or `null` if no labeled row
+   * is currently rendered for it. Useful as a live anchor for popovers/menus
+   * triggered from a `seriesEditRequest`/`seriesRemoveRequest` event — the
+   * payload's `anchorEl` is detached after a series remove+add cycle, so
+   * re-resolving via this method keeps the affordance attached.
+   */
+  getLegendRow(seriesId: string): HTMLElement | null;
 
   // Signals & Trades
   addSignals(signals: SignalMarker[]): void;

--- a/packages/chart/src/core/types/event.ts
+++ b/packages/chart/src/core/types/event.ts
@@ -12,9 +12,27 @@ export type ChartEvent =
   | "paneResize"
   | "seriesAdded"
   | "seriesRemoved"
+  | "seriesEditRequest"
+  | "seriesRemoveRequest"
   | "dataFiltered"
   | "drawingComplete"
   | "error";
+
+/**
+ * Payload for `seriesEditRequest` and `seriesRemoveRequest` events. Fired when
+ * the user clicks the edit / remove affordance on a legend row. The chart
+ * never edits or removes the series itself — it only delegates the intent
+ * back to the host application, which owns indicator parameters and lifecycle.
+ *
+ * `anchorEl` is the DOM element of the clicked legend row (or button), so the
+ * host can position a popover next to the user's cursor without having to
+ * query the chart's internal selectors. Same window only — for cross-frame
+ * use, derive a bounding rect from it on the host side.
+ */
+export type SeriesActionData = {
+  seriesId: string;
+  anchorEl: HTMLElement;
+};
 
 export type CrosshairMoveData = {
   time: TimeValue | null;

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -165,6 +165,49 @@ export class CanvasChart implements ChartInstance {
   }
 
   /**
+   * Wire a freshly created LegendOverlay to the chart's mutation/event surface.
+   * Toggle is handled internally (chart owns visibility); edit/remove are
+   * forwarded to host listeners as `seriesEditRequest` / `seriesRemoveRequest`
+   * so the host can run its own indicator pipeline. The chart never removes a
+   * series in response to the legend ✕ — that would orphan host-side state.
+   */
+  private _wireLegend(legend: LegendOverlay): void {
+    legend.setOnToggle((seriesId, visible) => {
+      const series = this._data.getAllSeries().find((s) => s.id === seriesId);
+      if (series) {
+        series.visible = visible;
+        this._needsRender = true;
+      }
+    });
+    // Edit / remove affordances are wired lazily from `on()` so the legend
+    // only renders ⚙ / ✕ when the host has actually subscribed.
+    this._syncLegendActions(legend);
+  }
+
+  private _syncLegendActions(legend: LegendOverlay = this._legendOverlay as LegendOverlay): void {
+    if (!legend) return;
+    legend.setOnEdit(
+      this._hasListener("seriesEditRequest")
+        ? (seriesId, anchorEl) => this._emit("seriesEditRequest", { seriesId, anchorEl })
+        : null,
+    );
+    legend.setOnRemove(
+      this._hasListener("seriesRemoveRequest")
+        ? (seriesId, anchorEl) => this._emit("seriesRemoveRequest", { seriesId, anchorEl })
+        : null,
+    );
+  }
+
+  private _hasListener(event: ChartEvent): boolean {
+    const set = this._listeners.get(event);
+    return !!set && set.size > 0;
+  }
+
+  getLegendRow(seriesId: string): HTMLElement | null {
+    return this._legendOverlay?.getRowAnchor(seriesId) ?? null;
+  }
+
+  /**
    * Fire `crosshairMove` when the user's interaction has moved the snapped
    * index relative to the last emit. Called synchronously from the viewport's
    * onUpdate hook (mouse/wheel/keyboard) so syncCharts can propagate to peers
@@ -368,13 +411,7 @@ export class CanvasChart implements ChartInstance {
     // Legend overlay
     if (options?.legend !== false) {
       this._legendOverlay = new LegendOverlay(container, this._theme, this._locale);
-      this._legendOverlay.setOnToggle((seriesId, visible) => {
-        const series = this._data.getAllSeries().find((s) => s.id === seriesId);
-        if (series) {
-          series.visible = visible;
-          this._needsRender = true;
-        }
-      });
+      this._wireLegend(this._legendOverlay);
     }
 
     // Watermark
@@ -792,11 +829,24 @@ export class CanvasChart implements ChartInstance {
       set = new Set();
       this._listeners.set(event, set);
     }
+    const wasEmpty = set.size === 0;
     set.add(handler);
+    if (wasEmpty && (event === "seriesEditRequest" || event === "seriesRemoveRequest")) {
+      this._syncLegendActions();
+    }
   }
 
   off<E extends ChartEvent>(event: E, handler: (data: unknown) => void): void {
-    this._listeners.get(event)?.delete(handler);
+    const set = this._listeners.get(event);
+    if (!set) return;
+    const removed = set.delete(handler);
+    if (
+      removed &&
+      set.size === 0 &&
+      (event === "seriesEditRequest" || event === "seriesRemoveRequest")
+    ) {
+      this._syncLegendActions();
+    }
   }
 
   // ---- Public API: Theme ----
@@ -898,13 +948,7 @@ export class CanvasChart implements ChartInstance {
         this._legendOverlay = null;
       } else if (opts.legend !== false && !this._legendOverlay) {
         this._legendOverlay = new LegendOverlay(this._container, this._theme, this._locale);
-        this._legendOverlay.setOnToggle((seriesId, visible) => {
-          const series = this._data.getAllSeries().find((s) => s.id === seriesId);
-          if (series) {
-            series.visible = visible;
-            this._needsRender = true;
-          }
-        });
+        this._wireLegend(this._legendOverlay);
       }
       this._needsRender = true;
     }

--- a/packages/chart/src/renderer/info-overlay.ts
+++ b/packages/chart/src/renderer/info-overlay.ts
@@ -5,6 +5,7 @@
 
 import type { InternalSeries } from "../core/data-layer";
 import { autoFormatPrice, formatVolume } from "../core/format";
+import { escapeHtml } from "../core/html";
 import { type ChartLocale, DEFAULT_LOCALE } from "../core/i18n";
 import type { RendererRegistry } from "../core/renderer-registry";
 import { defaultRegistry } from "../core/series-registry";
@@ -250,15 +251,3 @@ export class InfoOverlay {
 const fmtVol = (n: number) => escapeHtml(formatVolume(n));
 
 /** Prevent XSS from custom formatters */
-function escapeHtml(s: string): string {
-  return s.replace(/[&<>"']/g, (c) => {
-    const map: Record<string, string> = {
-      "&": "&amp;",
-      "<": "&lt;",
-      ">": "&gt;",
-      '"': "&quot;",
-      "'": "&#39;",
-    };
-    return map[c] ?? c;
-  });
-}

--- a/packages/chart/src/renderer/legend-overlay.ts
+++ b/packages/chart/src/renderer/legend-overlay.ts
@@ -1,17 +1,26 @@
 /**
- * Legend Overlay — DOM-based series list with visibility toggles.
- * Uses event delegation to avoid listener leaks on frequent updates.
+ * DOM-based per-series legend with click-to-toggle plus hover-revealed
+ * ⚙ edit / ✕ remove affordances. Edit and remove emit callbacks; the chart
+ * never mutates series in response — host owns indicator lifecycle.
+ *
+ * Uses event delegation so only one click listener exists regardless of how
+ * many rows are rendered.
  */
 
 import type { InternalSeries } from "../core/data-layer";
+import { escapeHtml } from "../core/html";
 import { type ChartLocale, DEFAULT_LOCALE } from "../core/i18n";
 import type { ThemeColors } from "../core/types";
+
+type LegendAction = "toggle" | "edit" | "remove";
 
 export class LegendOverlay {
   private _container: HTMLElement;
   private _el: HTMLElement;
   private _theme: ThemeColors;
   private _onToggle: ((seriesId: string, visible: boolean) => void) | null = null;
+  private _onEdit: ((seriesId: string, anchorEl: HTMLElement) => void) | null = null;
+  private _onRemove: ((seriesId: string, anchorEl: HTMLElement) => void) | null = null;
   private _currentSeries: InternalSeries[] = [];
   private _handleClick: (e: MouseEvent) => void;
   private _lastHtml = "";
@@ -24,26 +33,40 @@ export class LegendOverlay {
     this._theme = theme;
     this._locale = locale ?? DEFAULT_LOCALE;
 
-    // Inject responsive styles once
     this._styleEl = document.createElement("style");
-    this._styleEl.textContent = `
-      .tc-legend { position:absolute; top:22px; right:68px; left:4px; z-index:10; display:flex; justify-content:flex-end; gap:8px; flex-wrap:wrap; font-size:11px; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; pointer-events:none; }
-      .tc-legend-btn { cursor:pointer; white-space:nowrap; background:none; border:none; padding:2px 4px; font:inherit; line-height:inherit; min-height:24px; pointer-events:auto; }
-      @media (pointer:coarse) { .tc-legend-btn { min-height:36px; padding:6px 10px; font-size:13px; } }
-      @media (max-width:480px) { .tc-legend { right:4px; top:auto; bottom:4px; gap:4px; font-size:10px; justify-content:flex-start; } }
-    `;
+    this._styleEl.textContent =
+      '.tc-legend{position:absolute;top:22px;right:68px;left:4px;z-index:10;display:flex;justify-content:flex-end;gap:8px;flex-wrap:wrap;font-size:11px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;pointer-events:none}' +
+      ".tc-legend-row{display:inline-flex;align-items:center;gap:2px;pointer-events:auto}" +
+      ".tc-legend-btn,.tc-legend-action{cursor:pointer;background:none;border:none;font:inherit;color:inherit;pointer-events:auto}" +
+      ".tc-legend-btn{white-space:nowrap;padding:2px 4px;line-height:inherit;min-height:24px}" +
+      ".tc-legend-dot{display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:3px;vertical-align:middle}" +
+      ".tc-legend-actions{display:inline-flex;opacity:0;transition:opacity 120ms ease}" +
+      ".tc-legend-row:hover .tc-legend-actions,.tc-legend-row:focus-within .tc-legend-actions{opacity:1}" +
+      ".tc-legend-action{padding:2px 4px;line-height:1;min-height:24px;min-width:20px;opacity:.65}" +
+      ".tc-legend-action:hover,.tc-legend-action:focus-visible{opacity:1;outline:none}" +
+      "@media(pointer:coarse){.tc-legend-btn{min-height:36px;padding:6px 10px;font-size:13px}.tc-legend-action{min-height:36px;min-width:32px;padding:6px 8px;font-size:13px}.tc-legend-actions{opacity:1}}" +
+      "@media(max-width:480px){.tc-legend{right:4px;top:auto;bottom:4px;gap:4px;font-size:10px;justify-content:flex-start}}";
     container.appendChild(this._styleEl);
 
     this._el = document.createElement("div");
     this._el.className = "tc-legend";
     container.appendChild(this._el);
 
-    // Single delegated click handler — never leaked
+    // Single delegated click handler — never leaked across `update()` calls.
     this._handleClick = (e: MouseEvent) => {
       const target = (e.target as HTMLElement).closest("[data-series-id]") as HTMLElement | null;
       if (!target) return;
       const id = target.dataset.seriesId;
       if (!id) return;
+      const action = (target.dataset.action ?? "toggle") as LegendAction;
+      if (action === "edit") {
+        this._onEdit?.(id, target);
+        return;
+      }
+      if (action === "remove") {
+        this._onRemove?.(id, target);
+        return;
+      }
       const series = this._currentSeries.find((s) => s.id === id);
       if (!series) return;
       this._onToggle?.(id, !series.visible);
@@ -55,8 +78,43 @@ export class LegendOverlay {
     this._onToggle = cb;
   }
 
+  /**
+   * Edit and remove affordances are only rendered when a callback is wired,
+   * so the legend doesn't promise actions the host won't service. Pass `null`
+   * to clear. Toggling presence after rows are already on screen forces a
+   * re-render.
+   */
+  setOnEdit(cb: ((seriesId: string, anchorEl: HTMLElement) => void) | null): void {
+    const presenceChanged = (this._onEdit === null) !== (cb === null);
+    this._onEdit = cb;
+    if (presenceChanged && this._currentSeries.length > 0) this._rerender();
+  }
+
+  setOnRemove(cb: ((seriesId: string, anchorEl: HTMLElement) => void) | null): void {
+    const presenceChanged = (this._onRemove === null) !== (cb === null);
+    this._onRemove = cb;
+    if (presenceChanged && this._currentSeries.length > 0) this._rerender();
+  }
+
+  private _rerender(): void {
+    this._lastHtml = "";
+    this.update(this._currentSeries);
+  }
+
   setTheme(theme: ThemeColors): void {
     this._theme = theme;
+  }
+
+  /**
+   * Live lookup of the legend row element for a given series id. Hosts that
+   * anchor a popover to a row need this after a remove+add cycle (param edit)
+   * because the row's DOM is rebuilt and the original `anchorEl` is detached.
+   * Returns the always-present toggle button (`.tc-legend-btn`); action
+   * buttons depend on listener presence and may not exist.
+   */
+  getRowAnchor(seriesId: string): HTMLElement | null {
+    const sel = `.tc-legend-btn[data-series-id="${CSS.escape(seriesId)}"]`;
+    return this._el.querySelector(sel) as HTMLElement | null;
   }
 
   update(allSeries: InternalSeries[]): void {
@@ -71,28 +129,33 @@ export class LegendOverlay {
       return;
     }
 
-    const html = labeled
-      .map((s) => {
-        const color = s.config.color ?? this._theme.text;
-        const opacity = s.visible ? "1" : "0.35";
-        const textDecoration = s.visible ? "none" : "line-through";
-        const label = escapeHtml(s.config.label ?? "");
-        return `<button
-          type="button"
-          class="tc-legend-btn"
-          data-series-id="${escapeHtml(s.id)}"
-          aria-pressed="${s.visible}"
-          aria-label="${escapeHtml(this._locale.toggleVisibility(s.config.label ?? ""))}"
-          style="opacity:${opacity};text-decoration:${textDecoration};color:${this._theme.text}"
-        ><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${escapeHtml(color)};margin-right:3px;vertical-align:middle"></span>${label}</button>`;
-      })
-      .join("");
+    const html = labeled.map((s) => this._renderRow(s)).join("");
 
-    // Only update DOM when content actually changed
     if (html !== this._lastHtml) {
       this._el.innerHTML = html;
       this._lastHtml = html;
     }
+  }
+
+  private _renderRow(s: InternalSeries): string {
+    const rawLabel = s.config.label ?? "";
+    const color = escapeHtml(s.config.color ?? this._theme.text);
+    const style = s.visible ? "" : "opacity:.35;text-decoration:line-through";
+    const label = escapeHtml(rawLabel);
+    const id = escapeHtml(s.id);
+    const t = escapeHtml(this._theme.text);
+    const visAria = escapeHtml(this._locale.toggleVisibility(rawLabel));
+    let actions = "";
+    if (this._onEdit) {
+      const aria = escapeHtml(this._locale.editSeries?.(rawLabel) ?? `Edit ${rawLabel}`);
+      actions += `<button type="button" class="tc-legend-action" data-series-id="${id}" data-action="edit" aria-label="${aria}" title="${aria}">⚙</button>`;
+    }
+    if (this._onRemove) {
+      const aria = escapeHtml(this._locale.removeSeries?.(rawLabel) ?? `Remove ${rawLabel}`);
+      actions += `<button type="button" class="tc-legend-action" data-series-id="${id}" data-action="remove" aria-label="${aria}" title="${aria}">✕</button>`;
+    }
+    const actionsSpan = actions ? `<span class="tc-legend-actions">${actions}</span>` : "";
+    return `<span class="tc-legend-row" style="color:${t}"><button type="button" class="tc-legend-btn" data-series-id="${id}" data-action="toggle" aria-pressed="${s.visible}" aria-label="${visAria}" style="${style}"><span class="tc-legend-dot" style="background:${color}"></span>${label}</button>${actionsSpan}</span>`;
   }
 
   destroy(): void {
@@ -100,18 +163,4 @@ export class LegendOverlay {
     this._el.remove();
     this._styleEl?.remove();
   }
-}
-
-/** Prevent XSS from user-supplied labels/colors */
-function escapeHtml(s: string): string {
-  return s.replace(/[&<>"']/g, (c) => {
-    const map: Record<string, string> = {
-      "&": "&amp;",
-      "<": "&lt;",
-      ">": "&gt;",
-      '"': "&quot;",
-      "'": "&#39;",
-    };
-    return map[c] ?? c;
-  });
 }


### PR DESCRIPTION
## Summary

- **Chart**: per-row legend ⚙ / ✕ affordances + new events `seriesEditRequest` / `seriesRemoveRequest`. Buttons are presence-gated, so a bare chart still shows just the visibility toggle. Adds `chart.getLegendRow(seriesId)` for hosts to re-resolve the anchor after a remove+add cycle.
- **Strategy Studio (PR4)**: indicator parameter editor moves from a scroll-away side panel into a chart-anchored popover triggered from the legend ⚙. Preset list becomes a true toggle with a `+N` chip for stacking (SMA(5) + SMA(20) + SMA(60) etc.). Each instance has a stable id so editing one indicator never disturbs the others.
- **Drive-by fix**: `decimateCandles` now clamps to the live candle array length — surfaced during rapid remount cycles in this PR but also fixes a latent crash when the viewport requests a range past `candles.length`.

## Why this shape

The first iteration put a parameter list in the left pane, below the preset selector. It worked but forced constant up/down scrolling between the chart and the editor. Web research (TradingView, Highcharts Stock, ThinkorSwim, Binance/Coinbase) confirmed the canonical pattern is **\"settings cog on the legend row, popover near the click\"** — direct manipulation, not a faraway panel. That's chart-library territory, not host-app territory, hence the new chart events.

Codex review surfaced three concrete issues during iteration:
1. `ChartLocale.editSeries`/`removeSeries` were initially required → changed to optional with safe fallbacks.
2. Popover lost its anchor after a series remount (the original DOM node detached) → added `chart.getLegendRow(seriesId)` and Studio refreshes the anchor on remount.
3. Popover position wasn't recomputed on instance switch → keyed `useLayoutEffect` to `instance.id` so slider drags don't reposition (jitter) but a different ⚙ does.

## Test plan

- [x] `pnpm test` — 4865 (core) + 778 (chart, +3 new for legend-actions) + 59 (mcp) all pass
- [x] `pnpm lint` clean
- [x] `pnpm --filter @trendcraft/chart build` clean; `size-check` within limits (main 32.86 / Vue 31.29 kB)
- [x] `pnpm --filter @trendcraft/chart size-check` — main bumped 37→38 kB, wrappers 31→32 kB to absorb the new legend feature surface
- [x] Visual: agent-browser walkthrough — toggle on/off, +N stacking, ⚙ popover open, slider drag (no jitter), instance switch (popover relocates), ✕ remove, viewport-bottom anchor (flips above)
- [x] Codex review: all P2 findings addressed

## Notes

- Targets `epic/strategy-studio`. PR3 of 13 in the Studio epic.
- The popover doesn't follow scroll once opened — same trade-off TradingView's settings dialog makes (transient editor).