### PR TITLE
feat(strategy-studio): RiskPanel with position sizing + VaR/CVaR (PR8)

### DIFF
--- a/packages/chart/examples/strategy-studio/README.md
+++ b/packages/chart/examples/strategy-studio/README.md
@@ -25,8 +25,8 @@ The studio runs **fully offline with no LLM key**. It uses `detectMarketRegime` 
 | PR4 | ParamEditor — paramSchema-driven slider/input UI for the 96 presets | done |
 | PR5 | Replay mode — click-to-anchor, play/pause/step/speed, snapshot backtest | done |
 | PR6 | SignalsPanel — cross/divergence/pattern signal detection + markers | done |
-| PR7 | PluginsPanel — SMC / Pitchfork / Volume Profile / Wyckoff plugin toggles | **this PR** |
-| PR8 | RiskPanel — position sizing (Kelly/ATR) + VaR/CVaR/Risk Parity | |
+| PR7 | PluginsPanel — SMC / Pitchfork / Volume Profile / Wyckoff plugin toggles | done |
+| PR8 | RiskPanel — position sizing (Risk-%/ATR/Kelly) + VaR/CVaR | **this PR** |
 | PR9 | MetaStrategyPanel — equity curve trading + strategy rotation | |
 | PR10 | PortfolioPanel — `batchBacktest` + multi-symbol allocation | |
 | PR11 | ScoringPanel — signal scoring visualization | |

--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -17,6 +17,7 @@ import { PluginsPanel } from "./panels/PluginsPanel";
 import { PresetSelector } from "./panels/PresetSelector";
 import { ReplayControls, type SpeedTier } from "./panels/ReplayControls";
 import { ResultsSummary } from "./panels/ResultsSummary";
+import { RiskPanel } from "./panels/RiskPanel";
 import { SignalsPanel } from "./panels/SignalsPanel";
 import { StrategyBuilder } from "./panels/StrategyBuilder";
 
@@ -673,6 +674,8 @@ export function App() {
         />
         <div className="pane-divider" />
         <ResultsSummary result={runner.state.lastResult?.result} />
+        <div className="pane-divider" />
+        <RiskPanel candles={backtestCandles} lastBacktest={runner.state.lastResult?.result} />
       </aside>
 
       {popoverState && popoverInstance && (

--- a/packages/chart/examples/strategy-studio/src/lib/risk.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/risk.ts
@@ -1,0 +1,198 @@
+import {
+  type PositionSizeResult,
+  type Trade,
+  type VarMethod,
+  type VarResult,
+  atr,
+  atrBasedSize,
+  calculateVaR,
+  kellySize,
+  returns,
+  riskBasedSize,
+} from "trendcraft";
+import type { StudioCandle } from "./sample-data";
+
+export type SizingMethod = "risk-based" | "atr-based" | "kelly";
+
+export type SizingInputs = {
+  method: SizingMethod;
+  accountSize: number;
+  entryPrice: number;
+  /** Risk-based / ATR: % of account at risk per trade. */
+  riskPercent: number;
+  /** Risk-based: explicit stop-loss price. */
+  stopLossPrice?: number;
+  /** ATR: multiplier on the latest ATR(period) to set stop distance. */
+  atrPeriod: number;
+  atrMultiplier: number;
+  /** Kelly: win rate (0–1) and avgWin/avgLoss ratio. */
+  winRate: number;
+  winLossRatio: number;
+  kellyFraction: number;
+};
+
+export type SizingComputation =
+  | { kind: "ok"; result: PositionSizeResult; atrValue?: number }
+  | { kind: "error"; message: string };
+
+// Returns null if the slice is shorter than `period + 1`: TR[0] is undefined
+// because it depends on the previous close, so atr needs `period+1` candles.
+export function latestAtr(candles: StudioCandle[], period: number): number | null {
+  if (candles.length <= period) return null;
+  const series = atr(candles, { period });
+  for (let i = series.length - 1; i >= 0; i--) {
+    const v = series[i].value;
+    if (Number.isFinite(v)) return v;
+  }
+  return null;
+}
+
+// Use `returnPercent` (size-independent) rather than `return` (dollar P/L) so
+// scaled entries / partial exits / variable position sizing don't let larger
+// notionals dominate the avgWin/avgLoss ratio Kelly depends on. Partial exits
+// are folded in alongside full exits — Kelly is sensitive to the realised
+// payoff distribution, not just fully-closed trades.
+export function deriveKellyStats(trades: readonly Trade[]): {
+  winRate: number;
+  winLossRatio: number;
+  sampleSize: number;
+} | null {
+  if (trades.length === 0) return null;
+  let wins = 0;
+  let losses = 0;
+  let winSum = 0;
+  let lossSum = 0;
+  for (const t of trades) {
+    const pct = t.returnPercent;
+    if (pct > 0) {
+      wins += 1;
+      winSum += pct;
+    } else if (pct < 0) {
+      losses += 1;
+      lossSum += -pct;
+    }
+  }
+  const decided = wins + losses;
+  if (decided === 0) return null;
+  const avgWin = wins > 0 ? winSum / wins : 0;
+  const avgLoss = losses > 0 ? lossSum / losses : 0;
+  // No realised losses → ratio is undefined; fall back to a large but finite
+  // proxy so the UI can still surface a Kelly result rather than blank out.
+  const winLossRatio = avgLoss > 0 ? avgWin / avgLoss : Math.max(avgWin, 1);
+  return {
+    winRate: wins / decided,
+    winLossRatio,
+    sampleSize: decided,
+  };
+}
+
+export function defaultSizingInputs(entryPrice: number): SizingInputs {
+  return {
+    method: "risk-based",
+    accountSize: 100_000,
+    entryPrice,
+    riskPercent: 1,
+    stopLossPrice: Math.max(0.01, entryPrice * 0.95),
+    atrPeriod: 14,
+    atrMultiplier: 2,
+    winRate: 0.55,
+    winLossRatio: 1.5,
+    kellyFraction: 0.5,
+  };
+}
+
+export function computeSizing(inputs: SizingInputs, candles: StudioCandle[]): SizingComputation {
+  try {
+    if (inputs.method === "risk-based") {
+      const stop = inputs.stopLossPrice;
+      if (stop === undefined || !Number.isFinite(stop)) {
+        return { kind: "error", message: "Stop-loss price required" };
+      }
+      const result = riskBasedSize({
+        accountSize: inputs.accountSize,
+        entryPrice: inputs.entryPrice,
+        riskPercent: inputs.riskPercent,
+        stopLossPrice: stop,
+      });
+      return { kind: "ok", result };
+    }
+    if (inputs.method === "atr-based") {
+      const atrValue = latestAtr(candles, inputs.atrPeriod);
+      if (atrValue == null) {
+        return {
+          kind: "error",
+          message: `Need ${inputs.atrPeriod + 1}+ bars in slice for ATR(${inputs.atrPeriod})`,
+        };
+      }
+      const result = atrBasedSize({
+        accountSize: inputs.accountSize,
+        entryPrice: inputs.entryPrice,
+        riskPercent: inputs.riskPercent,
+        atrValue,
+        atrMultiplier: inputs.atrMultiplier,
+      });
+      return { kind: "ok", result, atrValue };
+    }
+    const result = kellySize({
+      accountSize: inputs.accountSize,
+      entryPrice: inputs.entryPrice,
+      winRate: inputs.winRate,
+      winLossRatio: inputs.winLossRatio,
+      kellyFraction: inputs.kellyFraction,
+    });
+    return { kind: "ok", result };
+  } catch (err) {
+    return { kind: "error", message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export type VarInputs = {
+  method: VarMethod;
+  confidence: number;
+  /** Lookback in bars used to derive returns (last N closes → N-1 returns). */
+  lookback: number;
+};
+
+export const DEFAULT_VAR_INPUTS: VarInputs = {
+  method: "historical",
+  confidence: 0.95,
+  lookback: 120,
+};
+
+export type VarComputation =
+  | { kind: "ok"; result: VarResult; returnsCount: number }
+  | { kind: "error"; message: string };
+
+/**
+ * Last `lookback` simple returns, dropping the first null slot from `returns()`
+ * and any null produced by zero/negative closes.
+ */
+export function returnsFromCloses(candles: StudioCandle[], lookback: number): number[] {
+  const slice = candles.slice(-lookback);
+  const out: number[] = [];
+  for (const point of returns(slice)) {
+    if (point.value != null && Number.isFinite(point.value)) out.push(point.value);
+  }
+  return out;
+}
+
+export function computeVar(inputs: VarInputs, candles: StudioCandle[]): VarComputation {
+  if (inputs.confidence <= 0 || inputs.confidence >= 1) {
+    return { kind: "error", message: "Confidence must be in (0, 1)" };
+  }
+  const returns = returnsFromCloses(candles, inputs.lookback);
+  if (returns.length < 10) {
+    return { kind: "error", message: `Need ≥10 returns (got ${returns.length})` };
+  }
+  try {
+    const result = calculateVaR(returns, {
+      confidence: inputs.confidence,
+      method: inputs.method,
+    });
+    return { kind: "ok", result, returnsCount: returns.length };
+  } catch (err) {
+    return { kind: "error", message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export type { PositionSizeResult, VarMethod, VarResult };

--- a/packages/chart/examples/strategy-studio/src/panels/RiskPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/RiskPanel.tsx
@@ -1,0 +1,363 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { BacktestResult } from "trendcraft";
+import {
+  DEFAULT_VAR_INPUTS,
+  type SizingInputs,
+  type SizingMethod,
+  type VarInputs,
+  type VarMethod,
+  computeSizing,
+  computeVar,
+  defaultSizingInputs,
+  deriveKellyStats,
+} from "../lib/risk";
+import type { StudioCandle } from "../lib/sample-data";
+
+type Props = {
+  /** Playhead-aware candle slice. Same source the backtest sees. */
+  candles: StudioCandle[];
+  /** Most recent backtest result, used to seed Kelly inputs from realised stats. */
+  lastBacktest: BacktestResult | undefined;
+};
+
+const SIZING_METHODS: ReadonlyArray<{ id: SizingMethod; label: string }> = [
+  { id: "risk-based", label: "Risk %" },
+  { id: "atr-based", label: "ATR" },
+  { id: "kelly", label: "Kelly" },
+];
+
+const VAR_METHODS: ReadonlyArray<{ id: VarMethod; label: string }> = [
+  { id: "historical", label: "Historical" },
+  { id: "parametric", label: "Parametric" },
+  { id: "cornishFisher", label: "Cornish-Fisher" },
+];
+
+export function RiskPanel({ candles, lastBacktest }: Props) {
+  const lastClose = candles.length > 0 ? candles[candles.length - 1].close : 100;
+
+  const [sizing, setSizing] = useState<SizingInputs>(() => defaultSizingInputs(lastClose));
+  const [varInputs, setVarInputs] = useState<VarInputs>(DEFAULT_VAR_INPUTS);
+  const [autoFromBacktest, setAutoFromBacktest] = useState(true);
+
+  // Track the last close we auto-seeded into entry/stop. When the playhead
+  // advances we only re-seed if the user hasn't overridden the field —
+  // detected by entry/stop still matching the previously-seeded values.
+  // Without this, every Replay tick wipes manual edits and triggers a
+  // no-op re-render even when the new close equals the old one.
+  const lastSeedRef = useRef<number>(lastClose);
+  useEffect(() => {
+    if (lastClose === lastSeedRef.current) return;
+    setSizing((prev) => {
+      const seedStop = Math.max(0.01, lastClose * 0.95);
+      const prevSeedStop = Math.max(0.01, lastSeedRef.current * 0.95);
+      const entryUntouched = prev.entryPrice === lastSeedRef.current;
+      const stopUntouched = prev.stopLossPrice === undefined || prev.stopLossPrice === prevSeedStop;
+      lastSeedRef.current = lastClose;
+      if (!entryUntouched && !stopUntouched) return prev;
+      return {
+        ...prev,
+        entryPrice: entryUntouched ? lastClose : prev.entryPrice,
+        stopLossPrice:
+          prev.stopLossPrice === undefined
+            ? prev.stopLossPrice
+            : stopUntouched
+              ? seedStop
+              : prev.stopLossPrice,
+      };
+    });
+  }, [lastClose]);
+
+  const kellyStats = useMemo(
+    () => (lastBacktest ? deriveKellyStats(lastBacktest.trades) : null),
+    [lastBacktest],
+  );
+
+  // When a fresh backtest comes in, optionally seed Kelly inputs from its
+  // realised win/loss stats. The toggle gives the user an explicit opt-out
+  // in case they want to model a hypothetical strategy.
+  useEffect(() => {
+    if (!autoFromBacktest || !kellyStats) return;
+    setSizing((prev) => ({
+      ...prev,
+      winRate: kellyStats.winRate,
+      winLossRatio: kellyStats.winLossRatio,
+    }));
+  }, [autoFromBacktest, kellyStats]);
+
+  const sizingResult = useMemo(() => computeSizing(sizing, candles), [sizing, candles]);
+  const varResult = useMemo(() => computeVar(varInputs, candles), [varInputs, candles]);
+
+  return (
+    <div className="risk-panel">
+      <div className="pane-header">Risk</div>
+
+      <section className="risk-section">
+        <div className="risk-section-title">Position Sizing</div>
+
+        <div className="risk-tabs">
+          {SIZING_METHODS.map((m) => (
+            <button
+              type="button"
+              key={m.id}
+              className={`risk-tab${sizing.method === m.id ? " active" : ""}`}
+              onClick={() => setSizing((prev) => ({ ...prev, method: m.id }))}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="risk-inputs">
+          <NumInput
+            label="Account $"
+            value={sizing.accountSize}
+            min={100}
+            step={1000}
+            onChange={(v) => setSizing((prev) => ({ ...prev, accountSize: v }))}
+          />
+          <NumInput
+            label="Entry $"
+            value={sizing.entryPrice}
+            min={0.01}
+            step={0.01}
+            onChange={(v) => setSizing((prev) => ({ ...prev, entryPrice: v }))}
+          />
+
+          {sizing.method === "risk-based" && (
+            <>
+              <NumInput
+                label="Risk %"
+                value={sizing.riskPercent}
+                min={0.01}
+                max={50}
+                step={0.1}
+                onChange={(v) => setSizing((prev) => ({ ...prev, riskPercent: v }))}
+              />
+              <NumInput
+                label="Stop $"
+                value={sizing.stopLossPrice ?? 0}
+                min={0.01}
+                step={0.01}
+                onChange={(v) => setSizing((prev) => ({ ...prev, stopLossPrice: v }))}
+              />
+            </>
+          )}
+
+          {sizing.method === "atr-based" && (
+            <>
+              <NumInput
+                label="Risk %"
+                value={sizing.riskPercent}
+                min={0.01}
+                max={50}
+                step={0.1}
+                onChange={(v) => setSizing((prev) => ({ ...prev, riskPercent: v }))}
+              />
+              <NumInput
+                label="ATR period"
+                value={sizing.atrPeriod}
+                min={2}
+                max={100}
+                step={1}
+                integer
+                onChange={(v) => setSizing((prev) => ({ ...prev, atrPeriod: v }))}
+              />
+              <NumInput
+                label="× ATR"
+                value={sizing.atrMultiplier}
+                min={0.1}
+                max={10}
+                step={0.1}
+                onChange={(v) => setSizing((prev) => ({ ...prev, atrMultiplier: v }))}
+              />
+            </>
+          )}
+
+          {sizing.method === "kelly" && (
+            <>
+              <NumInput
+                label="Win rate"
+                value={sizing.winRate}
+                min={0}
+                max={1}
+                step={0.01}
+                onChange={(v) => setSizing((prev) => ({ ...prev, winRate: v }))}
+              />
+              <NumInput
+                label="Win/Loss"
+                value={sizing.winLossRatio}
+                min={0.01}
+                step={0.05}
+                onChange={(v) => setSizing((prev) => ({ ...prev, winLossRatio: v }))}
+              />
+              <NumInput
+                label="Fraction"
+                value={sizing.kellyFraction}
+                min={0.05}
+                max={1}
+                step={0.05}
+                onChange={(v) => setSizing((prev) => ({ ...prev, kellyFraction: v }))}
+              />
+            </>
+          )}
+        </div>
+
+        {sizing.method === "kelly" && (
+          <label className="risk-checkbox">
+            <input
+              type="checkbox"
+              checked={autoFromBacktest}
+              onChange={(e) => setAutoFromBacktest(e.target.checked)}
+            />
+            <span>
+              Sync from backtest
+              {kellyStats && (
+                <span className="risk-hint"> ({kellyStats.sampleSize} decided trades)</span>
+              )}
+              {!kellyStats && <span className="risk-hint"> (run backtest to enable)</span>}
+            </span>
+          </label>
+        )}
+
+        <div className="risk-result">
+          {sizingResult.kind === "error" ? (
+            <div className="risk-error">{sizingResult.message}</div>
+          ) : (
+            <>
+              <RiskMetric label="Shares" value={sizingResult.result.shares.toLocaleString()} />
+              <RiskMetric label="Position" value={formatMoney(sizingResult.result.positionValue)} />
+              <RiskMetric
+                label="Risk"
+                value={`${formatMoney(sizingResult.result.riskAmount)} (${sizingResult.result.riskPercent.toFixed(2)}%)`}
+              />
+              {sizingResult.result.stopPrice != null && (
+                <RiskMetric label="Stop" value={`$${sizingResult.result.stopPrice.toFixed(2)}`} />
+              )}
+              {sizingResult.atrValue != null && (
+                <RiskMetric label="ATR" value={sizingResult.atrValue.toFixed(2)} />
+              )}
+            </>
+          )}
+        </div>
+      </section>
+
+      <section className="risk-section">
+        <div className="risk-section-title">VaR / CVaR</div>
+
+        <div className="risk-tabs">
+          {VAR_METHODS.map((m) => (
+            <button
+              type="button"
+              key={m.id}
+              className={`risk-tab${varInputs.method === m.id ? " active" : ""}`}
+              onClick={() => setVarInputs((prev) => ({ ...prev, method: m.id }))}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="risk-inputs">
+          <NumInput
+            label="Confidence"
+            value={varInputs.confidence}
+            min={0.5}
+            max={0.999}
+            step={0.005}
+            onChange={(v) => setVarInputs((prev) => ({ ...prev, confidence: v }))}
+          />
+          <NumInput
+            label="Lookback bars"
+            value={varInputs.lookback}
+            min={20}
+            max={1000}
+            step={10}
+            integer
+            onChange={(v) => setVarInputs((prev) => ({ ...prev, lookback: v }))}
+          />
+        </div>
+
+        <div className="risk-result">
+          {varResult.kind === "error" ? (
+            <div className="risk-error">{varResult.message}</div>
+          ) : (
+            <>
+              <RiskMetric
+                label={`VaR ${(varInputs.confidence * 100).toFixed(1)}%`}
+                value={formatPercent(varResult.result.var * 100)}
+                tone="bad"
+              />
+              <RiskMetric
+                label="CVaR"
+                value={formatPercent(varResult.result.cvar * 100)}
+                tone="bad"
+              />
+              <RiskMetric label="Obs" value={String(varResult.returnsCount)} />
+              <RiskMetric label="Skew" value={varResult.result.skewness.toFixed(2)} />
+              <RiskMetric label="Kurt" value={varResult.result.kurtosis.toFixed(2)} />
+            </>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+type NumInputProps = {
+  label: string;
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  integer?: boolean;
+  onChange: (v: number) => void;
+};
+
+function NumInput({ label, value, min, max, step, integer, onChange }: NumInputProps) {
+  return (
+    <label className="risk-input">
+      <span>{label}</span>
+      <input
+        type="number"
+        value={Number.isFinite(value) ? value : ""}
+        min={min}
+        max={max}
+        step={step}
+        onChange={(e) => {
+          const raw = e.target.value;
+          if (raw === "") return;
+          const n = integer ? Number.parseInt(raw, 10) : Number.parseFloat(raw);
+          if (Number.isFinite(n)) onChange(n);
+        }}
+      />
+    </label>
+  );
+}
+
+function RiskMetric({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone?: "good" | "bad";
+}) {
+  return (
+    <div className={`metric${tone ? ` ${tone}` : ""}`}>
+      <div className="metric-label">{label}</div>
+      <div className="metric-value">{value}</div>
+    </div>
+  );
+}
+
+function formatMoney(v: number): string {
+  if (!Number.isFinite(v)) return "—";
+  const sign = v < 0 ? "-" : "";
+  return `${sign}$${Math.abs(v).toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+}
+
+function formatPercent(v: number): string {
+  if (!Number.isFinite(v)) return "—";
+  return `${v.toFixed(2)}%`;
+}

--- a/packages/chart/examples/strategy-studio/src/styles.css
+++ b/packages/chart/examples/strategy-studio/src/styles.css
@@ -1000,3 +1000,127 @@ button.ghost.danger:hover {
 .signal-count.signal-count--warn {
   background: rgba(239, 83, 80, 0.35);
 }
+
+/* ---------- Risk panel ---------- */
+
+.risk-panel {
+  display: flex;
+  flex-direction: column;
+}
+
+.risk-section {
+  padding: 10px 12px 12px;
+  border-bottom: 1px solid #1e222d;
+}
+
+.risk-section:last-child {
+  border-bottom: none;
+}
+
+.risk-section-title {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #787b86;
+  margin-bottom: 8px;
+}
+
+.risk-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.risk-tab {
+  flex: 1;
+  padding: 4px 6px;
+  font-size: 11px;
+  background: #0e1320;
+  border: 1px solid #2a2e39;
+  color: #d1d4dc;
+  border-radius: 3px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.risk-tab:hover {
+  border-color: #3a3e49;
+}
+
+.risk-tab.active {
+  background: #2196f3;
+  border-color: #2196f3;
+  color: #fff;
+}
+
+.risk-inputs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.risk-input {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.risk-input span {
+  font-size: 10px;
+  color: #787b86;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.risk-input input {
+  background: #0a0e17;
+  border: 1px solid #2a2e39;
+  color: #d1d4dc;
+  border-radius: 3px;
+  padding: 4px 6px;
+  font-size: 12px;
+  font-family: inherit;
+  font-variant-numeric: tabular-nums;
+  width: 100%;
+}
+
+.risk-input input:focus {
+  outline: none;
+  border-color: #2196f3;
+}
+
+.risk-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: #d1d4dc;
+  margin-bottom: 8px;
+  cursor: pointer;
+}
+
+.risk-checkbox input {
+  cursor: pointer;
+}
+
+.risk-hint {
+  color: #787b86;
+}
+
+.risk-result {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.risk-error {
+  grid-column: 1 / -1;
+  font-size: 11px;
+  color: #ef5350;
+  padding: 6px 8px;
+  border: 1px solid rgba(239, 83, 80, 0.3);
+  border-radius: 3px;
+  background: rgba(239, 83, 80, 0.08);
+}


### PR DESCRIPTION
## Summary

PR8 of the Strategy Studio epic. Adds a **RiskPanel** in the right pane (below ResultsSummary) that surfaces TrendCraft's risk-management primitives without leaving the demo:

- **Position Sizing** — Risk-% / ATR / Kelly tabs wrapping `riskBasedSize` / `atrBasedSize` / `kellySize`. Kelly inputs auto-seed from the latest backtest's realised win rate + avgWin/avgLoss (using `Trade.returnPercent` so scaled entries / partial exits don't bias the payoff ratio). A checkbox lets the user override.
- **VaR / CVaR** — historical / parametric / Cornish-Fisher tabs over `calculateVaR`, with confidence + lookback inputs and a returns-count readout.

Both sections are **playhead-aware**: they consume the same `backtestCandles` slice StrategyBuilder runs against, so risk numbers match what's on the chart.

## Implementation notes

- Entry / stop auto-seed only when the user hasn't overridden them (tracked via `lastSeedRef`). Skips the no-op state update when the playhead doesn't move the close price — avoids per-tick re-render churn during Replay playback.
- ATR mode bails gracefully when the slice is shorter than `period + 1` (TR[0] needs a previous close).
- VaR returns reuse core's `returns()` helper rather than a hand-rolled loop.

## Review notes

- `/simplify` round: P1 fixes applied (override-defeating effect, redundant kind narrowing, type re-export wall, hand-rolled returns loop).
- `/codex:review` round: addressed the [P2] Kelly stats finding — switched from `Trade.return` (dollar P/L) to `Trade.returnPercent` (size-independent) in `deriveKellyStats`.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — all green (chart 781, core 4865, mcp 59, studio 15)
- [x] `pnpm build` — workspace builds
- [x] Manual: open Studio, run backtest, verify Kelly auto-fills sensible values; switch to ATR tab, confirm ATR readout reacts to playhead; switch VaR method tabs, confirm CVaR ≥ VaR.

Carved out for PR9: MetaStrategyPanel.