### PR TITLE
feat(strategy-studio): PortfolioPanel with batchBacktest + 3 synthetic symbols (PR10)

### DIFF
--- a/packages/chart/examples/strategy-studio/README.md
+++ b/packages/chart/examples/strategy-studio/README.md
@@ -27,8 +27,8 @@ The studio runs **fully offline with no LLM key**. It uses `detectMarketRegime` 
 | PR6 | SignalsPanel — cross/divergence/pattern signal detection + markers | done |
 | PR7 | PluginsPanel — SMC / Pitchfork / Volume Profile / Wyckoff plugin toggles | done |
 | PR8 | RiskPanel — position sizing (Risk-%/ATR/Kelly) + VaR/CVaR | done |
-| PR9 | MetaStrategyPanel — equity curve filter + strategy rotation | **this PR** |
-| PR10 | PortfolioPanel — `batchBacktest` + multi-symbol allocation | |
+| PR9 | MetaStrategyPanel — equity curve filter + strategy rotation | done |
+| PR10 | PortfolioPanel — `batchBacktest` + 3 synthetic symbols + sparkline rows | **this PR** |
 | PR11 | ScoringPanel — signal scoring visualization | |
 | PR12 | OptimizationPanel — grid search + walk-forward UI | |
 | PR13 | StrategyDnaPanel — genome viz + sensitivity heatmap + robustness | |

--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -15,6 +15,7 @@ import { localStudioAPI } from "./lib/studio-api";
 import { MetaStrategyPanel } from "./panels/MetaStrategyPanel";
 import { ParamPopover } from "./panels/ParamPopover";
 import { PluginsPanel } from "./panels/PluginsPanel";
+import { PortfolioPanel } from "./panels/PortfolioPanel";
 import { PresetSelector } from "./panels/PresetSelector";
 import { ReplayControls, type SpeedTier } from "./panels/ReplayControls";
 import { ResultsSummary } from "./panels/ResultsSummary";
@@ -588,10 +589,10 @@ export function App() {
 
   // Stale-result guard: stepping or toggling Replay changes the slice the
   // backtest *would* run against, but the cached result and chart trade
-  // markers are still from the previous slice. Drop the React state so the
-  // right pane prompts the user to re-run; chart-side trade markers persist
-  // until the next `addBacktest` call (no public clear API yet — accepted
-  // visual lag).
+  // markers are still from the previous slice. Drop the runner state so
+  // every right-pane panel (including PortfolioPanel) prompts the user to
+  // re-run in lockstep — they all read from `runner.state.lastResult`,
+  // which now carries the executed JSON too.
   // biome-ignore lint/correctness/useExhaustiveDependencies: only fires when the slice boundary moves; runner.reset/state are stable across renders.
   useEffect(() => {
     if (runner.state.lastResult) runner.reset();
@@ -681,6 +682,13 @@ export function App() {
         <MetaStrategyPanel
           lastResult={runner.state.lastResult?.result}
           candles={backtestCandles}
+          isReplayPlaying={replay.mode === "live" && replay.status === "playing"}
+        />
+        <div className="pane-divider" />
+        <PortfolioPanel
+          strategy={runner.state.lastResult?.json}
+          lastResult={runner.state.lastResult?.result}
+          sliceLength={backtestCandles.length}
           isReplayPlaying={replay.mode === "live" && replay.status === "playing"}
         />
       </aside>

--- a/packages/chart/examples/strategy-studio/src/lib/__tests__/portfolio.test.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/__tests__/portfolio.test.ts
@@ -1,0 +1,176 @@
+import type { StrategyJSON } from "trendcraft";
+import { describe, expect, it } from "vitest";
+import { defaultPortfolioInputs, runPortfolio, symbolEquityCurve } from "../portfolio";
+import type { SampleSymbol, StudioCandle } from "../sample-data";
+
+function makeCandles(n: number, basePrice = 100): StudioCandle[] {
+  return Array.from({ length: n }, (_, i) => ({
+    time: 1700000000000 + i * 86400000,
+    open: basePrice + i,
+    high: basePrice + i + 2,
+    low: basePrice + i - 2,
+    close: basePrice + i + 1,
+    volume: 1000,
+  }));
+}
+
+const SYMBOLS: SampleSymbol[] = [
+  { symbol: "A", label: "Symbol A", candles: makeCandles(40, 100) },
+  { symbol: "B", label: "Symbol B", candles: makeCandles(40, 200) },
+  { symbol: "C", label: "Symbol C", candles: makeCandles(40, 50) },
+];
+
+const ALWAYS_HOLD: StrategyJSON = {
+  $schema: "trendcraft/strategy",
+  version: 1,
+  id: "always-hold",
+  name: "Always Hold",
+  entry: { name: "alwaysTrue" },
+  exit: { name: "alwaysFalse" },
+};
+
+describe("runPortfolio", () => {
+  it("returns empty when no strategy is supplied", () => {
+    const out = runPortfolio(undefined, SYMBOLS, defaultPortfolioInputs(SYMBOLS));
+    expect(out.kind).toBe("empty");
+  });
+
+  it("returns empty when symbol list is empty", () => {
+    const out = runPortfolio(ALWAYS_HOLD, [], defaultPortfolioInputs([]));
+    expect(out.kind).toBe("empty");
+  });
+
+  it("equal allocation splits capital evenly across symbols", () => {
+    const inputs = defaultPortfolioInputs(SYMBOLS);
+    inputs.capital = 30_000;
+    const out = runPortfolio(ALWAYS_HOLD, SYMBOLS, inputs);
+    if (out.kind !== "ok") throw new Error(`expected ok, got ${out.kind}: ${JSON.stringify(out)}`);
+    expect(out.result.symbols).toHaveLength(3);
+    for (const s of out.result.symbols) {
+      expect(s.result.initialCapital).toBe(10_000);
+    }
+  });
+
+  it("custom allocation honours per-symbol weights", () => {
+    const inputs = defaultPortfolioInputs(SYMBOLS);
+    inputs.capital = 100_000;
+    inputs.allocation = "custom";
+    inputs.customWeights = { A: 0.5, B: 0.3, C: 0.2 };
+    const out = runPortfolio(ALWAYS_HOLD, SYMBOLS, inputs);
+    if (out.kind !== "ok") throw new Error(`expected ok, got ${out.kind}: ${JSON.stringify(out)}`);
+    const byId = new Map(out.result.symbols.map((s) => [s.symbol, s]));
+    expect(byId.get("A")?.result.initialCapital).toBe(50_000);
+    expect(byId.get("B")?.result.initialCapital).toBe(30_000);
+    expect(byId.get("C")?.result.initialCapital).toBe(20_000);
+  });
+
+  it("portfolio total return aggregates per-symbol results", () => {
+    const inputs = defaultPortfolioInputs(SYMBOLS);
+    inputs.capital = 30_000;
+    const out = runPortfolio(ALWAYS_HOLD, SYMBOLS, inputs);
+    if (out.kind !== "ok") throw new Error("expected ok");
+    const sumPerSymbol = out.result.symbols.reduce((s, sr) => s + sr.result.totalReturn, 0);
+    expect(out.result.portfolio.totalReturn).toBeCloseTo(sumPerSymbol, 6);
+  });
+
+  it("propagates overrides (stops) into per-symbol backtests", () => {
+    const inputs = defaultPortfolioInputs(SYMBOLS);
+    const out = runPortfolio(ALWAYS_HOLD, SYMBOLS, inputs, { stopLoss: 1.5 });
+    if (out.kind !== "ok") throw new Error("expected ok");
+    for (const s of out.result.symbols) {
+      expect(s.result.settings.stopLoss).toBe(1.5);
+    }
+  });
+
+  it("respects per-symbol candle slice (regression for playhead alignment)", () => {
+    // Each symbol is sliced before the panel calls runPortfolio, so passing
+    // a shorter candle array should reduce the number of trades. The exact
+    // count depends on goldenCross signals, but slicing to a tiny window
+    // must not produce *more* trades than the full window.
+    const fullInputs = defaultPortfolioInputs(SYMBOLS);
+    const fullOut = runPortfolio(ALWAYS_HOLD, SYMBOLS, fullInputs);
+    if (fullOut.kind !== "ok") throw new Error("expected ok");
+
+    const shortSymbols = SYMBOLS.map((s) => ({ ...s, candles: s.candles.slice(0, 10) }));
+    const shortOut = runPortfolio(ALWAYS_HOLD, shortSymbols, fullInputs);
+    if (shortOut.kind !== "ok") throw new Error("expected ok");
+
+    expect(shortOut.result.allTrades.length).toBeLessThanOrEqual(fullOut.result.allTrades.length);
+  });
+
+  it("portfolio capital input wins over strategy.backtest.capital and overrides", () => {
+    // Regression for a panel bug where opts spread `backtestOptions`/`overrides`
+    // *after* `capital`, silently overriding the panel's input. Both sources
+    // carry a `capital` field via `buildStrategyJSON` and `overridesFromResult`.
+    const strategyWithCapital: StrategyJSON = {
+      ...ALWAYS_HOLD,
+      backtest: { capital: 50_000 },
+    };
+    const inputs = defaultPortfolioInputs(SYMBOLS);
+    inputs.capital = 99_000;
+    const out = runPortfolio(strategyWithCapital, SYMBOLS, inputs, {
+      capital: 1_000_000,
+      stopLoss: 5,
+    });
+    if (out.kind !== "ok") throw new Error(`expected ok, got ${out.kind}`);
+    // Equal allocation over 3 symbols → 99,000 / 3 = 33,000 each.
+    for (const s of out.result.symbols) {
+      expect(s.result.initialCapital).toBe(33_000);
+    }
+    // Overrides for non-capital fields still flow through.
+    expect(out.result.symbols[0].result.settings.stopLoss).toBe(5);
+  });
+});
+
+describe("symbolEquityCurve", () => {
+  it("emits at least two points for no-trade symbols (sparkline visibility)", () => {
+    // Sparkline renderer skips single-point series — for a symbol that took
+    // no trades we still need a flat baseline so the row isn't a blank
+    // canvas next to the metrics.
+    const noTradeSymbol = {
+      symbol: "Q",
+      result: {
+        initialCapital: 1000,
+        finalCapital: 1000,
+        totalReturn: 0,
+        totalReturnPercent: 0,
+        tradeCount: 0,
+        winRate: 0,
+        maxDrawdown: 0,
+        sharpeRatio: 0,
+        profitFactor: 0,
+        avgHoldingDays: 0,
+        trades: [],
+        settings: {
+          fillMode: "next-bar-open" as const,
+          slTpMode: "close-only" as const,
+          slippage: 0,
+          commission: 0,
+          commissionRate: 0,
+          taxRate: 0,
+        },
+        drawdownPeriods: [],
+      },
+    };
+    const curve = symbolEquityCurve(noTradeSymbol);
+    expect(curve).toEqual([1000, 1000]);
+  });
+
+  it("starts at the symbol's initialCapital and accumulates trade returns", () => {
+    const inputs = defaultPortfolioInputs(SYMBOLS);
+    inputs.capital = 30_000;
+    const out = runPortfolio(ALWAYS_HOLD, SYMBOLS, inputs);
+    if (out.kind !== "ok") throw new Error("expected ok");
+    for (const s of out.result.symbols) {
+      const curve = symbolEquityCurve(s);
+      // Length = trade close events + 1 seed point. With alwaysHold there's
+      // exactly one trade per symbol, force-closed at end of stream.
+      expect(curve[0]).toBe(s.result.initialCapital);
+      expect(curve.length).toBe(s.result.trades.length + 1);
+      expect(curve[curve.length - 1]).toBeCloseTo(
+        s.result.initialCapital + s.result.totalReturn,
+        2,
+      );
+    }
+  });
+});

--- a/packages/chart/examples/strategy-studio/src/lib/portfolio.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/portfolio.ts
@@ -1,0 +1,100 @@
+import {
+  type BatchBacktestOptions,
+  type BatchBacktestResult,
+  type StrategyJSON,
+  type SymbolBacktestResult,
+  type SymbolData,
+  backtestRegistry,
+  batchBacktest,
+  loadStrategy,
+  normalizeCandles,
+} from "trendcraft";
+import type { SampleSymbol } from "./sample-data";
+
+export type AllocationMode = "equal" | "custom";
+
+export type PortfolioInputs = {
+  capital: number;
+  allocation: AllocationMode;
+  /** Per-symbol weight in [0, 1] when `allocation` is "custom". Sums to 1.0. */
+  customWeights: Record<string, number>;
+};
+
+export function defaultPortfolioInputs(symbols: ReadonlyArray<SampleSymbol>): PortfolioInputs {
+  const n = symbols.length || 1;
+  const weight = 1 / n;
+  const customWeights: Record<string, number> = {};
+  for (const s of symbols) customWeights[s.symbol] = weight;
+  return {
+    capital: 300_000,
+    allocation: "equal",
+    customWeights,
+  };
+}
+
+export type PortfolioComputation =
+  | { kind: "ok"; result: BatchBacktestResult }
+  | { kind: "empty" }
+  | { kind: "error"; message: string };
+
+/**
+ * Run `batchBacktest` against a set of symbol datasets. Returns `kind: "empty"`
+ * when there's no strategy to apply yet (user hasn't run anything and no
+ * fallback was provided). All symbol candles are normalised once up front.
+ *
+ * `overrides` carries the user's actual backtest assumptions (stops, fill
+ * mode, commission, etc.) extracted from a previous result via
+ * `overridesFromResult` — same pattern as MetaStrategyPanel so the rotation
+ * comparison is apples-to-apples with the user's solo backtest.
+ */
+export function runPortfolio(
+  strategy: StrategyJSON | undefined,
+  symbols: ReadonlyArray<SampleSymbol>,
+  inputs: PortfolioInputs,
+  overrides: Partial<BatchBacktestOptions> = {},
+): PortfolioComputation {
+  if (!strategy) return { kind: "empty" };
+  if (symbols.length === 0) return { kind: "empty" };
+  try {
+    const { entry, exit, backtestOptions } = loadStrategy(strategy, backtestRegistry);
+    const datasets: SymbolData[] = symbols.map((s) => ({
+      symbol: s.symbol,
+      candles: normalizeCandles(s.candles),
+    }));
+    // Order matters: spread strategy/builder defaults and solo-backtest
+    // overrides first, then re-assert `capital` so the panel's input wins.
+    // Both `buildStrategyJSON` and `overridesFromResult` carry a `capital`
+    // field, and without this re-assertion the panel's "Capital total $"
+    // control would be silently ignored.
+    const opts: BatchBacktestOptions = {
+      ...backtestOptions,
+      ...overrides,
+      capital: inputs.capital,
+      allocation: inputs.allocation,
+      ...(inputs.allocation === "custom" ? { allocations: inputs.customWeights } : {}),
+    };
+    const result = batchBacktest(datasets, entry, exit, opts);
+    return { kind: "ok", result };
+  } catch (err) {
+    return { kind: "error", message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Build a per-symbol equity curve as a `number[]` (cumulative equity) for
+ * the sparkline. `batchBacktest` only returns trade-close events; we seed
+ * with `initialCapital` and, for symbols that took no trades, emit a
+ * second flat point so the sparkline renderer (which skips single-point
+ * series) still draws a visible baseline.
+ */
+export function symbolEquityCurve(symbol: SymbolBacktestResult): number[] {
+  const initial = symbol.result.initialCapital;
+  const out: number[] = [initial];
+  let equity = initial;
+  for (const trade of symbol.result.trades) {
+    equity += trade.return;
+    out.push(equity);
+  }
+  if (out.length === 1) out.push(initial);
+  return out;
+}

--- a/packages/chart/examples/strategy-studio/src/lib/sample-data.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/sample-data.ts
@@ -10,3 +10,59 @@ export type StudioCandle = {
 };
 
 export const sampleCandles: StudioCandle[] = data;
+
+/**
+ * Synthetic multi-symbol dataset used by PortfolioPanel. We don't ship real
+ * OHLCV for three tickers, so we transform `sampleCandles` into three
+ * differently-shaped streams: a faster, more volatile name (×1.5 amplitude
+ * around price 220), a steadier large-cap (×0.6 amplitude around 60), and
+ * the original series as the baseline. Volumes are jittered so volume-based
+ * indicators see different shapes per symbol.
+ *
+ * Times are shared across all three so `batchBacktest`'s merged equity
+ * curve has a meaningful x-axis (a single trading calendar).
+ */
+function transformCandles(
+  base: StudioCandle[],
+  centerPrice: number,
+  amplitude: number,
+  volumeScale: number,
+): StudioCandle[] {
+  if (base.length === 0) return [];
+  const baseCenter = (base[0].open + base[0].close) / 2;
+  return base.map((c) => {
+    const reframe = (px: number) => centerPrice + (px - baseCenter) * amplitude;
+    return {
+      time: c.time,
+      open: reframe(c.open),
+      high: reframe(c.high),
+      low: reframe(c.low),
+      close: reframe(c.close),
+      volume: Math.max(1, Math.round(c.volume * volumeScale)),
+    };
+  });
+}
+
+export type SampleSymbol = {
+  symbol: string;
+  /** Display label shown in the panel; longer than the ticker. */
+  label: string;
+  candles: StudioCandle[];
+};
+
+// Synthetic ids only — these are NOT real ticker data. Real symbols would
+// imply real OHLCV which Studio doesn't ship; descriptive synthetic names
+// keep the demo honest and tell the user what each row is meant to show.
+export const sampleSymbols: SampleSymbol[] = [
+  { symbol: "BASE", label: "Baseline (sample data)", candles: sampleCandles },
+  {
+    symbol: "STEADY",
+    label: "Steady (low volatility)",
+    candles: transformCandles(sampleCandles, 60, 0.6, 1.4),
+  },
+  {
+    symbol: "VOLAT",
+    label: "Volatile (high amplitude)",
+    candles: transformCandles(sampleCandles, 220, 1.5, 0.7),
+  },
+];

--- a/packages/chart/examples/strategy-studio/src/lib/studio-api.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/studio-api.ts
@@ -64,6 +64,12 @@ function toManifestRegime(raw: MarketRegimeResult): {
 }
 
 export type StrategyRunResult = {
+  /** The JSON that was actually executed. Single source of truth for any
+   * downstream panel that needs to rerun the same strategy (PortfolioPanel,
+   * future PR12 OptimizationPanel) — keeps result + json bundled so the host
+   * can't accidentally show metrics for one strategy alongside settings from
+   * another. */
+  json: StrategyJSON;
   result: BacktestResult;
   trades: BacktestResult["trades"];
 };
@@ -138,6 +144,6 @@ export const localStudioAPI: StudioAPI = {
       capital: 100_000,
       ...backtestOptions,
     });
-    return { result, trades: result.trades };
+    return { json, result, trades: result.trades };
   },
 };

--- a/packages/chart/examples/strategy-studio/src/panels/PortfolioPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/PortfolioPanel.tsx
@@ -1,0 +1,234 @@
+import { Sparkline, SparklineList } from "@trendcraft/chart/react/sparkline";
+import { useEffect, useMemo, useState } from "react";
+import type { BacktestResult, StrategyJSON } from "trendcraft";
+import { NumInput } from "../components/NumInput";
+import { overridesFromResult } from "../lib/meta-strategy";
+import {
+  type AllocationMode,
+  type PortfolioInputs,
+  defaultPortfolioInputs,
+  runPortfolio,
+  symbolEquityCurve,
+} from "../lib/portfolio";
+import { sampleSymbols } from "../lib/sample-data";
+
+type Props = {
+  /** Builder JSON to apply to all symbols. */
+  strategy: StrategyJSON | undefined;
+  /** Most recent solo backtest, used to inherit settings (stops, fees, etc.). */
+  lastResult: BacktestResult | undefined;
+  /**
+   * Active candle range — `backtestCandles.length` from the host. Used to
+   * slice every synthetic symbol to the same horizon so portfolio metrics
+   * track the same window the solo backtest and chart show. The synthetic
+   * symbols share the parent candle stream's time axis 1:1, so a single
+   * length is enough.
+   */
+  sliceLength: number;
+  /** Replay playing → freeze recompute (multi-symbol backtest is heavy). */
+  isReplayPlaying: boolean;
+};
+
+const ALLOCATIONS: ReadonlyArray<{ id: AllocationMode; label: string }> = [
+  { id: "equal", label: "Equal" },
+  { id: "custom", label: "Custom" },
+];
+
+export function PortfolioPanel({ strategy, lastResult, sliceLength, isReplayPlaying }: Props) {
+  const [inputs, setInputs] = useState<PortfolioInputs>(() =>
+    defaultPortfolioInputs(sampleSymbols),
+  );
+
+  const slicedSymbols = useMemo(
+    () =>
+      sampleSymbols.map((s) => ({
+        ...s,
+        candles: sliceLength > 0 ? s.candles.slice(0, sliceLength) : s.candles,
+      })),
+    [sliceLength],
+  );
+
+  // Recompute on strategy / inputs / settings change. We don't need to key on
+  // the candle slice — sampleSymbols is fixed (synthetic, not playhead-bound).
+  // Replay playback freezes the *result state* below so the panel doesn't
+  // churn at Max speed; setting changes still flow through immediately when
+  // playback isn't active.
+  const overridesKey = lastResult
+    ? `${lastResult.initialCapital}|${lastResult.settings.stopLoss ?? ""}|${lastResult.settings.takeProfit ?? ""}|${lastResult.settings.trailingStop ?? ""}|${lastResult.settings.direction ?? ""}|${lastResult.settings.fillMode}|${lastResult.settings.slTpMode}|${lastResult.settings.slippage}|${lastResult.settings.commission}|${lastResult.settings.commissionRate}|${lastResult.settings.taxRate}`
+    : "";
+
+  const [computation, setComputation] = useState<ReturnType<typeof runPortfolio>>(() => ({
+    kind: "empty",
+  }));
+
+  const strategyKey = strategy ? JSON.stringify(strategy) : "";
+  const inputsKey = `${inputs.capital}|${inputs.allocation}|${Object.entries(inputs.customWeights)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(",")}`;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: strategyKey + inputsKey + overridesKey + sliceLength are content hashes; raw `strategy`/`slicedSymbols` references shift on every render so we key on hashes instead.
+  useEffect(() => {
+    if (isReplayPlaying) return;
+    const overrides = lastResult ? overridesFromResult(lastResult) : {};
+    setComputation(runPortfolio(strategy, slicedSymbols, inputs, overrides));
+  }, [strategyKey, inputsKey, isReplayPlaying, overridesKey, sliceLength]);
+
+  const customWeightSum = useMemo(
+    () => Object.values(inputs.customWeights).reduce((s, w) => s + w, 0),
+    [inputs.customWeights],
+  );
+  // Match `batchBacktest`'s weight-sum tolerance (`> 0.01` throws). A
+  // tighter UI check would yell "invalid" on inputs the engine accepts
+  // (e.g. 0.99 / 1.01), confusing the user.
+  const customWeightsValid = Math.abs(customWeightSum - 1) <= 0.01;
+
+  return (
+    <div className="risk-panel">
+      <div className="pane-header">Portfolio</div>
+
+      <section className="risk-section">
+        <div className="risk-tabs">
+          {ALLOCATIONS.map((a) => (
+            <button
+              type="button"
+              key={a.id}
+              className={`risk-tab${inputs.allocation === a.id ? " active" : ""}`}
+              onClick={() => setInputs((prev) => ({ ...prev, allocation: a.id }))}
+            >
+              {a.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="risk-inputs">
+          <NumInput
+            label="Capital total $"
+            value={inputs.capital}
+            min={1000}
+            step={10_000}
+            onChange={(v) => setInputs((prev) => ({ ...prev, capital: v }))}
+          />
+        </div>
+
+        {inputs.allocation === "custom" && (
+          <>
+            <div className="risk-inputs">
+              {sampleSymbols.map((s) => (
+                <NumInput
+                  key={s.symbol}
+                  label={`${s.symbol} weight`}
+                  value={inputs.customWeights[s.symbol] ?? 0}
+                  min={0}
+                  max={1}
+                  step={0.05}
+                  onChange={(v) =>
+                    setInputs((prev) => ({
+                      ...prev,
+                      customWeights: { ...prev.customWeights, [s.symbol]: v },
+                    }))
+                  }
+                />
+              ))}
+            </div>
+            {!customWeightsValid && (
+              <div className="meta-strategy-caption">
+                Weights sum to {customWeightSum.toFixed(2)} (must be 1.00) — backtest will skip
+                until corrected.
+              </div>
+            )}
+          </>
+        )}
+
+        <PortfolioBody computation={computation} customWeightsValid={customWeightsValid} />
+        {isReplayPlaying && (
+          <div className="meta-strategy-caption">Frozen during replay playback.</div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function PortfolioBody({
+  computation,
+  customWeightsValid,
+}: {
+  computation: ReturnType<typeof runPortfolio>;
+  customWeightsValid: boolean;
+}) {
+  if (computation.kind === "empty") {
+    return <div className="meta-strategy-caption">Run a backtest to compare across symbols.</div>;
+  }
+  if (computation.kind === "error") {
+    if (!customWeightsValid) return null;
+    return <div className="risk-error">{computation.message}</div>;
+  }
+  const { result } = computation;
+  return (
+    <>
+      <SparklineList hover className="symbol-list">
+        {result.symbols.map((s) => {
+          const equity = symbolEquityCurve(s);
+          const ret = s.result.totalReturnPercent;
+          return (
+            <div key={s.symbol} className="symbol-row">
+              <span className="symbol-name">{s.symbol}</span>
+              <Sparkline
+                type="line"
+                data={equity}
+                width={80}
+                height={22}
+                color={{ fixed: ret >= 0 ? "#26a69a" : "#ef5350" }}
+                fill
+              />
+              <span
+                className={`symbol-return ${ret >= 0 ? "good" : "bad"}`}
+              >{`${ret >= 0 ? "+" : ""}${ret.toFixed(1)}%`}</span>
+              <span className="symbol-trades">{s.result.trades.length}t</span>
+            </div>
+          );
+        })}
+      </SparklineList>
+
+      <div className="risk-result" style={{ marginTop: 8 }}>
+        <PortfolioMetric
+          label="Total return"
+          value={`${result.portfolio.totalReturnPercent >= 0 ? "+" : ""}${result.portfolio.totalReturnPercent.toFixed(2)}%`}
+          tone={result.portfolio.totalReturnPercent >= 0 ? "good" : "bad"}
+        />
+        <PortfolioMetric label="Sharpe" value={result.portfolio.sharpeRatio.toFixed(2)} />
+        <PortfolioMetric
+          label="Max DD"
+          value={`${result.portfolio.maxDrawdown.toFixed(2)}%`}
+          tone="bad"
+        />
+        <PortfolioMetric
+          label="PF"
+          value={
+            Number.isFinite(result.portfolio.profitFactor)
+              ? result.portfolio.profitFactor.toFixed(2)
+              : "∞"
+          }
+        />
+        <PortfolioMetric label="Trades" value={String(result.portfolio.tradeCount)} />
+        <PortfolioMetric label="Win rate" value={`${result.portfolio.winRate.toFixed(1)}%`} />
+      </div>
+    </>
+  );
+}
+
+function PortfolioMetric({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone?: "good" | "bad";
+}) {
+  return (
+    <div className={`metric${tone ? ` ${tone}` : ""}`}>
+      <div className="metric-label">{label}</div>
+      <div className="metric-value">{value}</div>
+    </div>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/styles.css
+++ b/packages/chart/examples/strategy-studio/src/styles.css
@@ -1194,3 +1194,54 @@ button.ghost.danger:hover {
   min-width: 28px;
   text-align: right;
 }
+
+/* ---------- Portfolio panel ---------- */
+
+.symbol-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.symbol-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 4px;
+  border-bottom: 1px solid #1e222d;
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+}
+
+.symbol-row:last-child {
+  border-bottom: none;
+}
+
+.symbol-name {
+  color: #d1d4dc;
+  font-weight: 600;
+  width: 48px;
+  flex-shrink: 0;
+}
+
+.symbol-return {
+  margin-left: auto;
+  width: 56px;
+  text-align: right;
+}
+
+.symbol-return.good {
+  color: #26a69a;
+}
+
+.symbol-return.bad {
+  color: #ef5350;
+}
+
+.symbol-trades {
+  color: #787b86;
+  width: 32px;
+  text-align: right;
+  font-size: 10px;
+}

--- a/packages/chart/examples/strategy-studio/tsconfig.json
+++ b/packages/chart/examples/strategy-studio/tsconfig.json
@@ -14,6 +14,7 @@
       "@trendcraft/chart": ["../../src/index.ts"],
       "@trendcraft/chart/presets": ["../../src/presets.ts"],
       "@trendcraft/chart/react": ["../../react/TrendChart.tsx"],
+      "@trendcraft/chart/react/sparkline": ["../../react/sparkline.tsx"],
       "trendcraft": ["../../../core/src/index.ts"],
       "trendcraft/manifest": ["../../../core/src/manifest/index.ts"]
     }

--- a/packages/chart/examples/strategy-studio/vite.config.ts
+++ b/packages/chart/examples/strategy-studio/vite.config.ts
@@ -9,12 +9,34 @@ const useDist = process.env.USE_DIST === "1";
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: {
-      "@trendcraft/chart/react": resolve(__dirname, useDist ? "../../dist/react/TrendChart.js" : "../../react/TrendChart.tsx"),
-      "@trendcraft/chart/presets": resolve(__dirname, useDist ? "../../dist/presets.js" : "../../src/presets.ts"),
-      "@trendcraft/chart": resolve(__dirname, useDist ? "../../dist/index.js" : "../../src/index.ts"),
-      "trendcraft/manifest": resolve(__dirname, useDist ? "../../../core/dist/manifest/index.js" : "../../../core/src/manifest/index.ts"),
-      "trendcraft": resolve(__dirname, useDist ? "../../../core/dist/index.js" : "../../../core/src/index.ts"),
-    },
+    // Order matters: longer / more specific keys must come first so
+    // `@trendcraft/chart/react/sparkline` doesn't get re-mapped through the
+    // generic `@trendcraft/chart/react` alias before its own entry runs.
+    alias: [
+      {
+        find: "@trendcraft/chart/react/sparkline",
+        replacement: resolve(__dirname, useDist ? "../../dist/react/sparkline.js" : "../../react/sparkline.tsx"),
+      },
+      {
+        find: "@trendcraft/chart/react",
+        replacement: resolve(__dirname, useDist ? "../../dist/react/TrendChart.js" : "../../react/TrendChart.tsx"),
+      },
+      {
+        find: "@trendcraft/chart/presets",
+        replacement: resolve(__dirname, useDist ? "../../dist/presets.js" : "../../src/presets.ts"),
+      },
+      {
+        find: "@trendcraft/chart",
+        replacement: resolve(__dirname, useDist ? "../../dist/index.js" : "../../src/index.ts"),
+      },
+      {
+        find: "trendcraft/manifest",
+        replacement: resolve(__dirname, useDist ? "../../../core/dist/manifest/index.js" : "../../../core/src/manifest/index.ts"),
+      },
+      {
+        find: "trendcraft",
+        replacement: resolve(__dirname, useDist ? "../../../core/dist/index.js" : "../../../core/src/index.ts"),
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Summary

PR10 of the Strategy Studio epic. Adds **PortfolioPanel** below MetaStrategyPanel. Runs the user's last-executed strategy across **three synthetic symbols** (BASE / STEADY / VOLAT — price-shift/scale of `sampleCandles`, deliberately not real tickers so we don't imply real OHLCV) and renders per-symbol sparkline rows + a portfolio-level metrics grid via core's `batchBacktest`.

## Implementation notes

- **Single source of truth**: `useBacktestRunner` now bundles the executed `StrategyJSON` into `state.lastResult.json`. Every right-pane panel reads from `runner.state.lastResult`, so PortfolioPanel can never show metrics for a strategy the rest of the UI hasn't actually run. Failed runs leave `lastResult` untouched and `runner.reset()` (slice changes / replay anchor) clears the JSON in lockstep — no separate App-level mirror to drift.
- **Playhead-aware**: `sliceLength` prop slices each synthetic symbol to the same horizon as `backtestCandles`, so portfolio metrics track the same window the chart and solo backtest show.
- **Apples-to-apples**: per-symbol backtests inherit the user's stops/fees/fillMode via `overridesFromResult(lastResult)`, while the panel's `Capital total $` input *wins* over any `capital` carried by the strategy JSON or solo settings (regression tested).
- **Sparkline**: `@trendcraft/chart/react/sparkline` for per-symbol equity curve mini-charts. No-trade symbols emit a flat baseline so the row isn't a blank canvas.
- **Custom allocation**: weight inputs validated against `batchBacktest`'s `> 0.01` tolerance (matches engine; tighter UI checks would yell on inputs the engine accepts).
- **Replay-freeze**: heavy multi-symbol backtest is gated on `replay.status !== "playing"` to keep Max-speed playback responsive.

`vite.config.ts` and `tsconfig.json` gain `@trendcraft/chart/react/sparkline` aliases so both Vite and `tsc -b` resolve the new subpath.

## Review process

5 rounds of `/codex:review` surfaced a series of state-management findings (capital ignored / sparkline empty / tolerance / playhead alignment / draft-state vs lastResult drift / failed-run persistence / stale-clear). The first 4 rounds were patched reactively; the 5th went back to the structural fix — bundling `json` into `StrategyRunResult` so all right-pane panels share a single source of truth. Each finding has a regression test where the bug was non-obvious (5 new tests).

Memory note: this iteration validated the "3 patches deep → redesign" rule from `feedback_session_reflections_pr4_pr7.md`. State that lives in two places (App-side mirror + runner state) keeps drifting in new ways; consolidating to one source of truth eliminated the entire bug class.

## Surfaced upstream smell (deferred)

Investigation of `core/portfolioBacktest` (which we deliberately do **not** use here) revealed 4 stub options accepted but unimplemented or silently fallen back: `rebalance` / `maxPortfolioDrawdown` / `riskParity` / `positionSizing`. Tracked in epic memo as a follow-up `core` PR. PR10 sticks to `batchBacktest` so it doesn't hide those bugs.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — studio 32 (+10) / core 4888 / mcp 59 / chart 781 (1 known flaky perf)
- [x] `pnpm build` — workspace builds, both `tsc -b` and Vite resolve subpath
- [x] Manual: empty before Run / populated after / Replay anchor → empty / weights validation / Custom allocation per-symbol input

Carved out for PR11: ScoringPanel.