### PR TITLE
feat(strategy-studio): PluginsPanel with SMC / Wyckoff / Pitchfork / Volume Profile (PR7)

### DIFF
--- a/packages/chart/examples/strategy-studio/README.md
+++ b/packages/chart/examples/strategy-studio/README.md
@@ -24,8 +24,8 @@ The studio runs **fully offline with no LLM key**. It uses `detectMarketRegime` 
 | PR3 | StrategyBuilder (entry/exit dropdowns) + backtest + trade overlay + JSON I/O | done |
 | PR4 | ParamEditor — paramSchema-driven slider/input UI for the 96 presets | done |
 | PR5 | Replay mode — click-to-anchor, play/pause/step/speed, snapshot backtest | done |
-| PR6 | SignalsPanel — cross/divergence/pattern signal detection + markers | **this PR** |
-| PR7 | PluginsPanel — SMC / Pitchfork / Volume Profile / Wyckoff plugin toggles | |
+| PR6 | SignalsPanel — cross/divergence/pattern signal detection + markers | done |
+| PR7 | PluginsPanel — SMC / Pitchfork / Volume Profile / Wyckoff plugin toggles | **this PR** |
 | PR8 | RiskPanel — position sizing (Kelly/ATR) + VaR/CVaR/Risk Parity | |
 | PR9 | MetaStrategyPanel — equity curve trading + strategy rotation | |
 | PR10 | PortfolioPanel — `batchBacktest` + multi-symbol allocation | |

--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -6,12 +6,14 @@ import { indicatorPresets, parseStrategy, validateStrategyJSON } from "trendcraf
 import { useBacktestRunner } from "./hooks/useBacktestRunner";
 import { useRegime } from "./hooks/useRegime";
 import { type SimulatorHandle, createLiveSimulator } from "./lib/live-simulator";
+import { PLUGIN_BY_KIND, type PluginHandle } from "./lib/plugins";
 import { clampedSeedEnd, lastEmittedIdx } from "./lib/replay";
 import { sampleCandles } from "./lib/sample-data";
 import { SIGNAL_BY_KIND } from "./lib/signals";
 import { builderReducer, initialBuilderState, strategyJSONToState } from "./lib/strategy-state";
 import { KIND_TO_PRESET_KEY, localStudioAPI } from "./lib/studio-api";
 import { ParamPopover } from "./panels/ParamPopover";
+import { PluginsPanel } from "./panels/PluginsPanel";
 import { PresetSelector } from "./panels/PresetSelector";
 import { ReplayControls, type SpeedTier } from "./panels/ReplayControls";
 import { ResultsSummary } from "./panels/ResultsSummary";
@@ -131,6 +133,20 @@ export function App() {
       return next;
     });
   }, []);
+
+  const [enabledPlugins, setEnabledPlugins] = useState<ReadonlySet<string>>(() => new Set());
+  const togglePlugin = useCallback((kind: string) => {
+    setEnabledPlugins((prev) => {
+      const next = new Set(prev);
+      if (next.has(kind)) next.delete(kind);
+      else next.add(kind);
+      return next;
+    });
+  }, []);
+  const [unavailablePlugins, setUnavailablePlugins] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const pluginHandlesRef = useRef<Map<string, PluginHandle>>(new Map());
 
   // Compute markers for each enabled signal once per (set + candles); the
   // result is referentially stable across Replay progress ticks so the
@@ -491,6 +507,47 @@ export function App() {
 
   const runner = useBacktestRunner(chart, backtestCandles);
 
+  // Plugin lifecycle: each enabled kind reconnects when (a) the user toggles
+  // it, (b) the playhead moves (so plugins reflect the visible candle range
+  // without look-ahead), or (c) a new chart connection rebuilds (Replay
+  // anchor change). Failed builds — Andrews Pitchfork without three swings,
+  // Volume Profile under 20 bars — are recorded so the panel can dim the
+  // row instead of leaving the user wondering why nothing rendered.
+  useEffect(() => {
+    if (!chart) return;
+    const handles = pluginHandlesRef.current;
+    // Full teardown + rebuild on every change. backtestCandles shifts each
+    // playhead step in Replay, so plugins must recompute against the new
+    // slice; cheap enough at v1 catalog size that diffing is overkill.
+    for (const handle of handles.values()) handle.remove();
+    handles.clear();
+
+    const stillUnavailable = new Set<string>();
+    for (const kind of enabledPlugins) {
+      const def = PLUGIN_BY_KIND.get(kind);
+      if (!def) continue;
+      try {
+        const handle = def.build(chart, backtestCandles);
+        if (handle) handles.set(kind, handle);
+        else stillUnavailable.add(kind);
+      } catch (err) {
+        console.warn(`[strategy-studio] Plugin ${kind} failed:`, err);
+        stillUnavailable.add(kind);
+      }
+    }
+    setUnavailablePlugins((prev) => {
+      if (prev.size === stillUnavailable.size && [...prev].every((k) => stillUnavailable.has(k))) {
+        return prev;
+      }
+      return stillUnavailable;
+    });
+
+    return () => {
+      for (const handle of handles.values()) handle.remove();
+      handles.clear();
+    };
+  }, [chart, enabledPlugins, backtestCandles]);
+
   // Stale-result guard: stepping or toggling Replay changes the slice the
   // backtest *would* run against, but the cached result and chart trade
   // markers are still from the previous slice. Drop the React state so the
@@ -544,6 +601,12 @@ export function App() {
           enabled={enabledSignals}
           countByKind={signalCountByKind}
           onToggle={toggleSignal}
+        />
+        <div className="pane-divider" />
+        <PluginsPanel
+          enabled={enabledPlugins}
+          unavailable={unavailablePlugins}
+          onToggle={togglePlugin}
         />
       </aside>
 

--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -507,23 +507,48 @@ export function App() {
 
   const runner = useBacktestRunner(chart, backtestCandles);
 
-  // Plugin lifecycle: each enabled kind reconnects when (a) the user toggles
-  // it, (b) the playhead moves (so plugins reflect the visible candle range
-  // without look-ahead), or (c) a new chart connection rebuilds (Replay
-  // anchor change). Failed builds — Andrews Pitchfork without three swings,
-  // Volume Profile under 20 bars — are recorded so the panel can dim the
-  // row instead of leaving the user wondering why nothing rendered.
+  // Plugins are heavyweight (SMC alone runs 5 sub-computations across the
+  // slice) — rebuilding 25× / sec at Max-speed Replay would block the main
+  // thread. Strategy: freeze the playhead trigger during playback so existing
+  // overlays stay on their last snapshot, AND diff add/remove on toggle so
+  // flipping a single plugin only computes that one — not the unchanged
+  // siblings. The user gets a fresh snapshot the moment they pause / step
+  // / exit, which matches how analysts actually use these overlays.
+  const skipPluginRebuild = replay.mode === "live" && replay.status === "playing";
+  const lastPluginPlayheadRef = useRef<number | null>(playheadIdx);
+  if (!skipPluginRebuild) lastPluginPlayheadRef.current = playheadIdx;
+  const pluginPlayheadDep = lastPluginPlayheadRef.current;
+
+  const prevPluginSliceKeyRef = useRef<string>("init");
+  const prevPluginChartRef = useRef<typeof chart | null>(null);
+  const pluginSliceKey = `${sessionKey}:${pluginPlayheadDep ?? "null"}`;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: backtestCandles is read at build time; pluginSliceKey is the gated trigger and prevSliceKey/prevChart refs distinguish "slice or chart changed → rebuild all" from "toggle only → diff add/remove".
   useEffect(() => {
     if (!chart) return;
     const handles = pluginHandlesRef.current;
-    // Full teardown + rebuild on every change. backtestCandles shifts each
-    // playhead step in Replay, so plugins must recompute against the new
-    // slice; cheap enough at v1 catalog size that diffing is overkill.
-    for (const handle of handles.values()) handle.remove();
-    handles.clear();
+    // A new chart instance invalidates every primitive registration just
+    // like a slice move does — old handles point at the previous chart and
+    // would silently become orphans if we tried to diff against them.
+    const chartChanged = prevPluginChartRef.current !== chart;
+    const sliceMoved = prevPluginSliceKeyRef.current !== pluginSliceKey;
+    const fullRebuild = chartChanged || sliceMoved;
+
+    if (fullRebuild) {
+      for (const handle of handles.values()) handle.remove();
+      handles.clear();
+    } else {
+      for (const [kind, handle] of [...handles]) {
+        if (!enabledPlugins.has(kind)) {
+          handle.remove();
+          handles.delete(kind);
+        }
+      }
+    }
 
     const stillUnavailable = new Set<string>();
     for (const kind of enabledPlugins) {
+      if (handles.has(kind)) continue;
       const def = PLUGIN_BY_KIND.get(kind);
       if (!def) continue;
       try {
@@ -542,11 +567,22 @@ export function App() {
       return stillUnavailable;
     });
 
-    return () => {
+    prevPluginSliceKeyRef.current = pluginSliceKey;
+    prevPluginChartRef.current = chart;
+  }, [chart, enabledPlugins, pluginSliceKey]);
+
+  // Unmount-only cleanup: the build effect above manages add/remove
+  // imperatively (no per-run cleanup return), so primitives outlive each
+  // re-render. This `[]`-deps effect is the only place that tears down
+  // everything on App unmount.
+  useEffect(
+    () => () => {
+      const handles = pluginHandlesRef.current;
       for (const handle of handles.values()) handle.remove();
       handles.clear();
-    };
-  }, [chart, enabledPlugins, backtestCandles]);
+    },
+    [],
+  );
 
   // Stale-result guard: stepping or toggling Replay changes the slice the
   // backtest *would* run against, but the cached result and chart trade

--- a/packages/chart/examples/strategy-studio/src/lib/plugins.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/plugins.ts
@@ -1,16 +1,9 @@
 /**
- * Plugin catalog for the Strategy Studio PluginsPanel. Each entry knows how
- * to compute its data sources from a candle slice and connect a chart-side
- * primitive plugin.
- *
- * The `build` function returns a `PluginHandle` (or `null` if there isn't
- * enough data for the plugin to render — e.g. Andrews Pitchfork needs three
- * alternating swings). The host owns lifecycle: it calls `build` on toggle
- * on, stashes the handle, and calls `handle.remove()` on toggle off / on
- * any session rebuild.
- *
- * Replay-aware: pass `candles` already sliced to the playhead so plugins
- * never compute over future bars.
+ * Plugin catalog for the Strategy Studio PluginsPanel. Each entry's `build`
+ * returns a `PluginHandle` or `null` when the slice is too short to render
+ * (Andrews Pitchfork needs 3 alternating swings, Volume Profile needs ≥20
+ * bars). Host owns lifecycle: build on toggle on, `handle.remove()` on
+ * toggle off or session rebuild.
  */
 
 import {
@@ -31,17 +24,14 @@ import {
   vsa,
   wyckoffPhases,
 } from "trendcraft";
+import type { CatalogEntry } from "../panels/ToggleCatalogPanel";
 import type { StudioCandle } from "./sample-data";
 
 export type PluginCategory = "smc" | "structure" | "volume";
 
 export type PluginHandle = { remove(): void };
 
-export type PluginDef = {
-  kind: string;
-  label: string;
-  category: PluginCategory;
-  description: string;
+export type PluginDef = CatalogEntry<PluginCategory> & {
   build: (chart: ChartInstance, candles: StudioCandle[]) => PluginHandle | null;
 };
 

--- a/packages/chart/examples/strategy-studio/src/lib/plugins.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/plugins.ts
@@ -1,0 +1,113 @@
+/**
+ * Plugin catalog for the Strategy Studio PluginsPanel. Each entry knows how
+ * to compute its data sources from a candle slice and connect a chart-side
+ * primitive plugin.
+ *
+ * The `build` function returns a `PluginHandle` (or `null` if there isn't
+ * enough data for the plugin to render — e.g. Andrews Pitchfork needs three
+ * alternating swings). The host owns lifecycle: it calls `build` on toggle
+ * on, stashes the handle, and calls `handle.remove()` on toggle off / on
+ * any session rebuild.
+ *
+ * Replay-aware: pass `candles` already sliced to the playhead so plugins
+ * never compute over future bars.
+ */
+
+import {
+  type ChartInstance,
+  connectAndrewsPitchfork,
+  connectSmcLayer,
+  connectVolumeProfile,
+  connectWyckoffPhase,
+} from "@trendcraft/chart";
+import {
+  breakOfStructure,
+  changeOfCharacter,
+  fairValueGap,
+  getAlternatingSwingPoints,
+  liquiditySweep,
+  orderBlock,
+  volumeProfile,
+  vsa,
+  wyckoffPhases,
+} from "trendcraft";
+import type { StudioCandle } from "./sample-data";
+
+export type PluginCategory = "smc" | "structure" | "volume";
+
+export type PluginHandle = { remove(): void };
+
+export type PluginDef = {
+  kind: string;
+  label: string;
+  category: PluginCategory;
+  description: string;
+  build: (chart: ChartInstance, candles: StudioCandle[]) => PluginHandle | null;
+};
+
+export const PLUGIN_CATALOG: readonly PluginDef[] = [
+  {
+    kind: "smcLayer",
+    label: "SMC Layer",
+    category: "smc",
+    description:
+      "Smart Money Concepts overlay: order blocks, fair value gaps, liquidity sweeps, BoS / CHoCH.",
+    build: (chart, candles) => {
+      if (candles.length < 30) return null;
+      return connectSmcLayer(chart, {
+        orderBlocks: orderBlock(candles),
+        fvgs: fairValueGap(candles),
+        sweeps: liquiditySweep(candles),
+        bos: breakOfStructure(candles),
+        choch: changeOfCharacter(candles),
+      });
+    },
+  },
+  {
+    kind: "wyckoff",
+    label: "Wyckoff Phase",
+    category: "structure",
+    description:
+      "Phase boxes (accumulation / markup / distribution / markdown) with VSA confirmation.",
+    build: (chart, candles) => {
+      if (candles.length < 50) return null;
+      return connectWyckoffPhase(chart, {
+        phases: wyckoffPhases(candles),
+        vsa: vsa(candles),
+        candles,
+      });
+    },
+  },
+  {
+    kind: "andrewsPitchfork",
+    label: "Andrews Pitchfork",
+    category: "structure",
+    description:
+      "Median + parallel handles drawn from the three most recent alternating swing points.",
+    build: (chart, candles) => {
+      const swings = getAlternatingSwingPoints(candles, 3, { leftBars: 10, rightBars: 10 });
+      if (swings.length < 3) return null;
+      const [p0, p1, p2] = swings;
+      return connectAndrewsPitchfork(chart, {
+        p0: { index: p0.index, price: p0.price },
+        p1: { index: p1.index, price: p1.price },
+        p2: { index: p2.index, price: p2.price },
+      });
+    },
+  },
+  {
+    kind: "volumeProfile",
+    label: "Volume Profile",
+    category: "volume",
+    description: "Horizontal histogram on the right edge: POC, VAH, VAL, value-area shading.",
+    build: (chart, candles) => {
+      if (candles.length < 20) return null;
+      const profile = volumeProfile(candles, { levels: 30 });
+      return connectVolumeProfile(chart, profile);
+    },
+  },
+];
+
+export const PLUGIN_BY_KIND: Map<string, PluginDef> = new Map(
+  PLUGIN_CATALOG.map((d) => [d.kind, d]),
+);

--- a/packages/chart/examples/strategy-studio/src/lib/signals.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/signals.ts
@@ -21,16 +21,12 @@ import {
   macdDivergence,
   rsiDivergence,
 } from "trendcraft";
+import type { CatalogEntry } from "../panels/ToggleCatalogPanel";
 import type { StudioCandle } from "./sample-data";
 
 export type SignalCategory = "cross" | "divergence" | "pattern";
 
-export type SignalDef = {
-  kind: string;
-  label: string;
-  category: SignalCategory;
-  /** Short rationale shown in the row tooltip — what the signal means in trade terms. */
-  description: string;
+export type SignalDef = CatalogEntry<SignalCategory> & {
   compute: (candles: StudioCandle[]) => SignalMarker[];
 };
 

--- a/packages/chart/examples/strategy-studio/src/panels/PluginsPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/PluginsPanel.tsx
@@ -1,0 +1,75 @@
+import type { PluginCategory } from "../lib/plugins";
+import { PLUGIN_CATALOG } from "../lib/plugins";
+
+const CATEGORY_LABELS: Record<PluginCategory, string> = {
+  smc: "Smart Money",
+  structure: "Structure",
+  volume: "Volume",
+};
+
+const CATEGORY_ORDER: PluginCategory[] = ["smc", "structure", "volume"];
+
+type Props = {
+  enabled: ReadonlySet<string>;
+  /** kinds whose `build()` returned `null` last attempt (insufficient data). */
+  unavailable: ReadonlySet<string>;
+  onToggle: (kind: string) => void;
+};
+
+/**
+ * Toggle list for chart-side primitive plugins (SMC layer, Wyckoff phase,
+ * Andrews Pitchfork, Volume Profile). Each row's `build()` runs in App.tsx
+ * — this panel is pure presentation.
+ */
+export function PluginsPanel({ enabled, unavailable, onToggle }: Props) {
+  const grouped = new Map<PluginCategory, typeof PLUGIN_CATALOG>();
+  for (const def of PLUGIN_CATALOG) {
+    const list = (grouped.get(def.category) ?? []) as typeof PLUGIN_CATALOG;
+    grouped.set(def.category, [...list, def]);
+  }
+
+  return (
+    <>
+      <div className="pane-header">Plugins</div>
+      {CATEGORY_ORDER.map((cat) => {
+        const items = grouped.get(cat);
+        if (!items?.length) return null;
+        return (
+          <div key={cat}>
+            <div className="section-title">{CATEGORY_LABELS[cat]}</div>
+            <ul className="signals-list">
+              {items.map((def) => {
+                const isOn = enabled.has(def.kind);
+                const noData = unavailable.has(def.kind);
+                return (
+                  <li
+                    key={def.kind}
+                    className={`signal-item${isOn ? " active" : ""}${noData ? " unavailable" : ""}`}
+                  >
+                    <button
+                      type="button"
+                      className="signal-toggle"
+                      onClick={() => onToggle(def.kind)}
+                      aria-pressed={isOn}
+                      title={
+                        noData
+                          ? `${def.description} — not enough data at the current playhead.`
+                          : def.description
+                      }
+                    >
+                      <span className={`signal-check${isOn ? " on" : ""}`} aria-hidden="true">
+                        {isOn ? "✓" : ""}
+                      </span>
+                      <span className="signal-name">{def.label}</span>
+                      {isOn && noData && <span className="signal-count signal-count--warn">!</span>}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/panels/PluginsPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/PluginsPanel.tsx
@@ -1,5 +1,6 @@
 import type { PluginCategory } from "../lib/plugins";
 import { PLUGIN_CATALOG } from "../lib/plugins";
+import { ToggleCatalogPanel } from "./ToggleCatalogPanel";
 
 const CATEGORY_LABELS: Record<PluginCategory, string> = {
   smc: "Smart Money",
@@ -7,69 +8,35 @@ const CATEGORY_LABELS: Record<PluginCategory, string> = {
   volume: "Volume",
 };
 
-const CATEGORY_ORDER: PluginCategory[] = ["smc", "structure", "volume"];
+const CATEGORY_ORDER: readonly PluginCategory[] = ["smc", "structure", "volume"];
 
 type Props = {
   enabled: ReadonlySet<string>;
-  /** kinds whose `build()` returned `null` last attempt (insufficient data). */
+  /** Kinds whose `build()` returned `null` last attempt (insufficient data). */
   unavailable: ReadonlySet<string>;
   onToggle: (kind: string) => void;
 };
 
-/**
- * Toggle list for chart-side primitive plugins (SMC layer, Wyckoff phase,
- * Andrews Pitchfork, Volume Profile). Each row's `build()` runs in App.tsx
- * — this panel is pure presentation.
- */
 export function PluginsPanel({ enabled, unavailable, onToggle }: Props) {
-  const grouped = new Map<PluginCategory, typeof PLUGIN_CATALOG>();
-  for (const def of PLUGIN_CATALOG) {
-    const list = (grouped.get(def.category) ?? []) as typeof PLUGIN_CATALOG;
-    grouped.set(def.category, [...list, def]);
-  }
-
   return (
-    <>
-      <div className="pane-header">Plugins</div>
-      {CATEGORY_ORDER.map((cat) => {
-        const items = grouped.get(cat);
-        if (!items?.length) return null;
-        return (
-          <div key={cat}>
-            <div className="section-title">{CATEGORY_LABELS[cat]}</div>
-            <ul className="signals-list">
-              {items.map((def) => {
-                const isOn = enabled.has(def.kind);
-                const noData = unavailable.has(def.kind);
-                return (
-                  <li
-                    key={def.kind}
-                    className={`signal-item${isOn ? " active" : ""}${noData ? " unavailable" : ""}`}
-                  >
-                    <button
-                      type="button"
-                      className="signal-toggle"
-                      onClick={() => onToggle(def.kind)}
-                      aria-pressed={isOn}
-                      title={
-                        noData
-                          ? `${def.description} — not enough data at the current playhead.`
-                          : def.description
-                      }
-                    >
-                      <span className={`signal-check${isOn ? " on" : ""}`} aria-hidden="true">
-                        {isOn ? "✓" : ""}
-                      </span>
-                      <span className="signal-name">{def.label}</span>
-                      {isOn && noData && <span className="signal-count signal-count--warn">!</span>}
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
-        );
-      })}
-    </>
+    <ToggleCatalogPanel
+      title="Plugins"
+      items={PLUGIN_CATALOG}
+      categoryOrder={CATEGORY_ORDER}
+      categoryLabels={CATEGORY_LABELS}
+      enabled={enabled}
+      onToggle={onToggle}
+      classNameFor={(def) => (unavailable.has(def.kind) ? "unavailable" : undefined)}
+      tooltipFor={(def) =>
+        unavailable.has(def.kind)
+          ? `${def.description} — not enough data at the current playhead.`
+          : def.description
+      }
+      renderBadge={(def) =>
+        enabled.has(def.kind) && unavailable.has(def.kind) ? (
+          <span className="signal-count signal-count--warn">!</span>
+        ) : null
+      }
+    />
   );
 }

--- a/packages/chart/examples/strategy-studio/src/panels/SignalsPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/SignalsPanel.tsx
@@ -1,5 +1,6 @@
 import type { SignalCategory } from "../lib/signals";
 import { SIGNAL_CATALOG } from "../lib/signals";
+import { ToggleCatalogPanel } from "./ToggleCatalogPanel";
 
 const CATEGORY_LABELS: Record<SignalCategory, string> = {
   cross: "Crosses",
@@ -7,7 +8,7 @@ const CATEGORY_LABELS: Record<SignalCategory, string> = {
   pattern: "Chart Patterns",
 };
 
-const CATEGORY_ORDER: SignalCategory[] = ["cross", "divergence", "pattern"];
+const CATEGORY_ORDER: readonly SignalCategory[] = ["cross", "divergence", "pattern"];
 
 type Props = {
   enabled: ReadonlySet<string>;
@@ -15,53 +16,20 @@ type Props = {
   onToggle: (kind: string) => void;
 };
 
-/**
- * Checkbox-style list of signal detectors. Each detector computes deterministic
- * markers from the candle history and the host paints them via `chart.addSignals()`.
- * Replay mode filters the markers to the playhead in App.tsx.
- */
 export function SignalsPanel({ enabled, countByKind, onToggle }: Props) {
-  const grouped = new Map<SignalCategory, typeof SIGNAL_CATALOG>();
-  for (const def of SIGNAL_CATALOG) {
-    const list = (grouped.get(def.category) ?? []) as typeof SIGNAL_CATALOG;
-    grouped.set(def.category, [...list, def]);
-  }
-
   return (
-    <>
-      <div className="pane-header">Signals</div>
-      {CATEGORY_ORDER.map((cat) => {
-        const items = grouped.get(cat);
-        if (!items?.length) return null;
-        return (
-          <div key={cat}>
-            <div className="section-title">{CATEGORY_LABELS[cat]}</div>
-            <ul className="signals-list">
-              {items.map((def) => {
-                const isOn = enabled.has(def.kind);
-                const count = countByKind[def.kind] ?? 0;
-                return (
-                  <li key={def.kind} className={`signal-item${isOn ? " active" : ""}`}>
-                    <button
-                      type="button"
-                      className="signal-toggle"
-                      onClick={() => onToggle(def.kind)}
-                      aria-pressed={isOn}
-                      title={def.description}
-                    >
-                      <span className={`signal-check${isOn ? " on" : ""}`} aria-hidden="true">
-                        {isOn ? "✓" : ""}
-                      </span>
-                      <span className="signal-name">{def.label}</span>
-                      {isOn && count > 0 && <span className="signal-count">{count}</span>}
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
-        );
-      })}
-    </>
+    <ToggleCatalogPanel
+      title="Signals"
+      items={SIGNAL_CATALOG}
+      categoryOrder={CATEGORY_ORDER}
+      categoryLabels={CATEGORY_LABELS}
+      enabled={enabled}
+      onToggle={onToggle}
+      renderBadge={(def) => {
+        if (!enabled.has(def.kind)) return null;
+        const count = countByKind[def.kind] ?? 0;
+        return count > 0 ? <span className="signal-count">{count}</span> : null;
+      }}
+    />
   );
 }

--- a/packages/chart/examples/strategy-studio/src/panels/ToggleCatalogPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/ToggleCatalogPanel.tsx
@@ -1,0 +1,93 @@
+import type { ReactNode } from "react";
+
+/**
+ * Generic catalog entry shape used by SignalsPanel, PluginsPanel, and any
+ * future "categorized toggle list" panel. Each domain narrows `category` to
+ * its own union and adds a domain-specific payload alongside this base.
+ */
+export type CatalogEntry<C extends string = string> = {
+  kind: string;
+  label: string;
+  category: C;
+  description: string;
+};
+
+type Props<C extends string> = {
+  title: string;
+  items: readonly CatalogEntry<C>[];
+  categoryOrder: readonly C[];
+  categoryLabels: Record<C, string>;
+  enabled: ReadonlySet<string>;
+  onToggle: (kind: string) => void;
+  /** Optional right-side badge per row (e.g. signal count, warning chip). */
+  renderBadge?: (entry: CatalogEntry<C>) => ReactNode;
+  /** Optional override for the row tooltip; defaults to `entry.description`. */
+  tooltipFor?: (entry: CatalogEntry<C>) => string;
+  /** Optional row class modifier (e.g. "unavailable") per entry. */
+  classNameFor?: (entry: CatalogEntry<C>) => string | undefined;
+};
+
+/**
+ * Categorized checkbox-style toggle list. The presentation surface for
+ * SignalsPanel and PluginsPanel — both panels now collapse to a thin
+ * wrapper that supplies the catalog and per-row badge.
+ */
+export function ToggleCatalogPanel<C extends string>({
+  title,
+  items,
+  categoryOrder,
+  categoryLabels,
+  enabled,
+  onToggle,
+  renderBadge,
+  tooltipFor,
+  classNameFor,
+}: Props<C>) {
+  const grouped = new Map<C, CatalogEntry<C>[]>();
+  for (const def of items) {
+    const list = grouped.get(def.category) ?? [];
+    list.push(def);
+    grouped.set(def.category, list);
+  }
+
+  return (
+    <>
+      <div className="pane-header">{title}</div>
+      {categoryOrder.map((cat) => {
+        const entries = grouped.get(cat);
+        if (!entries?.length) return null;
+        return (
+          <div key={cat}>
+            <div className="section-title">{categoryLabels[cat]}</div>
+            <ul className="signals-list">
+              {entries.map((def) => {
+                const isOn = enabled.has(def.kind);
+                const extra = classNameFor?.(def);
+                return (
+                  <li
+                    key={def.kind}
+                    className={`signal-item${isOn ? " active" : ""}${extra ? ` ${extra}` : ""}`}
+                  >
+                    <button
+                      type="button"
+                      className="signal-toggle"
+                      onClick={() => onToggle(def.kind)}
+                      aria-pressed={isOn}
+                      title={tooltipFor?.(def) ?? def.description}
+                    >
+                      <span className={`signal-check${isOn ? " on" : ""}`} aria-hidden="true">
+                        {isOn ? "✓" : ""}
+                      </span>
+                      <span className="signal-name">{def.label}</span>
+                      {renderBadge?.(def)}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/styles.css
+++ b/packages/chart/examples/strategy-studio/src/styles.css
@@ -992,3 +992,11 @@ button.ghost.danger:hover {
   background: rgba(38, 166, 154, 0.35);
   color: #fff;
 }
+
+.signal-item.unavailable .signal-name {
+  color: #787b86;
+}
+
+.signal-count.signal-count--warn {
+  background: rgba(239, 83, 80, 0.35);
+}


### PR DESCRIPTION
## Summary

- New PluginsPanel in the left pane (below SignalsPanel): toggleable chart-side primitive plugins.
- v1 catalog: **SMC Layer** (order blocks + FVG + sweeps + BoS/CHoCH), **Wyckoff Phase** (phases + VSA), **Andrews Pitchfork** (last 3 alternating swings), **Volume Profile** (POC/VAH/VAL).
- Replay-aware: each plugin's `build()` receives `backtestCandles` (sliced to the playhead per PR5), so all four plugins recompute against the visible range without leaking future data.
- Plugins that can't render at the current slice length (Pitchfork without 3 swings, VP under 20 bars) show an inline `!` chip and a tooltip explaining why.

## v1 catalog

- **Smart Money**: SMC Layer
- **Structure**: Wyckoff Phase, Andrews Pitchfork
- **Volume**: Volume Profile

The catalog (`lib/plugins.ts`) is the single place to add a new plugin to the UI; each entry is a small `PluginDef` with `build(chart, candles) → PluginHandle | null`.

## Out of scope

- Other primitives in `@trendcraft/chart/plugins/` (S/R confluence, market profile, session zones, regime heatmap, trade analysis, squeeze dots) — defer until Studio asks for them
- Per-plugin parameter UI (VP `levels`, Pitchfork `leftBars`, etc.) — defaults only
- Live-mode primitives (`connectLivePrimitives`) — Studio rebuilds plugins on each playhead step instead

## Test plan

- [x] `pnpm test` — studio 15 + chart 781 + core 4865 + mcp 59 all pass
- [x] `pnpm lint` clean
- [x] `pnpm --filter @trendcraft/chart size-check` within limits (Vue 31.29 / 32 kB)
- [x] Visual via agent-browser:
  - Toggle SMC Layer + Andrews Pitchfork + Volume Profile → all three render correctly (BoS/CHoCH labels, parallel lines, right-edge histogram)
  - Anchor Replay early → plugins recompute over seed range (POC shifts to seed-only data)

## Notes

- Targets `epic/strategy-studio`. PR7 of 14 in the Studio epic.
- Visual richness for signal patterns (zigzag + neckline + measured-move target) remains carved out as PR15.