### PR TITLE
feat(strategy-studio): ScoringPanel with 6 composite presets (PR11)

### DIFF
--- a/packages/chart/examples/strategy-studio/README.md
+++ b/packages/chart/examples/strategy-studio/README.md
@@ -28,8 +28,8 @@ The studio runs **fully offline with no LLM key**. It uses `detectMarketRegime` 
 | PR7 | PluginsPanel — SMC / Pitchfork / Volume Profile / Wyckoff plugin toggles | done |
 | PR8 | RiskPanel — position sizing (Risk-%/ATR/Kelly) + VaR/CVaR | done |
 | PR9 | MetaStrategyPanel — equity curve filter + strategy rotation | done |
-| PR10 | PortfolioPanel — `batchBacktest` + 3 synthetic symbols + sparkline rows | **this PR** |
-| PR11 | ScoringPanel — signal scoring visualization | |
+| PR10 | PortfolioPanel — `batchBacktest` + 3 synthetic symbols + sparkline rows | done |
+| PR11 | ScoringPanel — composite scoring (6 presets, sparkline + breakdown) | **this PR** |
 | PR12 | OptimizationPanel — grid search + walk-forward UI | |
 | PR13 | StrategyDnaPanel — genome viz + sensitivity heatmap + robustness | |
 | PR14 | chart: live recompute for batch-only presets in Replay (carved out from PR5) | |

--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -20,6 +20,7 @@ import { PresetSelector } from "./panels/PresetSelector";
 import { ReplayControls, type SpeedTier } from "./panels/ReplayControls";
 import { ResultsSummary } from "./panels/ResultsSummary";
 import { RiskPanel } from "./panels/RiskPanel";
+import { ScoringPanel } from "./panels/ScoringPanel";
 import { SignalsPanel } from "./panels/SignalsPanel";
 import { StrategyBuilder } from "./panels/StrategyBuilder";
 
@@ -689,6 +690,11 @@ export function App() {
           strategy={runner.state.lastResult?.json}
           lastResult={runner.state.lastResult?.result}
           sliceLength={backtestCandles.length}
+          isReplayPlaying={replay.mode === "live" && replay.status === "playing"}
+        />
+        <div className="pane-divider" />
+        <ScoringPanel
+          candles={backtestCandles}
           isReplayPlaying={replay.mode === "live" && replay.status === "playing"}
         />
       </aside>

--- a/packages/chart/examples/strategy-studio/src/lib/__tests__/scoring.test.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/__tests__/scoring.test.ts
@@ -1,0 +1,108 @@
+import { type ScoringPreset, getPreset } from "trendcraft";
+import { describe, expect, it } from "vitest";
+import type { StudioCandle } from "../sample-data";
+import { SCORING_PRESETS, runScoring } from "../scoring";
+
+function makeCandles(n: number): StudioCandle[] {
+  return Array.from({ length: n }, (_, i) => {
+    // Mild zig-zag so signals (RSI, momentum, etc.) actually fire.
+    const t = 1700000000000 + i * 86400000;
+    const drift = i * 0.5;
+    const wave = Math.sin(i / 8) * 4;
+    const close = 100 + drift + wave;
+    return {
+      time: t,
+      open: close - 0.3,
+      high: close + 1,
+      low: close - 1,
+      close,
+      volume: 1000 + (i % 7) * 80,
+    };
+  });
+}
+
+const ALL_PRESETS: ScoringPreset[] = SCORING_PRESETS.map((p) => p.id);
+
+describe("runScoring (PR11 invariants)", () => {
+  it("returns kind:'empty' for too-short candle slices", () => {
+    const out = runScoring(makeCandles(1), "momentum");
+    expect(out.kind).toBe("empty");
+  });
+
+  it("returns kind:'empty' for an empty array", () => {
+    const out = runScoring([], "balanced");
+    expect(out.kind).toBe("empty");
+  });
+
+  it.each(ALL_PRESETS)("each preset (%s) produces an ok result on a non-trivial slice", (p) => {
+    const out = runScoring(makeCandles(120), p);
+    if (out.kind !== "ok") throw new Error(`expected ok for ${p}, got ${out.kind}`);
+    expect(out.series.length).toBe(120);
+    expect(out.breakdown.contributions.length).toBeGreaterThan(0);
+  });
+
+  it("normalizedScore stays in [0, 100] for every preset across a full series", () => {
+    const candles = makeCandles(300);
+    for (const preset of ALL_PRESETS) {
+      const out = runScoring(candles, preset);
+      if (out.kind !== "ok") throw new Error(`expected ok for ${preset}`);
+      for (const point of out.series) {
+        expect(point.score.normalizedScore).toBeGreaterThanOrEqual(0);
+        expect(point.score.normalizedScore).toBeLessThanOrEqual(100);
+      }
+      expect(out.breakdown.normalizedScore).toBeGreaterThanOrEqual(0);
+      expect(out.breakdown.normalizedScore).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("strength tier is consistent with normalizedScore + the preset's own thresholds", () => {
+    // Different presets ship different thresholds (momentum 70/50/30,
+    // meanReversion 75/55/35, aggressive 60/40/25, conservative 80/60/40).
+    // The invariant we want is "strength agrees with the *preset's* config",
+    // not "strength agrees with a hardcoded 70/50/30".
+    const candles = makeCandles(300);
+    for (const preset of ALL_PRESETS) {
+      const out = runScoring(candles, preset);
+      if (out.kind !== "ok") throw new Error(`expected ok for ${preset}`);
+      const config = getPreset(preset);
+      const strong = config.strongThreshold ?? 70;
+      const moderate = config.moderateThreshold ?? 50;
+      const weak = config.weakThreshold ?? 30;
+      const { normalizedScore, strength } = out.breakdown;
+      const expected =
+        normalizedScore >= strong
+          ? "strong"
+          : normalizedScore >= moderate
+            ? "moderate"
+            : normalizedScore >= weak
+              ? "weak"
+              : "none";
+      expect(strength).toBe(expected);
+    }
+  });
+
+  it("is deterministic — identical inputs produce identical outputs", () => {
+    const candles = makeCandles(80);
+    const a = runScoring(candles, "balanced");
+    const b = runScoring(candles, "balanced");
+    expect(a).toEqual(b);
+  });
+
+  it("breakdown contributions sum to rawScore (within fp tolerance)", () => {
+    const out = runScoring(makeCandles(200), "trendFollowing");
+    if (out.kind !== "ok") throw new Error("expected ok");
+    const sum = out.breakdown.contributions.reduce((s, c) => s + c.score, 0);
+    expect(sum).toBeCloseTo(out.breakdown.rawScore, 6);
+  });
+
+  it("activeSignals never exceeds totalSignals", () => {
+    const candles = makeCandles(150);
+    for (const preset of ALL_PRESETS) {
+      const out = runScoring(candles, preset);
+      if (out.kind !== "ok") throw new Error("expected ok");
+      for (const point of out.series) {
+        expect(point.score.activeSignals).toBeLessThanOrEqual(point.score.totalSignals);
+      }
+    }
+  });
+});

--- a/packages/chart/examples/strategy-studio/src/lib/scoring.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/scoring.ts
@@ -1,0 +1,53 @@
+import {
+  type ScoreBreakdown,
+  type ScoreResult,
+  type ScoringPreset,
+  calculateScoreBreakdown,
+  calculateScoreSeries,
+  getPreset,
+  normalizeCandles,
+} from "trendcraft";
+import type { StudioCandle } from "./sample-data";
+
+export const SCORING_PRESETS: ReadonlyArray<{ id: ScoringPreset; label: string }> = [
+  { id: "momentum", label: "Momentum" },
+  { id: "meanReversion", label: "Mean Rev" },
+  { id: "trendFollowing", label: "Trend" },
+  { id: "balanced", label: "Balanced" },
+  { id: "aggressive", label: "Aggressive" },
+  { id: "conservative", label: "Conservative" },
+];
+
+export type ScoringComputation =
+  | {
+      kind: "ok";
+      series: Array<{ time: number; score: ScoreResult }>;
+      breakdown: ScoreBreakdown;
+    }
+  | { kind: "empty"; message: string }
+  | { kind: "error"; message: string };
+
+/**
+ * Wrap core's `calculateScoreSeries` + `calculateScoreBreakdown` so the panel
+ * deals with one discriminated union instead of two parallel calls. The
+ * series spans the full candle slice and the breakdown is for the *last*
+ * bar — what the panel renders for "current setup quality".
+ *
+ * Pure: same `(candles, presetName)` always produces the same shape, no I/O,
+ * no Math.random. Replay-aware behavior lives one layer up (the panel
+ * stops calling this while playback is running).
+ */
+export function runScoring(candles: StudioCandle[], presetName: ScoringPreset): ScoringComputation {
+  if (candles.length < 2) {
+    return { kind: "empty", message: "Need at least 2 bars to score" };
+  }
+  try {
+    const config = getPreset(presetName);
+    const normalized = normalizeCandles(candles);
+    const series = calculateScoreSeries(normalized, config);
+    const breakdown = calculateScoreBreakdown(normalized, normalized.length - 1, config);
+    return { kind: "ok", series, breakdown };
+  } catch (err) {
+    return { kind: "error", message: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/packages/chart/examples/strategy-studio/src/panels/ScoringPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/ScoringPanel.tsx
@@ -1,0 +1,124 @@
+import { Sparkline } from "@trendcraft/chart/react/sparkline";
+import { useEffect, useRef, useState } from "react";
+import type { ScoreResult, ScoringPreset } from "trendcraft";
+import type { StudioCandle } from "../lib/sample-data";
+import { SCORING_PRESETS, type ScoringComputation, runScoring } from "../lib/scoring";
+
+type Props = {
+  /** Playhead-aware candle slice from App. */
+  candles: StudioCandle[];
+  /** Replay playing → freeze recompute (score series is O(N candles × N signals)). */
+  isReplayPlaying: boolean;
+};
+
+const STRENGTH_COLOR: Record<ScoreResult["strength"], string> = {
+  strong: "#26a69a",
+  moderate: "#90c980",
+  weak: "#e9b770",
+  none: "#787b86",
+};
+
+export function ScoringPanel({ candles, isReplayPlaying }: Props) {
+  const [presetName, setPresetName] = useState<ScoringPreset>("balanced");
+  const [computation, setComputation] = useState<ScoringComputation>({
+    kind: "empty",
+    message: "Computing…",
+  });
+
+  // The replay-playing freeze exists to skip the heavy series recompute
+  // (~125 ticks/sec at Max speed). It must NOT skip user-initiated preset
+  // changes — those are single rare clicks that should always reflect on
+  // screen, otherwise the highlighted tab disagrees with the displayed
+  // numbers. Distinguish "candles tick" from "preset click" via refs.
+  const prevPresetRef = useRef(presetName);
+  const prevCandlesLenRef = useRef(candles.length);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: we deliberately key on candles.length not the array reference.
+  useEffect(() => {
+    const presetChanged = prevPresetRef.current !== presetName;
+    const candlesChanged = prevCandlesLenRef.current !== candles.length;
+    prevPresetRef.current = presetName;
+    prevCandlesLenRef.current = candles.length;
+    // Only the candle-tick path is freezable. A preset click always wins.
+    if (!presetChanged && candlesChanged && isReplayPlaying) return;
+    setComputation(runScoring(candles, presetName));
+  }, [candles.length, presetName, isReplayPlaying]);
+
+  return (
+    <div className="risk-panel">
+      <div className="pane-header">Scoring</div>
+      <section className="risk-section">
+        <div className="risk-tabs">
+          {SCORING_PRESETS.map((p) => (
+            <button
+              type="button"
+              key={p.id}
+              className={`risk-tab${presetName === p.id ? " active" : ""}`}
+              onClick={() => setPresetName(p.id)}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+        <ScoringBody computation={computation} />
+        {isReplayPlaying && (
+          <div className="meta-strategy-caption">Frozen during replay playback.</div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function ScoringBody({ computation }: { computation: ScoringComputation }) {
+  if (computation.kind === "empty") {
+    return <div className="meta-strategy-caption">{computation.message}</div>;
+  }
+  if (computation.kind === "error") {
+    return <div className="risk-error">{computation.message}</div>;
+  }
+  const { series, breakdown } = computation;
+  const sparkData = series.map((s) => s.score.normalizedScore);
+  const color = STRENGTH_COLOR[breakdown.strength];
+
+  return (
+    <>
+      <div className="scoring-spark-wrap">
+        <Sparkline
+          type="line"
+          data={sparkData}
+          width={328}
+          height={36}
+          color={{ fixed: color }}
+          baseline={breakdown.normalizedScore}
+          fill
+        />
+      </div>
+      <div className={`scoring-strength scoring-strength-${breakdown.strength}`}>
+        <span className="scoring-tier">{breakdown.strength.toUpperCase()}</span>
+        <span className="scoring-value">{breakdown.normalizedScore.toFixed(0)} / 100</span>
+        <span className="scoring-active">
+          {breakdown.activeSignals} of {breakdown.totalSignals} signals active
+        </span>
+      </div>
+      <table className="scoring-table">
+        <thead>
+          <tr>
+            <th>Signal</th>
+            <th className="num">Weight</th>
+            <th className="num">Value</th>
+            <th className="num">Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {breakdown.contributions.map((c) => (
+            <tr key={c.name} className={c.isActive ? "scoring-active-row" : "scoring-inactive-row"}>
+              <td>{c.displayName}</td>
+              <td className="num">{c.weight.toFixed(1)}</td>
+              <td className="num">{c.rawValue.toFixed(2)}</td>
+              <td className="num">{c.score.toFixed(2)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/styles.css
+++ b/packages/chart/examples/strategy-studio/src/styles.css
@@ -1245,3 +1245,91 @@ button.ghost.danger:hover {
   text-align: right;
   font-size: 10px;
 }
+
+/* ---------- Scoring panel ---------- */
+
+.scoring-spark-wrap {
+  margin: 8px 0 6px;
+}
+
+.scoring-strength {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  margin-bottom: 8px;
+  font-variant-numeric: tabular-nums;
+}
+
+.scoring-strength-strong {
+  background: rgba(38, 166, 154, 0.15);
+  color: #26a69a;
+}
+
+.scoring-strength-moderate {
+  background: rgba(144, 201, 128, 0.15);
+  color: #90c980;
+}
+
+.scoring-strength-weak {
+  background: rgba(233, 183, 112, 0.15);
+  color: #e9b770;
+}
+
+.scoring-strength-none {
+  background: rgba(120, 123, 134, 0.15);
+  color: #787b86;
+}
+
+.scoring-tier {
+  font-weight: 700;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+}
+
+.scoring-value {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.scoring-active {
+  margin-left: auto;
+  font-size: 10px;
+  color: #787b86;
+}
+
+.scoring-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.scoring-table th,
+.scoring-table td {
+  padding: 3px 4px;
+  border-bottom: 1px solid #1e222d;
+  text-align: left;
+}
+
+.scoring-table th {
+  background: #131722;
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: #787b86;
+}
+
+.scoring-table .num {
+  text-align: right;
+}
+
+.scoring-table tr:last-child td {
+  border-bottom: none;
+}
+
+.scoring-inactive-row td {
+  color: #585b66;
+}


### PR DESCRIPTION
## Summary

PR11 of the Strategy Studio epic. Adds **ScoringPanel** below PortfolioPanel as a standalone scoring playground over core's `scoring` module. Pick one of six presets (Momentum / Mean Reversion / Trend Following / Balanced / Aggressive / Conservative), see the score series as a sparkline, the current bar's strength tier (STRONG / MODERATE / WEAK / NONE) with a value badge, and the per-signal contribution breakdown table.

## Implementation notes

- **Independent system**: core's `ScoringConfig.signals[]` is its own signal universe, completely separate from PR6 SignalsPanel's `SIGNAL_CATALOG`. ScoringPanel doesn't bridge the two — bridging would re-introduce the state-drift bug class PR10's redesign just eliminated.
- **Panel-local state only**: panel takes `(candles, isReplayPlaying)` and owns `presetName` + `computation` internally. App never reads or mutates those — drift impossible at the seam.
- **Replay freeze, but only for candle-tick churn**: heavy series compute is gated on `isReplayPlaying` for the `candles.length`-change path; user preset clicks bypass the freeze so the highlighted tab and the rendered numbers can never disagree (codex P2 surfaced this; ref-tracked dispatch fixes it).
- **Invariant tests upfront**: 8 tests in `__tests__/scoring.test.ts` lock the contract before the panel is built — every preset produces an ok result, normalizedScore ∈ [0, 100], strength tier matches the preset's own thresholds (presets ship 60-80/40-60/25-40, *not* a hardcoded 70/50/30), determinism, contributions sum to rawScore, activeSignals ≤ totalSignals, gracefully empty for too-short slices.

## Review process — invariants worked

PR10's PortfolioPanel went 5 rounds of codex (state lived in two places — App-level mirror + runner state — and kept drifting). PR11 closed in **1 round** with a single P2 about preset clicks during replay. The differences:
1. State ownership single-axis (App → panel only, no mirror)
2. Invariant tests written *before* the panel (locked the contract upfront)
3. dogfooding-checked the upstream API for smells before committing to the design

Memory: `feedback_session_reflections_pr4_pr7.md` "3 patches deep → redesign" — applied here as "lock invariants up front, not patch after".

## dogfooding pass

core scoring API was clean — no silent fallback, units already 0-100 (PR-A unification carries forward), evaluator outputs are clamped to [0, 1] inside core so external `evaluate` callbacks can't overflow.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — studio 45 (+8) / core 4888 / mcp 59 / chart 781 (1 known flaky perf)
- [x] `pnpm build` — workspace builds
- [x] Manual: populates without backtest run / 6 preset switching / strength color / replay freeze + preset click during playback updates correctly

Carved out for PR12: OptimizationPanel.