### PR TITLE
feat(strategy-studio): MetaStrategyPanel with equity curve filter + rotation (PR9)

### DIFF
--- a/packages/chart/examples/strategy-studio/README.md
+++ b/packages/chart/examples/strategy-studio/README.md
@@ -26,8 +26,8 @@ The studio runs **fully offline with no LLM key**. It uses `detectMarketRegime` 
 | PR5 | Replay mode — click-to-anchor, play/pause/step/speed, snapshot backtest | done |
 | PR6 | SignalsPanel — cross/divergence/pattern signal detection + markers | done |
 | PR7 | PluginsPanel — SMC / Pitchfork / Volume Profile / Wyckoff plugin toggles | done |
-| PR8 | RiskPanel — position sizing (Risk-%/ATR/Kelly) + VaR/CVaR | **this PR** |
-| PR9 | MetaStrategyPanel — equity curve trading + strategy rotation | |
+| PR8 | RiskPanel — position sizing (Risk-%/ATR/Kelly) + VaR/CVaR | done |
+| PR9 | MetaStrategyPanel — equity curve filter + strategy rotation | **this PR** |
 | PR10 | PortfolioPanel — `batchBacktest` + multi-symbol allocation | |
 | PR11 | ScoringPanel — signal scoring visualization | |
 | PR12 | OptimizationPanel — grid search + walk-forward UI | |

--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -12,6 +12,7 @@ import { sampleCandles } from "./lib/sample-data";
 import { SIGNAL_BY_KIND } from "./lib/signals";
 import { builderReducer, initialBuilderState, strategyJSONToState } from "./lib/strategy-state";
 import { KIND_TO_PRESET_KEY, localStudioAPI } from "./lib/studio-api";
+import { MetaStrategyPanel } from "./panels/MetaStrategyPanel";
 import { ParamPopover } from "./panels/ParamPopover";
 import { PluginsPanel } from "./panels/PluginsPanel";
 import { PresetSelector } from "./panels/PresetSelector";
@@ -676,6 +677,12 @@ export function App() {
         <ResultsSummary result={runner.state.lastResult?.result} />
         <div className="pane-divider" />
         <RiskPanel candles={backtestCandles} lastBacktest={runner.state.lastResult?.result} />
+        <div className="pane-divider" />
+        <MetaStrategyPanel
+          lastResult={runner.state.lastResult?.result}
+          candles={backtestCandles}
+          isReplayPlaying={replay.mode === "live" && replay.status === "playing"}
+        />
       </aside>
 
       {popoverState && popoverInstance && (

--- a/packages/chart/examples/strategy-studio/src/components/NumInput.tsx
+++ b/packages/chart/examples/strategy-studio/src/components/NumInput.tsx
@@ -1,0 +1,30 @@
+type NumInputProps = {
+  label: string;
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  integer?: boolean;
+  onChange: (v: number) => void;
+};
+
+export function NumInput({ label, value, min, max, step, integer, onChange }: NumInputProps) {
+  return (
+    <label className="risk-input">
+      <span>{label}</span>
+      <input
+        type="number"
+        value={Number.isFinite(value) ? value : ""}
+        min={min}
+        max={max}
+        step={step}
+        onChange={(e) => {
+          const raw = e.target.value;
+          if (raw === "") return;
+          const n = integer ? Number.parseInt(raw, 10) : Number.parseFloat(raw);
+          if (Number.isFinite(n)) onChange(n);
+        }}
+      />
+    </label>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/lib/__tests__/meta-strategy.test.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/__tests__/meta-strategy.test.ts
@@ -1,0 +1,118 @@
+import type { BacktestResult, Trade } from "trendcraft";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_FILTER_INPUTS,
+  DEFAULT_ROTATION_INPUTS,
+  type RotationSlot,
+  buildRotation,
+  computeFilter,
+} from "../meta-strategy";
+
+function makeTrade(returnPct: number, idx: number): Trade {
+  const entryTime = 1700000000000 + idx * 86400000;
+  return {
+    entryTime,
+    entryPrice: 100,
+    exitTime: entryTime + 86400000,
+    exitPrice: 100 * (1 + returnPct / 100),
+    return: 1000 * (returnPct / 100),
+    returnPercent: returnPct,
+    holdingDays: 1,
+  };
+}
+
+function makeResult(returnsPct: number[], capital = 100_000): BacktestResult {
+  const trades = returnsPct.map((r, i) => makeTrade(r, i));
+  const totalReturn = trades.reduce((s, t) => s + t.return, 0);
+  const wins = trades.filter((t) => t.return > 0).length;
+  return {
+    initialCapital: capital,
+    finalCapital: capital + totalReturn,
+    totalReturn,
+    totalReturnPercent: (totalReturn / capital) * 100,
+    tradeCount: trades.length,
+    winRate: trades.length > 0 ? (wins / trades.length) * 100 : 0,
+    maxDrawdown: 5,
+    sharpeRatio: 1,
+    profitFactor: 2,
+    avgHoldingDays: 1,
+    trades,
+    settings: {
+      fillMode: "same-bar-close",
+      slTpMode: "close-only",
+      direction: "long",
+      slippage: 0,
+      commission: 0,
+      commissionRate: 0,
+      taxRate: 0,
+    },
+    drawdownPeriods: [],
+  };
+}
+
+describe("computeFilter", () => {
+  it("returns empty for missing or trade-less results", () => {
+    expect(computeFilter(undefined, DEFAULT_FILTER_INPUTS).kind).toBe("empty");
+    expect(computeFilter(makeResult([]), DEFAULT_FILTER_INPUTS).kind).toBe("empty");
+  });
+
+  it("produces an analysis + health for non-empty results", () => {
+    const result = makeResult([5, -3, 7, -2, 4, -1, 6, 2, -4, 3]);
+    const out = computeFilter(result, DEFAULT_FILTER_INPUTS);
+    if (out.kind !== "ok") throw new Error(`expected ok, got ${out.kind}`);
+    expect(out.analysis.original).toBe(result);
+    expect(out.analysis.filtered.trades.length).toBeLessThanOrEqual(result.trades.length);
+    expect(out.health.healthScore).toBeGreaterThanOrEqual(0);
+    expect(out.health.healthScore).toBeLessThanOrEqual(100);
+  });
+});
+
+describe("buildRotation", () => {
+  function slot(label: string, returns: number[]): RotationSlot {
+    return { label, source: "demo", result: makeResult(returns) };
+  }
+
+  it("returns empty for empty slot list", () => {
+    expect(buildRotation([], DEFAULT_ROTATION_INPUTS).kind).toBe("empty");
+  });
+
+  it("allocations sum to 1 (proportional, all positive)", () => {
+    const slots = [slot("A", [5, 3, 4]), slot("B", [2, 1, 2]), slot("C", [6, 5, 4])];
+    const out = buildRotation(slots, { ...DEFAULT_ROTATION_INPUTS, allocation: "proportional" });
+    if (out.kind !== "ok") throw new Error("expected ok");
+    const total = out.rotation.allocations.reduce((s, a) => s + a.weight, 0);
+    expect(total).toBeCloseTo(1, 6);
+  });
+
+  it("allocations sum to 1 (equal)", () => {
+    const slots = [slot("A", [1]), slot("B", [-1]), slot("C", [2])];
+    const out = buildRotation(slots, { ...DEFAULT_ROTATION_INPUTS, allocation: "equal" });
+    if (out.kind !== "ok") throw new Error("expected ok");
+    const total = out.rotation.allocations.reduce((s, a) => s + a.weight, 0);
+    expect(total).toBeCloseTo(1, 6);
+  });
+
+  it("higher-metric strategy ranks first", () => {
+    const slots = [slot("Low", [1, -1, 0.5]), slot("High", [10, 8, 9]), slot("Mid", [3, 2, 4])];
+    const out = buildRotation(slots, {
+      ...DEFAULT_ROTATION_INPUTS,
+      metric: "returnPercent",
+      allocation: "proportional",
+    });
+    if (out.kind !== "ok") throw new Error("expected ok");
+    expect(out.rotation.rankings[0]).toBe(1); // "High"
+  });
+
+  it("respects maxActive cap", () => {
+    const slots = [slot("A", [5, 4]), slot("B", [3, 2]), slot("C", [-1, -2])];
+    const out = buildRotation(slots, {
+      ...DEFAULT_ROTATION_INPUTS,
+      allocation: "topN",
+      maxActive: 2,
+    });
+    if (out.kind !== "ok") throw new Error("expected ok");
+    // topN with 2 active → exactly 2 non-zero weights
+    const nonZero = out.rotation.allocations.filter((a) => a.weight > 0);
+    expect(nonZero.length).toBe(2);
+  });
+});

--- a/packages/chart/examples/strategy-studio/src/lib/demo-strategies.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/demo-strategies.ts
@@ -1,0 +1,50 @@
+import type { StrategyJSON } from "trendcraft";
+
+/**
+ * Three baseline strategies the rotation panel runs against the same candle
+ * slice so the user can see meaningful allocation differences without having
+ * to compose multiple strategies in StrategyBuilder.
+ *
+ * All conditions resolve through `backtestRegistry` so the JSON round-trips
+ * cleanly through `parseStrategy` / `loadStrategy` (see lib/strategy-state).
+ */
+
+export const GOLDEN_CROSS_STRATEGY: StrategyJSON = {
+  $schema: "trendcraft/strategy",
+  version: 1,
+  id: "demo-golden-cross",
+  name: "Golden Cross 5/25",
+  entry: { name: "goldenCross", params: { shortPeriod: 5, longPeriod: 25 } },
+  exit: { name: "deadCross", params: { shortPeriod: 5, longPeriod: 25 } },
+  backtest: { capital: 100_000 },
+};
+
+export const MEAN_REVERSION_STRATEGY: StrategyJSON = {
+  $schema: "trendcraft/strategy",
+  version: 1,
+  id: "demo-mean-reversion",
+  name: "RSI Mean Reversion",
+  entry: { name: "rsiBelow", params: { threshold: 30, period: 14 } },
+  exit: { name: "rsiAbove", params: { threshold: 60, period: 14 } },
+  backtest: { capital: 100_000 },
+};
+
+// `rsiBelow(100)` is true once RSI is defined and `rsiAbove(100)` never fires
+// — together they approximate "buy on first valid bar, never exit" without
+// needing an `alwaysTrue` condition (which isn't registered in the public
+// registry).
+export const BUY_AND_HOLD_STRATEGY: StrategyJSON = {
+  $schema: "trendcraft/strategy",
+  version: 1,
+  id: "demo-buy-and-hold",
+  name: "Buy and Hold",
+  entry: { name: "rsiBelow", params: { threshold: 100, period: 14 } },
+  exit: { name: "rsiAbove", params: { threshold: 100, period: 14 } },
+  backtest: { capital: 100_000 },
+};
+
+export const DEMO_STRATEGIES: ReadonlyArray<StrategyJSON> = [
+  GOLDEN_CROSS_STRATEGY,
+  MEAN_REVERSION_STRATEGY,
+  BUY_AND_HOLD_STRATEGY,
+];

--- a/packages/chart/examples/strategy-studio/src/lib/meta-strategy.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/meta-strategy.ts
@@ -1,0 +1,174 @@
+import {
+  type BacktestOptions,
+  type BacktestResult,
+  type EquityCurveAnalysis,
+  type EquityCurveFilterType,
+  type EquityCurveHealthResult,
+  type StrategyJSON,
+  type StrategyPerformanceMetric,
+  type StrategyRotationOptions,
+  type StrategyRotationResult,
+  applyEquityCurveFilter,
+  backtestRegistry,
+  equityCurveHealth,
+  loadStrategy,
+  normalizeCandles,
+  rotateStrategies,
+  runBacktest,
+} from "trendcraft";
+import type { StudioCandle } from "./sample-data";
+
+/**
+ * Project the runtime settings of a finished backtest onto a `BacktestOptions`
+ * shape so demo strategies can be re-run with the same assumptions. Without
+ * this, the user's strategy and the demos compete with different stop/TP/
+ * commission/slippage rules and the rotation ranking measures the settings
+ * difference, not the strategy edge.
+ */
+export function overridesFromResult(result: BacktestResult): Partial<BacktestOptions> {
+  return {
+    capital: result.initialCapital,
+    direction: result.settings.direction,
+    stopLoss: result.settings.stopLoss,
+    takeProfit: result.settings.takeProfit,
+    trailingStop: result.settings.trailingStop,
+    fillMode: result.settings.fillMode,
+    slTpMode: result.settings.slTpMode,
+    slippage: result.settings.slippage,
+    commission: result.settings.commission,
+    commissionRate: result.settings.commissionRate,
+    taxRate: result.settings.taxRate,
+  };
+}
+
+export type AllocationMethod = NonNullable<StrategyRotationOptions["allocationMethod"]>;
+
+export type FilterInputs = {
+  type: EquityCurveFilterType;
+  maPeriod: number;
+  maxDrawdown: number;
+  minWinRate: number;
+  filteredSizeFactor: number;
+};
+
+export const DEFAULT_FILTER_INPUTS: FilterInputs = {
+  type: "ma",
+  maPeriod: 10,
+  maxDrawdown: 0.15,
+  minWinRate: 0.4,
+  filteredSizeFactor: 0,
+};
+
+export type RotationInputs = {
+  metric: StrategyPerformanceMetric;
+  lookbackTrades: number;
+  allocation: AllocationMethod;
+  maxActive: number;
+};
+
+export const DEFAULT_ROTATION_INPUTS: RotationInputs = {
+  metric: "returnPercent",
+  lookbackTrades: 20,
+  allocation: "proportional",
+  maxActive: 3,
+};
+
+export type FilterComputation =
+  | { kind: "ok"; analysis: EquityCurveAnalysis; health: EquityCurveHealthResult }
+  | { kind: "empty" }
+  | { kind: "error"; message: string };
+
+export function computeFilter(
+  result: BacktestResult | undefined,
+  inputs: FilterInputs,
+): FilterComputation {
+  if (!result) return { kind: "empty" };
+  if (result.trades.length === 0) return { kind: "empty" };
+  try {
+    const analysis = applyEquityCurveFilter(result, {
+      type: inputs.type,
+      maPeriod: inputs.maPeriod,
+      maxDrawdown: inputs.maxDrawdown,
+      minWinRate: inputs.minWinRate,
+      filteredSizeFactor: inputs.filteredSizeFactor,
+    });
+    const health = equityCurveHealth(result, { maPeriod: inputs.maPeriod });
+    return { kind: "ok", analysis, health };
+  } catch (err) {
+    return { kind: "error", message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export type RotationSlot = {
+  /** Display label shown in the panel — "Slot 1: your strategy" etc. */
+  label: string;
+  /** Source: "user" when fed from the live builder, "demo" for hardcoded. */
+  source: "user" | "demo";
+  result: BacktestResult;
+};
+
+export type RotationComputation =
+  | {
+      kind: "ok";
+      slots: RotationSlot[];
+      rotation: StrategyRotationResult;
+    }
+  | { kind: "empty" }
+  | { kind: "error"; message: string };
+
+export type DemoBacktest = {
+  strategy: StrategyJSON;
+  result: BacktestResult;
+};
+
+/**
+ * Run each demo strategy against the candle slice and pair every result back
+ * with its source strategy. The pairing matters: the panel labels rows from
+ * `strategy.name`, so a `BacktestResult[]` that silently dropped a failed
+ * strategy would shift labels and mislead the user.
+ *
+ * `overrides` lets the caller force shared backtest assumptions (stops,
+ * commission, fill mode, etc.) so the rotation comparison is apples-to-apples
+ * with the user's strategy. Demo-specific defaults from each `strategy.json`
+ * sit underneath; overrides win on conflict.
+ */
+export function runDemoBacktests(
+  candles: StudioCandle[],
+  demos: ReadonlyArray<StrategyJSON>,
+  overrides: Partial<BacktestOptions> = {},
+): DemoBacktest[] {
+  const normalized = normalizeCandles(candles);
+  const out: DemoBacktest[] = [];
+  for (const strategy of demos) {
+    try {
+      const { entry, exit, backtestOptions } = loadStrategy(strategy, backtestRegistry);
+      const result = runBacktest(normalized, entry, exit, {
+        capital: 100_000,
+        ...backtestOptions,
+        ...overrides,
+      });
+      out.push({ strategy, result });
+    } catch (err) {
+      console.warn(`[strategy-studio] Demo backtest failed for ${strategy.name}:`, err);
+    }
+  }
+  return out;
+}
+
+export function buildRotation(slots: RotationSlot[], inputs: RotationInputs): RotationComputation {
+  if (slots.length === 0) return { kind: "empty" };
+  try {
+    const rotation = rotateStrategies(
+      slots.map((s) => s.result),
+      {
+        rankingMetric: inputs.metric,
+        lookbackTrades: inputs.lookbackTrades,
+        allocationMethod: inputs.allocation,
+        maxActiveStrategies: Math.min(inputs.maxActive, slots.length),
+      },
+    );
+    return { kind: "ok", slots, rotation };
+  } catch (err) {
+    return { kind: "error", message: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/packages/chart/examples/strategy-studio/src/panels/MetaStrategyPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/MetaStrategyPanel.tsx
@@ -1,0 +1,358 @@
+import { useEffect, useMemo, useState } from "react";
+import type { BacktestResult, EquityCurveFilterType, StrategyPerformanceMetric } from "trendcraft";
+import { NumInput } from "../components/NumInput";
+import { DEMO_STRATEGIES } from "../lib/demo-strategies";
+import {
+  type AllocationMethod,
+  DEFAULT_FILTER_INPUTS,
+  DEFAULT_ROTATION_INPUTS,
+  type DemoBacktest,
+  type FilterInputs,
+  type RotationInputs,
+  type RotationSlot,
+  buildRotation,
+  computeFilter,
+  overridesFromResult,
+  runDemoBacktests,
+} from "../lib/meta-strategy";
+import type { StudioCandle } from "../lib/sample-data";
+
+type Props = {
+  /** User's most recent backtest result (Slot 1 source when present). */
+  lastResult: BacktestResult | undefined;
+  /** Playhead-aware candle slice; same source the StrategyBuilder runs on. */
+  candles: StudioCandle[];
+  /** True while Replay is actively playing — used to freeze rotation work. */
+  isReplayPlaying: boolean;
+};
+
+const FILTER_TYPES: ReadonlyArray<{ id: EquityCurveFilterType; label: string }> = [
+  { id: "ma", label: "MA" },
+  { id: "drawdown", label: "Drawdown" },
+  { id: "winRate", label: "Win Rate" },
+  { id: "combined", label: "Combined" },
+];
+
+const ROTATION_METRICS: ReadonlyArray<{ id: StrategyPerformanceMetric; label: string }> = [
+  { id: "returnPercent", label: "Return" },
+  { id: "sharpeRatio", label: "Sharpe" },
+  { id: "profitFactor", label: "PF" },
+  { id: "winRate", label: "Win %" },
+];
+
+const ALLOCATIONS: ReadonlyArray<{ id: AllocationMethod; label: string }> = [
+  { id: "proportional", label: "Proportional" },
+  { id: "equal", label: "Equal" },
+  { id: "topN", label: "Top N" },
+];
+
+export function MetaStrategyPanel({ lastResult, candles, isReplayPlaying }: Props) {
+  const [filter, setFilter] = useState<FilterInputs>(DEFAULT_FILTER_INPUTS);
+  const [rotation, setRotation] = useState<RotationInputs>(DEFAULT_ROTATION_INPUTS);
+
+  const filterResult = useMemo(() => computeFilter(lastResult, filter), [lastResult, filter]);
+
+  // Demo backtests are heavy (3 backtests over up to 1000 bars). The freeze-
+  // during-playback gate keeps Max-speed Replay (~125 ticks/sec) responsive;
+  // the user gets fresh results the moment they pause/step/exit. We keep the
+  // results in `useState` (not `useRef`) so the recompute is committed via
+  // `setState` — writing to a ref inside `useMemo` would be StrictMode-unsafe
+  // (memos can run, get discarded, and re-run during concurrent rendering).
+  const candlesKey = candles.length;
+  // Use the user's actual backtest assumptions (stops, fill mode, commission,
+  // etc.) for the demos too — otherwise the rotation ranking measures the
+  // settings difference, not the strategy edge. When the user hasn't run yet
+  // the demos use their own JSON defaults, which is fine because there's no
+  // user strategy to compare against.
+  const overridesKey = lastResult
+    ? `${lastResult.initialCapital}|${lastResult.settings.stopLoss ?? ""}|${lastResult.settings.takeProfit ?? ""}|${lastResult.settings.trailingStop ?? ""}|${lastResult.settings.direction ?? ""}|${lastResult.settings.fillMode}|${lastResult.settings.slTpMode}|${lastResult.settings.slippage}|${lastResult.settings.commission}|${lastResult.settings.commissionRate}|${lastResult.settings.taxRate}`
+    : "";
+  const [demoResults, setDemoResults] = useState<DemoBacktest[]>([]);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: candlesKey + overridesKey are the deliberate triggers; `candles` (the array reference) and `lastResult` (a new object every Run) churn every Replay tick / re-render but their content-hashes don't, so we key off the hashes instead. Safe because Replay extends the slice monotonically.
+  useEffect(() => {
+    if (isReplayPlaying) return;
+    const overrides = lastResult ? overridesFromResult(lastResult) : {};
+    setDemoResults(runDemoBacktests(candles, DEMO_STRATEGIES, overrides));
+  }, [candlesKey, isReplayPlaying, overridesKey]);
+
+  // Slots pair the user's result (when present) with the surviving demos.
+  // We iterate `demoResults` (not `DEMO_STRATEGIES`) so a failed demo just
+  // produces a shorter list — labels never drift to a different strategy.
+  const slots = useMemo<RotationSlot[]>(() => {
+    const out: RotationSlot[] = [];
+    if (lastResult) {
+      out.push({ label: "Slot 1: your strategy", source: "user", result: lastResult });
+      for (const demo of demoResults) {
+        out.push({
+          label: `Slot ${out.length + 1}: ${demo.strategy.name} (demo)`,
+          source: "demo",
+          result: demo.result,
+        });
+      }
+    } else {
+      for (const demo of demoResults) {
+        out.push({
+          label: `Slot ${out.length + 1}: ${demo.strategy.name} (demo)`,
+          source: "demo",
+          result: demo.result,
+        });
+      }
+    }
+    return out;
+  }, [lastResult, demoResults]);
+
+  const rotationResult = useMemo(() => buildRotation(slots, rotation), [slots, rotation]);
+
+  return (
+    <div className="risk-panel">
+      <div className="pane-header">Meta-Strategy</div>
+
+      <section className="risk-section">
+        <div className="risk-section-title">Equity Curve Filter</div>
+
+        <div className="risk-tabs">
+          {FILTER_TYPES.map((t) => (
+            <button
+              type="button"
+              key={t.id}
+              className={`risk-tab${filter.type === t.id ? " active" : ""}`}
+              onClick={() => setFilter((prev) => ({ ...prev, type: t.id }))}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="risk-inputs">
+          {(filter.type === "ma" || filter.type === "combined") && (
+            <NumInput
+              label="MA period"
+              value={filter.maPeriod}
+              min={2}
+              max={100}
+              step={1}
+              integer
+              onChange={(v) => setFilter((prev) => ({ ...prev, maPeriod: v }))}
+            />
+          )}
+          {(filter.type === "drawdown" || filter.type === "combined") && (
+            <NumInput
+              label="Max DD"
+              value={filter.maxDrawdown}
+              min={0.01}
+              max={0.95}
+              step={0.01}
+              onChange={(v) => setFilter((prev) => ({ ...prev, maxDrawdown: v }))}
+            />
+          )}
+          {(filter.type === "winRate" || filter.type === "combined") && (
+            <NumInput
+              label="Min WR"
+              value={filter.minWinRate}
+              min={0}
+              max={1}
+              step={0.05}
+              onChange={(v) => setFilter((prev) => ({ ...prev, minWinRate: v }))}
+            />
+          )}
+          <NumInput
+            label="Size factor"
+            value={filter.filteredSizeFactor}
+            min={0}
+            max={1}
+            step={0.05}
+            onChange={(v) => setFilter((prev) => ({ ...prev, filteredSizeFactor: v }))}
+          />
+        </div>
+
+        <FilterResult result={filterResult} />
+      </section>
+
+      <section className="risk-section">
+        <div className="risk-section-title">Strategy Rotation</div>
+
+        <div className="risk-tabs">
+          {ROTATION_METRICS.map((m) => (
+            <button
+              type="button"
+              key={m.id}
+              className={`risk-tab${rotation.metric === m.id ? " active" : ""}`}
+              onClick={() => setRotation((prev) => ({ ...prev, metric: m.id }))}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="risk-inputs">
+          <NumInput
+            label="Lookback"
+            value={rotation.lookbackTrades}
+            min={1}
+            max={500}
+            step={1}
+            integer
+            onChange={(v) => setRotation((prev) => ({ ...prev, lookbackTrades: v }))}
+          />
+          <NumInput
+            label="Max active"
+            value={rotation.maxActive}
+            min={1}
+            max={Math.max(1, slots.length)}
+            step={1}
+            integer
+            onChange={(v) => setRotation((prev) => ({ ...prev, maxActive: v }))}
+          />
+        </div>
+
+        <div className="risk-tabs">
+          {ALLOCATIONS.map((a) => (
+            <button
+              type="button"
+              key={a.id}
+              className={`risk-tab${rotation.allocation === a.id ? " active" : ""}`}
+              onClick={() => setRotation((prev) => ({ ...prev, allocation: a.id }))}
+            >
+              {a.label}
+            </button>
+          ))}
+        </div>
+
+        <RotationResult
+          result={rotationResult}
+          metric={rotation.metric}
+          isReplayPlaying={isReplayPlaying}
+        />
+      </section>
+    </div>
+  );
+}
+
+function FilterResult({ result }: { result: ReturnType<typeof computeFilter> }) {
+  if (result.kind === "empty") {
+    return <div className="meta-strategy-caption">Run a backtest to see filter improvement.</div>;
+  }
+  if (result.kind === "error") {
+    return <div className="risk-error">{result.message}</div>;
+  }
+  const { analysis, health } = result;
+  return (
+    <>
+      <div className="risk-result">
+        <DeltaMetric label="Δ Sharpe" delta={analysis.improvement.sharpeRatio} digits={2} />
+        {/* `improvement.maxDrawdown` is already in the same units as
+            `original.maxDrawdown` (percent points from `runBacktest`); no
+            extra ×100. Note: `filtered.maxDrawdown` from core's rebuildResult
+            uses decimal units so the absolute filtered value is tiny here —
+            we display the delta, not the absolute filtered DD. */}
+        <DeltaMetric label="Δ MaxDD" delta={analysis.improvement.maxDrawdown} digits={2} unit="%" />
+        <DeltaMetric
+          label="Δ Return"
+          delta={analysis.improvement.returnPercent}
+          digits={2}
+          unit="%"
+        />
+        <DeltaMetric label="Δ PF" delta={analysis.improvement.profitFactor} digits={2} />
+      </div>
+      <div className="meta-strategy-caption">
+        Skipped {analysis.tradesSkipped}/{analysis.original.trades.length} trades · health{" "}
+        {health.healthScore}/100
+        {health.aboveMa ? " · above MA" : " · below MA"} · DD{" "}
+        {(health.currentDrawdown * 100).toFixed(1)}%
+      </div>
+    </>
+  );
+}
+
+function RotationResult({
+  result,
+  metric,
+  isReplayPlaying,
+}: {
+  result: ReturnType<typeof buildRotation>;
+  metric: StrategyPerformanceMetric;
+  isReplayPlaying: boolean;
+}) {
+  if (result.kind === "empty") {
+    return <div className="meta-strategy-caption">Computing rotation…</div>;
+  }
+  if (result.kind === "error") {
+    return <div className="risk-error">{result.message}</div>;
+  }
+  const { slots, rotation } = result;
+  const allocByIdx = new Map(rotation.allocations.map((a) => [a.strategyIndex, a]));
+  return (
+    <>
+      <table className="rotation-table">
+        <tbody>
+          {slots.map((slot, idx) => {
+            const alloc = allocByIdx.get(idx);
+            const weight = alloc?.weight ?? 0;
+            return (
+              <tr key={slot.label}>
+                <td className="rotation-name">{slot.label}</td>
+                <td className="rotation-metric">{formatMetric(alloc?.metricValue, metric)}</td>
+                <td className="rotation-weight">
+                  <div className="weight-bar">
+                    <div
+                      className="weight-bar-fill"
+                      style={{ width: `${(weight * 100).toFixed(1)}%` }}
+                    />
+                  </div>
+                  <span className="weight-label">{(weight * 100).toFixed(0)}%</span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      <div className="meta-strategy-caption">
+        {rotation.activeCount} active of {slots.length}
+        {isReplayPlaying ? " · frozen during playback" : ""}
+      </div>
+    </>
+  );
+}
+
+function DeltaMetric({
+  label,
+  delta,
+  digits,
+  unit = "",
+}: {
+  label: string;
+  delta: number;
+  digits: number;
+  unit?: string;
+}) {
+  if (!Number.isFinite(delta)) {
+    return (
+      <div className="metric">
+        <div className="metric-label">{label}</div>
+        <div className="metric-value">—</div>
+      </div>
+    );
+  }
+  // For Δ MaxDD, lower drawdown is "good"; the wrapper passes the delta as
+  // `original - filtered` (so a positive delta means the filter reduced DD).
+  // Color all positive deltas green for consistency.
+  const tone = delta > 0 ? "good" : delta < 0 ? "bad" : undefined;
+  const sign = delta > 0 ? "+" : "";
+  return (
+    <div className={`metric${tone ? ` ${tone}` : ""}`}>
+      <div className="metric-label">{label}</div>
+      <div className="metric-value">
+        {sign}
+        {delta.toFixed(digits)}
+        {unit}
+      </div>
+    </div>
+  );
+}
+
+function formatMetric(value: number | undefined, metric: StrategyPerformanceMetric): string {
+  if (value === undefined || !Number.isFinite(value)) return "—";
+  if (metric === "winRate") return `${(value * 100).toFixed(0)}%`;
+  if (metric === "returnPercent") return `${value.toFixed(1)}%`;
+  return value.toFixed(2);
+}

--- a/packages/chart/examples/strategy-studio/src/panels/RiskPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/RiskPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { BacktestResult } from "trendcraft";
+import { NumInput } from "../components/NumInput";
 import {
   DEFAULT_VAR_INPUTS,
   type SizingInputs,
@@ -300,37 +301,6 @@ export function RiskPanel({ candles, lastBacktest }: Props) {
         </div>
       </section>
     </div>
-  );
-}
-
-type NumInputProps = {
-  label: string;
-  value: number;
-  min?: number;
-  max?: number;
-  step?: number;
-  integer?: boolean;
-  onChange: (v: number) => void;
-};
-
-function NumInput({ label, value, min, max, step, integer, onChange }: NumInputProps) {
-  return (
-    <label className="risk-input">
-      <span>{label}</span>
-      <input
-        type="number"
-        value={Number.isFinite(value) ? value : ""}
-        min={min}
-        max={max}
-        step={step}
-        onChange={(e) => {
-          const raw = e.target.value;
-          if (raw === "") return;
-          const n = integer ? Number.parseInt(raw, 10) : Number.parseFloat(raw);
-          if (Number.isFinite(n)) onChange(n);
-        }}
-      />
-    </label>
   );
 }
 

--- a/packages/chart/examples/strategy-studio/src/styles.css
+++ b/packages/chart/examples/strategy-studio/src/styles.css
@@ -1124,3 +1124,73 @@ button.ghost.danger:hover {
   border-radius: 3px;
   background: rgba(239, 83, 80, 0.08);
 }
+
+/* ---------- Meta-Strategy panel ---------- */
+
+.meta-strategy-caption {
+  font-size: 10px;
+  color: #787b86;
+  margin-top: 6px;
+  line-height: 1.4;
+}
+
+.rotation-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.rotation-table td {
+  padding: 4px 4px;
+  border-bottom: 1px solid #1e222d;
+  vertical-align: middle;
+}
+
+.rotation-table tr:last-child td {
+  border-bottom: none;
+}
+
+.rotation-name {
+  color: #d1d4dc;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 0;
+  width: 50%;
+}
+
+.rotation-metric {
+  color: #787b86;
+  text-align: right;
+  width: 50px;
+}
+
+.rotation-weight {
+  width: 40%;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.weight-bar {
+  flex: 1;
+  height: 6px;
+  background: #0e1320;
+  border: 1px solid #2a2e39;
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.weight-bar-fill {
+  height: 100%;
+  background: #2196f3;
+  transition: width 120ms ease-out;
+}
+
+.weight-label {
+  color: #d1d4dc;
+  font-size: 10px;
+  min-width: 28px;
+  text-align: right;
+}


### PR DESCRIPTION
## Summary

PR9 of the Strategy Studio epic. Adds **MetaStrategyPanel** below RiskPanel in the right pane, wrapping core's meta-strategy primitives:

- **Equity Curve Filter** — MA / Drawdown / Win-Rate / Combined tabs over `applyEquityCurveFilter`, side-by-side Δ metrics (Sharpe / MaxDD / Return / PF) + skipped-trade count + `equityCurveHealth` score.
- **Strategy Rotation** — Return / Sharpe / PF / Win-% ranking + Proportional / Equal / Top-N allocation. Slot 1 is the user's built strategy when present, otherwise falls back to a hardcoded demo so the section is never empty.

## Implementation notes

- **Apples-to-apples comparison**: demo backtests inherit the user's actual settings (capital, stops, fill mode, commission, ...) via `overridesFromResult(lastResult)`. Without this, rotation ranking would measure settings drift, not strategy edge.
- **Strategy↔result pairing**: `runDemoBacktests` returns `DemoBacktest[]` (`{strategy, result}` pairs). A failed demo just produces a shorter list — labels never drift to the wrong strategy.
- **Replay-aware**: rotation backtests freeze while `replay.status === "playing"` (PluginsPanel pattern). Pause / step / exit refreshes.
- **StrictMode-safe**: `demoResults` lives in `useState` driven by `useEffect`, not `useRef` written from inside `useMemo` (which would be unsafe under concurrent rendering).
- **NumInput extracted** to `src/components/NumInput.tsx`; RiskPanel imports from there.

## Known carry-overs (must be fixed before epic → main)

This PR **does not absorb** core/chart bugs in user-visible math but does carry two contract workarounds the epic memo now tracks as blockers:

- `Δ MaxDD` display omits `*100` to compensate for `applyEquityCurveFilter.improvement.maxDrawdown` mixing units (core's `runBacktest` returns 0-100 percent, `rebuildResult` returns 0-1 fraction).
- `BUY_AND_HOLD_STRATEGY` uses `rsiBelow(100)` / `rsiAbove(100)` because no `alwaysTrue` / `alwaysFalse` is registered in `backtestRegistry`.

Both will be fixed in core PRs against `main`, after which this epic's workarounds get cleaned up before the final epic → main merge.

## Review notes

- `/simplify` round: applied P1 fixes — strategy↔result pairing bug, `useMemo` ref-write fragility, FilterAllocation indirection, error→empty kind for symmetry.
- `/codex:review` round: addressed [P2] — demos now inherit user backtest settings via `overridesFromResult`.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — studio 22 / core 4865 / mcp 59 / chart 781 (chart 1 flaky perf test, pre-existing per memory)
- [x] `pnpm build` — workspace builds
- [x] Manual: filter populates after backtest, Δ MaxDD reads `+20.19%` (sane), Slot 1 swaps to "your strategy", Equal allocation = 33%/33%/33%/0%, demos pick up user stop% changes (33.3% vs 30.9% before).

Carved out for PR10: PortfolioPanel.