### PR TITLE
chore(strategy-studio): drop core/chart workarounds after upstream fixes

### DIFF
--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -11,7 +11,7 @@ import { clampedSeedEnd, lastEmittedIdx } from "./lib/replay";
 import { sampleCandles } from "./lib/sample-data";
 import { SIGNAL_BY_KIND } from "./lib/signals";
 import { builderReducer, initialBuilderState, strategyJSONToState } from "./lib/strategy-state";
-import { KIND_TO_PRESET_KEY, localStudioAPI } from "./lib/studio-api";
+import { localStudioAPI } from "./lib/studio-api";
 import { MetaStrategyPanel } from "./panels/MetaStrategyPanel";
 import { ParamPopover } from "./panels/ParamPopover";
 import { PluginsPanel } from "./panels/PluginsPanel";
@@ -23,7 +23,7 @@ import { SignalsPanel } from "./panels/SignalsPanel";
 import { StrategyBuilder } from "./panels/StrategyBuilder";
 
 function resolvePresetId(kind: string): string {
-  return KIND_TO_PRESET_KEY[kind] ?? kind;
+  return localStudioAPI.resolvePresetKey(kind) ?? kind;
 }
 
 /**

--- a/packages/chart/examples/strategy-studio/src/lib/demo-strategies.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/demo-strategies.ts
@@ -29,17 +29,13 @@ export const MEAN_REVERSION_STRATEGY: StrategyJSON = {
   backtest: { capital: 100_000 },
 };
 
-// `rsiBelow(100)` is true once RSI is defined and `rsiAbove(100)` never fires
-// — together they approximate "buy on first valid bar, never exit" without
-// needing an `alwaysTrue` condition (which isn't registered in the public
-// registry).
 export const BUY_AND_HOLD_STRATEGY: StrategyJSON = {
   $schema: "trendcraft/strategy",
   version: 1,
   id: "demo-buy-and-hold",
   name: "Buy and Hold",
-  entry: { name: "rsiBelow", params: { threshold: 100, period: 14 } },
-  exit: { name: "rsiAbove", params: { threshold: 100, period: 14 } },
+  entry: { name: "alwaysTrue" },
+  exit: { name: "alwaysFalse" },
   backtest: { capital: 100_000 },
 };
 

--- a/packages/chart/examples/strategy-studio/src/lib/meta-strategy.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/meta-strategy.ts
@@ -54,8 +54,8 @@ export type FilterInputs = {
 export const DEFAULT_FILTER_INPUTS: FilterInputs = {
   type: "ma",
   maPeriod: 10,
-  maxDrawdown: 0.15,
-  minWinRate: 0.4,
+  maxDrawdown: 15,
+  minWinRate: 40,
   filteredSizeFactor: 0,
 };
 

--- a/packages/chart/examples/strategy-studio/src/lib/risk.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/risk.ts
@@ -37,14 +37,12 @@ export type SizingComputation =
 
 // Returns null if the slice is shorter than `period + 1`: TR[0] is undefined
 // because it depends on the previous close, so atr needs `period+1` candles.
+// Past warm-up, atr() guarantees a finite tail value — Wilder's smoothing
+// is fully defined from index `period` onward.
 export function latestAtr(candles: StudioCandle[], period: number): number | null {
   if (candles.length <= period) return null;
   const series = atr(candles, { period });
-  for (let i = series.length - 1; i >= 0; i--) {
-    const v = series[i].value;
-    if (Number.isFinite(v)) return v;
-  }
-  return null;
+  return series[series.length - 1]?.value ?? null;
 }
 
 // Use `returnPercent` (size-independent) rather than `return` (dollar P/L) so

--- a/packages/chart/examples/strategy-studio/src/lib/studio-api.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/studio-api.ts
@@ -8,6 +8,7 @@ import {
   type StrategyJSON,
   backtestRegistry,
   detectMarketRegime,
+  getIndicatorPreset,
   indicatorPresets,
   loadStrategy,
   normalizeCandles,
@@ -78,41 +79,24 @@ export interface StudioAPI {
   suggestPresets(regime: MarketRegime): IndicatorManifest[];
   listIndicators(filter?: { category?: IndicatorCategory }): IndicatorManifest[];
   /**
-   * Resolve a manifest `kind` to its `indicatorPresets` entry. Some manifest
-   * kinds use a different short key in the preset registry (`bollingerBands`
-   * vs `bb`, etc.) — see `KIND_TO_PRESET_KEY`. Returns `undefined` for kinds
-   * that intentionally have no series preset (e.g. `hmmRegimes`, `liquiditySweep`).
+   * Resolve a manifest `kind` to its `indicatorPresets` entry. Returns
+   * `undefined` for kinds that intentionally have no series preset (regime
+   * classifiers, smc events, etc.). Manifest long-name ↔ short-key drift is
+   * handled by core's `getIndicatorPreset`.
    */
   getIndicatorPreset(kind: string): IndicatorPreset | undefined;
+  /**
+   * Reverse-lookup: manifest `kind` → the canonical `indicatorPresets`
+   * registry key the chart's `connectIndicators({ presets }).add(key, ...)`
+   * expects. Needed because the chart's bracket lookup wants the short key
+   * (`bb`) while the host typically carries the manifest's long name
+   * (`bollingerBands`). Returns `undefined` for unresolved kinds.
+   */
+  resolvePresetKey(kind: string): string | undefined;
   /** All registered backtest conditions, optionally filtered by category. */
   listConditions(category?: ConditionCategory): ConditionRegistryEntry<Condition>[];
   runStrategy(json: StrategyJSON, candles: StudioCandle[]): StrategyRunResult;
 }
-
-/**
- * Manifest `kind` → `indicatorPresets` key for entries where the two registries
- * use different identifiers. Manifest kinds use the function name (e.g.
- * `bollingerBands`); the preset registry uses a shorter key (`bb`).
- *
- * Kinds not listed here use their manifest kind as the preset key directly.
- * Kinds with no preset entry at all (regime classifiers, smc events) resolve
- * to `undefined` from `getIndicatorPreset`.
- */
-export const KIND_TO_PRESET_KEY: Record<string, string> = {
-  awesomeOscillator: "ao",
-  balanceOfPower: "bop",
-  bollingerBands: "bb",
-  choppinessIndex: "choppiness",
-  coppockCurve: "coppock",
-  donchianChannel: "donchian",
-  easeOfMovement: "emv",
-  ewmaVolatility: "ewmaVol",
-  fairValueGap: "fvg",
-  historicalVolatility: "hv",
-  keltnerChannel: "keltner",
-  openingRange: "orb",
-  ulcerIndex: "ulcer",
-};
 
 export const localStudioAPI: StudioAPI = {
   detectRegime(candles) {
@@ -130,7 +114,17 @@ export const localStudioAPI: StudioAPI = {
   },
 
   getIndicatorPreset(kind) {
-    return indicatorPresets[KIND_TO_PRESET_KEY[kind] ?? kind];
+    return getIndicatorPreset(kind);
+  },
+
+  resolvePresetKey(kind) {
+    const preset = getIndicatorPreset(kind);
+    if (!preset) return undefined;
+    if (indicatorPresets[kind] === preset) return kind;
+    for (const [key, p] of Object.entries(indicatorPresets)) {
+      if (p === preset) return key;
+    }
+    return undefined;
   },
 
   listConditions(category) {

--- a/packages/chart/examples/strategy-studio/src/panels/MetaStrategyPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/MetaStrategyPanel.tsx
@@ -137,21 +137,21 @@ export function MetaStrategyPanel({ lastResult, candles, isReplayPlaying }: Prop
           )}
           {(filter.type === "drawdown" || filter.type === "combined") && (
             <NumInput
-              label="Max DD"
+              label="Max DD %"
               value={filter.maxDrawdown}
-              min={0.01}
-              max={0.95}
-              step={0.01}
+              min={1}
+              max={95}
+              step={1}
               onChange={(v) => setFilter((prev) => ({ ...prev, maxDrawdown: v }))}
             />
           )}
           {(filter.type === "winRate" || filter.type === "combined") && (
             <NumInput
-              label="Min WR"
+              label="Min WR %"
               value={filter.minWinRate}
               min={0}
-              max={1}
-              step={0.05}
+              max={100}
+              step={5}
               onChange={(v) => setFilter((prev) => ({ ...prev, minWinRate: v }))}
             />
           )}
@@ -240,11 +240,6 @@ function FilterResult({ result }: { result: ReturnType<typeof computeFilter> }) 
     <>
       <div className="risk-result">
         <DeltaMetric label="Δ Sharpe" delta={analysis.improvement.sharpeRatio} digits={2} />
-        {/* `improvement.maxDrawdown` is already in the same units as
-            `original.maxDrawdown` (percent points from `runBacktest`); no
-            extra ×100. Note: `filtered.maxDrawdown` from core's rebuildResult
-            uses decimal units so the absolute filtered value is tiny here —
-            we display the delta, not the absolute filtered DD. */}
         <DeltaMetric label="Δ MaxDD" delta={analysis.improvement.maxDrawdown} digits={2} unit="%" />
         <DeltaMetric
           label="Δ Return"
@@ -257,8 +252,7 @@ function FilterResult({ result }: { result: ReturnType<typeof computeFilter> }) 
       <div className="meta-strategy-caption">
         Skipped {analysis.tradesSkipped}/{analysis.original.trades.length} trades · health{" "}
         {health.healthScore}/100
-        {health.aboveMa ? " · above MA" : " · below MA"} · DD{" "}
-        {(health.currentDrawdown * 100).toFixed(1)}%
+        {health.aboveMa ? " · above MA" : " · below MA"} · DD {health.currentDrawdown.toFixed(1)}%
       </div>
     </>
   );


### PR DESCRIPTION
## Summary

Cleanup pass on `epic/strategy-studio` to drop workarounds that became unnecessary after PR #143 (`fix/core-meta-strategy-units`) and PR #144 (`feat/core-preset-lookup-and-always-conditions`) landed on `main`.

This PR depends on those two having been merged into the epic via `git merge main` — already done in `743f266`.

## Removed

| # | Workaround | Resolution |
|---|---|---|
| #1 | `Δ MaxDD = +2018%` display bug — `* 100` workaround + WHY comment in `MetaStrategyPanel`, `health.currentDrawdown * 100` double-multiply | Core's `equityCurveHealth`/`applyEquityCurveFilter` now report consistent percent units |
| #1 | `DEFAULT_FILTER_INPUTS.maxDrawdown: 0.15` and `minWinRate: 0.4` (fractional) | Migrated to `15` / `40` to match `EquityCurveFilterOptions` percent contract; NumInput min/max/step adjusted |
| #2 | `KIND_TO_PRESET_KEY` const (13 manifest-kind ↔ preset-key mappings) | Replaced by core's `getIndicatorPreset(kind)` + a small `localStudioAPI.resolvePresetKey()` helper for the chart's short-key lookup |
| #3 | `BUY_AND_HOLD_STRATEGY` using `rsiBelow(threshold:100)` / `rsiAbove(100)` (RSI bounded-range exploit) | Uses registered `alwaysTrue` / `alwaysFalse` conditions from core |
| #6 | `latestAtr()` walk-back-for-finite loop | Simplified to `series[series.length - 1]?.value` — Wilder's smoothing in core's `atr()` guarantees finite tail past warm-up |

## Remaining workarounds (deferred)

| # | Workaround | Status |
|---|---|---|
| #4 | `toManifestRegime()` granular → 4-bucket projection | **Acceptable adapter** — UX projection, not a core bug. Promote to core helper only if a 2nd consumer needs it |
| #5 | `unavailablePlugins` set + try/catch around chart primitive build | **Deferred to chart-side epic** — proper fix is `definePrimitive({ requirements })` metadata, scope is bigger than this PR |

## Net change

**+41 / -59** (-18 net). One workaround comment removed, one helper added (`resolvePresetKey`), three direct API substitutions.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — studio 22 / core 4888 / mcp 59 / chart 781 all pass
- [x] `pnpm build` — workspace builds
- [ ] Manual: dev server visual check at /tmp (deferred to user; rotation values + Δ MaxDD display verified pre-cleanup)

## Follow-ups for epic→main

After this PR merges, the epic→main blocker checklist (epic memo) drops to **0 hard blockers**. The two deferred items above are tracked but not blocking.