### PR TITLE
fix(core): align equity-curve metrics to BacktestResult percent contract

### DIFF
--- a/packages/core/src/meta-strategy/__tests__/equity-curve.test.ts
+++ b/packages/core/src/meta-strategy/__tests__/equity-curve.test.ts
@@ -30,8 +30,9 @@ function makeResult(trades: Trade[]): BacktestResult {
     totalReturn,
     totalReturnPercent: (totalReturn / initial) * 100,
     tradeCount: trades.length,
-    winRate: trades.length > 0 ? wins.length / trades.length : 0,
-    maxDrawdown: 0.1,
+    // winRate and maxDrawdown follow the BacktestResult contract: 0-100 percent.
+    winRate: trades.length > 0 ? (wins.length / trades.length) * 100 : 0,
+    maxDrawdown: 10,
     sharpeRatio: 1.0,
     profitFactor:
       grossLoss > 0 ? grossProfit / grossLoss : grossProfit > 0 ? Number.POSITIVE_INFINITY : 0,
@@ -89,7 +90,7 @@ describe("applyEquityCurveFilter", () => {
     const result = makeResult(trades);
     const analysis = applyEquityCurveFilter(result, {
       type: "drawdown",
-      maxDrawdown: 0.1,
+      maxDrawdown: 10,
     });
     expect(analysis.tradesSkipped).toBeGreaterThan(0);
   });
@@ -120,7 +121,7 @@ describe("applyEquityCurveFilter", () => {
     }
   });
 
-  it("improvement shows correct direction for maxDrawdown", () => {
+  it("improvement.maxDrawdown follows the original − filtered convention", () => {
     const trades: Trade[] = [];
     for (let i = 0; i < 10; i++) trades.push(makeTrade(i, 200));
     for (let i = 10; i < 20; i++) trades.push(makeTrade(i, -300));
@@ -129,10 +130,13 @@ describe("applyEquityCurveFilter", () => {
     const result = makeResult(trades);
     const analysis = applyEquityCurveFilter(result, { type: "ma", maPeriod: 5 });
 
-    if (analysis.tradesSkipped > 0) {
-      // DD improvement should be non-negative (filtered DD <= original)
-      expect(analysis.improvement.maxDrawdown).toBeGreaterThanOrEqual(0);
-    }
+    // Sign convention: positive = filter improved the metric. For maxDrawdown
+    // (lower is better) the formula is `original − filtered`. This invariant
+    // holds regardless of whether the filter actually helped on this data.
+    expect(analysis.improvement.maxDrawdown).toBeCloseTo(
+      result.maxDrawdown - analysis.filtered.maxDrawdown,
+      10,
+    );
   });
 
   it("all losses → most trades skipped", () => {
@@ -155,7 +159,7 @@ describe("equityCurveHealth", () => {
 
     expect(health.aboveMa).toBe(true);
     expect(health.currentDrawdown).toBe(0);
-    expect(health.rollingWinRate).toBe(1);
+    expect(health.rollingWinRate).toBe(100);
     expect(health.healthScore).toBeGreaterThanOrEqual(80);
   });
 
@@ -168,7 +172,7 @@ describe("equityCurveHealth", () => {
     const health = equityCurveHealth(result, { maPeriod: 10 });
 
     expect(health.currentDrawdown).toBeGreaterThan(0);
-    expect(health.rollingWinRate).toBeLessThan(0.5);
+    expect(health.rollingWinRate).toBeLessThan(50);
   });
 
   it("equityCurve has correct length", () => {
@@ -187,5 +191,40 @@ describe("equityCurveHealth", () => {
 
     expect(health.healthScore).toBeGreaterThanOrEqual(0);
     expect(health.healthScore).toBeLessThanOrEqual(100);
+  });
+
+  it("currentDrawdown and rollingWinRate use the BacktestResult percent scale", () => {
+    // Mixed wins/losses → both fields land in the (0, 100] range, not (0, 1].
+    // Locks in unit alignment with runBacktest's BacktestResult contract so
+    // callers can compare equityCurveHealth output against backtest summary
+    // metrics without manual unit conversion.
+    const trades: Trade[] = [];
+    for (let i = 0; i < 5; i++) trades.push(makeTrade(i, 200));
+    for (let i = 5; i < 15; i++) trades.push(makeTrade(i, -300));
+    const result = makeResult(trades);
+    const health = equityCurveHealth(result);
+
+    expect(health.currentDrawdown).toBeGreaterThan(1);
+    expect(health.currentDrawdown).toBeLessThanOrEqual(100);
+    expect(health.rollingWinRate).toBeGreaterThanOrEqual(0);
+    expect(health.rollingWinRate).toBeLessThanOrEqual(100);
+  });
+});
+
+describe("rebuildResult unit alignment with runBacktest", () => {
+  it("filtered.winRate and filtered.maxDrawdown match BacktestResult contract", () => {
+    const trades: Trade[] = [];
+    for (let i = 0; i < 10; i++) trades.push(makeTrade(i, 200));
+    for (let i = 10; i < 20; i++) trades.push(makeTrade(i, -300));
+    const result = makeResult(trades);
+    const analysis = applyEquityCurveFilter(result, { type: "ma", maPeriod: 5 });
+
+    // Both fields documented as percent (0-100) on BacktestResult; the filter's
+    // rebuilt result must follow the same scale so improvement deltas have
+    // consistent units (was buggy pre-fix: rebuildResult emitted fractions).
+    expect(analysis.filtered.winRate).toBeGreaterThanOrEqual(0);
+    expect(analysis.filtered.winRate).toBeLessThanOrEqual(100);
+    expect(analysis.filtered.maxDrawdown).toBeGreaterThanOrEqual(0);
+    expect(analysis.filtered.maxDrawdown).toBeLessThanOrEqual(100);
   });
 });

--- a/packages/core/src/meta-strategy/equity-curve.ts
+++ b/packages/core/src/meta-strategy/equity-curve.ts
@@ -25,13 +25,13 @@ export type EquityCurveFilterOptions = {
   maPeriod?: number;
   /** MA type (default: 'sma') */
   maType?: "sma" | "ema";
-  /** Max drawdown threshold to pause trading (default: 0.15 = 15%) */
+  /** Max drawdown threshold to pause trading, in percent (default: 15 = 15%) */
   maxDrawdown?: number;
   /** Rolling window for win rate calculation (default: 20 trades) */
   winRateWindow?: number;
-  /** Minimum win rate to continue trading (default: 0.4) */
+  /** Minimum win rate to continue trading, in percent (default: 40 = 40%) */
   minWinRate?: number;
-  /** Position size factor when filtered (0 = skip trade, 0.5 = half size) (default: 0) */
+  /** Position size factor when filtered, as fraction (0 = skip trade, 0.5 = half size, default: 0) */
   filteredSizeFactor?: number;
 };
 
@@ -56,9 +56,9 @@ export type EquityCurveAnalysis = {
 export type EquityCurveHealthResult = {
   /** Whether equity is above its MA */
   aboveMa: boolean;
-  /** Current drawdown from peak (0-1) */
+  /** Current drawdown from peak as percentage (0-100), matching BacktestResult.maxDrawdown */
   currentDrawdown: number;
-  /** Rolling win rate (last N trades) */
+  /** Rolling win rate as percentage (0-100), matching BacktestResult.winRate */
   rollingWinRate: number;
   /** Overall health score (0-100) */
   healthScore: number;
@@ -113,6 +113,12 @@ function computeEma(values: number[], period: number): (number | null)[] {
   return result;
 }
 
+// All drawdown / win-rate helpers below report values as percent (0-100) to
+// stay consistent with `BacktestResult.{maxDrawdown,winRate}` and with the
+// public `EquityCurveFilterOptions.{maxDrawdown,minWinRate}` thresholds. A
+// single scale across the equity-curve API keeps health readings, filter
+// options, and rebuilt result fields directly comparable.
+
 function getCurrentDrawdown(equityCurve: number[]): number {
   if (equityCurve.length === 0) return 0;
   let peak = equityCurve[0];
@@ -120,7 +126,7 @@ function getCurrentDrawdown(equityCurve: number[]): number {
     if (e > peak) peak = e;
   }
   const current = equityCurve[equityCurve.length - 1];
-  return peak > 0 ? (peak - current) / peak : 0;
+  return peak > 0 ? ((peak - current) / peak) * 100 : 0;
 }
 
 function getDrawdownAt(equityCurve: number[], index: number): number {
@@ -129,15 +135,15 @@ function getDrawdownAt(equityCurve: number[], index: number): number {
   for (let i = 1; i <= index; i++) {
     if (equityCurve[i] > peak) peak = equityCurve[i];
   }
-  return peak > 0 ? (peak - equityCurve[index]) / peak : 0;
+  return peak > 0 ? ((peak - equityCurve[index]) / peak) * 100 : 0;
 }
 
 function getRollingWinRate(trades: Trade[], endIndex: number, window: number): number {
   const start = Math.max(0, endIndex - window + 1);
   const slice = trades.slice(start, endIndex + 1);
-  if (slice.length === 0) return 1;
+  if (slice.length === 0) return 100;
   const wins = slice.filter((t) => t.return > 0).length;
-  return wins / slice.length;
+  return (wins / slice.length) * 100;
 }
 
 function computeProfitFactor(grossProfit: number, grossLoss: number): number {
@@ -194,8 +200,11 @@ function rebuildResult(trades: Trade[], original: BacktestResult): BacktestResul
     totalReturn,
     totalReturnPercent: (totalReturn / initialCapital) * 100,
     tradeCount: trades.length,
-    winRate: wins.length / trades.length,
-    maxDrawdown: maxDd,
+    // winRate and maxDrawdown follow the BacktestResult contract: percentage
+    // (0-100), not fraction (0-1). Aligning with runBacktest so callers can
+    // compare both shapes directly (e.g. applyEquityCurveFilter.improvement).
+    winRate: (wins.length / trades.length) * 100,
+    maxDrawdown: maxDd * 100,
     sharpeRatio: sharpe,
     profitFactor: computeProfitFactor(grossProfit, grossLoss),
     avgHoldingDays: trades.reduce((sum, t) => sum + t.holdingDays, 0) / trades.length,
@@ -250,9 +259,9 @@ export function applyEquityCurveFilter(
     type = "ma",
     maPeriod = 20,
     maType = "sma",
-    maxDrawdown = 0.15,
+    maxDrawdown = 15,
     winRateWindow = 20,
-    minWinRate = 0.4,
+    minWinRate = 40,
     filteredSizeFactor = 0,
   } = options;
 
@@ -395,15 +404,17 @@ export function equityCurveHealth(
   const currentMa = maValues[maValues.length - 1];
   const aboveMa = currentMa !== null ? currentEquity >= currentMa : true;
 
+  // Drawdown / win-rate helpers already report percent (0-100); coefficients
+  // are scaled accordingly so the composite output stays numerically identical
+  // to the pre-fix version.
   const currentDrawdown = getCurrentDrawdown(curve);
 
   const rollingWinRate =
-    trades.length > 0 ? getRollingWinRate(trades, trades.length - 1, winRateWindow) : 1;
+    trades.length > 0 ? getRollingWinRate(trades, trades.length - 1, winRateWindow) : 100;
 
-  // Health score: weighted composite
   const maScore = aboveMa ? 100 : 0;
-  const ddScore = Math.max(0, 100 - currentDrawdown * 500); // 20% DD = 0
-  const wrScore = Math.min(100, (rollingWinRate / 0.6) * 100); // 60% WR = 100
+  const ddScore = Math.max(0, 100 - currentDrawdown * 5); // 20% DD = 0
+  const wrScore = Math.min(100, (rollingWinRate / 60) * 100); // 60% WR = 100
   const healthScore = Math.round(maScore * 0.4 + ddScore * 0.3 + wrScore * 0.3);
 
   const equityCurve: EquityPoint[] = [];


### PR DESCRIPTION
## Summary

Unify the entire `meta-strategy/equity-curve` API on the **0–100 percent** scale so filter options, rebuilt results, and health readings can be compared without per-call unit conversion.

The bug was surfaced by Strategy Studio's MetaStrategyPanel (PR9) which displayed `Δ MaxDD = +2018%` because `applyEquityCurveFilter().improvement.maxDrawdown` mixed `original (percent) − filtered (fraction)`.

## Root cause

| API | Pre-fix | Post-fix |
|---|---|---|
| `runBacktest().{winRate, maxDrawdown}` | percent (canonical) | unchanged |
| `rebuildResult().{winRate, maxDrawdown}` | **fraction (bug)** | percent |
| `equityCurveHealth().{currentDrawdown, rollingWinRate}` | fraction | percent |
| `EquityCurveFilterOptions.{maxDrawdown, minWinRate}` | fraction (default `0.15` / `0.4`) | **percent (default `15` / `40`)** |

`BacktestResult.maxDrawdown` JSDoc literally says _"Maximum drawdown percentage"_ — `rebuildResult` was a contract violation. Half-fixing only the result fields would have created a new trap (callers feeding `health.currentDrawdown` (now percent) into `applyEquityCurveFilter({ maxDrawdown })` (still fraction) would silently be off by 100×). This PR fixes both sides together.

## Changes

- `rebuildResult()`: `winRate × 100`, `maxDrawdown × 100`
- Internal helpers (`getCurrentDrawdown`, `getDrawdownAt`, `getRollingWinRate`) return percent so filter and health code paths share a single unit
- `equityCurveHealth()`: re-exports the helper output unchanged (`* 100` boilerplate gone)
- `EquityCurveFilterOptions.{maxDrawdown, minWinRate}` defaults migrated from `0.15` / `0.4` to `15` / `40`; JSDoc updated
- `healthScore` coefficients scaled (`* 500` → `* 5`, `/ 0.6` → `/ 60`) so the composite output is **numerically identical** to pre-fix
- Test fixture `makeResult` updated to be contract-compliant
- `improvement.maxDrawdown` direction test rewritten as a sign-convention invariant (`original − filtered`) instead of an unguaranteed "always positive" assertion that previously passed only because of the unit bug
- New invariant tests lock in the percent contract for `filtered.*` and `health.*` so future drift fails loudly

## Breaking change

Direct callers of `applyEquityCurveFilter` / `equityCurveHealth` who:
- passed `maxDrawdown: 0.15` style fractions → must change to `15`
- read `filtered.maxDrawdown`, `filtered.winRate`, `health.currentDrawdown`, `health.rollingWinRate` and expected 0–1 → must divide by 100 (or, better, treat the entire API as percent)

Internal-only API (no echarts-viewer / alpaca-demo / chart consumers — `grep` confirmed). Strategy Studio (`packages/chart/examples/strategy-studio/`) uses these APIs and will be updated to drop its `Δ MaxDD` workaround in a follow-up PR against `epic/strategy-studio`.

## Test plan

- [x] `pnpm test` — core 4867 (+2 invariant) / mcp 59 / chart 774 all pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — workspace builds
- [x] `pnpm test src/meta-strategy` — 23 / 23 pass
- [ ] CHANGELOG entry to be added in this PR's review cycle if requested