### PR TITLE
feat(strategy-studio): SignalsPanel with cross/divergence/pattern detectors (PR6)

### DIFF
--- a/packages/chart/examples/strategy-studio/README.md
+++ b/packages/chart/examples/strategy-studio/README.md
@@ -23,8 +23,8 @@ The studio runs **fully offline with no LLM key**. It uses `detectMarketRegime` 
 | PR2 | scaffold + 3-pane layout + regime banner + manifest preset selector | done |
 | PR3 | StrategyBuilder (entry/exit dropdowns) + backtest + trade overlay + JSON I/O | done |
 | PR4 | ParamEditor — paramSchema-driven slider/input UI for the 96 presets | done |
-| PR5 | Replay mode — click-to-anchor, play/pause/step/speed, snapshot backtest | **this PR** |
-| PR6 | SignalsPanel — cross/divergence/pattern signal detection + markers | |
+| PR5 | Replay mode — click-to-anchor, play/pause/step/speed, snapshot backtest | done |
+| PR6 | SignalsPanel — cross/divergence/pattern signal detection + markers | **this PR** |
 | PR7 | PluginsPanel — SMC / Pitchfork / Volume Profile / Wyckoff plugin toggles | |
 | PR8 | RiskPanel — position sizing (Kelly/ATR) + VaR/CVaR/Risk Parity | |
 | PR9 | MetaStrategyPanel — equity curve trading + strategy rotation | |

--- a/packages/chart/examples/strategy-studio/README.md
+++ b/packages/chart/examples/strategy-studio/README.md
@@ -33,6 +33,7 @@ The studio runs **fully offline with no LLM key**. It uses `detectMarketRegime` 
 | PR12 | OptimizationPanel — grid search + walk-forward UI | |
 | PR13 | StrategyDnaPanel — genome viz + sensitivity heatmap + robustness | |
 | PR14 | chart: live recompute for batch-only presets in Replay (carved out from PR5) | |
+| PR15 | chart: shared signal-pattern primitive (zigzag + neckline + target, extracted from indicator-showcase; carved out from PR6) | |
 | Phase 2 | Ask AI panel via `@trendcraft/mcp` tools (LLM tool-use) | future |
 
 When the full set lands, Studio will be a true superset of `echarts-viewer`'s analysis surface, all rendered through `@trendcraft/chart`.

--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -1,4 +1,4 @@
-import { type IndicatorConnection, connectIndicators } from "@trendcraft/chart";
+import { type IndicatorConnection, type SignalMarker, connectIndicators } from "@trendcraft/chart";
 import { registerTrendCraftPresets } from "@trendcraft/chart/presets";
 import { useTrendChart } from "@trendcraft/chart/react";
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
@@ -8,12 +8,14 @@ import { useRegime } from "./hooks/useRegime";
 import { type SimulatorHandle, createLiveSimulator } from "./lib/live-simulator";
 import { clampedSeedEnd, lastEmittedIdx } from "./lib/replay";
 import { sampleCandles } from "./lib/sample-data";
+import { SIGNAL_BY_KIND } from "./lib/signals";
 import { builderReducer, initialBuilderState, strategyJSONToState } from "./lib/strategy-state";
 import { KIND_TO_PRESET_KEY, localStudioAPI } from "./lib/studio-api";
 import { ParamPopover } from "./panels/ParamPopover";
 import { PresetSelector } from "./panels/PresetSelector";
 import { ReplayControls, type SpeedTier } from "./panels/ReplayControls";
 import { ResultsSummary } from "./panels/ResultsSummary";
+import { SignalsPanel } from "./panels/SignalsPanel";
 import { StrategyBuilder } from "./panels/StrategyBuilder";
 
 function resolvePresetId(kind: string): string {
@@ -119,6 +121,42 @@ export function App() {
     for (const i of instances) counts[i.kind] = (counts[i.kind] ?? 0) + 1;
     return counts;
   }, [instances]);
+
+  const [enabledSignals, setEnabledSignals] = useState<ReadonlySet<string>>(() => new Set());
+  const toggleSignal = useCallback((kind: string) => {
+    setEnabledSignals((prev) => {
+      const next = new Set(prev);
+      if (next.has(kind)) next.delete(kind);
+      else next.add(kind);
+      return next;
+    });
+  }, []);
+
+  // Compute markers for each enabled signal once per (set + candles); the
+  // result is referentially stable across Replay progress ticks so the
+  // playhead-filter memo below skips recompute unless the playhead moves.
+  const signalMarkersByKind = useMemo(() => {
+    const out: Record<string, SignalMarker[]> = {};
+    for (const kind of enabledSignals) {
+      const def = SIGNAL_BY_KIND.get(kind);
+      if (!def) continue;
+      try {
+        out[kind] = def.compute(candles);
+      } catch (err) {
+        console.warn(`[strategy-studio] Signal ${kind} failed:`, err);
+        out[kind] = [];
+      }
+    }
+    return out;
+  }, [enabledSignals, candles]);
+
+  const signalCountByKind = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const [kind, markers] of Object.entries(signalMarkersByKind)) {
+      counts[kind] = markers.length;
+    }
+    return counts;
+  }, [signalMarkersByKind]);
 
   const { containerRef, chart } = useTrendChart({
     candles,
@@ -416,6 +454,20 @@ export function App() {
     [candles, playheadIdx],
   );
 
+  // Markers visible to the chart: in Replay mode, hide anything past the
+  // playhead so the user can't see signals that haven't "happened yet".
+  const visibleSignalMarkers = useMemo(() => {
+    const all: SignalMarker[] = [];
+    for (const markers of Object.values(signalMarkersByKind)) all.push(...markers);
+    if (playheadIdx == null) return all;
+    const cutoff = candles[playheadIdx]?.time;
+    return cutoff == null ? all : all.filter((m) => m.time <= cutoff);
+  }, [signalMarkersByKind, playheadIdx, candles]);
+
+  useEffect(() => {
+    chart?.addSignals(visibleSignalMarkers);
+  }, [chart, visibleSignalMarkers]);
+
   const headerInfo = useMemo(
     () => `${candles.length} bars · LLM-free · regime-aware`,
     [candles.length],
@@ -486,6 +538,12 @@ export function App() {
           instanceCountsByKind={instanceCountsByKind}
           onToggle={toggleKind}
           onAdd={addInstanceOfKind}
+        />
+        <div className="pane-divider" />
+        <SignalsPanel
+          enabled={enabledSignals}
+          countByKind={signalCountByKind}
+          onToggle={toggleSignal}
         />
       </aside>
 

--- a/packages/chart/examples/strategy-studio/src/lib/signals.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/signals.ts
@@ -1,0 +1,130 @@
+/**
+ * Signal catalog for the Strategy Studio SignalsPanel. Each entry knows how to
+ * compute its signal from candles and how to convert the result into the
+ * chart's `SignalMarker` shape (`{ time, type: "buy" | "sell", label }`).
+ *
+ * Categorized to match the panel's grouping. Keep entries small and additive
+ * — this is the canonical place to add a new detector to the UI.
+ */
+
+import type { SignalMarker } from "@trendcraft/chart";
+import {
+  type DivergenceSignal,
+  type PatternSignal,
+  type Series,
+  deadCross,
+  doubleBottom,
+  doubleTop,
+  goldenCross,
+  headAndShoulders,
+  inverseHeadAndShoulders,
+  macdDivergence,
+  rsiDivergence,
+} from "trendcraft";
+import type { StudioCandle } from "./sample-data";
+
+export type SignalCategory = "cross" | "divergence" | "pattern";
+
+export type SignalDef = {
+  kind: string;
+  label: string;
+  category: SignalCategory;
+  /** Short rationale shown in the row tooltip — what the signal means in trade terms. */
+  description: string;
+  compute: (candles: StudioCandle[]) => SignalMarker[];
+};
+
+export const SIGNAL_CATALOG: readonly SignalDef[] = [
+  {
+    kind: "goldenCross",
+    label: "Golden Cross",
+    category: "cross",
+    description: "SMA(5) crosses above SMA(25) — classic medium-term bullish trigger.",
+    compute: (candles) => seriesToMarkers(goldenCross(candles), candles, "buy", "Golden Cross"),
+  },
+  {
+    kind: "deadCross",
+    label: "Dead Cross",
+    category: "cross",
+    description: "SMA(5) crosses below SMA(25) — bearish counterpart of Golden Cross.",
+    compute: (candles) => seriesToMarkers(deadCross(candles), candles, "sell", "Dead Cross"),
+  },
+  {
+    kind: "rsiDivergence",
+    label: "RSI Divergence",
+    category: "divergence",
+    description: "Price makes a new extreme but RSI(14) doesn't — momentum is fading.",
+    compute: (candles) => divergenceToMarkers(rsiDivergence(candles), "RSI Div"),
+  },
+  {
+    kind: "macdDivergence",
+    label: "MACD Divergence",
+    category: "divergence",
+    description: "Price extreme not confirmed by MACD histogram — early reversal hint.",
+    compute: (candles) => divergenceToMarkers(macdDivergence(candles), "MACD Div"),
+  },
+  {
+    kind: "doubleTop",
+    label: "Double Top",
+    category: "pattern",
+    description: "Two failed attempts to break the same resistance — bearish reversal.",
+    compute: (candles) => patternToMarkers(doubleTop(candles), "sell", "Double Top"),
+  },
+  {
+    kind: "doubleBottom",
+    label: "Double Bottom",
+    category: "pattern",
+    description: "Two failed attempts to break the same support — bullish reversal.",
+    compute: (candles) => patternToMarkers(doubleBottom(candles), "buy", "Double Bottom"),
+  },
+  {
+    kind: "headAndShoulders",
+    label: "Head & Shoulders",
+    category: "pattern",
+    description: "Three peaks with the middle highest — well-known bearish reversal.",
+    compute: (candles) => patternToMarkers(headAndShoulders(candles), "sell", "H&S"),
+  },
+  {
+    kind: "inverseHeadAndShoulders",
+    label: "Inverse Head & Shoulders",
+    category: "pattern",
+    description: "Three troughs with the middle lowest — bullish counterpart of H&S.",
+    compute: (candles) => patternToMarkers(inverseHeadAndShoulders(candles), "buy", "Inv H&S"),
+  },
+];
+
+export const SIGNAL_BY_KIND: Map<string, SignalDef> = new Map(
+  SIGNAL_CATALOG.map((d) => [d.kind, d]),
+);
+
+function seriesToMarkers(
+  series: Series<boolean>,
+  candles: StudioCandle[],
+  type: "buy" | "sell",
+  label: string,
+): SignalMarker[] {
+  const out: SignalMarker[] = [];
+  for (let i = 0; i < series.length; i++) {
+    if (series[i]?.value === true) {
+      const candle = candles[i];
+      if (candle) out.push({ time: candle.time, type, label });
+    }
+  }
+  return out;
+}
+
+function divergenceToMarkers(divergences: DivergenceSignal[], label: string): SignalMarker[] {
+  return divergences.map((d) => ({
+    time: d.time,
+    type: d.type === "bullish" ? "buy" : "sell",
+    label,
+  }));
+}
+
+function patternToMarkers(
+  patterns: PatternSignal[],
+  type: "buy" | "sell",
+  label: string,
+): SignalMarker[] {
+  return patterns.map((p) => ({ time: p.time, type, label }));
+}

--- a/packages/chart/examples/strategy-studio/src/panels/SignalsPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/SignalsPanel.tsx
@@ -1,0 +1,67 @@
+import type { SignalCategory } from "../lib/signals";
+import { SIGNAL_CATALOG } from "../lib/signals";
+
+const CATEGORY_LABELS: Record<SignalCategory, string> = {
+  cross: "Crosses",
+  divergence: "Divergence",
+  pattern: "Chart Patterns",
+};
+
+const CATEGORY_ORDER: SignalCategory[] = ["cross", "divergence", "pattern"];
+
+type Props = {
+  enabled: ReadonlySet<string>;
+  countByKind: Record<string, number>;
+  onToggle: (kind: string) => void;
+};
+
+/**
+ * Checkbox-style list of signal detectors. Each detector computes deterministic
+ * markers from the candle history and the host paints them via `chart.addSignals()`.
+ * Replay mode filters the markers to the playhead in App.tsx.
+ */
+export function SignalsPanel({ enabled, countByKind, onToggle }: Props) {
+  const grouped = new Map<SignalCategory, typeof SIGNAL_CATALOG>();
+  for (const def of SIGNAL_CATALOG) {
+    const list = (grouped.get(def.category) ?? []) as typeof SIGNAL_CATALOG;
+    grouped.set(def.category, [...list, def]);
+  }
+
+  return (
+    <>
+      <div className="pane-header">Signals</div>
+      {CATEGORY_ORDER.map((cat) => {
+        const items = grouped.get(cat);
+        if (!items?.length) return null;
+        return (
+          <div key={cat}>
+            <div className="section-title">{CATEGORY_LABELS[cat]}</div>
+            <ul className="signals-list">
+              {items.map((def) => {
+                const isOn = enabled.has(def.kind);
+                const count = countByKind[def.kind] ?? 0;
+                return (
+                  <li key={def.kind} className={`signal-item${isOn ? " active" : ""}`}>
+                    <button
+                      type="button"
+                      className="signal-toggle"
+                      onClick={() => onToggle(def.kind)}
+                      aria-pressed={isOn}
+                      title={def.description}
+                    >
+                      <span className={`signal-check${isOn ? " on" : ""}`} aria-hidden="true">
+                        {isOn ? "✓" : ""}
+                      </span>
+                      <span className="signal-name">{def.label}</span>
+                      {isOn && count > 0 && <span className="signal-count">{count}</span>}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/styles.css
+++ b/packages/chart/examples/strategy-studio/src/styles.css
@@ -913,3 +913,82 @@ button.ghost.danger:hover {
     opacity: 0.3;
   }
 }
+
+/* ============================================
+ * Signals Panel (left pane, below presets)
+ * ============================================ */
+
+.signals-list {
+  list-style: none;
+  padding: 0 8px 12px;
+}
+
+.signal-item {
+  border-radius: 4px;
+}
+
+.signal-item:hover {
+  background: #1e222d;
+}
+
+.signal-item.active {
+  background: rgba(38, 166, 154, 0.15);
+}
+
+.signal-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.signal-toggle:focus-visible {
+  outline: 2px solid #26a69a;
+  outline-offset: -2px;
+}
+
+.signal-check {
+  width: 14px;
+  height: 14px;
+  border: 1px solid #2a2e39;
+  border-radius: 3px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  color: #fff;
+  background: #1e222d;
+  flex-shrink: 0;
+}
+
+.signal-check.on {
+  background: #26a69a;
+  border-color: #26a69a;
+}
+
+.signal-name {
+  flex: 1 1 auto;
+  font-weight: 500;
+}
+
+.signal-item.active .signal-name {
+  color: #fff;
+}
+
+.signal-count {
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: rgba(38, 166, 154, 0.35);
+  color: #fff;
+}


### PR DESCRIPTION
## Summary

- New SignalsPanel in the left pane: 8 toggleable detectors across 3 categories (Crosses, Divergence, Chart Patterns).
- Detectors compute markers from candle history; chart paints them via `chart.addSignals()`.
- Replay-aware: playhead filters visible markers (no look-ahead, consistent with PR5).
- The catalog (`lib/signals.ts`) is the single place to add a new detector — each entry is a small `SignalDef` with `compute(candles) → SignalMarker[]`.

## v1 catalog

- **Crosses**: Golden Cross, Dead Cross (SMA 5/25)
- **Divergence**: RSI(14), MACD — self-contained, no indicator dependency
- **Chart Patterns**: Double Top, Double Bottom, Head & Shoulders, Inverse H&S

Tooltip on each row carries a one-line trade rationale ("Two failed attempts to break the same resistance — bearish reversal").

## Out of scope

- Candlestick patterns (20+ → too many for v1 UI noise)
- Volume signals, harmonic/wedge/triangle/channel patterns
- User-tunable signal parameters (RSI period etc.) — defaults only

## Test plan

- [x] `pnpm test` — studio 15 + chart 781 + core 4865 + mcp 59 all pass
- [x] `pnpm lint` clean
- [x] `pnpm --filter @trendcraft/chart size-check` within limits (Vue 31.29 / 32 kB)
- [x] Visual via agent-browser:
  - Toggle Golden Cross → 23 markers (green ▲) appear on chart
  - Toggle RSI Divergence + Double Top → 14 + 1 additional markers
  - Anchor Replay early → only seed-range markers visible (look-ahead filter)

## Notes

- Targets `epic/strategy-studio`. PR6 of 14 in the Studio epic.