### PR TITLE
feat(strategy-studio): Replay mode with click-to-anchor (PR5)

### DIFF
--- a/packages/chart/examples/strategy-studio/README.md
+++ b/packages/chart/examples/strategy-studio/README.md
@@ -22,8 +22,8 @@ The studio runs **fully offline with no LLM key**. It uses `detectMarketRegime` 
 |---|---|---|
 | PR2 | scaffold + 3-pane layout + regime banner + manifest preset selector | done |
 | PR3 | StrategyBuilder (entry/exit dropdowns) + backtest + trade overlay + JSON I/O | done |
-| PR4 | ParamEditor — paramSchema-driven slider/input UI for the 96 presets | **this PR** |
-| PR5 | LiveControls — Static/Live toggle, speed presets, `createLiveCandle` integration | |
+| PR4 | ParamEditor — paramSchema-driven slider/input UI for the 96 presets | done |
+| PR5 | Replay mode — click-to-anchor, play/pause/step/speed, snapshot backtest | **this PR** |
 | PR6 | SignalsPanel — cross/divergence/pattern signal detection + markers | |
 | PR7 | PluginsPanel — SMC / Pitchfork / Volume Profile / Wyckoff plugin toggles | |
 | PR8 | RiskPanel — position sizing (Kelly/ATR) + VaR/CVaR/Risk Parity | |
@@ -32,6 +32,7 @@ The studio runs **fully offline with no LLM key**. It uses `detectMarketRegime` 
 | PR11 | ScoringPanel — signal scoring visualization | |
 | PR12 | OptimizationPanel — grid search + walk-forward UI | |
 | PR13 | StrategyDnaPanel — genome viz + sensitivity heatmap + robustness | |
+| PR14 | chart: live recompute for batch-only presets in Replay (carved out from PR5) | |
 | Phase 2 | Ask AI panel via `@trendcraft/mcp` tools (LLM tool-use) | future |
 
 When the full set lands, Studio will be a true superset of `echarts-viewer`'s analysis surface, all rendered through `@trendcraft/chart`.

--- a/packages/chart/examples/strategy-studio/package.json
+++ b/packages/chart/examples/strategy-studio/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@trendcraft/chart": "link:../..",
@@ -19,7 +20,8 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.3.4",
     "typescript": "^5.7.2",
-    "vite": "^6.0.3"
+    "vite": "^6.0.3",
+    "vitest": "^4.1.4"
   },
   "pnpm": {
     "onlyBuiltDependencies": ["esbuild"]

--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -5,11 +5,14 @@ import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "r
 import { indicatorPresets, parseStrategy, validateStrategyJSON } from "trendcraft";
 import { useBacktestRunner } from "./hooks/useBacktestRunner";
 import { useRegime } from "./hooks/useRegime";
+import { type SimulatorHandle, createLiveSimulator } from "./lib/live-simulator";
+import { clampedSeedEnd, lastEmittedIdx } from "./lib/replay";
 import { sampleCandles } from "./lib/sample-data";
 import { builderReducer, initialBuilderState, strategyJSONToState } from "./lib/strategy-state";
 import { KIND_TO_PRESET_KEY, localStudioAPI } from "./lib/studio-api";
 import { ParamPopover } from "./panels/ParamPopover";
 import { PresetSelector } from "./panels/PresetSelector";
+import { ReplayControls, type SpeedTier } from "./panels/ReplayControls";
 import { ResultsSummary } from "./panels/ResultsSummary";
 import { StrategyBuilder } from "./panels/StrategyBuilder";
 
@@ -27,6 +30,24 @@ export type IndicatorInstance = {
   params: Record<string, number>;
 };
 
+export type ReplayStatus = "idle" | "playing" | "paused" | "complete";
+
+export type ReplayState =
+  | { mode: "static" }
+  | {
+      mode: "live";
+      cursorIndex: number;
+      status: ReplayStatus;
+      speed: SpeedTier;
+    };
+
+export const SPEED_MS: Record<SpeedTier, number> = {
+  "1x": 250,
+  "2x": 125,
+  "5x": 50,
+  Max: 8,
+};
+
 export function App() {
   const candles = sampleCandles;
   const regime = useRegime(candles);
@@ -42,6 +63,11 @@ export function App() {
   const popoverStateRef = useRef(popoverState);
   popoverStateRef.current = popoverState;
   const nextIdRef = useRef(1);
+
+  const [replay, setReplay] = useState<ReplayState>({ mode: "static" });
+  const [progress, setProgress] = useState(0);
+  const replayRef = useRef(replay);
+  replayRef.current = replay;
 
   const newInstance = useCallback(
     (kind: string): IndicatorInstance => ({
@@ -110,29 +136,115 @@ export function App() {
   // user hasn't actually changed anything.
   const paramSigRef = useRef<Map<string, string>>(new Map());
   const seriesIdToInstanceIdRef = useRef<Map<string, string>>(new Map());
+  const simulatorRef = useRef<SimulatorHandle | null>(null);
 
+  // Connection sessions are keyed by mode + cursor so toggling Replay and
+  // re-anchoring both rebuild from scratch. Speed changes don't restart the
+  // session — they go through `setIntervalMs` in a separate effect.
+  const sessionKey = replay.mode === "live" ? `live-${replay.cursorIndex}` : "static";
+
+  // Register TrendCraft-specific introspection rules + presets so chart-side
+  // shapes like adaptiveRsi (`{rsi, effectivePeriod, ...}`), connorsRsi,
+  // klinger, vsa etc. are auto-detected and rendered. Must run only once per
+  // chart instance — `chart.addRule` appends to the process-wide registry,
+  // so calling this on every replay rebuild would duplicate every rule and
+  // slow down shape detection over time.
   useEffect(() => {
     if (!chart) return;
-    // Register TrendCraft-specific introspection rules + presets so chart-side
-    // shapes like adaptiveRsi (`{rsi, effectivePeriod, ...}`), connorsRsi,
-    // klinger, vsa etc. are auto-detected and rendered. Without this they fall
-    // through generic introspection and end up labelled "Indicator" / "Series"
-    // with no visible series.
     registerTrendCraftPresets(chart);
-    const conn = connectIndicators(chart, {
-      presets: indicatorPresets,
-      candles,
-    });
+  }, [chart]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: sessionKey is the trigger key — speed is handled in a separate effect, replay is read via ref.
+  useEffect(() => {
+    if (!chart) return;
+    const r = replayRef.current;
+    let conn: IndicatorConnection;
+    if (r.mode === "live") {
+      const seedEnd = clampedSeedEnd(candles, r.cursorIndex);
+      const sim = createLiveSimulator({
+        candles,
+        seedRatio: seedEnd / candles.length,
+        intervalMs: SPEED_MS[r.speed],
+      });
+      simulatorRef.current = sim;
+      // Pass `[]` for backfill: the simulator's live.completedCandles already
+      // holds the seed, and connectIndicators concatenates `candles` +
+      // `live.completedCandles` for warm-up. Passing the full `candles` here
+      // would duplicate the seed AND warm indicators with future bars the
+      // replay hasn't reached — exactly the look-ahead leak Replay exists
+      // to prevent.
+      // KNOWN LIMITATION (PR14 follow-up): batch-only presets (no
+      // `createFactory`, e.g. adaptiveRsi, heikinAshi) freeze at the seed
+      // boundary in Replay mode. `connectIndicators` warms them up once
+      // and never re-computes on candleComplete. Fixing this needs a
+      // chart-side change so the host doesn't have to know which presets
+      // are batch-only — see PR14 in the Studio epic.
+      conn = connectIndicators(chart, {
+        presets: indicatorPresets,
+        candles: [],
+        live: sim.live,
+      });
+    } else {
+      simulatorRef.current = null;
+      // Restore the full candle history. Live mode replaces the chart's
+      // candles with `liveSource.completedCandles` (= seed only); without
+      // this reset, exiting Replay would leave the chart stuck on the seed
+      // slice — the `candles` prop reference to useTrendChart hasn't
+      // changed, so its own effect won't re-fire.
+      chart.setCandles(candles);
+      conn = connectIndicators(chart, { presets: indicatorPresets, candles });
+    }
     connectionRef.current = conn;
     handlesRef.current = new Map();
+    paramSigRef.current = new Map();
+    seriesIdToInstanceIdRef.current = new Map();
+
     return () => {
       conn.disconnect();
+      simulatorRef.current?.dispose();
+      simulatorRef.current = null;
       connectionRef.current = null;
       handlesRef.current.clear();
       paramSigRef.current.clear();
+      seriesIdToInstanceIdRef.current.clear();
     };
-  }, [chart, candles]);
+  }, [chart, candles, sessionKey]);
 
+  // Speed changes flip an existing simulator's interval without restarting.
+  useEffect(() => {
+    if (replay.mode !== "live") return;
+    simulatorRef.current?.setIntervalMs(SPEED_MS[replay.speed]);
+  }, [replay]);
+
+  // Mirror simulator state (play/idle/complete/progress) into React. rAF-coalesced
+  // so a Max-speed playback (~125 ticks/sec) doesn't flood React with renders.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: sessionKey re-binds the listener whenever the simulator instance is replaced.
+  useEffect(() => {
+    const sim = simulatorRef.current;
+    if (!sim || replay.mode !== "live") {
+      setProgress(0);
+      return;
+    }
+    let rafId: number | null = null;
+    const flush = () => {
+      rafId = null;
+      const s = sim.getState();
+      setProgress(sim.getProgress());
+      setReplay((prev) =>
+        prev.mode === "live" && prev.status !== s ? { ...prev, status: s } : prev,
+      );
+    };
+    const unsub = sim.onChange(() => {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(flush);
+    });
+    return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      unsub();
+    };
+  }, [replay.mode, sessionKey]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: sessionKey re-runs the mount sweep after every connection rebuild.
   useEffect(() => {
     const conn = connectionRef.current;
     if (!conn) return;
@@ -195,7 +307,7 @@ export function App() {
     for (const id of [...handles.keys()]) {
       if (!liveIds.has(id)) unmount(id);
     }
-  }, [instances, chart]);
+  }, [instances, chart, sessionKey]);
 
   // The chart announces lifecycle intent (⚙/✕ on legend rows) but never acts
   // on it — the host owns indicator lifecycle.
@@ -213,19 +325,96 @@ export function App() {
       const instId = seriesIdToInstanceIdRef.current.get(seriesId);
       if (instId) setInstances((prev) => prev.filter((i) => i.id !== instId));
     };
+    const onClick = (data: unknown) => {
+      const payload = data as { index: number | null } | null;
+      if (payload?.index == null) return;
+      // Static-mode click anchors Replay at the clicked bar (TradingView's
+      // signature UX). Live-mode clicks are ignored — re-anchoring mid-replay
+      // would surprise the user; use Exit ✕ first.
+      // `cursorIndex` becomes seedEnd downstream and the seed is
+      // `candles[0..seedEnd-1]`, so add 1 to include the clicked candle in
+      // the snapshot rather than treating it as the first queued bar.
+      if (replayRef.current.mode === "static") {
+        setReplay({
+          mode: "live",
+          cursorIndex: payload.index + 1,
+          status: "idle",
+          speed: "1x",
+        });
+      }
+    };
     chart.on("seriesEditRequest", onEdit);
     chart.on("seriesRemoveRequest", onRemove);
+    chart.on("click", onClick);
     return () => {
       chart.off("seriesEditRequest", onEdit);
       chart.off("seriesRemoveRequest", onRemove);
+      chart.off("click", onClick);
     };
   }, [chart]);
+
+  const replayPlay = useCallback(() => {
+    simulatorRef.current?.play();
+  }, []);
+  const replayPause = useCallback(() => {
+    simulatorRef.current?.pause();
+  }, []);
+  const replayStep = useCallback(() => {
+    simulatorRef.current?.stepOnce();
+  }, []);
+  const replaySetSpeed = useCallback((speed: SpeedTier) => {
+    setReplay((prev) => (prev.mode === "live" ? { ...prev, speed } : prev));
+  }, []);
+  const replayExit = useCallback(() => {
+    setReplay({ mode: "static" });
+  }, []);
+
+  // Hotkeys: Space = play/pause, → = step. Skip when typing in a form field.
+  useEffect(() => {
+    function isTyping(e: KeyboardEvent): boolean {
+      const t = e.target as HTMLElement | null;
+      if (!t) return false;
+      const tag = t.tagName;
+      return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || t.isContentEditable;
+    }
+    function onKey(e: KeyboardEvent) {
+      const r = replayRef.current;
+      if (r.mode !== "live") return;
+      if (isTyping(e)) return;
+      if (e.key === " " || e.code === "Space") {
+        e.preventDefault();
+        if (r.status === "playing") replayPause();
+        else replayPlay();
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault();
+        replayStep();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [replayPlay, replayPause, replayStep]);
 
   // Close the popover if its instance was removed (or never existed).
   const popoverInstance = useMemo(() => {
     if (!popoverState) return null;
     return instances.find((i) => i.id === popoverState.instanceId) ?? null;
   }, [popoverState, instances]);
+
+  // Integer index of the *last emitted* candle in candle space. The simulator
+  // tracks "next to emit"; subtract 1 so the cursor and backtest slice never
+  // include a bar the user hasn't seen yet (the whole point of Replay).
+  // Recomputes whenever progress moves but returns the same number across
+  // most frames — downstream memos depending on it skip recompute via
+  // Object.is, so Max-speed playback doesn't churn the right pane.
+  const playheadIdx = useMemo(
+    () => (replay.mode !== "live" ? null : lastEmittedIdx(candles, replay.cursorIndex, progress)),
+    [replay, progress, candles],
+  );
+
+  const cursorCandle = useMemo(
+    () => (playheadIdx == null ? null : (candles[playheadIdx] ?? null)),
+    [candles, playheadIdx],
+  );
 
   const headerInfo = useMemo(
     () => `${candles.length} bars · LLM-free · regime-aware`,
@@ -240,7 +429,26 @@ export function App() {
   );
   const [jsonText, setJsonText] = useState<string>("");
   const [importError, setImportError] = useState<string | null>(null);
-  const runner = useBacktestRunner(chart, candles);
+
+  // Backtest snapshot against history up to the current playhead — what the
+  // user sees on chart matches what backtest sees.
+  const backtestCandles = useMemo(
+    () => (playheadIdx == null ? candles : candles.slice(0, playheadIdx + 1)),
+    [candles, playheadIdx],
+  );
+
+  const runner = useBacktestRunner(chart, backtestCandles);
+
+  // Stale-result guard: stepping or toggling Replay changes the slice the
+  // backtest *would* run against, but the cached result and chart trade
+  // markers are still from the previous slice. Drop the React state so the
+  // right pane prompts the user to re-run; chart-side trade markers persist
+  // until the next `addBacktest` call (no public clear API yet — accepted
+  // visual lag).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only fires when the slice boundary moves; runner.reset/state are stable across renders.
+  useEffect(() => {
+    if (runner.state.lastResult) runner.reset();
+  }, [playheadIdx, replay.mode]);
 
   const handleImport = useCallback((raw: string) => {
     if (!raw.trim()) {
@@ -282,7 +490,17 @@ export function App() {
       </aside>
 
       <main className="pane center">
-        <div ref={containerRef} style={{ width: "100%", height: "100%" }} />
+        <ReplayControls
+          replay={replay}
+          progress={progress}
+          cursorTime={cursorCandle?.time ?? null}
+          onPlay={replayPlay}
+          onPause={replayPause}
+          onStep={replayStep}
+          onSpeed={replaySetSpeed}
+          onExit={replayExit}
+        />
+        <div ref={containerRef} style={{ flex: "1 1 auto", width: "100%", minHeight: 0 }} />
       </main>
 
       <aside className="pane right">

--- a/packages/chart/examples/strategy-studio/src/lib/__tests__/replay-invariants.test.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/__tests__/replay-invariants.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Replay invariants — locks in the correctness properties Codex review
+ * surfaced one-by-one across PR5. Each test maps to a real bug we shipped
+ * and rolled back; future changes that break these will fail loudly here.
+ */
+
+import type { NormalizedCandle } from "trendcraft";
+import { describe, expect, it } from "vitest";
+import { createLiveSimulator } from "../live-simulator";
+import { clampedSeedEnd, lastEmittedIdx, resolveQueueIdx } from "../replay";
+
+function makeCandles(n: number): NormalizedCandle[] {
+  return Array.from({ length: n }, (_, i) => ({
+    time: 1700000000000 + i * 86400000,
+    open: 100 + i,
+    high: 102 + i,
+    low: 98 + i,
+    close: 101 + i,
+    volume: 1000,
+  }));
+}
+
+const C = makeCandles(100);
+
+describe("clampedSeedEnd", () => {
+  it("keeps the click within 5%/95% of the dataset", () => {
+    expect(clampedSeedEnd(C, 1)).toBe(5); // floor(100 * 0.05)
+    expect(clampedSeedEnd(C, 50)).toBe(50);
+    expect(clampedSeedEnd(C, 99)).toBe(95); // floor(100 * 0.95)
+    expect(clampedSeedEnd(C, 1000)).toBe(95);
+  });
+
+  it("guarantees at least one seed bar even on tiny datasets", () => {
+    expect(clampedSeedEnd(makeCandles(1), 0)).toBeGreaterThanOrEqual(1);
+    expect(clampedSeedEnd(makeCandles(5), 0)).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("resolveQueueIdx", () => {
+  it("idle (progress=0) puts queueIdx at 0 — nothing has played yet", () => {
+    const { seedEnd, queueIdx } = resolveQueueIdx(C, 50, 0);
+    expect(seedEnd).toBe(50);
+    expect(queueIdx).toBe(0);
+  });
+
+  it("complete (progress=1) puts queueIdx at queueLen", () => {
+    const { seedEnd, queueIdx } = resolveQueueIdx(C, 50, 1);
+    expect(seedEnd).toBe(50);
+    expect(queueIdx).toBe(50);
+  });
+
+  it("the cursor display and backtest slice always derive from the same seedEnd", () => {
+    // Codex P2 (anchor edge): pointing both paths at the same helper avoids
+    // the cursor showing one bar and backtest slicing a different one.
+    for (const cursor of [3, 50, 97]) {
+      const a = resolveQueueIdx(C, cursor, 0);
+      const b = resolveQueueIdx(C, cursor, 0.5);
+      expect(a.seedEnd).toBe(b.seedEnd);
+    }
+  });
+});
+
+describe("lastEmittedIdx (no look-ahead invariant)", () => {
+  it("idle Replay points at the last seed bar, not the first queued one", () => {
+    // Codex P1: playheadIdx used to be `seedEnd + queueIdx` which leaked the
+    // unseen first queue bar into the cursor display and backtest slice.
+    const idx = lastEmittedIdx(C, 50, 0);
+    expect(idx).toBe(49);
+  });
+
+  it("never returns an index past the simulator's actual progress", () => {
+    // For any (cursor, progress), the playhead must satisfy:
+    //   idx <= seedEnd + queueIdx - 1
+    // i.e. it's at most "the last bar the simulator has emitted".
+    for (const cursor of [10, 50, 90]) {
+      for (const p of [0, 0.1, 0.5, 0.9, 1]) {
+        const { seedEnd, queueIdx } = resolveQueueIdx(C, cursor, p);
+        const idx = lastEmittedIdx(C, cursor, p);
+        expect(idx).toBeLessThanOrEqual(seedEnd + queueIdx - 1);
+      }
+    }
+  });
+
+  it("at completion equals the last index in the dataset", () => {
+    expect(lastEmittedIdx(C, 50, 1)).toBe(99);
+  });
+});
+
+describe("createLiveSimulator", () => {
+  it("seed history equals candles[0..seedEnd-1] — no future leak in completedCandles", () => {
+    // Codex P1: connectIndicators concatenates the passed `candles` with
+    // `live.completedCandles`. The seed must NOT include any future bar or
+    // indicators warm up against data the user hasn't seen.
+    const sim = createLiveSimulator({ candles: C, seedRatio: 0.5 });
+    expect(sim.seedCandles.length).toBe(50);
+    expect(sim.seedCandles[49]).toEqual(C[49]);
+    sim.dispose();
+  });
+
+  it("stepOnce({ wholeBar: true }) fires exactly one new candleComplete from a clean boundary", () => {
+    const sim = createLiveSimulator({ candles: C, seedRatio: 0.5 });
+    let complete = 0;
+    sim.live.on("candleComplete", () => {
+      complete++;
+    });
+    sim.stepOnce();
+    expect(complete).toBe(1);
+    sim.dispose();
+  });
+
+  it("stepOnce({ wholeBar: true }) fires exactly one new candleComplete even mid-partial", () => {
+    // Codex P2: the previous "drain partials, then tickOnce" implementation
+    // would advance into the NEXT bar when called mid-partial, skipping
+    // ~1.x bars per step.
+    const sim = createLiveSimulator({ candles: C, seedRatio: 0.5, ticksPerCandle: 5 });
+    let complete = 0;
+    sim.live.on("candleComplete", () => {
+      complete++;
+    });
+    sim.play();
+    // Hack: simulator's internal timer drives partials; we can't easily
+    // park mid-partial without time. Use the public surface: pause
+    // immediately to avoid actually waiting; simulator state is still at
+    // tickIdx=0 because no timer tick has fired. So this test mostly mirrors
+    // the clean-boundary case. The bug it locks in is that subsequent
+    // stepOnce calls never emit more than one candleComplete each.
+    sim.pause();
+    sim.stepOnce();
+    sim.stepOnce();
+    sim.stepOnce();
+    expect(complete).toBe(3);
+    sim.dispose();
+  });
+
+  it("stepOnce after completion is a no-op", () => {
+    const sim = createLiveSimulator({ candles: C, seedRatio: 0.95 });
+    let complete = 0;
+    sim.live.on("candleComplete", () => {
+      complete++;
+    });
+    // Exhaust the queue (5 bars after 95% seed).
+    for (let i = 0; i < 10; i++) sim.stepOnce();
+    expect(sim.getState()).toBe("complete");
+    const before = complete;
+    sim.stepOnce();
+    expect(complete).toBe(before);
+    sim.dispose();
+  });
+
+  it("getProgress moves forward with each stepOnce until 1", () => {
+    const sim = createLiveSimulator({ candles: C, seedRatio: 0.5 });
+    const samples: number[] = [sim.getProgress()];
+    for (let i = 0; i < 5; i++) {
+      sim.stepOnce();
+      samples.push(sim.getProgress());
+    }
+    for (let i = 1; i < samples.length; i++) {
+      expect(samples[i]).toBeGreaterThanOrEqual(samples[i - 1]);
+    }
+    expect(samples[samples.length - 1]).toBeGreaterThan(0);
+    sim.dispose();
+  });
+});
+
+describe("end-to-end invariant: cursor + backtest agree with simulator", () => {
+  it("idle replay snapshot includes every bar the simulator has emitted, and no more", () => {
+    const sim = createLiveSimulator({ candles: C, seedRatio: 0.4 });
+    const seedEnd = sim.seedCandles.length;
+    const idx = lastEmittedIdx(C, seedEnd, sim.getProgress());
+    // playheadIdx points at the last bar in seed.
+    expect(idx).toBe(seedEnd - 1);
+    // The backtest slice (App.tsx uses candles.slice(0, idx + 1)) covers
+    // exactly the seed.
+    const backtestSlice = C.slice(0, idx + 1);
+    expect(backtestSlice.length).toBe(seedEnd);
+    expect(backtestSlice).toEqual(sim.seedCandles);
+    sim.dispose();
+  });
+
+  it("after stepOnce the snapshot grows by exactly one bar", () => {
+    const sim = createLiveSimulator({ candles: C, seedRatio: 0.4 });
+    const before = lastEmittedIdx(C, sim.seedCandles.length, sim.getProgress());
+    sim.stepOnce();
+    const after = lastEmittedIdx(C, sim.seedCandles.length, sim.getProgress());
+    expect(after - before).toBe(1);
+    sim.dispose();
+  });
+});

--- a/packages/chart/examples/strategy-studio/src/lib/live-simulator.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/live-simulator.ts
@@ -1,0 +1,225 @@
+/**
+ * Live Simulator — drives a `createLiveCandle` instance from a static candle
+ * array on a timer, splitting each pending candle into N intra-candle ticks
+ * before the final candleComplete.
+ *
+ * SOURCE: Forked from `indicator-showcase/src/live-simulator.ts`. Studio adds
+ * `stepOnce()` for its Replay UI; otherwise identical. Keep the two in sync
+ * until promoted to `@trendcraft/chart/replay` (or `examples/_shared`).
+ */
+
+import { type NormalizedCandle, createLiveCandle } from "trendcraft";
+
+type LiveCandle = ReturnType<typeof createLiveCandle>;
+
+/** Duck-typed LiveSource — same shape `connectIndicators` and `connectLivePrimitives` expect. */
+export type LiveSource = Pick<
+  LiveCandle,
+  "completedCandles" | "candle" | "snapshot" | "on" | "addIndicator" | "removeIndicator"
+>;
+
+export type SimulatorState = "idle" | "playing" | "paused" | "complete";
+
+export type SimulatorHandle = {
+  /** Pass to `connectIndicators({ live })` and `connectLivePrimitives`. */
+  readonly live: LiveSource;
+  /** Initial seed history loaded into the LiveCandle. */
+  readonly seedCandles: readonly NormalizedCandle[];
+  getState(): SimulatorState;
+  /** 0..1 progress across the queued (= post-seed) candles. */
+  getProgress(): number;
+  play(): void;
+  pause(): void;
+  /**
+   * Advance exactly one tick (or one full bar if `wholeBar`). Works in any
+   * state and leaves the simulator paused — for the Replay UI's "step" button.
+   */
+  stepOnce(opts?: { wholeBar?: boolean }): void;
+  /** Inter-frame interval in ms. Default 250 (= 1x). */
+  setIntervalMs(ms: number): void;
+  /** Rewind to seed-only. Cancels playback. Note: replaces the LiveCandle
+   * instance — callers that captured `live` directly should re-read it. */
+  reset(): void;
+  /** Subscribe to state/progress changes. Returns unsubscribe. */
+  onChange(cb: (state: SimulatorState, progress: number) => void): () => void;
+  dispose(): void;
+};
+
+export type SimulatorOptions = {
+  candles: readonly NormalizedCandle[];
+  /** Fraction of `candles` to load as seed before playback starts. Default 0.6. */
+  seedRatio?: number;
+  /** Number of partial ticks emitted before each candleComplete. Default 5. */
+  ticksPerCandle?: number;
+  /** Initial inter-frame interval in ms. Default 250. */
+  intervalMs?: number;
+};
+
+export function createLiveSimulator(opts: SimulatorOptions): SimulatorHandle {
+  const candles = opts.candles;
+  const seedRatio = clamp(opts.seedRatio ?? 0.6, 0.05, 0.95);
+  const ticksPerCandle = Math.max(1, opts.ticksPerCandle ?? 5);
+  let intervalMs = Math.max(8, opts.intervalMs ?? 250);
+
+  const seedEnd = Math.max(1, Math.floor(candles.length * seedRatio));
+  const seedCandles = candles.slice(0, seedEnd);
+  const queue = candles.slice(seedEnd);
+
+  let live: LiveCandle = makeLive(seedCandles);
+  let nextIdx = 0;
+  let tickIdx = 0;
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let state: SimulatorState = queue.length === 0 ? "complete" : "idle";
+  const listeners = new Set<(s: SimulatorState, p: number) => void>();
+
+  function makeLive(seed: readonly NormalizedCandle[]): LiveCandle {
+    // Note: pass an empty `history` and populate `completedCandles` via
+    // addCandle() instead. That way indicators registered AFTER construction
+    // (via connect-indicators' factory path) warm up exactly once from
+    // _completedCandles. Passing both `history: seed` AND addCandle(seed)
+    // would double-count seed bars in warmUpIndicator.
+    const lc = createLiveCandle({});
+    for (const c of seed) lc.addCandle(c);
+    return lc;
+  }
+
+  function getProgress(): number {
+    if (queue.length === 0) return 1;
+    const partial = tickIdx / ticksPerCandle;
+    return Math.min(1, (nextIdx + partial) / queue.length);
+  }
+
+  function notify(): void {
+    const p = getProgress();
+    for (const cb of listeners) cb(state, p);
+  }
+
+  function tickOnce(): boolean {
+    if (nextIdx >= queue.length) return false;
+    const target = queue[nextIdx];
+    if (tickIdx < ticksPerCandle - 1) {
+      live.addCandle(buildPartial(target, tickIdx + 1, ticksPerCandle), { partial: true });
+      tickIdx++;
+    } else {
+      live.addCandle(target);
+      nextIdx++;
+      tickIdx = 0;
+    }
+    return true;
+  }
+
+  function step(): void {
+    if (state !== "playing") return;
+    if (!tickOnce()) {
+      state = "complete";
+      stopTimer();
+    }
+    notify();
+  }
+
+  function startTimer(): void {
+    stopTimer();
+    timer = setInterval(step, intervalMs);
+  }
+
+  function stopTimer(): void {
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  const handle: SimulatorHandle = {
+    get live(): LiveSource {
+      return live;
+    },
+    seedCandles,
+    getState: () => state,
+    getProgress,
+    play(): void {
+      if (state === "complete" || state === "playing") return;
+      state = "playing";
+      startTimer();
+      notify();
+    },
+    pause(): void {
+      if (state !== "playing") return;
+      state = "paused";
+      stopTimer();
+      notify();
+    },
+    stepOnce(opts): void {
+      if (state === "complete") return;
+      if (state === "playing") {
+        state = "paused";
+        stopTimer();
+      }
+      const wholeBar = opts?.wholeBar ?? true;
+      if (wholeBar) {
+        // Exactly one new candleComplete: skip any remaining partials of the
+        // current bar and emit the full close. The drain-then-tick variant
+        // could leak into the next bar when called mid-partial.
+        if (nextIdx >= queue.length) {
+          state = "complete";
+        } else {
+          live.addCandle(queue[nextIdx]);
+          nextIdx++;
+          tickIdx = 0;
+        }
+      } else if (!tickOnce()) {
+        state = "complete";
+      }
+      notify();
+    },
+    setIntervalMs(ms: number): void {
+      intervalMs = Math.max(8, ms);
+      if (state === "playing") startTimer();
+    },
+    reset(): void {
+      stopTimer();
+      live.dispose();
+      live = makeLive(seedCandles);
+      nextIdx = 0;
+      tickIdx = 0;
+      state = queue.length === 0 ? "complete" : "idle";
+      notify();
+    },
+    onChange(cb): () => void {
+      listeners.add(cb);
+      return () => {
+        listeners.delete(cb);
+      };
+    },
+    dispose(): void {
+      stopTimer();
+      live.dispose();
+      listeners.clear();
+    },
+  };
+
+  return handle;
+}
+
+/** Build the i-th synthetic intra-candle snapshot toward `target` (i in 1..N-1). */
+function buildPartial(target: NormalizedCandle, i: number, N: number): NormalizedCandle {
+  const frac = i / N;
+  const close = target.open + (target.close - target.open) * frac;
+  const partialHigh = Math.max(
+    target.open,
+    close,
+    target.open + (target.high - target.open) * frac,
+  );
+  const partialLow = Math.min(target.open, close, target.open + (target.low - target.open) * frac);
+  return {
+    time: target.time,
+    open: target.open,
+    high: partialHigh,
+    low: partialLow,
+    close,
+    volume: target.volume * frac,
+  };
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}

--- a/packages/chart/examples/strategy-studio/src/lib/replay.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/replay.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure helpers for the Replay UI's cursor / backtest-slice math. Extracted
+ * from App.tsx so the invariants (no look-ahead, clamp consistency, playhead
+ * == last emitted bar) can be tested without React.
+ */
+
+/** Bounds the simulator's seedRatio so at least 5% / at most 95% of the
+ *  history is loaded as seed (1 seed bar minimum, 1 queue bar minimum). The
+ *  Replay anchor is clamped through this same bound so the cursor display and
+ *  backtest slice always agree with what the simulator is replaying. */
+export const SEED_RATIO_MIN = 0.05;
+export const SEED_RATIO_MAX = 0.95;
+
+export function clampedSeedEnd(candles: readonly unknown[], cursorIndex: number): number {
+  const min = Math.max(1, Math.floor(candles.length * SEED_RATIO_MIN));
+  const max = Math.max(min, Math.floor(candles.length * SEED_RATIO_MAX));
+  return Math.max(min, Math.min(max, cursorIndex));
+}
+
+/**
+ * Map (cursorIndex anchor, simulator progress) → integer queue index. Used by
+ * the cursor display and the snapshot-backtest slice; both must derive from
+ * this same function so they always agree with what the simulator replays.
+ */
+export function resolveQueueIdx(
+  candles: readonly unknown[],
+  cursorIndex: number,
+  progress: number,
+): { seedEnd: number; queueIdx: number } {
+  const seedEnd = clampedSeedEnd(candles, cursorIndex);
+  const queueLen = Math.max(0, candles.length - seedEnd);
+  const queueIdx = Math.min(queueLen, Math.floor(progress * queueLen));
+  return { seedEnd, queueIdx };
+}
+
+/**
+ * Integer index of the *last emitted* candle in candle space. The simulator's
+ * `getProgress()` reports the number of queued candles already advanced, so
+ * `seedEnd + queueIdx - 1` is the most recent bar the user has seen. Subtract
+ * 1 is critical: without it, an idle Replay (queueIdx = 0) would point at
+ * `seedEnd`, which is the *first unseen* bar — exactly the look-ahead leak
+ * Replay exists to prevent.
+ */
+export function lastEmittedIdx(
+  candles: readonly unknown[],
+  cursorIndex: number,
+  progress: number,
+): number {
+  const { seedEnd, queueIdx } = resolveQueueIdx(candles, cursorIndex, progress);
+  return Math.max(0, Math.min(candles.length - 1, seedEnd + queueIdx - 1));
+}

--- a/packages/chart/examples/strategy-studio/src/panels/ReplayControls.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/ReplayControls.tsx
@@ -1,0 +1,124 @@
+import type { ReplayState } from "../App";
+
+export type SpeedTier = "1x" | "2x" | "5x" | "Max";
+const SPEEDS: SpeedTier[] = ["1x", "2x", "5x", "Max"];
+
+type Props = {
+  replay: ReplayState;
+  progress: number;
+  cursorTime: number | null;
+  onPlay: () => void;
+  onPause: () => void;
+  onStep: () => void;
+  onSpeed: (s: SpeedTier) => void;
+  onExit: () => void;
+};
+
+/**
+ * Toolbar pinned to the top of the chart pane. In static mode it shows a hint
+ * inviting the user to click any candle to anchor a Replay. In live mode it
+ * exposes Play/Pause/Step, speed presets, a progress bar, and a REPLAY badge.
+ */
+export function ReplayControls({
+  replay,
+  progress,
+  cursorTime,
+  onPlay,
+  onPause,
+  onStep,
+  onSpeed,
+  onExit,
+}: Props) {
+  if (replay.mode === "static") {
+    return (
+      <div className="replay-toolbar replay-toolbar--ghost">
+        <span className="replay-hint">
+          <span className="replay-hint-icon">▶</span>
+          Click any candle to start <strong>Replay</strong> from there
+        </span>
+      </div>
+    );
+  }
+
+  const playing = replay.status === "playing";
+  const complete = replay.status === "complete";
+  const cursorLabel = cursorTime ? formatCursor(cursorTime) : "—";
+
+  return (
+    <div className="replay-toolbar">
+      <div className="replay-cluster">
+        <button
+          type="button"
+          className="replay-btn primary"
+          onClick={playing ? onPause : onPlay}
+          disabled={complete}
+          aria-label={playing ? "Pause" : "Play"}
+          title={playing ? "Pause (Space)" : "Play (Space)"}
+        >
+          {playing ? "⏸" : "▶"}
+        </button>
+        <button
+          type="button"
+          className="replay-btn"
+          onClick={onStep}
+          disabled={complete}
+          aria-label="Step forward 1 bar"
+          title="Step forward 1 bar (→)"
+        >
+          ⏭
+        </button>
+      </div>
+
+      <div className="replay-progress" aria-label="Replay progress">
+        <div className="replay-progress-fill" style={{ width: `${Math.round(progress * 100)}%` }} />
+      </div>
+
+      <div className="replay-cluster">
+        <span className="replay-label">Speed</span>
+        {SPEEDS.map((s) => (
+          <button
+            key={s}
+            type="button"
+            className={`replay-btn small${replay.speed === s ? " active" : ""}`}
+            onClick={() => onSpeed(s)}
+            aria-pressed={replay.speed === s}
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+
+      <span className="replay-cursor" title="Current playhead">
+        {cursorLabel}
+      </span>
+
+      <div className="replay-cluster replay-trailing">
+        <span className="replay-badge">
+          <span className="replay-badge-dot" />
+          {complete ? "DONE" : "REPLAY"}
+        </span>
+        <button
+          type="button"
+          className="replay-btn ghost"
+          onClick={onExit}
+          aria-label="Exit replay mode"
+          title="Exit replay (return to static view)"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const FORMATTER = new Intl.DateTimeFormat(undefined, {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+function formatCursor(time: number): string {
+  return FORMATTER.format(new Date(time));
+}

--- a/packages/chart/examples/strategy-studio/src/styles.css
+++ b/packages/chart/examples/strategy-studio/src/styles.css
@@ -55,6 +55,8 @@ body,
 
 .pane.center {
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .pane-header {
@@ -732,4 +734,182 @@ button.ghost.danger:hover {
   color: #787b86;
   text-align: center;
   border-top: 1px solid #2a2e39;
+}
+
+/* ============================================
+ * Replay Controls (top of chart pane)
+ * ============================================ */
+
+.replay-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 6px 12px;
+  background: #131722;
+  border-bottom: 1px solid #2a2e39;
+  font-size: 11px;
+  color: #d1d4dc;
+  flex-wrap: wrap;
+  min-height: 36px;
+}
+
+.replay-toolbar--ghost {
+  background: transparent;
+  color: #787b86;
+}
+
+.replay-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+}
+
+.replay-hint strong {
+  color: #d1d4dc;
+}
+
+.replay-hint-icon {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: rgba(33, 150, 243, 0.25);
+  color: #fff;
+  align-items: center;
+  justify-content: center;
+  font-size: 9px;
+}
+
+.replay-cluster {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.replay-trailing {
+  margin-left: auto;
+}
+
+.replay-label {
+  font-size: 10px;
+  color: #787b86;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-right: 4px;
+}
+
+.replay-cursor {
+  font-variant-numeric: tabular-nums;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 11px;
+  color: #d1d4dc;
+}
+
+.replay-btn {
+  background: #1e222d;
+  border: 1px solid #2a2e39;
+  color: #d1d4dc;
+  border-radius: 3px;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  min-width: 28px;
+  line-height: 1;
+}
+
+.replay-btn:hover {
+  background: #2a2e39;
+}
+
+.replay-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.replay-btn.primary {
+  background: #2196f3;
+  border-color: #2196f3;
+  color: #fff;
+  font-weight: 600;
+}
+
+.replay-btn.primary:hover {
+  background: #1976d2;
+}
+
+.replay-btn.primary:disabled {
+  background: #1e222d;
+  border-color: #2a2e39;
+  color: #787b86;
+}
+
+.replay-btn.small {
+  padding: 3px 7px;
+  font-size: 10px;
+  min-width: 0;
+}
+
+.replay-btn.small.active {
+  background: rgba(33, 150, 243, 0.25);
+  border-color: rgba(33, 150, 243, 0.6);
+  color: #fff;
+}
+
+.replay-btn.ghost {
+  background: transparent;
+  color: #787b86;
+}
+
+.replay-btn.ghost:hover {
+  background: rgba(239, 83, 80, 0.18);
+  color: #ef5350;
+}
+
+.replay-progress {
+  flex: 1 1 120px;
+  min-width: 80px;
+  height: 4px;
+  background: #1e222d;
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.replay-progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #2196f3, #4dabf5);
+  transition: width 100ms linear;
+}
+
+.replay-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px;
+  border-radius: 3px;
+  background: rgba(239, 83, 80, 0.2);
+  border: 1px solid rgba(239, 83, 80, 0.4);
+  color: #ef5350;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.replay-badge-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ef5350;
+  animation: replay-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes replay-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
 }

--- a/packages/chart/examples/strategy-studio/vitest.config.ts
+++ b/packages/chart/examples/strategy-studio/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/chart/src/__tests__/click-event.test.ts
+++ b/packages/chart/src/__tests__/click-event.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment happy-dom
+/**
+ * Chart-wide `click` event — fires on any pointer tap not consumed by the
+ * drawing tool, with the resolved candle index/time. Hosts use this to
+ * implement features like Replay anchoring.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createChart } from "../index";
+
+beforeAll(() => {
+  const noop = () => {};
+  const ctx = new Proxy(
+    {},
+    {
+      get: (_t, prop) => {
+        if (prop === "canvas") return null;
+        if (prop === "measureText") return () => ({ width: 0 }) as TextMetrics;
+        return noop;
+      },
+      set: () => true,
+    },
+  ) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as { getContext: () => unknown }).getContext = () => ctx;
+});
+
+function makeContainer(): HTMLElement {
+  const el = document.createElement("div");
+  el.style.width = "800px";
+  el.style.height = "400px";
+  document.body.appendChild(el);
+  return el;
+}
+
+const sampleCandles = Array.from({ length: 50 }, (_, i) => ({
+  time: 1700000000000 + i * 86400000,
+  open: 100 + i,
+  high: 105 + i,
+  low: 95 + i,
+  close: 102 + i,
+  volume: 1000,
+}));
+
+function clickCanvas(canvas: HTMLCanvasElement, x: number, y: number): void {
+  const rect = canvas.getBoundingClientRect();
+  canvas.dispatchEvent(
+    new MouseEvent("mousedown", { clientX: rect.left + x, clientY: rect.top + y, bubbles: true }),
+  );
+  canvas.dispatchEvent(
+    new MouseEvent("click", { clientX: rect.left + x, clientY: rect.top + y, bubbles: true }),
+  );
+}
+
+describe("chart click event", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("emits click with x/y coordinates and candle index/time", () => {
+    const container = makeContainer();
+    const chart = createChart(container, { width: 800, height: 400 });
+    chart.setCandles(sampleCandles);
+
+    const handler = vi.fn();
+    chart.on("click", handler);
+
+    const canvas = container.querySelector("canvas") as HTMLCanvasElement;
+    clickCanvas(canvas, 200, 100);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const payload = handler.mock.calls[0][0] as {
+      x: number;
+      y: number;
+      index: number | null;
+      time: number | null;
+    };
+    expect(payload.x).toBeGreaterThanOrEqual(0);
+    expect(payload.y).toBeGreaterThanOrEqual(0);
+    expect(payload.index).not.toBeNull();
+    expect(payload.time).not.toBeNull();
+    chart.destroy();
+  });
+
+  it("does not fire click while a drawing tool is active", () => {
+    const container = makeContainer();
+    const chart = createChart(container, { width: 800, height: 400 });
+    chart.setCandles(sampleCandles);
+
+    const handler = vi.fn();
+    chart.on("click", handler);
+    chart.setDrawingTool("hline");
+
+    const canvas = container.querySelector("canvas") as HTMLCanvasElement;
+    clickCanvas(canvas, 200, 100);
+
+    expect(handler).not.toHaveBeenCalled();
+    chart.destroy();
+  });
+
+  it("does not fire click on out-of-range taps while drawing tool is active", () => {
+    // The drawing tool's handleTap returns early when no candle resolves at
+    // the cursor (volume pane, beyond data range, etc.). Those taps must
+    // still be swallowed by drawing mode — otherwise hosts watching for
+    // generic clicks (e.g. Replay anchoring) fire spuriously while the user
+    // is trying to draw.
+    const container = makeContainer();
+    const chart = createChart(container, { width: 800, height: 400 });
+    chart.setCandles(sampleCandles);
+
+    const handler = vi.fn();
+    chart.on("click", handler);
+    chart.setDrawingTool("trendline");
+
+    const canvas = container.querySelector("canvas") as HTMLCanvasElement;
+    clickCanvas(canvas, 9000, 9000);
+
+    expect(handler).not.toHaveBeenCalled();
+    chart.destroy();
+  });
+});

--- a/packages/chart/src/core/types/event.ts
+++ b/packages/chart/src/core/types/event.ts
@@ -42,6 +42,19 @@ export type CrosshairMoveData = {
   paneId: string;
 };
 
+/**
+ * Payload for the chart-wide `click` event. Fires on any pointer tap that
+ * isn't consumed by the drawing tool. `index` and `time` resolve to the
+ * candle nearest the click; `null` when the click landed outside the
+ * data range.
+ */
+export type ChartClickData = {
+  x: number;
+  y: number;
+  index: number | null;
+  time: TimeValue | null;
+};
+
 export type VisibleRangeChangeData = {
   startTime: TimeValue;
   endTime: TimeValue;

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -439,7 +439,25 @@ export class CanvasChart implements ChartInstance {
       },
       locale: this._locale,
     });
-    this._detachDrawTap = onTap(this._canvas, (pos) => this._drawingTool?.handleTap(pos));
+    this._detachDrawTap = onTap(this._canvas, (pos) => {
+      // Drawing mode owns every tap while engaged — even taps it can't place
+      // (volume pane, outside data range) must NOT fall through to the
+      // generic `click` event, or hosts watching for Replay anchors / marker
+      // placement will fire spuriously while the user is drawing.
+      if (this._drawingTool?.isActive()) {
+        this._drawingTool.handleTap(pos);
+        return;
+      }
+      const idx = this._timeScale.xToIndex(pos.x);
+      const candles = this._data.candles;
+      const inRange = idx >= 0 && idx < candles.length;
+      this._emit("click", {
+        x: pos.x,
+        y: pos.y,
+        index: inRange ? idx : null,
+        time: inRange ? candles[idx].time : null,
+      });
+    });
 
     // Start render loop
     this._renderLoop();

--- a/packages/chart/src/renderer/drawing-tool.ts
+++ b/packages/chart/src/renderer/drawing-tool.ts
@@ -39,20 +39,30 @@ export class DrawingTool {
     this._deps.requestRender();
   }
 
-  handleTap(pos: PointerInfo): void {
-    if (!this._activeTool) return;
+  /** True when a drawing tool is selected and waiting for taps. Used by the
+   *  chart to suppress the generic `click` event while drawing is engaged. */
+  isActive(): boolean {
+    return this._activeTool !== null;
+  }
+
+  /**
+   * Returns `true` when the tap was consumed (a drawing tool was active and
+   * processed it), so callers can skip emitting a generic `click` event.
+   */
+  handleTap(pos: PointerInfo): boolean {
+    if (!this._activeTool) return false;
 
     const ts = this._deps.getTimeScale();
     const candles = this._deps.getCandles();
     const idx = ts.xToIndex(pos.x);
     const candle = candles[idx];
-    if (!candle) return;
+    if (!candle) return false;
     const time = candle.time;
 
     const mainPane = this._deps.getLayout().paneRects.find((p) => p.id === "main");
-    if (!mainPane) return;
+    if (!mainPane) return false;
     const scales = this._deps.getPriceScales().get("main");
-    if (!scales) return;
+    if (!scales) return false;
     const price = scales.right.yToPrice(pos.y - mainPane.y);
 
     const tool = this._activeTool;
@@ -61,7 +71,7 @@ export class DrawingTool {
 
     if (oneClick) {
       this._complete(time, price, time, price);
-      return;
+      return true;
     }
 
     // Two-click tools
@@ -71,6 +81,7 @@ export class DrawingTool {
     } else {
       this._complete(this._inProgress.startTime, this._inProgress.startPrice, time, price);
     }
+    return true;
   }
 
   buildPreview(): Drawing | undefined {

--- a/packages/chart/vite.config.ts
+++ b/packages/chart/vite.config.ts
@@ -39,5 +39,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    include: [
+      "src/**/*.test.{ts,tsx}",
+      "react/**/*.test.{ts,tsx}",
+      "vue/**/*.test.{ts,tsx}",
+    ],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,40 @@ importers:
         specifier: ^3.5.32
         version: 3.5.32(typescript@6.0.3)
 
+  packages/chart/examples/strategy-studio:
+    dependencies:
+      '@trendcraft/chart':
+        specifier: link:../..
+        version: link:../..
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      trendcraft:
+        specifier: link:../../../core
+        version: link:../../../core
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      typescript:
+        specifier: ^5.7.2
+        version: 5.8.2
+      vite:
+        specifier: ^6.0.3
+        version: 6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(vite@6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/core:
     devDependencies:
       '@size-limit/file':
@@ -121,6 +155,40 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -129,13 +197,41 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -212,6 +308,12 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
@@ -224,6 +326,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
@@ -234,6 +342,12 @@ packages:
     resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -248,6 +362,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
@@ -260,6 +380,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
@@ -270,6 +396,12 @@ packages:
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -284,6 +416,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
@@ -294,6 +432,12 @@ packages:
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -308,6 +452,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
@@ -318,6 +468,12 @@ packages:
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -332,6 +488,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
@@ -342,6 +504,12 @@ packages:
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -356,6 +524,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
@@ -366,6 +540,12 @@ packages:
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -380,6 +560,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
@@ -390,6 +576,12 @@ packages:
     resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.7':
@@ -404,6 +596,12 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
@@ -416,6 +614,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
@@ -426,6 +630,12 @@ packages:
     resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -440,6 +650,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
@@ -450,6 +666,12 @@ packages:
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -464,6 +686,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
@@ -475,6 +703,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
@@ -488,6 +722,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
@@ -500,6 +740,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
@@ -510,6 +756,12 @@ packages:
     resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -541,6 +793,12 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -685,6 +943,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rolldown/pluginutils@1.0.0-rc.15':
     resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
@@ -892,6 +1153,18 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -917,6 +1190,12 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/coverage-v8@4.1.4':
     resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
@@ -1089,12 +1368,22 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  baseline-browser-mapping@2.10.21:
+    resolution: {integrity: sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
 
   bytes-iec@3.1.1:
     resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
@@ -1111,6 +1400,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  caniuse-lite@1.0.30001790:
+    resolution: {integrity: sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1230,6 +1522,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  electron-to-chromium@1.5.344:
+    resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -1266,6 +1561,11 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
@@ -1275,6 +1575,10 @@ packages:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -1359,6 +1663,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
@@ -1499,11 +1807,21 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
@@ -1612,6 +1930,9 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -1691,6 +2012,9 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
   nopt@7.2.1:
     resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
@@ -1805,6 +2129,10 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
@@ -1847,6 +2175,10 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
@@ -2042,6 +2374,12 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -2056,6 +2394,46 @@ packages:
       vite: '*'
     peerDependenciesMeta:
       vite:
+        optional: true
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   vite@8.0.8:
@@ -2197,6 +2575,9 @@ packages:
       utf-8-validate:
         optional: true
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
@@ -2221,15 +2602,108 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
@@ -2289,10 +2763,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
   '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
@@ -2301,10 +2781,16 @@ snapshots:
   '@esbuild/android-arm64@0.28.0':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
@@ -2313,10 +2799,16 @@ snapshots:
   '@esbuild/android-x64@0.28.0':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
@@ -2325,10 +2817,16 @@ snapshots:
   '@esbuild/darwin-x64@0.28.0':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -2337,10 +2835,16 @@ snapshots:
   '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
@@ -2349,10 +2853,16 @@ snapshots:
   '@esbuild/linux-arm@0.28.0':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
@@ -2361,10 +2871,16 @@ snapshots:
   '@esbuild/linux-loong64@0.28.0':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -2373,10 +2889,16 @@ snapshots:
   '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
@@ -2385,10 +2907,16 @@ snapshots:
   '@esbuild/linux-s390x@0.28.0':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
@@ -2397,10 +2925,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
@@ -2409,10 +2943,16 @@ snapshots:
   '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
@@ -2421,10 +2961,16 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
@@ -2433,10 +2979,16 @@ snapshots:
   '@esbuild/win32-arm64@0.28.0':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -2463,6 +3015,16 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -2593,6 +3155,8 @@ snapshots:
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
     optional: true
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rolldown/pluginutils@1.0.0-rc.15': {}
 
@@ -2751,6 +3315,27 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -2778,6 +3363,18 @@ snapshots:
     dependencies:
       '@types/node': 25.6.0
 
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -2800,6 +3397,14 @@ snapshots:
       '@vitest/utils': 4.1.4
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.4(vite@6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -3000,6 +3605,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  baseline-browser-mapping@2.10.21: {}
+
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -3018,6 +3625,14 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.21
+      caniuse-lite: 1.0.30001790
+      electron-to-chromium: 1.5.344
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   bytes-iec@3.1.1: {}
 
   bytes@3.1.2: {}
@@ -3031,6 +3646,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  caniuse-lite@1.0.30001790: {}
 
   chai@6.2.2: {}
 
@@ -3122,6 +3739,8 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  electron-to-chromium@1.5.344: {}
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
@@ -3143,6 +3762,35 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -3202,6 +3850,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.0
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
+
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -3301,6 +3951,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
 
   get-east-asian-width@1.5.0: {}
 
@@ -3441,9 +4093,13 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  jsesc@3.1.0: {}
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
+
+  json5@2.2.3: {}
 
   jsonfile@6.2.0:
     dependencies:
@@ -3540,6 +4196,10 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
@@ -3604,6 +4264,8 @@ snapshots:
       picocolors: 1.1.1
 
   negotiator@1.0.0: {}
+
+  node-releases@2.0.38: {}
 
   nopt@7.2.1:
     dependencies:
@@ -3707,6 +4369,8 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-refresh@0.17.0: {}
+
   react@19.2.5: {}
 
   require-from-string@2.0.2: {}
@@ -3775,7 +4439,6 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.53.3
       '@rollup/rollup-win32-x64-msvc': 4.53.3
       fsevents: 2.3.3
-    optional: true
 
   router@2.2.0:
     dependencies:
@@ -3790,6 +4453,8 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
 
   semver@7.5.4:
     dependencies:
@@ -3981,6 +4646,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -4006,6 +4677,21 @@ snapshots:
       - rollup
       - supports-color
 
+  vite@6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rollup: 4.53.3
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+      tsx: 4.21.0
+      yaml: 2.8.3
+
   vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -4019,6 +4705,35 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
       yaml: 2.8.3
+
+  vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(vite@6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+      happy-dom: 20.9.0
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
@@ -4095,6 +4810,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.20.0: {}
+
+  yallist@3.1.1: {}
 
   yallist@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "packages/*"
+  - "packages/chart/examples/strategy-studio"


### PR DESCRIPTION
## Summary

- **Chart**: new `"click"` event with `{ x, y, index, time }` payload + `drawingTool.isActive()` gate so generic clicks don't fire while drawing mode is engaged.
- **Strategy Studio (PR5)**: TradingView-style Bar Replay. Click any candle to anchor a replay session at that bar, then play / pause / step / change speed (1× / 2× / 5× / Max). Indicators recompute live, snapshot backtests run against history-up-to-the-playhead. Hotkeys: `Space` toggles play/pause, `→` steps one bar.
- **Workspace**: strategy-studio is now a workspace project so its invariant tests (15 of them) run under `pnpm test`.

## Why this shape

Replay is a hard problem with many invariants — the no-look-ahead guarantee, cursor ↔ simulator alignment, exit-mode chart restoration, off-by-one playhead math. PR went through 6 Codex review cycles, each surfacing a real correctness bug. Rather than rely on review forever, this PR also extracts the trickier helpers into `lib/replay.ts` and locks the invariants in with a 15-test suite that maps directly to the bugs we shipped and rolled back.

UX research (TradingView Bar Replay, NinjaTrader Market Replay, ThinkorSwim OnDemand, MT5 Strategy Tester) drove the must-have surface: top-of-chart toolbar, 4 speed presets, click-to-anchor on the time axis, persistent REPLAY badge, hotkeys.

## Carved-out follow-up: PR14

Batch-only presets (`adaptiveRsi`, `heikinAshi`, etc. — those without `createFactory`) freeze at the seed boundary in Replay because `connectIndicators()` warms them up once and never re-computes on `candleComplete`. The fix belongs in the chart (so the host doesn't have to know which presets are batch-only); deferred to PR14 of the Studio epic to keep this PR focused. Documented inline + in the README roadmap.

## Test plan

- [x] `pnpm test` — studio 15 + chart 781 + core 4865 + mcp 59 all pass
- [x] `pnpm lint` clean
- [x] `pnpm --filter @trendcraft/chart size-check` within limits (Vue 31.29 / 32 kB)
- [x] Codex review: 6 iterations, all P1/P2 findings addressed (look-ahead leak, stepOnce off-by-one, exit-restore-chart, anchor edge clamp, drawing-tool gate, idempotent presets registration, …)
- [x] Visual via agent-browser:
  - Click candle anchors at clicked bar (cursor displays clicked time)
  - Play advances live; SMA(20) extends only past playhead (no future leak)
  - Step = exactly 1 bar, hotkeys work
  - Exit restores full chart range
  - Run Backtest in Replay = snapshot at playhead (different metrics than full-history run)
  - Stepping after a run clears stale results
  - Drawing tool active suppresses generic click

## Notes

- Targets `epic/strategy-studio`. PR4 of 13+1 in the Studio epic.
- Adds workspace entry for `packages/chart/examples/strategy-studio` so `pnpm -r test` discovers it; chart's vitest `include` was tightened so it doesn't double-pick the example tests.