### PR TITLE
feat(strategy-studio): OptimizationPanel with grid search (PR12)

### DIFF
--- a/packages/chart/examples/strategy-studio/README.md
+++ b/packages/chart/examples/strategy-studio/README.md
@@ -29,8 +29,8 @@ The studio runs **fully offline with no LLM key**. It uses `detectMarketRegime` 
 | PR8 | RiskPanel — position sizing (Risk-%/ATR/Kelly) + VaR/CVaR | done |
 | PR9 | MetaStrategyPanel — equity curve filter + strategy rotation | done |
 | PR10 | PortfolioPanel — `batchBacktest` + 3 synthetic symbols + sparkline rows | done |
-| PR11 | ScoringPanel — composite scoring (6 presets, sparkline + breakdown) | **this PR** |
-| PR12 | OptimizationPanel — grid search + walk-forward UI | |
+| PR11 | ScoringPanel — composite scoring (6 presets, sparkline + breakdown) | done |
+| PR12 | OptimizationPanel — grid search (push-to-run, auto-derived ranges, top-10 table) | **this PR** |
 | PR13 | StrategyDnaPanel — genome viz + sensitivity heatmap + robustness | |
 | PR14 | chart: live recompute for batch-only presets in Replay (carved out from PR5) | |
 | PR15 | chart: shared signal-pattern primitive (zigzag + neckline + target, extracted from indicator-showcase; carved out from PR6) | |

--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -13,6 +13,7 @@ import { SIGNAL_BY_KIND } from "./lib/signals";
 import { builderReducer, initialBuilderState, strategyJSONToState } from "./lib/strategy-state";
 import { localStudioAPI } from "./lib/studio-api";
 import { MetaStrategyPanel } from "./panels/MetaStrategyPanel";
+import { OptimizationPanel } from "./panels/OptimizationPanel";
 import { ParamPopover } from "./panels/ParamPopover";
 import { PluginsPanel } from "./panels/PluginsPanel";
 import { PortfolioPanel } from "./panels/PortfolioPanel";
@@ -694,6 +695,12 @@ export function App() {
         />
         <div className="pane-divider" />
         <ScoringPanel
+          candles={backtestCandles}
+          isReplayPlaying={replay.mode === "live" && replay.status === "playing"}
+        />
+        <div className="pane-divider" />
+        <OptimizationPanel
+          strategy={runner.state.lastResult?.json}
           candles={backtestCandles}
           isReplayPlaying={replay.mode === "live" && replay.status === "playing"}
         />

--- a/packages/chart/examples/strategy-studio/src/components/NumInput.tsx
+++ b/packages/chart/examples/strategy-studio/src/components/NumInput.tsx
@@ -1,26 +1,49 @@
+import { useEffect, useState } from "react";
+
 type NumInputProps = {
   label: string;
   value: number;
   min?: number;
   max?: number;
-  step?: number;
+  /** Number for fixed cadence, or `"any"` to allow arbitrary decimals. */
+  step?: number | "any";
   integer?: boolean;
   onChange: (v: number) => void;
 };
 
+/**
+ * Mirrors the parent's numeric `value` but keeps the user's in-progress
+ * text locally so transient strings like `"-"`, `"-0."`, or `"0."` aren't
+ * snapped back to the previous committed number on every keystroke.
+ * Only emits `onChange` when the text parses to a finite number.
+ */
 export function NumInput({ label, value, min, max, step, integer, onChange }: NumInputProps) {
+  const [draft, setDraft] = useState<string>(() => (Number.isFinite(value) ? String(value) : ""));
+
+  // Snap the local draft to the parent's value when it changes via some
+  // other path (range reset, programmatic update). Skip while the draft
+  // is mid-edit and would round-trip back to the same number — otherwise
+  // typing `2.05` flickers as `2 → 2.0 → 2.05`.
+  useEffect(() => {
+    const parsed = Number.parseFloat(draft);
+    if (!Number.isFinite(parsed) || parsed !== value) {
+      setDraft(Number.isFinite(value) ? String(value) : "");
+    }
+  }, [value, draft]);
+
   return (
     <label className="risk-input">
       <span>{label}</span>
       <input
         type="number"
-        value={Number.isFinite(value) ? value : ""}
+        value={draft}
         min={min}
         max={max}
         step={step}
         onChange={(e) => {
           const raw = e.target.value;
-          if (raw === "") return;
+          setDraft(raw);
+          if (raw === "" || raw === "-" || raw === "." || raw === "-.") return;
           const n = integer ? Number.parseInt(raw, 10) : Number.parseFloat(raw);
           if (Number.isFinite(n)) onChange(n);
         }}

--- a/packages/chart/examples/strategy-studio/src/lib/__tests__/optimization.test.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/__tests__/optimization.test.ts
@@ -1,9 +1,10 @@
-import type { StrategyJSON } from "trendcraft";
+import type { ParamDef, StrategyJSON } from "trendcraft";
 import { describe, expect, it } from "vitest";
 import {
   autoDeriveRange,
   combinationCount,
-  extractTunableParams,
+  findIntegerRangeViolation,
+  listTunables,
   runGridSearch,
 } from "../optimization";
 import type { StudioCandle } from "../sample-data";
@@ -43,20 +44,16 @@ const ALWAYS_HOLD: StrategyJSON = {
   exit: { name: "alwaysFalse" },
 };
 
-describe("extractTunableParams", () => {
-  it("captures every tunable param across entry and exit (PR12 invariant 1)", () => {
-    const tunables = extractTunableParams(GOLDEN_CROSS_DEAD_CROSS);
-    // entry.shortPeriod, entry.longPeriod, exit.shortPeriod, exit.longPeriod = 4
-    expect(tunables).toHaveLength(4);
+describe("listTunables", () => {
+  it("uses core path syntax (`bucket.leafIndex.paramName`) so keys round-trip through gridSearchFromJSON", () => {
+    const tunables = listTunables(GOLDEN_CROSS_DEAD_CROSS);
     const keys = tunables.map((t) => t.key).sort();
     expect(keys).toEqual([
-      "entry-0.longPeriod",
-      "entry-0.shortPeriod",
-      "exit-0.longPeriod",
-      "exit-0.shortPeriod",
+      "entry.0.longPeriod",
+      "entry.0.shortPeriod",
+      "exit.0.longPeriod",
+      "exit.0.shortPeriod",
     ]);
-    // Period params are integer-valued — captured by the registry's int default+min.
-    for (const t of tunables) expect(t.isInteger).toBe(true);
   });
 
   it("treats omitted registry min as no-lower-bound (regression — CMF threshold default 0)", () => {
@@ -71,7 +68,7 @@ describe("extractTunableParams", () => {
       entry: { name: "cmfAbove", params: { threshold: 0 } },
       exit: { name: "cmfBelow", params: { threshold: 0 } },
     };
-    const tunables = extractTunableParams(cmf);
+    const tunables = listTunables(cmf);
     const t = tunables.find((x) => x.paramName === "threshold");
     expect(t?.registryMin).toBe(Number.NEGATIVE_INFINITY);
     expect(t?.currentValue).toBe(0);
@@ -86,25 +83,9 @@ describe("extractTunableParams", () => {
       entry: { name: "bollingerBreakout", params: { period: 20, stdDev: 2 } },
       exit: { name: "bollingerTouch", params: { period: 20, stdDev: 2 } },
     };
-    const tunables = extractTunableParams(bollinger);
+    const tunables = listTunables(bollinger);
     const stdDev = tunables.find((t) => t.paramName === "stdDev");
     expect(stdDev?.isInteger).toBe(false);
-  });
-
-  it("returns [] for strategies whose conditions take no params (PR12 invariant 2a)", () => {
-    expect(extractTunableParams(ALWAYS_HOLD)).toEqual([]);
-  });
-
-  it("safely skips conditions not in the registry (PR12 invariant 2b)", () => {
-    const bogus: StrategyJSON = {
-      $schema: "trendcraft/strategy",
-      version: 1,
-      id: "bogus",
-      name: "bogus",
-      entry: { name: "thisDoesNotExist", params: { p: 1 } },
-      exit: { name: "alsoMissing" },
-    };
-    expect(extractTunableParams(bogus)).toEqual([]);
   });
 
   it("uses registry default when JSON omits the param", () => {
@@ -113,17 +94,21 @@ describe("extractTunableParams", () => {
       version: 1,
       id: "partial",
       name: "partial",
-      entry: { name: "goldenCross" }, // no params at all
+      entry: { name: "goldenCross" },
       exit: { name: "deadCross" },
     };
-    const tunables = extractTunableParams(partial);
-    const short = tunables.find((t) => t.key === "entry-0.shortPeriod");
+    const tunables = listTunables(partial);
+    const short = tunables.find((t) => t.key === "entry.0.shortPeriod");
     expect(short?.currentValue).toBe(5); // registry default
+  });
+
+  it("returns [] for strategies whose conditions take no params", () => {
+    expect(listTunables(ALWAYS_HOLD)).toEqual([]);
   });
 });
 
 describe("autoDeriveRange", () => {
-  it("respects registry min (PR12 invariant 3)", () => {
+  it("respects registry min", () => {
     const range = autoDeriveRange(2, 1);
     expect(range.min).toBeGreaterThanOrEqual(1);
   });
@@ -143,8 +128,6 @@ describe("autoDeriveRange", () => {
   });
 
   it("preserves fractional resolution for float params (regression — Bollinger stdDev etc.)", () => {
-    // currentValue=2.0, registryMin=0.1, isInteger=false → step must allow
-    // values like 1.5, 2.0, 2.5, not snap everything to integers.
     const r = autoDeriveRange(2.0, 0.1, false);
     expect(r.step).toBeLessThan(1);
     expect(r.min).toBeGreaterThanOrEqual(0.1);
@@ -152,8 +135,6 @@ describe("autoDeriveRange", () => {
   });
 
   it("expands range around zero-valued params (regression — CMF threshold = 0)", () => {
-    // currentValue=0 with no lower bound → range must include 0 and span
-    // some non-zero width so optimization actually exercises nearby values.
     const r = autoDeriveRange(0, Number.NEGATIVE_INFINITY, false);
     expect(r.min).toBeLessThanOrEqual(0);
     expect(r.max).toBeGreaterThan(r.min);
@@ -167,22 +148,113 @@ describe("autoDeriveRange", () => {
   });
 
   it("scales step with value magnitude — sub-0.1 params reach below 0.1 step (regression)", () => {
-    // For a tolerance default 0.02 with min 0.001, the step must be
-    // <= 0.01 so the search space contains values around 0.02 at meaningful
-    // resolution. A hard-coded 0.1 floor would coarsen this beyond the
-    // useful range.
     const r = autoDeriveRange(0.02, 0.001, false);
     expect(r.step).toBeLessThan(0.01);
     expect(r.min).toBeGreaterThanOrEqual(0.001);
     expect(r.max).toBeGreaterThan(r.min);
   });
+
+  it("uses ParamDef.precision when annotated (PR-A1 hybrid path)", () => {
+    // schema.precision: 1 → step exactly 0.1 regardless of magnitude.
+    const schema: ParamDef = { type: "number", default: 2, min: 0.1, precision: 1 };
+    const r = autoDeriveRange(2.0, 0.1, false, schema);
+    expect(r.step).toBeCloseTo(0.1, 10);
+  });
+
+  it("clamps range to ParamDef.suggestedMax when annotated (PR-A1 hybrid path)", () => {
+    // currentValue=180, suggestedMax=200 → upper bound shouldn't exceed 200
+    // even though magnitude-based heuristic would push to 270.
+    const schema: ParamDef = {
+      type: "number",
+      default: 14,
+      min: 1,
+      integer: true,
+      suggestedMax: 200,
+    };
+    const r = autoDeriveRange(180, 1, true, schema);
+    expect(r.max).toBeLessThanOrEqual(200);
+  });
+
+  it("ignores suggestedMax when current value exceeds it (regression — period=500 saved against suggestedMax=200)", () => {
+    // suggestedMax is a UI hint, not validation, so persisted strategies
+    // can legitimately carry a `period: 500` even when the registry
+    // declares `suggestedMax: 200`. The auto-derived range must center
+    // around 500 and ignore the hint, otherwise the optimization panel
+    // can't search around the user's actual saved value.
+    const schema: ParamDef = {
+      type: "number",
+      default: 14,
+      min: 1,
+      integer: true,
+      suggestedMax: 200,
+    };
+    const r = autoDeriveRange(500, 1, true, schema);
+    expect(r.min).toBeLessThan(500);
+    expect(r.max).toBeGreaterThanOrEqual(500);
+    expect(r.min).toBeLessThan(r.max);
+    expect(r.min).toBeGreaterThanOrEqual(1); // registryMin (hard contract) honoured
+    expect(r.step).toBeGreaterThan(0);
+  });
+
+  it("ignores suggestedMax for floats too when current exceeds it (regression)", () => {
+    const schema: ParamDef = {
+      type: "number",
+      default: 2,
+      min: 0.1,
+      precision: 1,
+      suggestedMax: 5,
+    };
+    const r = autoDeriveRange(8, 0.1, false, schema);
+    expect(r.min).toBeLessThan(8);
+    expect(r.max).toBeGreaterThanOrEqual(8);
+    expect(r.min).toBeLessThan(r.max);
+    expect(r.min).toBeGreaterThanOrEqual(0.1);
+  });
+
+  it("ignores suggestedMin when current value is below it (regression — saved CMF threshold=-5 against suggestedMin=-1)", () => {
+    // suggestedMin is a UI hint, not validation. Persisted strategies
+    // with threshold=-5 are legal even when the registry annotates
+    // suggestedMin=-1, and the auto-derived range must still center
+    // around -5 instead of clipping to [-1, -0.99].
+    const schema: ParamDef = {
+      type: "number",
+      default: 0,
+      precision: 2,
+      suggestedMin: -1,
+      suggestedMax: 1,
+    };
+    const r = autoDeriveRange(-5, Number.NEGATIVE_INFINITY, false, schema);
+    expect(r.min).toBeLessThan(-1);
+    expect(r.max).toBeGreaterThanOrEqual(-5);
+    expect(r.min).toBeLessThan(r.max);
+  });
+
+  it("clamps range to ParamDef.suggestedMin when annotated (PR-A1 hybrid path)", () => {
+    const schema: ParamDef = {
+      type: "number",
+      default: 0,
+      precision: 2,
+      suggestedMin: -1,
+      suggestedMax: 1,
+    };
+    const r = autoDeriveRange(0, Number.NEGATIVE_INFINITY, false, schema);
+    expect(r.min).toBeGreaterThanOrEqual(-1);
+    expect(r.max).toBeLessThanOrEqual(1);
+  });
+
+  it("falls back to heuristic when schema is omitted (backwards compatibility)", () => {
+    // Same call shape as the existing 8 heuristic tests above — ensure
+    // the new `schema?` arg defaulting to undefined doesn't change behavior.
+    const r = autoDeriveRange(20, 1, true);
+    expect(r.min).toBeLessThan(20);
+    expect(r.max).toBeGreaterThan(20);
+    expect(r.step).toBeGreaterThanOrEqual(1);
+  });
 });
 
 describe("combinationCount", () => {
-  it("matches gridSearch's internal counter (PR12 invariant 4)", () => {
-    // For one range [1..5 step 1] = 5 combinations.
+  it("matches gridSearch's internal counter", () => {
     expect(combinationCount([{ name: "a", min: 1, max: 5, step: 1 }])).toBe(5);
-    // Two ranges combine multiplicatively.
     expect(
       combinationCount([
         { name: "a", min: 1, max: 5, step: 1 },
@@ -192,44 +264,64 @@ describe("combinationCount", () => {
   });
 
   it("returns -1 for invalid ranges instead of throwing (regression)", () => {
-    // The panel calls combinationCount on every keystroke. core's
-    // countCombinations throws on max<min or step<=0; we return -1 so the
-    // panel can render a validation message rather than unmount.
     expect(combinationCount([{ name: "a", min: 50, max: 10, step: 1 }])).toBe(-1);
     expect(combinationCount([{ name: "a", min: 1, max: 5, step: 0 }])).toBe(-1);
     expect(combinationCount([{ name: "a", min: 1, max: 5, step: -1 }])).toBe(-1);
   });
 
   it("agrees with gridSearch's inclusive decimal stepping (regression — float off-by-one)", () => {
-    // core's getParameterValues walks `min += step while value <= max + ε`,
-    // so 0..0.3 step 0.1 yields [0, 0.1, 0.2, 0.3] = 4 values. A naive
-    // floor((0.3-0)/0.1)+1 returns 3 because 0.3/0.1 = 2.9999... in fp.
     expect(combinationCount([{ name: "a", min: 0, max: 0.3, step: 0.1 }])).toBe(4);
     expect(combinationCount([{ name: "a", min: 1, max: 1.5, step: 0.1 }])).toBe(6);
     expect(combinationCount([{ name: "a", min: 0.1, max: 1.0, step: 0.1 }])).toBe(10);
   });
 
   it("doesn't enumerate the grid (regression — perf trap on small step)", () => {
-    // core's countCombinations enumerates every value via getParameterValues.
-    // For range 0..1 step 0.0001 that's 10,001 entries; on every keystroke
-    // before the >10_000 guard fires the panel would lock up. We compute
-    // by formula so the call stays O(1) per range.
     const start = performance.now();
     const result = combinationCount([{ name: "a", min: 0, max: 100, step: 0.000_001 }]);
     const elapsed = performance.now() - start;
-    expect(elapsed).toBeLessThan(50); // O(1) per range — should be sub-millisecond
-    expect(result).toBeGreaterThan(10_000); // capped by Number.MAX_SAFE_INTEGER fallback
+    expect(elapsed).toBeLessThan(50);
+    expect(result).toBeGreaterThan(10_000);
+  });
+});
+
+describe("findIntegerRangeViolation", () => {
+  it("returns null when ranges are valid", () => {
+    const tunables = listTunables(GOLDEN_CROSS_DEAD_CROSS);
+    const ranges = [{ name: "entry.0.shortPeriod", min: 5, max: 10, step: 1 }];
+    expect(findIntegerRangeViolation(tunables, ranges)).toBeNull();
+  });
+
+  it("returns null when integer schema is annotated and range is integer-clean", () => {
+    const tunables = listTunables(GOLDEN_CROSS_DEAD_CROSS);
+    const ranges = [{ name: "entry.0.shortPeriod", min: 5, max: 7, step: 2 }];
+    expect(findIntegerRangeViolation(tunables, ranges)).toBeNull();
+  });
+
+  it("flags fractional values when schema.integer is true (annotated)", () => {
+    const tunables = listTunables(GOLDEN_CROSS_DEAD_CROSS);
+    // goldenCross.shortPeriod is annotated integer:true in core.
+    const ranges = [{ name: "entry.0.shortPeriod", min: 5, max: 10, step: 0.5 }];
+    const v = findIntegerRangeViolation(tunables, ranges);
+    expect(v).not.toBeNull();
+    expect(v?.field).toBe("step");
+    expect(v?.value).toBe(0.5);
+  });
+
+  it("ignores ranges that do not address a known tunable", () => {
+    const tunables = listTunables(GOLDEN_CROSS_DEAD_CROSS);
+    const ranges = [{ name: "entry.99.bogus", min: 1.5, max: 2.5, step: 0.5 }];
+    expect(findIntegerRangeViolation(tunables, ranges)).toBeNull();
   });
 });
 
 describe("runGridSearch", () => {
-  it("is deterministic — identical inputs produce identical outputs (PR12 invariant 5)", () => {
+  it("is deterministic — identical inputs produce identical outputs", () => {
     const candles = makeCandles(100);
     const ranges = [
-      { name: "entry-0.shortPeriod", min: 3, max: 7, step: 2 },
-      { name: "entry-0.longPeriod", min: 20, max: 30, step: 5 },
-      { name: "exit-0.shortPeriod", min: 3, max: 7, step: 2 },
-      { name: "exit-0.longPeriod", min: 20, max: 30, step: 5 },
+      { name: "entry.0.shortPeriod", min: 3, max: 7, step: 2 },
+      { name: "entry.0.longPeriod", min: 20, max: 30, step: 5 },
+      { name: "exit.0.shortPeriod", min: 3, max: 7, step: 2 },
+      { name: "exit.0.longPeriod", min: 20, max: 30, step: 5 },
     ];
     const a = runGridSearch(candles, GOLDEN_CROSS_DEAD_CROSS, ranges, "returns");
     const b = runGridSearch(candles, GOLDEN_CROSS_DEAD_CROSS, ranges, "returns");
@@ -238,21 +330,18 @@ describe("runGridSearch", () => {
     expect(a.result.bestScore).toBe(b.result.bestScore);
   });
 
-  it("returns kind:'empty' when 0 tunables (alwaysTrue strategy) (PR12 invariant 8)", () => {
+  it("returns kind:'empty' when 0 tunables (alwaysTrue strategy)", () => {
     const out = runGridSearch(makeCandles(100), ALWAYS_HOLD, [], "returns");
     expect(out.kind).toBe("empty");
   });
 
-  it("returns kind:'empty' when no parameter combinations produce trades (PR12 invariant 6)", () => {
-    // Tiny slice + tiny ranges → no signals fire → no trades on any combo.
+  it("returns kind:'empty' when no parameter combinations produce trades", () => {
     const out = runGridSearch(
       makeCandles(40),
       GOLDEN_CROSS_DEAD_CROSS,
-      [{ name: "entry-0.shortPeriod", min: 30, max: 35, step: 5 }],
+      [{ name: "entry.0.shortPeriod", min: 30, max: 35, step: 5 }],
       "returns",
     );
-    // Either empty (no trades) or ok with valid combinations — both are
-    // legitimate; what matters is we don't show bestScore=0 misleadingly.
     if (out.kind === "ok") {
       expect(out.result.validCombinations).toBeGreaterThan(0);
     } else {
@@ -261,43 +350,29 @@ describe("runGridSearch", () => {
   });
 
   it("rebuilds bestParams/bestScore/validCombinations after filtering zero-trade rows (regression)", () => {
-    // Same setup as the zero-trade exclusion test — also assert that the
-    // summary fields reference a row that's actually still in the table.
-    // Otherwise the caption could claim "best 0.00" while the displayed
-    // top-N has no such row.
     const ranges = [
-      { name: "entry-0.shortPeriod", min: 5, max: 7, step: 1 },
-      { name: "entry-0.longPeriod", min: 6, max: 8, step: 1 },
-      { name: "exit-0.shortPeriod", min: 5, max: 5, step: 1 },
-      { name: "exit-0.longPeriod", min: 25, max: 25, step: 1 },
+      { name: "entry.0.shortPeriod", min: 5, max: 7, step: 1 },
+      { name: "entry.0.longPeriod", min: 6, max: 8, step: 1 },
+      { name: "exit.0.shortPeriod", min: 5, max: 5, step: 1 },
+      { name: "exit.0.longPeriod", min: 25, max: 25, step: 1 },
     ];
     const out = runGridSearch(makeCandles(120), GOLDEN_CROSS_DEAD_CROSS, ranges, "returns");
-    if (out.kind !== "ok") return; // empty case is acceptable
+    if (out.kind !== "ok") return;
     const { result } = out;
-    // bestScore must equal the top row's score; bestParams must match its params.
     expect(result.bestScore).toBe(result.results[0].score);
     expect(result.bestParams).toEqual(result.results[0].params);
-    // validCombinations should be the count of rows we actually kept.
     expect(result.validCombinations).toBe(result.results.length);
   });
 
   it("excludes zero-trade entries from ranked results (regression)", () => {
-    // Mix one combo that should produce trades with several that won't,
-    // and assert that none of the entries in `result.results` have zero
-    // trades — otherwise zero-trade configs would tie with score=0 and
-    // pollute the top-N table.
     const ranges = [
-      // shortPeriod range overlaps with longPeriod range so some combos are
-      // invalid (long <= short → no signals); mixing in a sane combo too.
-      { name: "entry-0.shortPeriod", min: 5, max: 7, step: 1 },
-      { name: "entry-0.longPeriod", min: 6, max: 8, step: 1 },
-      { name: "exit-0.shortPeriod", min: 5, max: 5, step: 1 },
-      { name: "exit-0.longPeriod", min: 25, max: 25, step: 1 },
+      { name: "entry.0.shortPeriod", min: 5, max: 7, step: 1 },
+      { name: "entry.0.longPeriod", min: 6, max: 8, step: 1 },
+      { name: "exit.0.shortPeriod", min: 5, max: 5, step: 1 },
+      { name: "exit.0.longPeriod", min: 25, max: 25, step: 1 },
     ];
     const out = runGridSearch(makeCandles(120), GOLDEN_CROSS_DEAD_CROSS, ranges, "returns");
     if (out.kind !== "ok") {
-      // Acceptable: if all combos happen to produce zero trades we expect
-      // an empty result (also handled by the existing empty-state path).
       expect(out.kind).toBe("empty");
       return;
     }
@@ -307,17 +382,14 @@ describe("runGridSearch", () => {
   });
 
   it("returns kind:'empty' when no combination produces any trades (regression)", () => {
-    // 30-bar slice + period range 50..60 → indicators never warm up → 0
-    // trades on every combination. Without this guard the panel would show
-    // a misleading "best 0.00" ranking instead of an empty state.
     const out = runGridSearch(
       makeCandles(30),
       GOLDEN_CROSS_DEAD_CROSS,
       [
-        { name: "entry-0.shortPeriod", min: 50, max: 55, step: 5 },
-        { name: "entry-0.longPeriod", min: 56, max: 60, step: 4 },
-        { name: "exit-0.shortPeriod", min: 50, max: 55, step: 5 },
-        { name: "exit-0.longPeriod", min: 56, max: 60, step: 4 },
+        { name: "entry.0.shortPeriod", min: 50, max: 55, step: 5 },
+        { name: "entry.0.longPeriod", min: 56, max: 60, step: 4 },
+        { name: "exit.0.shortPeriod", min: 50, max: 55, step: 5 },
+        { name: "exit.0.longPeriod", min: 56, max: 60, step: 4 },
       ],
       "returns",
     );
@@ -325,22 +397,18 @@ describe("runGridSearch", () => {
   });
 
   it("forwards strategy.backtest settings to every grid run (regression)", () => {
-    // direction, stops, fees etc must reach runBacktest — silently dropping
-    // them would optimise against a different ruleset than the user's solo
-    // backtest, producing misleading "best" params.
     const strategyWithSettings: StrategyJSON = {
       ...GOLDEN_CROSS_DEAD_CROSS,
       backtest: { capital: 50_000, stopLoss: 5, takeProfit: 10 },
     };
     const ranges = [
-      { name: "entry-0.shortPeriod", min: 5, max: 7, step: 2 },
-      { name: "entry-0.longPeriod", min: 25, max: 27, step: 2 },
-      { name: "exit-0.shortPeriod", min: 5, max: 7, step: 2 },
-      { name: "exit-0.longPeriod", min: 25, max: 27, step: 2 },
+      { name: "entry.0.shortPeriod", min: 5, max: 7, step: 2 },
+      { name: "entry.0.longPeriod", min: 25, max: 27, step: 2 },
+      { name: "exit.0.shortPeriod", min: 5, max: 7, step: 2 },
+      { name: "exit.0.longPeriod", min: 25, max: 27, step: 2 },
     ];
     const out = runGridSearch(makeCandles(120), strategyWithSettings, ranges, "returns");
     if (out.kind !== "ok") throw new Error(`expected ok, got ${out.kind}`);
-    // Every result's backtest must reflect the strategy's settings.
     for (const entry of out.result.results) {
       expect(entry.backtest.initialCapital).toBe(50_000);
       expect(entry.backtest.settings.stopLoss).toBe(5);
@@ -348,15 +416,13 @@ describe("runGridSearch", () => {
     }
   });
 
-  it("returns kind:'error' when combinations exceed core's maxCombinations (PR12 invariant 7)", () => {
-    // Force > 10000 combinations across 4 params.
+  it("returns kind:'error' when combinations exceed core's maxCombinations", () => {
     const ranges = [
-      { name: "entry-0.shortPeriod", min: 1, max: 20, step: 1 }, // 20
-      { name: "entry-0.longPeriod", min: 21, max: 40, step: 1 }, // 20
-      { name: "exit-0.shortPeriod", min: 1, max: 20, step: 1 }, // 20
-      { name: "exit-0.longPeriod", min: 21, max: 40, step: 1 }, // 20
+      { name: "entry.0.shortPeriod", min: 1, max: 20, step: 1 },
+      { name: "entry.0.longPeriod", min: 21, max: 40, step: 1 },
+      { name: "exit.0.shortPeriod", min: 1, max: 20, step: 1 },
+      { name: "exit.0.longPeriod", min: 21, max: 40, step: 1 },
     ];
-    // 20^4 = 160,000 — well over the 10k cap.
     const out = runGridSearch(makeCandles(100), GOLDEN_CROSS_DEAD_CROSS, ranges, "returns");
     expect(out.kind).toBe("error");
   });

--- a/packages/chart/examples/strategy-studio/src/lib/__tests__/optimization.test.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/__tests__/optimization.test.ts
@@ -1,0 +1,363 @@
+import type { StrategyJSON } from "trendcraft";
+import { describe, expect, it } from "vitest";
+import {
+  autoDeriveRange,
+  combinationCount,
+  extractTunableParams,
+  runGridSearch,
+} from "../optimization";
+import type { StudioCandle } from "../sample-data";
+
+function makeCandles(n: number): StudioCandle[] {
+  return Array.from({ length: n }, (_, i) => {
+    const t = 1700000000000 + i * 86400000;
+    const wave = Math.sin(i / 8) * 5;
+    const drift = i * 0.3;
+    const close = 100 + drift + wave;
+    return {
+      time: t,
+      open: close - 0.3,
+      high: close + 1.2,
+      low: close - 1.2,
+      close,
+      volume: 1000 + (i % 5) * 60,
+    };
+  });
+}
+
+const GOLDEN_CROSS_DEAD_CROSS: StrategyJSON = {
+  $schema: "trendcraft/strategy",
+  version: 1,
+  id: "test-gc-dc",
+  name: "Test GC/DC",
+  entry: { name: "goldenCross", params: { shortPeriod: 5, longPeriod: 25 } },
+  exit: { name: "deadCross", params: { shortPeriod: 5, longPeriod: 25 } },
+};
+
+const ALWAYS_HOLD: StrategyJSON = {
+  $schema: "trendcraft/strategy",
+  version: 1,
+  id: "test-always",
+  name: "Always Hold",
+  entry: { name: "alwaysTrue" },
+  exit: { name: "alwaysFalse" },
+};
+
+describe("extractTunableParams", () => {
+  it("captures every tunable param across entry and exit (PR12 invariant 1)", () => {
+    const tunables = extractTunableParams(GOLDEN_CROSS_DEAD_CROSS);
+    // entry.shortPeriod, entry.longPeriod, exit.shortPeriod, exit.longPeriod = 4
+    expect(tunables).toHaveLength(4);
+    const keys = tunables.map((t) => t.key).sort();
+    expect(keys).toEqual([
+      "entry-0.longPeriod",
+      "entry-0.shortPeriod",
+      "exit-0.longPeriod",
+      "exit-0.shortPeriod",
+    ]);
+    // Period params are integer-valued — captured by the registry's int default+min.
+    for (const t of tunables) expect(t.isInteger).toBe(true);
+  });
+
+  it("treats omitted registry min as no-lower-bound (regression — CMF threshold default 0)", () => {
+    // cmfAbove/cmfBelow declare `threshold: { default: 0 }` with no `min`.
+    // Falling back to `min = 1` would auto-derive a 1..2 range and never
+    // search around the actual threshold of 0.
+    const cmf: StrategyJSON = {
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "test-cmf",
+      name: "CMF",
+      entry: { name: "cmfAbove", params: { threshold: 0 } },
+      exit: { name: "cmfBelow", params: { threshold: 0 } },
+    };
+    const tunables = extractTunableParams(cmf);
+    const t = tunables.find((x) => x.paramName === "threshold");
+    expect(t?.registryMin).toBe(Number.NEGATIVE_INFINITY);
+    expect(t?.currentValue).toBe(0);
+  });
+
+  it("flags fractional registry params as non-integer (regression — Bollinger etc.)", () => {
+    const bollinger: StrategyJSON = {
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "test-bb",
+      name: "BB Breakout",
+      entry: { name: "bollingerBreakout", params: { period: 20, stdDev: 2 } },
+      exit: { name: "bollingerTouch", params: { period: 20, stdDev: 2 } },
+    };
+    const tunables = extractTunableParams(bollinger);
+    const stdDev = tunables.find((t) => t.paramName === "stdDev");
+    expect(stdDev?.isInteger).toBe(false);
+  });
+
+  it("returns [] for strategies whose conditions take no params (PR12 invariant 2a)", () => {
+    expect(extractTunableParams(ALWAYS_HOLD)).toEqual([]);
+  });
+
+  it("safely skips conditions not in the registry (PR12 invariant 2b)", () => {
+    const bogus: StrategyJSON = {
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "bogus",
+      name: "bogus",
+      entry: { name: "thisDoesNotExist", params: { p: 1 } },
+      exit: { name: "alsoMissing" },
+    };
+    expect(extractTunableParams(bogus)).toEqual([]);
+  });
+
+  it("uses registry default when JSON omits the param", () => {
+    const partial: StrategyJSON = {
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "partial",
+      name: "partial",
+      entry: { name: "goldenCross" }, // no params at all
+      exit: { name: "deadCross" },
+    };
+    const tunables = extractTunableParams(partial);
+    const short = tunables.find((t) => t.key === "entry-0.shortPeriod");
+    expect(short?.currentValue).toBe(5); // registry default
+  });
+});
+
+describe("autoDeriveRange", () => {
+  it("respects registry min (PR12 invariant 3)", () => {
+    const range = autoDeriveRange(2, 1);
+    expect(range.min).toBeGreaterThanOrEqual(1);
+  });
+
+  it("centres around currentValue with reasonable step", () => {
+    const range = autoDeriveRange(20, 1);
+    expect(range.min).toBeLessThan(20);
+    expect(range.max).toBeGreaterThan(20);
+    expect(range.step).toBeGreaterThanOrEqual(1);
+  });
+
+  it("never produces an empty range (max > min)", () => {
+    for (const v of [1, 2, 5, 14, 50, 200]) {
+      const r = autoDeriveRange(v, 1);
+      expect(r.max).toBeGreaterThan(r.min);
+    }
+  });
+
+  it("preserves fractional resolution for float params (regression — Bollinger stdDev etc.)", () => {
+    // currentValue=2.0, registryMin=0.1, isInteger=false → step must allow
+    // values like 1.5, 2.0, 2.5, not snap everything to integers.
+    const r = autoDeriveRange(2.0, 0.1, false);
+    expect(r.step).toBeLessThan(1);
+    expect(r.min).toBeGreaterThanOrEqual(0.1);
+    expect(r.max).toBeGreaterThan(r.min);
+  });
+
+  it("expands range around zero-valued params (regression — CMF threshold = 0)", () => {
+    // currentValue=0 with no lower bound → range must include 0 and span
+    // some non-zero width so optimization actually exercises nearby values.
+    const r = autoDeriveRange(0, Number.NEGATIVE_INFINITY, false);
+    expect(r.min).toBeLessThanOrEqual(0);
+    expect(r.max).toBeGreaterThan(r.min);
+    expect(r.step).toBeGreaterThan(0);
+  });
+
+  it("respects negative-allowed registryMin (registryMin = NEGATIVE_INFINITY)", () => {
+    const r = autoDeriveRange(-2, Number.NEGATIVE_INFINITY, false);
+    expect(r.min).toBeLessThanOrEqual(-2);
+    expect(r.max).toBeGreaterThanOrEqual(-2);
+  });
+
+  it("scales step with value magnitude — sub-0.1 params reach below 0.1 step (regression)", () => {
+    // For a tolerance default 0.02 with min 0.001, the step must be
+    // <= 0.01 so the search space contains values around 0.02 at meaningful
+    // resolution. A hard-coded 0.1 floor would coarsen this beyond the
+    // useful range.
+    const r = autoDeriveRange(0.02, 0.001, false);
+    expect(r.step).toBeLessThan(0.01);
+    expect(r.min).toBeGreaterThanOrEqual(0.001);
+    expect(r.max).toBeGreaterThan(r.min);
+  });
+});
+
+describe("combinationCount", () => {
+  it("matches gridSearch's internal counter (PR12 invariant 4)", () => {
+    // For one range [1..5 step 1] = 5 combinations.
+    expect(combinationCount([{ name: "a", min: 1, max: 5, step: 1 }])).toBe(5);
+    // Two ranges combine multiplicatively.
+    expect(
+      combinationCount([
+        { name: "a", min: 1, max: 5, step: 1 },
+        { name: "b", min: 10, max: 30, step: 5 },
+      ]),
+    ).toBe(5 * 5);
+  });
+
+  it("returns -1 for invalid ranges instead of throwing (regression)", () => {
+    // The panel calls combinationCount on every keystroke. core's
+    // countCombinations throws on max<min or step<=0; we return -1 so the
+    // panel can render a validation message rather than unmount.
+    expect(combinationCount([{ name: "a", min: 50, max: 10, step: 1 }])).toBe(-1);
+    expect(combinationCount([{ name: "a", min: 1, max: 5, step: 0 }])).toBe(-1);
+    expect(combinationCount([{ name: "a", min: 1, max: 5, step: -1 }])).toBe(-1);
+  });
+
+  it("agrees with gridSearch's inclusive decimal stepping (regression — float off-by-one)", () => {
+    // core's getParameterValues walks `min += step while value <= max + ε`,
+    // so 0..0.3 step 0.1 yields [0, 0.1, 0.2, 0.3] = 4 values. A naive
+    // floor((0.3-0)/0.1)+1 returns 3 because 0.3/0.1 = 2.9999... in fp.
+    expect(combinationCount([{ name: "a", min: 0, max: 0.3, step: 0.1 }])).toBe(4);
+    expect(combinationCount([{ name: "a", min: 1, max: 1.5, step: 0.1 }])).toBe(6);
+    expect(combinationCount([{ name: "a", min: 0.1, max: 1.0, step: 0.1 }])).toBe(10);
+  });
+
+  it("doesn't enumerate the grid (regression — perf trap on small step)", () => {
+    // core's countCombinations enumerates every value via getParameterValues.
+    // For range 0..1 step 0.0001 that's 10,001 entries; on every keystroke
+    // before the >10_000 guard fires the panel would lock up. We compute
+    // by formula so the call stays O(1) per range.
+    const start = performance.now();
+    const result = combinationCount([{ name: "a", min: 0, max: 100, step: 0.000_001 }]);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(50); // O(1) per range — should be sub-millisecond
+    expect(result).toBeGreaterThan(10_000); // capped by Number.MAX_SAFE_INTEGER fallback
+  });
+});
+
+describe("runGridSearch", () => {
+  it("is deterministic — identical inputs produce identical outputs (PR12 invariant 5)", () => {
+    const candles = makeCandles(100);
+    const ranges = [
+      { name: "entry-0.shortPeriod", min: 3, max: 7, step: 2 },
+      { name: "entry-0.longPeriod", min: 20, max: 30, step: 5 },
+      { name: "exit-0.shortPeriod", min: 3, max: 7, step: 2 },
+      { name: "exit-0.longPeriod", min: 20, max: 30, step: 5 },
+    ];
+    const a = runGridSearch(candles, GOLDEN_CROSS_DEAD_CROSS, ranges, "returns");
+    const b = runGridSearch(candles, GOLDEN_CROSS_DEAD_CROSS, ranges, "returns");
+    if (a.kind !== "ok" || b.kind !== "ok") throw new Error("expected ok");
+    expect(a.result.bestParams).toEqual(b.result.bestParams);
+    expect(a.result.bestScore).toBe(b.result.bestScore);
+  });
+
+  it("returns kind:'empty' when 0 tunables (alwaysTrue strategy) (PR12 invariant 8)", () => {
+    const out = runGridSearch(makeCandles(100), ALWAYS_HOLD, [], "returns");
+    expect(out.kind).toBe("empty");
+  });
+
+  it("returns kind:'empty' when no parameter combinations produce trades (PR12 invariant 6)", () => {
+    // Tiny slice + tiny ranges → no signals fire → no trades on any combo.
+    const out = runGridSearch(
+      makeCandles(40),
+      GOLDEN_CROSS_DEAD_CROSS,
+      [{ name: "entry-0.shortPeriod", min: 30, max: 35, step: 5 }],
+      "returns",
+    );
+    // Either empty (no trades) or ok with valid combinations — both are
+    // legitimate; what matters is we don't show bestScore=0 misleadingly.
+    if (out.kind === "ok") {
+      expect(out.result.validCombinations).toBeGreaterThan(0);
+    } else {
+      expect(out.kind).toBe("empty");
+    }
+  });
+
+  it("rebuilds bestParams/bestScore/validCombinations after filtering zero-trade rows (regression)", () => {
+    // Same setup as the zero-trade exclusion test — also assert that the
+    // summary fields reference a row that's actually still in the table.
+    // Otherwise the caption could claim "best 0.00" while the displayed
+    // top-N has no such row.
+    const ranges = [
+      { name: "entry-0.shortPeriod", min: 5, max: 7, step: 1 },
+      { name: "entry-0.longPeriod", min: 6, max: 8, step: 1 },
+      { name: "exit-0.shortPeriod", min: 5, max: 5, step: 1 },
+      { name: "exit-0.longPeriod", min: 25, max: 25, step: 1 },
+    ];
+    const out = runGridSearch(makeCandles(120), GOLDEN_CROSS_DEAD_CROSS, ranges, "returns");
+    if (out.kind !== "ok") return; // empty case is acceptable
+    const { result } = out;
+    // bestScore must equal the top row's score; bestParams must match its params.
+    expect(result.bestScore).toBe(result.results[0].score);
+    expect(result.bestParams).toEqual(result.results[0].params);
+    // validCombinations should be the count of rows we actually kept.
+    expect(result.validCombinations).toBe(result.results.length);
+  });
+
+  it("excludes zero-trade entries from ranked results (regression)", () => {
+    // Mix one combo that should produce trades with several that won't,
+    // and assert that none of the entries in `result.results` have zero
+    // trades — otherwise zero-trade configs would tie with score=0 and
+    // pollute the top-N table.
+    const ranges = [
+      // shortPeriod range overlaps with longPeriod range so some combos are
+      // invalid (long <= short → no signals); mixing in a sane combo too.
+      { name: "entry-0.shortPeriod", min: 5, max: 7, step: 1 },
+      { name: "entry-0.longPeriod", min: 6, max: 8, step: 1 },
+      { name: "exit-0.shortPeriod", min: 5, max: 5, step: 1 },
+      { name: "exit-0.longPeriod", min: 25, max: 25, step: 1 },
+    ];
+    const out = runGridSearch(makeCandles(120), GOLDEN_CROSS_DEAD_CROSS, ranges, "returns");
+    if (out.kind !== "ok") {
+      // Acceptable: if all combos happen to produce zero trades we expect
+      // an empty result (also handled by the existing empty-state path).
+      expect(out.kind).toBe("empty");
+      return;
+    }
+    for (const entry of out.result.results) {
+      expect(entry.backtest.trades.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns kind:'empty' when no combination produces any trades (regression)", () => {
+    // 30-bar slice + period range 50..60 → indicators never warm up → 0
+    // trades on every combination. Without this guard the panel would show
+    // a misleading "best 0.00" ranking instead of an empty state.
+    const out = runGridSearch(
+      makeCandles(30),
+      GOLDEN_CROSS_DEAD_CROSS,
+      [
+        { name: "entry-0.shortPeriod", min: 50, max: 55, step: 5 },
+        { name: "entry-0.longPeriod", min: 56, max: 60, step: 4 },
+        { name: "exit-0.shortPeriod", min: 50, max: 55, step: 5 },
+        { name: "exit-0.longPeriod", min: 56, max: 60, step: 4 },
+      ],
+      "returns",
+    );
+    expect(out.kind).toBe("empty");
+  });
+
+  it("forwards strategy.backtest settings to every grid run (regression)", () => {
+    // direction, stops, fees etc must reach runBacktest — silently dropping
+    // them would optimise against a different ruleset than the user's solo
+    // backtest, producing misleading "best" params.
+    const strategyWithSettings: StrategyJSON = {
+      ...GOLDEN_CROSS_DEAD_CROSS,
+      backtest: { capital: 50_000, stopLoss: 5, takeProfit: 10 },
+    };
+    const ranges = [
+      { name: "entry-0.shortPeriod", min: 5, max: 7, step: 2 },
+      { name: "entry-0.longPeriod", min: 25, max: 27, step: 2 },
+      { name: "exit-0.shortPeriod", min: 5, max: 7, step: 2 },
+      { name: "exit-0.longPeriod", min: 25, max: 27, step: 2 },
+    ];
+    const out = runGridSearch(makeCandles(120), strategyWithSettings, ranges, "returns");
+    if (out.kind !== "ok") throw new Error(`expected ok, got ${out.kind}`);
+    // Every result's backtest must reflect the strategy's settings.
+    for (const entry of out.result.results) {
+      expect(entry.backtest.initialCapital).toBe(50_000);
+      expect(entry.backtest.settings.stopLoss).toBe(5);
+      expect(entry.backtest.settings.takeProfit).toBe(10);
+    }
+  });
+
+  it("returns kind:'error' when combinations exceed core's maxCombinations (PR12 invariant 7)", () => {
+    // Force > 10000 combinations across 4 params.
+    const ranges = [
+      { name: "entry-0.shortPeriod", min: 1, max: 20, step: 1 }, // 20
+      { name: "entry-0.longPeriod", min: 21, max: 40, step: 1 }, // 20
+      { name: "exit-0.shortPeriod", min: 1, max: 20, step: 1 }, // 20
+      { name: "exit-0.longPeriod", min: 21, max: 40, step: 1 }, // 20
+    ];
+    // 20^4 = 160,000 — well over the 10k cap.
+    const out = runGridSearch(makeCandles(100), GOLDEN_CROSS_DEAD_CROSS, ranges, "returns");
+    expect(out.kind).toBe("error");
+  });
+});

--- a/packages/chart/examples/strategy-studio/src/lib/optimization.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/optimization.ts
@@ -1,0 +1,317 @@
+import {
+  type ConditionSpec,
+  type GridSearchResult,
+  type OptimizationMetric,
+  type ParameterRange,
+  type StrategyJSON,
+  backtestRegistry,
+  gridSearch,
+  hydrateCondition,
+  normalizeCandles,
+} from "trendcraft";
+import type { StudioCandle } from "./sample-data";
+
+/**
+ * One tunable parameter discovered by walking a strategy's ConditionSpec.
+ * `key` is the panel-stable identifier ("entry-0.shortPeriod"), used both
+ * as the React key for input rows and as the lookup key when injecting
+ * grid-search params back into the strategy at evaluation time.
+ */
+export type Tunable = {
+  key: string;
+  /** Which side this leaf came from — "entry" or "exit". */
+  bucket: "entry" | "exit";
+  /** Index of the leaf within entry/exit (top-level AND-of-leaves only). */
+  leafIndex: number;
+  /** Registered condition name, e.g. "goldenCross". */
+  conditionName: string;
+  /** Param name within the condition, e.g. "shortPeriod". */
+  paramName: string;
+  /** Current value taken from the strategy JSON, falling back to registry default. */
+  currentValue: number;
+  /** Registry-declared minimum (>= 1 for periods, etc.). */
+  registryMin: number;
+  /**
+   * Hint that the param "looks integer-valued" based on the registry's
+   * default and min — used only to seed the auto-derived range's step.
+   * Inputs are always allowed to be fractional regardless: the registry
+   * doesn't carry an explicit integer/float marker, so any heuristic here
+   * is fragile (RSI thresholds with `default: 20, min: 0` look integer-ish
+   * but real users want `19.5`). Rest of Studio accepts fractional values
+   * for these params; the panel must too.
+   */
+  isInteger: boolean;
+};
+
+/**
+ * Walk a strategy JSON's `entry` and `exit` and pull out every tunable
+ * numeric parameter. AND-of-leaves only (matches the Studio builder's UI
+ * model). Conditions whose registry entry has zero `params` (e.g.
+ * `alwaysTrue`) are silently skipped.
+ */
+export function extractTunableParams(strategy: StrategyJSON): Tunable[] {
+  const out: Tunable[] = [];
+  for (const bucket of ["entry", "exit"] as const) {
+    const spec = strategy[bucket];
+    const leaves = flattenLeaves(spec);
+    for (let i = 0; i < leaves.length; i++) {
+      const leaf = leaves[i];
+      const entry = backtestRegistry.get(leaf.name);
+      if (!entry) continue;
+      for (const [paramName, schema] of Object.entries(entry.params)) {
+        if (schema.type !== "number") continue;
+        // `min` may legitimately be 0 or negative (CMF threshold etc.) or
+        // omitted entirely. Negative-infinity-equivalent (`Number.NEGATIVE_INFINITY`)
+        // means "no lower bound" so the auto-derived range can include the
+        // current value even when it's 0 or negative.
+        const min = typeof schema.min === "number" ? schema.min : Number.NEGATIVE_INFINITY;
+        const def =
+          typeof schema.default === "number" ? schema.default : Number.isFinite(min) ? min : 0;
+        const supplied = leaf.params?.[paramName];
+        const currentValue = typeof supplied === "number" ? supplied : def;
+        const isInteger =
+          (min === Number.NEGATIVE_INFINITY || Number.isInteger(min)) && Number.isInteger(def);
+        out.push({
+          key: `${bucket}-${i}.${paramName}`,
+          bucket,
+          leafIndex: i,
+          conditionName: leaf.name,
+          paramName,
+          currentValue,
+          registryMin: min,
+          isInteger,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Studio's builder UI only models AND-of-leaves. Anything more complex
+ * (OR / NOT) is collapsed to its leaves with no logical meaning preserved
+ * — fine for parameter discovery, since the leaves still drive backtest
+ * indicators.
+ */
+function flattenLeaves(
+  spec: ConditionSpec,
+): Array<{ name: string; params?: Record<string, unknown> }> {
+  if ("name" in spec) return [{ name: spec.name, params: spec.params }];
+  return spec.conditions.flatMap(flattenLeaves);
+}
+
+/**
+ * Choose a sensible default range around the user's current parameter
+ * value. Centres on `currentValue`, expanded by ±half the value's
+ * magnitude, targeting ~10 grid buckets. Step granularity scales with
+ * the magnitude so `0.001`-scale tolerances stay reachable. The registry
+ * minimum is always honoured (may be `Number.NEGATIVE_INFINITY` for
+ * params with no declared lower bound — CMF threshold etc.).
+ */
+export function autoDeriveRange(
+  currentValue: number,
+  registryMin: number,
+  isInteger = true,
+): ParameterRange {
+  // `span` is the half-width of the search range. Use the absolute value's
+  // magnitude so threshold=0 and threshold=-50 both expand to a visible
+  // range instead of degenerating to [0, 0].
+  const magnitudeSeed = Math.abs(currentValue) || 1;
+  const half = magnitudeSeed * 0.5;
+  const respectMin = (v: number) =>
+    registryMin === Number.NEGATIVE_INFINITY ? v : Math.max(registryMin, v);
+
+  if (isInteger) {
+    const lower = respectMin(Math.floor(currentValue - half));
+    const upper = Math.max(lower + 1, Math.ceil(currentValue + half));
+    const step = Math.max(1, Math.round((upper - lower) / 10));
+    return { name: "", min: lower, max: upper, step };
+  }
+  const lower = respectMin(currentValue - half);
+  const upper = Math.max(lower + Number.EPSILON, currentValue + half);
+  const span = upper - lower;
+  const targetStep = span / 10;
+  // Power-of-ten grid keeps the visible numbers clean and scales with the
+  // value's magnitude so `0.001`-scale params get `0.0001`-ish steps.
+  const magnitude = 10 ** Math.floor(Math.log10(Math.max(targetStep, Number.MIN_VALUE)));
+  const step = Math.max(magnitude, Number.EPSILON);
+  const round = (v: number) => Math.round(v / magnitude) * magnitude;
+  const minRounded = respectMin(round(lower));
+  const maxRounded = Math.max(minRounded + step, round(upper));
+  return { name: "", min: minRounded, max: maxRounded, step };
+}
+
+export type OptimizationMetricUI = "returns" | "sharpe" | "profitFactor" | "winRate";
+
+export const OPTIMIZATION_METRICS: ReadonlyArray<{ id: OptimizationMetricUI; label: string }> = [
+  { id: "returns", label: "Return %" },
+  { id: "sharpe", label: "Sharpe" },
+  { id: "profitFactor", label: "Profit Factor" },
+  { id: "winRate", label: "Win Rate" },
+];
+
+export type OptimizationComputation =
+  | { kind: "idle" }
+  | { kind: "ok"; result: GridSearchResult; metric: OptimizationMetricUI }
+  | { kind: "empty"; message: string }
+  | { kind: "error"; message: string };
+
+/** Inject grid-search params into a strategy JSON's leaves at runtime. */
+function buildFactoryStrategy(
+  base: StrategyJSON,
+  tunables: Tunable[],
+  params: Record<string, number>,
+): { entry: ConditionSpec; exit: ConditionSpec } {
+  const tunableByKey = new Map(tunables.map((t) => [t.key, t]));
+  const apply = (spec: ConditionSpec, bucket: "entry" | "exit", index: number): ConditionSpec => {
+    if ("name" in spec) {
+      const updated: Record<string, unknown> = { ...(spec.params ?? {}) };
+      for (const [paramName, value] of Object.entries(spec.params ?? {})) {
+        updated[paramName] = value;
+      }
+      // Override only the params present in `params` and addressed at this leaf.
+      for (const t of tunables) {
+        if (t.bucket === bucket && t.leafIndex === index) {
+          const v = params[t.key];
+          if (v !== undefined) updated[t.paramName] = v;
+        }
+      }
+      // Also fill in defaults for any tunable that didn't have an existing value.
+      for (const t of tunables) {
+        if (t.bucket === bucket && t.leafIndex === index && updated[t.paramName] === undefined) {
+          updated[t.paramName] = tunableByKey.get(t.key)?.currentValue;
+        }
+      }
+      return { name: spec.name, params: updated };
+    }
+    // For combined specs we map each child positionally; flattenLeaves uses
+    // the same depth-first order so leaf indices align.
+    let leafCount = 0;
+    const newConditions: ConditionSpec[] = [];
+    for (const child of spec.conditions) {
+      const childLeaves = flattenLeaves(child).length;
+      newConditions.push(apply(child, bucket, index + leafCount));
+      leafCount += childLeaves;
+    }
+    return { op: spec.op, conditions: newConditions };
+  };
+  return {
+    entry: apply(base.entry, "entry", 0),
+    exit: apply(base.exit, "exit", 0),
+  };
+}
+
+/**
+ * Run gridSearch over the user-supplied parameter ranges. The strategy
+ * JSON is the source of truth for shape (entry/exit conditions); the
+ * factory only swaps numeric values keyed by the tunable's `key`.
+ *
+ * Pure: same `(candles, strategy, ranges, metric)` always produces the
+ * same output. Replay-aware behavior lives one layer up (panel disables
+ * the Run button while playback is running).
+ */
+export function runGridSearch(
+  candles: StudioCandle[],
+  strategy: StrategyJSON,
+  ranges: ParameterRange[],
+  metric: OptimizationMetricUI,
+): OptimizationComputation {
+  const tunables = extractTunableParams(strategy);
+  if (tunables.length === 0) {
+    return { kind: "empty", message: "Strategy has no tunable parameters" };
+  }
+  if (ranges.length === 0) {
+    return { kind: "empty", message: "No parameter ranges configured" };
+  }
+  if (candles.length < 20) {
+    return { kind: "empty", message: "Slice too short to optimize" };
+  }
+  try {
+    const normalized = normalizeCandles(candles);
+    // Forward the *full* strategy.backtest config — silently dropping
+    // direction / stops / fees / fillMode would optimise against assumptions
+    // that don't match the user's solo backtest, so the "best" params would
+    // disagree with what the user gets re-running the strategy. capital
+    // defaults if missing; everything else is passthrough.
+    const baseOptions = {
+      capital: 100_000,
+      ...(strategy.backtest ?? {}),
+    };
+    const result = gridSearch(
+      normalized,
+      (params) => {
+        const { entry, exit } = buildFactoryStrategy(strategy, tunables, params);
+        return {
+          entry: hydrateCondition(entry, backtestRegistry),
+          exit: hydrateCondition(exit, backtestRegistry),
+          options: baseOptions,
+        };
+      },
+      ranges,
+      { metric: metric === "returns" ? "returns" : metric, keepAllResults: false },
+    );
+    // `validCombinations` only reflects constraint passes — with no
+    // constraints (our default) every combo "passes" even when the backtest
+    // emits zero trades. Worse, a no-trade backtest scores 0 on every
+    // metric, so zero-trade entries can rank above real losing configs in
+    // the top-N table. Filter them out entirely and rebuild the summary
+    // fields (bestScore/bestParams/validCombinations) so they reference
+    // a row that's actually still in the table — otherwise the caption can
+    // claim "best 0.00" while the displayed top-N has no such row.
+    const tradingResults = result.results.filter((r) => r.backtest.trades.length > 0);
+    if (tradingResults.length === 0) {
+      return {
+        kind: "empty",
+        message: "No parameter combinations produced any trades on this slice",
+      };
+    }
+    const sorted = [...tradingResults].sort((a, b) => b.score - a.score);
+    const best = sorted[0];
+    const filtered = {
+      ...result,
+      results: sorted,
+      bestParams: best.params,
+      bestScore: best.score,
+      validCombinations: tradingResults.length,
+    };
+    return { kind: "ok", result: filtered, metric };
+  } catch (err) {
+    return { kind: "error", message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Combination count, defensively. core's `countCombinations` enumerates
+ * each range via `getParameterValues` — fine for the cap check inside
+ * `gridSearch`, but the panel calls this on every keystroke and a wide
+ * range with a small decimal step (e.g. `0.001`) builds millions of
+ * entries before the `> 10_000` guard fires, freezing the UI.
+ *
+ * We compute it with math only (`floor((max - min) / step) + 1` per
+ * range, multiplicative across ranges) and short-circuit at the first
+ * range that already pushes the total over `Number.MAX_SAFE_INTEGER` —
+ * that's "too many" by any practical definition. Invalid ranges
+ * (`max < min`, `step <= 0`) return `-1` so the panel can render a
+ * validation message instead of unmounting on render.
+ */
+export function combinationCount(ranges: ParameterRange[]): number {
+  if (ranges.length === 0) return 0;
+  let total = 1;
+  for (const r of ranges) {
+    if (r.step <= 0 || r.max < r.min) return -1;
+    // Mirror core `getParameterValues`: it walks `min += step` while
+    // `value <= max + epsilon`, so e.g. `0..0.3 step 0.1` produces
+    // [0, 0.1, 0.2, 0.3] = 4 values, not 3 like a naive `floor((max-min)/step)+1`
+    // would say (floating point makes 0.3/0.1 = 2.9999...). Use the same
+    // epsilon convention so the panel's count agrees with what gridSearch
+    // will actually evaluate.
+    const epsilon = Math.abs(r.step) / 1_000_000;
+    const count = Math.floor((r.max - r.min + epsilon) / r.step) + 1;
+    if (count <= 0) return -1;
+    total *= count;
+    if (total > Number.MAX_SAFE_INTEGER) return Number.MAX_SAFE_INTEGER;
+  }
+  return total;
+}
+
+export type { ParameterRange, OptimizationMetric, GridSearchResult };

--- a/packages/chart/examples/strategy-studio/src/lib/optimization.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/optimization.ts
@@ -1,143 +1,206 @@
 import {
-  type ConditionSpec,
   type GridSearchResult,
   type OptimizationMetric,
+  type ParamDef,
   type ParameterRange,
+  type PathParameterRange,
   type StrategyJSON,
   backtestRegistry,
-  gridSearch,
-  hydrateCondition,
+  flattenStrategyLeaves,
+  gridSearchFromJSON,
   normalizeCandles,
 } from "trendcraft";
 import type { StudioCandle } from "./sample-data";
 
 /**
  * One tunable parameter discovered by walking a strategy's ConditionSpec.
- * `key` is the panel-stable identifier ("entry-0.shortPeriod"), used both
- * as the React key for input rows and as the lookup key when injecting
- * grid-search params back into the strategy at evaluation time.
+ * `key` follows core's path syntax (`<bucket>.<leafIndex>.<paramName>`,
+ * see core's `parseLeafPath` / `applyParamOverrides`) so it round-trips
+ * through `gridSearchFromJSON` without translation.
  */
 export type Tunable = {
   key: string;
-  /** Which side this leaf came from — "entry" or "exit". */
   bucket: "entry" | "exit";
-  /** Index of the leaf within entry/exit (top-level AND-of-leaves only). */
   leafIndex: number;
-  /** Registered condition name, e.g. "goldenCross". */
   conditionName: string;
-  /** Param name within the condition, e.g. "shortPeriod". */
   paramName: string;
-  /** Current value taken from the strategy JSON, falling back to registry default. */
   currentValue: number;
-  /** Registry-declared minimum (>= 1 for periods, etc.). */
+  /**
+   * Registry-declared minimum (`Number.NEGATIVE_INFINITY` when absent —
+   * CMF threshold etc.). Studio never lets the search range fall below
+   * this, so a CMF default 0 with no declared min still searches around
+   * zero instead of degenerating to [0,0].
+   */
   registryMin: number;
   /**
-   * Hint that the param "looks integer-valued" based on the registry's
-   * default and min — used only to seed the auto-derived range's step.
-   * Inputs are always allowed to be fractional regardless: the registry
-   * doesn't carry an explicit integer/float marker, so any heuristic here
-   * is fragile (RSI thresholds with `default: 20, min: 0` look integer-ish
-   * but real users want `19.5`). Rest of Studio accepts fractional values
-   * for these params; the panel must too.
+   * `true` when the param accepts only integer values. Source of truth:
+   * `ParamDef.integer` from PR-A1 when annotated; falls back to a
+   * heuristic (`isInteger(default) && isInteger(min)`) for entries the
+   * registry hasn't been annotated for yet.
    */
   isInteger: boolean;
+  /**
+   * Full registry `ParamDef`. Lets `autoDeriveRange` consult
+   * `schema.precision` / `schema.suggestedMax` annotations without
+   * re-querying the registry.
+   */
+  schema: ParamDef;
 };
 
 /**
- * Walk a strategy JSON's `entry` and `exit` and pull out every tunable
- * numeric parameter. AND-of-leaves only (matches the Studio builder's UI
- * model). Conditions whose registry entry has zero `params` (e.g.
- * `alwaysTrue`) are silently skipped.
+ * Walk a strategy JSON's `entry`/`exit` and pull out every numeric
+ * tunable. Studio-specific wrapper around core's `flattenStrategyLeaves`
+ * — adds registry-aware default hydration and the `Tunable` shape.
+ *
+ * Conditions whose registry entry is missing or whose params are all
+ * non-numeric are silently skipped, so a strategy with `alwaysTrue` /
+ * `alwaysFalse` returns `[]` (used by the panel to render the empty
+ * state). For partially-registered strategies (one valid + one
+ * unknown), only the valid leaves are surfaced — `gridSearchFromJSON`
+ * will reject the unknown leaf upfront when actually run.
  */
-export function extractTunableParams(strategy: StrategyJSON): Tunable[] {
+export function listTunables(strategy: StrategyJSON): Tunable[] {
   const out: Tunable[] = [];
-  for (const bucket of ["entry", "exit"] as const) {
-    const spec = strategy[bucket];
-    const leaves = flattenLeaves(spec);
-    for (let i = 0; i < leaves.length; i++) {
-      const leaf = leaves[i];
-      const entry = backtestRegistry.get(leaf.name);
-      if (!entry) continue;
-      for (const [paramName, schema] of Object.entries(entry.params)) {
-        if (schema.type !== "number") continue;
-        // `min` may legitimately be 0 or negative (CMF threshold etc.) or
-        // omitted entirely. Negative-infinity-equivalent (`Number.NEGATIVE_INFINITY`)
-        // means "no lower bound" so the auto-derived range can include the
-        // current value even when it's 0 or negative.
-        const min = typeof schema.min === "number" ? schema.min : Number.NEGATIVE_INFINITY;
-        const def =
-          typeof schema.default === "number" ? schema.default : Number.isFinite(min) ? min : 0;
-        const supplied = leaf.params?.[paramName];
-        const currentValue = typeof supplied === "number" ? supplied : def;
-        const isInteger =
-          (min === Number.NEGATIVE_INFINITY || Number.isInteger(min)) && Number.isInteger(def);
-        out.push({
-          key: `${bucket}-${i}.${paramName}`,
-          bucket,
-          leafIndex: i,
-          conditionName: leaf.name,
-          paramName,
-          currentValue,
-          registryMin: min,
-          isInteger,
-        });
-      }
+  for (const leaf of flattenStrategyLeaves(strategy)) {
+    const entry = backtestRegistry.get(leaf.name);
+    if (!entry) continue;
+    for (const [paramName, schema] of Object.entries(entry.params)) {
+      if (schema.type !== "number") continue;
+      const min = typeof schema.min === "number" ? schema.min : Number.NEGATIVE_INFINITY;
+      const def =
+        typeof schema.default === "number" ? schema.default : Number.isFinite(min) ? min : 0;
+      const supplied = leaf.params?.[paramName];
+      const currentValue = typeof supplied === "number" ? supplied : def;
+      const isInteger =
+        schema.integer ??
+        ((min === Number.NEGATIVE_INFINITY || Number.isInteger(min)) && Number.isInteger(def));
+      out.push({
+        key: `${leaf.bucket}.${leaf.leafIndex}.${paramName}`,
+        bucket: leaf.bucket,
+        leafIndex: leaf.leafIndex,
+        conditionName: leaf.name,
+        paramName,
+        currentValue,
+        registryMin: min,
+        isInteger,
+        schema,
+      });
     }
   }
   return out;
 }
 
 /**
- * Studio's builder UI only models AND-of-leaves. Anything more complex
- * (OR / NOT) is collapsed to its leaves with no logical meaning preserved
- * — fine for parameter discovery, since the leaves still drive backtest
- * indicators.
- */
-function flattenLeaves(
-  spec: ConditionSpec,
-): Array<{ name: string; params?: Record<string, unknown> }> {
-  if ("name" in spec) return [{ name: spec.name, params: spec.params }];
-  return spec.conditions.flatMap(flattenLeaves);
-}
-
-/**
  * Choose a sensible default range around the user's current parameter
- * value. Centres on `currentValue`, expanded by ±half the value's
- * magnitude, targeting ~10 grid buckets. Step granularity scales with
- * the magnitude so `0.001`-scale tolerances stay reachable. The registry
- * minimum is always honoured (may be `Number.NEGATIVE_INFINITY` for
- * params with no declared lower bound — CMF threshold etc.).
+ * value. Hybrid: prefers `ParamDef` annotations from PR-A1 when present
+ * (`schema.integer` / `schema.precision` / `schema.suggestedMin/Max`)
+ * and falls back to the original magnitude-based heuristic for entries
+ * the registry hasn't been annotated for yet.
+ *
+ * - Integer params: range is integer-rounded; step is `(span / 10)`
+ *   rounded up to ≥1.
+ * - Float params: when `schema.precision` is set, step is
+ *   `10 ** -precision` (e.g. `precision: 1` → step 0.1). Otherwise the
+ *   step scales with the value's magnitude as a power-of-ten so
+ *   `0.001`-scale params get `0.0001`-ish steps.
+ * - `schema.suggestedMin/Max` clamp the auto-derived bounds (UI hints,
+ *   not enforced by core's validator). The registry's hard `min` is
+ *   always honoured.
  */
 export function autoDeriveRange(
   currentValue: number,
   registryMin: number,
   isInteger = true,
+  schema?: ParamDef,
 ): ParameterRange {
-  // `span` is the half-width of the search range. Use the absolute value's
-  // magnitude so threshold=0 and threshold=-50 both expand to a visible
-  // range instead of degenerating to [0, 0].
   const magnitudeSeed = Math.abs(currentValue) || 1;
   const half = magnitudeSeed * 0.5;
+  // `suggestedMin` / `suggestedMax` are UI hints, not validation. They
+  // narrow the auto-derived range only when the current value is
+  // *inside* the hint window — otherwise the hint would clip away the
+  // user's actual saved value (e.g. `threshold: -5` against
+  // `suggestedMin: -1` would otherwise collapse to `[-1, -0.99]` and
+  // the panel could not search around -5). registryMin (hard contract)
+  // is always enforced regardless.
+  const rawSuggestedMax =
+    schema && typeof schema.suggestedMax === "number" ? schema.suggestedMax : undefined;
+  const rawSuggestedMin =
+    schema && typeof schema.suggestedMin === "number" ? schema.suggestedMin : undefined;
+  const suggestedMax =
+    rawSuggestedMax !== undefined && currentValue <= rawSuggestedMax ? rawSuggestedMax : undefined;
+  const suggestedMin =
+    rawSuggestedMin !== undefined && currentValue >= rawSuggestedMin ? rawSuggestedMin : undefined;
+  const lowerFloor = (() => {
+    if (suggestedMin !== undefined && registryMin !== Number.NEGATIVE_INFINITY) {
+      return Math.max(registryMin, suggestedMin);
+    }
+    if (suggestedMin !== undefined) return suggestedMin;
+    return registryMin;
+  })();
   const respectMin = (v: number) =>
-    registryMin === Number.NEGATIVE_INFINITY ? v : Math.max(registryMin, v);
+    lowerFloor === Number.NEGATIVE_INFINITY ? v : Math.max(lowerFloor, v);
+  const respectMax = (v: number) => (suggestedMax !== undefined ? Math.min(suggestedMax, v) : v);
 
   if (isInteger) {
-    const lower = respectMin(Math.floor(currentValue - half));
-    const upper = Math.max(lower + 1, Math.ceil(currentValue + half));
-    const step = Math.max(1, Math.round((upper - lower) / 10));
+    const idealLower = respectMin(Math.floor(currentValue - half));
+    const idealUpper = Math.max(idealLower + 1, Math.ceil(currentValue + half));
+    const upper = respectMax(idealUpper);
+    // When the suggestedMax clamp brings `upper` below the centered
+    // lower (e.g. a saved `period: 500` with `suggestedMax: 200` —
+    // legal because suggestedMax is only a hint), re-anchor `lower`
+    // under `upper` so the result stays a valid range. registryMin
+    // (hard contract) still wins over the clamp.
+    const lowerCandidate = Math.min(idealLower, upper - 1);
+    const lower =
+      lowerFloor === Number.NEGATIVE_INFINITY
+        ? lowerCandidate
+        : Math.max(lowerFloor, lowerCandidate);
+    const span = Math.max(1, upper - lower);
+    const step = Math.max(1, Math.round(span / 10));
     return { name: "", min: lower, max: upper, step };
   }
-  const lower = respectMin(currentValue - half);
-  const upper = Math.max(lower + Number.EPSILON, currentValue + half);
-  const span = upper - lower;
-  const targetStep = span / 10;
-  // Power-of-ten grid keeps the visible numbers clean and scales with the
-  // value's magnitude so `0.001`-scale params get `0.0001`-ish steps.
-  const magnitude = 10 ** Math.floor(Math.log10(Math.max(targetStep, Number.MIN_VALUE)));
-  const step = Math.max(magnitude, Number.EPSILON);
-  const round = (v: number) => Math.round(v / magnitude) * magnitude;
-  const minRounded = respectMin(round(lower));
-  const maxRounded = Math.max(minRounded + step, round(upper));
+  const lowerRaw = respectMin(currentValue - half);
+  const upperRaw = Math.max(lowerRaw + Number.EPSILON, currentValue + half);
+  const upper = respectMax(upperRaw);
+  // Same re-anchor logic for floats: if suggestedMax clamped upper
+  // below the centered lower, slide lower back to maintain `lower < upper`.
+  const lowerCandidate = Math.min(lowerRaw, upper);
+  const lower =
+    lowerFloor === Number.NEGATIVE_INFINITY ? lowerCandidate : Math.max(lowerFloor, lowerCandidate);
+
+  // Step granularity: annotated precision wins, otherwise scale with magnitude.
+  let step: number;
+  if (schema && typeof schema.precision === "number" && schema.precision > 0) {
+    step = 10 ** -schema.precision;
+  } else {
+    const span = Math.max(upper - lower, Number.EPSILON);
+    const targetStep = span / 10;
+    const magnitude = 10 ** Math.floor(Math.log10(Math.max(targetStep, Number.MIN_VALUE)));
+    step = Math.max(magnitude, Number.EPSILON);
+  }
+  const round = (v: number) => Math.round(v / step) * step;
+  let minRounded = respectMin(round(lower));
+  // Cap the final max at `upper` so the `suggestedMax` clamp cannot be
+  // exceeded by `minRounded + step` rounding (e.g. saved `stdDev: 20`
+  // with `suggestedMax: 5` + `precision: 1` would otherwise yield
+  // `5..5.1`).
+  const maxRoundedRaw = Math.max(minRounded + step, round(upper));
+  const maxRounded = Math.min(upper, maxRoundedRaw);
+  // If the upper clamp collapses `min == max`, slide `min` down by
+  // ~10 steps (clamped by registryMin) so optimization still has a
+  // meaningful range to search instead of degenerating to a single
+  // value. This keeps out-of-range saved strategies (current >
+  // suggestedMax) usable in the panel without manual editing.
+  if (minRounded >= maxRounded) {
+    const slideTarget = round(maxRounded - 10 * step);
+    minRounded =
+      lowerFloor === Number.NEGATIVE_INFINITY ? slideTarget : Math.max(lowerFloor, slideTarget);
+    if (minRounded >= maxRounded) {
+      // registryMin is at or above suggestedMax — genuinely degenerate
+      // search space, collapse to single-value rather than emit min > max.
+      minRounded = maxRounded;
+    }
+  }
   return { name: "", min: minRounded, max: maxRounded, step };
 }
 
@@ -150,65 +213,60 @@ export const OPTIMIZATION_METRICS: ReadonlyArray<{ id: OptimizationMetricUI; lab
   { id: "winRate", label: "Win Rate" },
 ];
 
+/**
+ * Find the first range whose values violate `schema.integer === true`
+ * for the addressed param. Used by the panel to disable Run + render
+ * an inline warning before the user clicks, so the violation is caught
+ * at edit time rather than after `gridSearchFromJSON` rejects it with
+ * a generic-looking error. Returns `null` when every range is valid.
+ *
+ * The check is path-keyed: `range.name` must match a `Tunable.key`.
+ * Ranges that don't address a tunable are ignored (they'll be flagged
+ * by `gridSearchFromJSON` upfront in any case).
+ */
+export function findIntegerRangeViolation(
+  tunables: Tunable[],
+  ranges: ParameterRange[],
+): { paramName: string; field: "min" | "max" | "step"; value: number } | null {
+  const byKey = new Map(tunables.map((t) => [t.key, t]));
+  for (const r of ranges) {
+    const t = byKey.get(r.name);
+    if (!t || t.schema.integer !== true) continue;
+    for (const field of ["min", "max", "step"] as const) {
+      const value = r[field];
+      if (!Number.isInteger(value)) {
+        return { paramName: t.paramName, field, value };
+      }
+    }
+  }
+  return null;
+}
+
 export type OptimizationComputation =
   | { kind: "idle" }
   | { kind: "ok"; result: GridSearchResult; metric: OptimizationMetricUI }
   | { kind: "empty"; message: string }
   | { kind: "error"; message: string };
 
-/** Inject grid-search params into a strategy JSON's leaves at runtime. */
-function buildFactoryStrategy(
-  base: StrategyJSON,
-  tunables: Tunable[],
-  params: Record<string, number>,
-): { entry: ConditionSpec; exit: ConditionSpec } {
-  const tunableByKey = new Map(tunables.map((t) => [t.key, t]));
-  const apply = (spec: ConditionSpec, bucket: "entry" | "exit", index: number): ConditionSpec => {
-    if ("name" in spec) {
-      const updated: Record<string, unknown> = { ...(spec.params ?? {}) };
-      for (const [paramName, value] of Object.entries(spec.params ?? {})) {
-        updated[paramName] = value;
-      }
-      // Override only the params present in `params` and addressed at this leaf.
-      for (const t of tunables) {
-        if (t.bucket === bucket && t.leafIndex === index) {
-          const v = params[t.key];
-          if (v !== undefined) updated[t.paramName] = v;
-        }
-      }
-      // Also fill in defaults for any tunable that didn't have an existing value.
-      for (const t of tunables) {
-        if (t.bucket === bucket && t.leafIndex === index && updated[t.paramName] === undefined) {
-          updated[t.paramName] = tunableByKey.get(t.key)?.currentValue;
-        }
-      }
-      return { name: spec.name, params: updated };
-    }
-    // For combined specs we map each child positionally; flattenLeaves uses
-    // the same depth-first order so leaf indices align.
-    let leafCount = 0;
-    const newConditions: ConditionSpec[] = [];
-    for (const child of spec.conditions) {
-      const childLeaves = flattenLeaves(child).length;
-      newConditions.push(apply(child, bucket, index + leafCount));
-      leafCount += childLeaves;
-    }
-    return { op: spec.op, conditions: newConditions };
-  };
-  return {
-    entry: apply(base.entry, "entry", 0),
-    exit: apply(base.exit, "exit", 0),
-  };
-}
-
 /**
- * Run gridSearch over the user-supplied parameter ranges. The strategy
- * JSON is the source of truth for shape (entry/exit conditions); the
- * factory only swaps numeric values keyed by the tunable's `key`.
+ * Run grid search via core's `gridSearchFromJSON` and apply Studio's
+ * UX-level no-trade filter on top.
+ *
+ * The wrapper exists for two Studio-specific concerns that core
+ * deliberately leaves to the caller:
+ *
+ * 1. **Empty-state handling.** Studio short-circuits with `kind:"empty"`
+ *    when there are no tunables, no ranges, or the slice is too short.
+ *    These are user-recoverable conditions, not errors.
+ * 2. **No-trade filtering.** A backtest that emits zero trades scores 0
+ *    on every metric, so zero-trade combos would otherwise tie at
+ *    "score 0" and pollute the top-N table. Studio drops them and
+ *    rebuilds `bestScore`/`bestParams`/`validCombinations` from what
+ *    remains; if nothing remains, the panel renders an empty-state.
  *
  * Pure: same `(candles, strategy, ranges, metric)` always produces the
- * same output. Replay-aware behavior lives one layer up (panel disables
- * the Run button while playback is running).
+ * same output. Replay-aware behavior lives one layer up (the panel
+ * disables the Run button while playback is running).
  */
 export function runGridSearch(
   candles: StudioCandle[],
@@ -216,7 +274,7 @@ export function runGridSearch(
   ranges: ParameterRange[],
   metric: OptimizationMetricUI,
 ): OptimizationComputation {
-  const tunables = extractTunableParams(strategy);
+  const tunables = listTunables(strategy);
   if (tunables.length === 0) {
     return { kind: "empty", message: "Strategy has no tunable parameters" };
   }
@@ -228,36 +286,23 @@ export function runGridSearch(
   }
   try {
     const normalized = normalizeCandles(candles);
-    // Forward the *full* strategy.backtest config — silently dropping
-    // direction / stops / fees / fillMode would optimise against assumptions
-    // that don't match the user's solo backtest, so the "best" params would
-    // disagree with what the user gets re-running the strategy. capital
-    // defaults if missing; everything else is passthrough.
-    const baseOptions = {
-      capital: 100_000,
-      ...(strategy.backtest ?? {}),
-    };
-    const result = gridSearch(
-      normalized,
-      (params) => {
-        const { entry, exit } = buildFactoryStrategy(strategy, tunables, params);
-        return {
-          entry: hydrateCondition(entry, backtestRegistry),
-          exit: hydrateCondition(exit, backtestRegistry),
-          options: baseOptions,
-        };
-      },
-      ranges,
-      { metric: metric === "returns" ? "returns" : metric, keepAllResults: false },
-    );
-    // `validCombinations` only reflects constraint passes — with no
-    // constraints (our default) every combo "passes" even when the backtest
-    // emits zero trades. Worse, a no-trade backtest scores 0 on every
-    // metric, so zero-trade entries can rank above real losing configs in
-    // the top-N table. Filter them out entirely and rebuild the summary
-    // fields (bestScore/bestParams/validCombinations) so they reference
-    // a row that's actually still in the table — otherwise the caption can
-    // claim "best 0.00" while the displayed top-N has no such row.
+    // `ParameterRange.name` is the path (set by the panel using
+    // `Tunable.key`); convert to `PathParameterRange` shape.
+    const pathRanges: PathParameterRange[] = ranges.map((r) => ({
+      path: r.name,
+      min: r.min,
+      max: r.max,
+      step: r.step,
+    }));
+    const result = gridSearchFromJSON(normalized, strategy, pathRanges, backtestRegistry, {
+      metric: metric === "returns" ? "returns" : metric,
+      keepAllResults: false,
+    });
+    // Studio UX: zero-trade backtests score 0 across every metric, so
+    // they'd otherwise tie at the top of a Sharpe / returns ranking
+    // when nothing actually traded. Drop them and rebuild the summary
+    // fields from the surviving rows. If everything was zero-trade,
+    // surface an empty-state instead of a misleading "best 0.00".
     const tradingResults = result.results.filter((r) => r.backtest.trades.length > 0);
     if (tradingResults.length === 0) {
       return {
@@ -267,7 +312,7 @@ export function runGridSearch(
     }
     const sorted = [...tradingResults].sort((a, b) => b.score - a.score);
     const best = sorted[0];
-    const filtered = {
+    const filtered: GridSearchResult = {
       ...result,
       results: sorted,
       bestParams: best.params,
@@ -287,12 +332,16 @@ export function runGridSearch(
  * range with a small decimal step (e.g. `0.001`) builds millions of
  * entries before the `> 10_000` guard fires, freezing the UI.
  *
- * We compute it with math only (`floor((max - min) / step) + 1` per
- * range, multiplicative across ranges) and short-circuit at the first
- * range that already pushes the total over `Number.MAX_SAFE_INTEGER` —
- * that's "too many" by any practical definition. Invalid ranges
- * (`max < min`, `step <= 0`) return `-1` so the panel can render a
- * validation message instead of unmounting on render.
+ * Studio computes it with math only (`floor((max - min) / step) + 1`
+ * per range, multiplicative across ranges) and short-circuits at the
+ * first range that already pushes the total over
+ * `Number.MAX_SAFE_INTEGER`. Invalid ranges (`max < min`, `step <= 0`)
+ * return `-1` so the panel can render a validation message instead of
+ * unmounting on render.
+ *
+ * **TODO**: when core ships `countCombinationsFast` (planned PR-A1.5,
+ * see memo `project_count_combinations_fast.md`), swap this for a
+ * single-line re-export.
  */
 export function combinationCount(ranges: ParameterRange[]): number {
   if (ranges.length === 0) return 0;
@@ -301,10 +350,10 @@ export function combinationCount(ranges: ParameterRange[]): number {
     if (r.step <= 0 || r.max < r.min) return -1;
     // Mirror core `getParameterValues`: it walks `min += step` while
     // `value <= max + epsilon`, so e.g. `0..0.3 step 0.1` produces
-    // [0, 0.1, 0.2, 0.3] = 4 values, not 3 like a naive `floor((max-min)/step)+1`
-    // would say (floating point makes 0.3/0.1 = 2.9999...). Use the same
-    // epsilon convention so the panel's count agrees with what gridSearch
-    // will actually evaluate.
+    // [0, 0.1, 0.2, 0.3] = 4 values, not 3 like a naive
+    // `floor((max-min)/step)+1` would say (floating point makes
+    // 0.3/0.1 = 2.9999...). Use the same epsilon convention so the
+    // panel's count agrees with what gridSearch will actually evaluate.
     const epsilon = Math.abs(r.step) / 1_000_000;
     const count = Math.floor((r.max - r.min + epsilon) / r.step) + 1;
     if (count <= 0) return -1;

--- a/packages/chart/examples/strategy-studio/src/panels/OptimizationPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/OptimizationPanel.tsx
@@ -1,0 +1,299 @@
+import { useEffect, useMemo, useState } from "react";
+import type { ParameterRange, StrategyJSON } from "trendcraft";
+import { NumInput } from "../components/NumInput";
+import {
+  OPTIMIZATION_METRICS,
+  type OptimizationComputation,
+  type OptimizationMetricUI,
+  type Tunable,
+  autoDeriveRange,
+  combinationCount,
+  extractTunableParams,
+  runGridSearch,
+} from "../lib/optimization";
+import type { StudioCandle } from "../lib/sample-data";
+
+const MAX_COMBINATIONS = 10_000;
+
+type Props = {
+  /** Last-run strategy JSON (PR10 single source of truth). */
+  strategy: StrategyJSON | undefined;
+  /** Playhead-aware candle slice. */
+  candles: StudioCandle[];
+  /** True while Replay is actively playing — disables Run button. */
+  isReplayPlaying: boolean;
+};
+
+type RangeMap = Record<string, { min: number; max: number; step: number }>;
+
+function initRanges(tunables: Tunable[]): RangeMap {
+  const out: RangeMap = {};
+  for (const t of tunables) {
+    const r = autoDeriveRange(t.currentValue, t.registryMin, t.isInteger);
+    out[t.key] = { min: r.min, max: r.max, step: r.step };
+  }
+  return out;
+}
+
+export function OptimizationPanel({ strategy, candles, isReplayPlaying }: Props) {
+  const tunables = useMemo<Tunable[]>(
+    () => (strategy ? extractTunableParams(strategy) : []),
+    [strategy],
+  );
+
+  const [ranges, setRanges] = useState<RangeMap>(() => initRanges(tunables));
+  const [metric, setMetric] = useState<OptimizationMetricUI>("returns");
+  const [result, setResult] = useState<OptimizationComputation>({ kind: "idle" });
+
+  // Anything that changes how `runGridSearch` would evaluate the strategy
+  // must invalidate the panel state. Stringify the full entry/exit specs
+  // (so `and` → `or` or wrapping in `not` flips the key even when leaves
+  // are identical) plus the backtest settings (stops/fees/fillMode change
+  // the search space). id is included for free.
+  const strategyKey = strategy
+    ? JSON.stringify({
+        id: strategy.id,
+        entry: strategy.entry,
+        exit: strategy.exit,
+        backtest: strategy.backtest ?? null,
+      })
+    : "";
+  // biome-ignore lint/correctness/useExhaustiveDependencies: strategyKey hashes the relevant strategy shape; raw `strategy` reference shifts on every Run.
+  useEffect(() => {
+    setRanges(initRanges(tunables));
+    setResult({ kind: "idle" });
+  }, [strategyKey]);
+
+  // Any slice change → the prior optimisation was computed against different
+  // candles. Drop *any* non-idle result (ok / empty / error all get cleared)
+  // and key on the first/last bar's time + length so a same-length slice
+  // from a different range still invalidates.
+  const slicedKey =
+    candles.length === 0
+      ? "0"
+      : `${candles.length}-${candles[0].time}-${candles[candles.length - 1].time}`;
+  // Same idea for range edits: once the user changes any min/max/step the
+  // displayed top-10 is from a different search space. Hash the entire
+  // ranges map so any field bump invalidates.
+  const rangesKey = useMemo(() => JSON.stringify(ranges), [ranges]);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keys are content hashes; we don't want to depend on the `candles` reference or the `ranges` object identity.
+  useEffect(() => {
+    setResult((prev) => (prev.kind === "idle" ? prev : { kind: "idle" }));
+  }, [slicedKey, rangesKey]);
+
+  const rangeArray = useMemo<ParameterRange[]>(
+    () =>
+      tunables.map((t) => {
+        // Fallback range used only on the first render before initRanges
+        // commits. registryMin can legitimately be NEGATIVE_INFINITY (CMF
+        // threshold etc.) so we anchor on the current value's magnitude
+        // instead of the sentinel.
+        const fallback = autoDeriveRange(t.currentValue, t.registryMin, t.isInteger);
+        const r = ranges[t.key] ?? { min: fallback.min, max: fallback.max, step: fallback.step };
+        return { name: t.key, min: r.min, max: r.max, step: r.step };
+      }),
+    [tunables, ranges],
+  );
+
+  const totalCombinations = useMemo(
+    () => (rangeArray.length === 0 ? 0 : combinationCount(rangeArray)),
+    [rangeArray],
+  );
+
+  const invalidRanges = totalCombinations < 0;
+  const tooManyCombinations = totalCombinations > MAX_COMBINATIONS;
+  const runDisabled =
+    !strategy ||
+    tunables.length === 0 ||
+    invalidRanges ||
+    tooManyCombinations ||
+    isReplayPlaying ||
+    candles.length < 20;
+
+  const handleRun = () => {
+    if (!strategy || runDisabled) return;
+    setResult(runGridSearch(candles, strategy, rangeArray, metric));
+  };
+
+  if (!strategy) {
+    return (
+      <div className="risk-panel">
+        <div className="pane-header">Optimization</div>
+        <section className="risk-section">
+          <div className="meta-strategy-caption">Run a backtest to enable optimization.</div>
+        </section>
+      </div>
+    );
+  }
+
+  if (tunables.length === 0) {
+    return (
+      <div className="risk-panel">
+        <div className="pane-header">Optimization</div>
+        <section className="risk-section">
+          <div className="meta-strategy-caption">
+            Strategy has no tunable parameters (alwaysTrue / alwaysFalse only).
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="risk-panel">
+      <div className="pane-header">Optimization</div>
+      <section className="risk-section">
+        <div className="optimization-header">
+          <label className="optimization-metric-label">
+            <span>Metric</span>
+            <select
+              value={metric}
+              onChange={(e) => {
+                // Drop any prior result — its ranking is by the *old* metric
+                // and would be misread as if recomputed for the new one.
+                setMetric(e.target.value as OptimizationMetricUI);
+                setResult({ kind: "idle" });
+              }}
+            >
+              {OPTIMIZATION_METRICS.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <span
+            className={`optimization-combos${tooManyCombinations || invalidRanges ? " optimization-combos-warn" : ""}`}
+          >
+            {invalidRanges ? "invalid range" : `${totalCombinations.toLocaleString()} combos`}
+          </span>
+        </div>
+
+        <div className="optimization-param-list">
+          {tunables.map((t) => {
+            const r = ranges[t.key];
+            if (!r) return null;
+            return (
+              <div className="optimization-param-row" key={t.key}>
+                <span className="optimization-param-name">
+                  {t.bucket}.{t.conditionName}.{t.paramName}
+                </span>
+                {/* Inputs always accept fractional values — the registry
+                    doesn't reliably mark integer-only params, and other
+                    Studio panels treat these threshold params as floats.
+                    `t.isInteger` only seeds the auto-derived step so
+                    period-style params start at integer cadence. */}
+                <NumInput
+                  label="min"
+                  value={r.min}
+                  min={Number.isFinite(t.registryMin) ? t.registryMin : undefined}
+                  step="any"
+                  onChange={(v) => setRanges((prev) => ({ ...prev, [t.key]: { ...r, min: v } }))}
+                />
+                <NumInput
+                  label="max"
+                  value={r.max}
+                  min={Number.isFinite(t.registryMin) ? t.registryMin : undefined}
+                  step="any"
+                  onChange={(v) => setRanges((prev) => ({ ...prev, [t.key]: { ...r, max: v } }))}
+                />
+                {/* Accept any value the user types, including a transient
+                    `0` while they're working their way to `0.05`. Validation
+                    happens upstream: `combinationCount` returns -1 for
+                    `step <= 0` and the panel disables Run + shows
+                    "invalid range" until the user finishes typing. */}
+                <NumInput
+                  label="step"
+                  value={r.step}
+                  step="any"
+                  onChange={(v) => setRanges((prev) => ({ ...prev, [t.key]: { ...r, step: v } }))}
+                />
+              </div>
+            );
+          })}
+        </div>
+
+        <button
+          type="button"
+          className="optimization-run-btn"
+          onClick={handleRun}
+          disabled={runDisabled}
+        >
+          {isReplayPlaying ? "Run grid search (paused during replay)" : "Run grid search"}
+        </button>
+
+        {invalidRanges && (
+          <div className="optimization-warning">
+            One or more parameter ranges are invalid (min &gt; max, or step ≤ 0).
+          </div>
+        )}
+        {tooManyCombinations && (
+          <div className="optimization-warning">
+            Too many combinations ({totalCombinations.toLocaleString()}). Reduce ranges or increase
+            step (max {MAX_COMBINATIONS.toLocaleString()}).
+          </div>
+        )}
+
+        <ResultBody result={result} tunables={tunables} />
+      </section>
+    </div>
+  );
+}
+
+function ResultBody({
+  result,
+  tunables,
+}: {
+  result: OptimizationComputation;
+  tunables: Tunable[];
+}) {
+  if (result.kind === "idle") {
+    return null;
+  }
+  if (result.kind === "empty") {
+    return <div className="meta-strategy-caption">{result.message}</div>;
+  }
+  if (result.kind === "error") {
+    return <div className="risk-error">{result.message}</div>;
+  }
+  const top = result.result.results.slice(0, 10);
+  return (
+    <>
+      <div className="meta-strategy-caption">
+        {result.result.validCombinations} of {result.result.totalCombinations} combos passed
+        constraints · best {result.metric}: {result.result.bestScore.toFixed(2)}
+      </div>
+      <table className="optimization-result-table">
+        <thead>
+          <tr>
+            <th>#</th>
+            {tunables.map((t) => (
+              // Prefix the bucket so a strategy with the same param name on
+              // both legs (goldenCross.shortPeriod / deadCross.shortPeriod)
+              // doesn't collapse to two indistinguishable columns.
+              <th key={t.key} className="num">
+                {t.bucket === "entry" ? "in" : "out"}.{t.paramName}
+              </th>
+            ))}
+            <th className="num">Score</th>
+            <th className="num">Trades</th>
+          </tr>
+        </thead>
+        <tbody>
+          {top.map((entry, i) => (
+            <tr key={`${i}-${entry.score}`} className={i === 0 ? "optimization-best" : undefined}>
+              <td>{i + 1}</td>
+              {tunables.map((t) => (
+                <td key={t.key} className="num">
+                  {entry.params[t.key] ?? "—"}
+                </td>
+              ))}
+              <td className="num">{entry.score.toFixed(2)}</td>
+              <td className="num">{entry.backtest.trades.length}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/panels/OptimizationPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/OptimizationPanel.tsx
@@ -8,7 +8,8 @@ import {
   type Tunable,
   autoDeriveRange,
   combinationCount,
-  extractTunableParams,
+  findIntegerRangeViolation,
+  listTunables,
   runGridSearch,
 } from "../lib/optimization";
 import type { StudioCandle } from "../lib/sample-data";
@@ -29,17 +30,14 @@ type RangeMap = Record<string, { min: number; max: number; step: number }>;
 function initRanges(tunables: Tunable[]): RangeMap {
   const out: RangeMap = {};
   for (const t of tunables) {
-    const r = autoDeriveRange(t.currentValue, t.registryMin, t.isInteger);
+    const r = autoDeriveRange(t.currentValue, t.registryMin, t.isInteger, t.schema);
     out[t.key] = { min: r.min, max: r.max, step: r.step };
   }
   return out;
 }
 
 export function OptimizationPanel({ strategy, candles, isReplayPlaying }: Props) {
-  const tunables = useMemo<Tunable[]>(
-    () => (strategy ? extractTunableParams(strategy) : []),
-    [strategy],
-  );
+  const tunables = useMemo<Tunable[]>(() => (strategy ? listTunables(strategy) : []), [strategy]);
 
   const [ranges, setRanges] = useState<RangeMap>(() => initRanges(tunables));
   const [metric, setMetric] = useState<OptimizationMetricUI>("returns");
@@ -88,7 +86,7 @@ export function OptimizationPanel({ strategy, candles, isReplayPlaying }: Props)
         // commits. registryMin can legitimately be NEGATIVE_INFINITY (CMF
         // threshold etc.) so we anchor on the current value's magnitude
         // instead of the sentinel.
-        const fallback = autoDeriveRange(t.currentValue, t.registryMin, t.isInteger);
+        const fallback = autoDeriveRange(t.currentValue, t.registryMin, t.isInteger, t.schema);
         const r = ranges[t.key] ?? { min: fallback.min, max: fallback.max, step: fallback.step };
         return { name: t.key, min: r.min, max: r.max, step: r.step };
       }),
@@ -102,11 +100,20 @@ export function OptimizationPanel({ strategy, candles, isReplayPlaying }: Props)
 
   const invalidRanges = totalCombinations < 0;
   const tooManyCombinations = totalCombinations > MAX_COMBINATIONS;
+  // schema.integer params reject fractional min/max/step inside
+  // gridSearchFromJSON. Catch the violation at edit time so the user
+  // sees an actionable inline warning before clicking Run, not a
+  // generic "press-then-error" surprise.
+  const integerViolation = useMemo(
+    () => findIntegerRangeViolation(tunables, rangeArray),
+    [tunables, rangeArray],
+  );
   const runDisabled =
     !strategy ||
     tunables.length === 0 ||
     invalidRanges ||
     tooManyCombinations ||
+    integerViolation !== null ||
     isReplayPlaying ||
     candles.length < 20;
 
@@ -233,6 +240,12 @@ export function OptimizationPanel({ strategy, candles, isReplayPlaying }: Props)
             step (max {MAX_COMBINATIONS.toLocaleString()}).
           </div>
         )}
+        {integerViolation && (
+          <div className="optimization-warning">
+            <strong>{integerViolation.paramName}</strong> requires integer values, but{" "}
+            {integerViolation.field}={integerViolation.value} is not an integer.
+          </div>
+        )}
 
         <ResultBody result={result} tunables={tunables} />
       </section>
@@ -261,7 +274,8 @@ function ResultBody({
     <>
       <div className="meta-strategy-caption">
         {result.result.validCombinations} of {result.result.totalCombinations} combos passed
-        constraints · best {result.metric}: {result.result.bestScore.toFixed(2)}
+        constraints · best {result.metric}:{" "}
+        {result.result.bestScore !== null ? result.result.bestScore.toFixed(2) : "—"}
       </div>
       <table className="optimization-result-table">
         <thead>

--- a/packages/chart/examples/strategy-studio/src/styles.css
+++ b/packages/chart/examples/strategy-studio/src/styles.css
@@ -1333,3 +1333,151 @@ button.ghost.danger:hover {
 .scoring-inactive-row td {
   color: #585b66;
 }
+
+/* ---------- Optimization panel ---------- */
+
+.optimization-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.optimization-metric-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: #d1d4dc;
+}
+
+.optimization-metric-label span {
+  color: #787b86;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 10px;
+}
+
+.optimization-metric-label select {
+  background: #0a0e17;
+  border: 1px solid #2a2e39;
+  color: #d1d4dc;
+  border-radius: 3px;
+  padding: 3px 6px;
+  font-size: 11px;
+  font-family: inherit;
+}
+
+.optimization-combos {
+  margin-left: auto;
+  font-size: 11px;
+  color: #787b86;
+  font-variant-numeric: tabular-nums;
+}
+
+.optimization-combos-warn {
+  color: #ef5350;
+  font-weight: 600;
+}
+
+.optimization-param-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.optimization-param-row {
+  display: grid;
+  grid-template-columns: 1fr repeat(3, 60px);
+  gap: 6px;
+  align-items: end;
+  padding: 4px 0;
+  border-bottom: 1px solid #1e222d;
+}
+
+.optimization-param-row:last-child {
+  border-bottom: none;
+}
+
+.optimization-param-name {
+  font-size: 10px;
+  color: #d1d4dc;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  align-self: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.optimization-run-btn {
+  width: 100%;
+  padding: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  background: #2196f3;
+  color: #fff;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  font-family: inherit;
+  margin-bottom: 8px;
+}
+
+.optimization-run-btn:hover:not(:disabled) {
+  background: #1976d2;
+}
+
+.optimization-run-btn:disabled {
+  background: #2a2e39;
+  color: #787b86;
+  cursor: not-allowed;
+}
+
+.optimization-warning {
+  font-size: 10px;
+  color: #ef5350;
+  background: rgba(239, 83, 80, 0.08);
+  border: 1px solid rgba(239, 83, 80, 0.25);
+  border-radius: 3px;
+  padding: 6px 8px;
+  margin-bottom: 8px;
+}
+
+.optimization-result-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  margin-top: 6px;
+}
+
+.optimization-result-table th,
+.optimization-result-table td {
+  padding: 3px 4px;
+  border-bottom: 1px solid #1e222d;
+  text-align: left;
+}
+
+.optimization-result-table th {
+  background: #131722;
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: #787b86;
+}
+
+.optimization-result-table .num {
+  text-align: right;
+}
+
+.optimization-result-table tr:last-child td {
+  border-bottom: none;
+}
+
+.optimization-best td {
+  background: rgba(38, 166, 154, 0.08);
+  color: #26a69a;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary

PR12 of the Strategy Studio epic. Adds **OptimizationPanel** below ScoringPanel: walks the user's last-run strategy to discover tunable numeric parameters via the backtest registry, presents an auto-derived ±50% range editor per param, and runs core's `gridSearch` on demand to display the top 10 parameter combinations ranked by the chosen metric (Return / Sharpe / Profit Factor / Win Rate).

## Implementation notes

- **Display-only**: no "apply best params" button, builder state is never mutated. Same panel-local state-ownership model PR10/11 established.
- **Push-to-run**: grid search fires only on button click. Run is disabled during Replay playback / when combinations exceed 10,000 / when ranges are invalid / when the slice is too short.
- **Result clears on any input change** (strategy / candles / ranges / metric / replay slice) so the displayed table can never disagree with the surrounding controls.
- **Combo count math-only**: computes via `floor((max - min + ε) / step) + 1` (mirroring core's inclusive decimal stepping) instead of enumerating, so wide ranges with small decimal steps don't freeze the panel.
- **Zero-trade entries are filtered out** before ranking and the summary fields (`bestScore` / `bestParams` / `validCombinations`) are recomputed to stay consistent with the displayed table.
- **NumInput keeps a local draft string** so transient `"-"` / `"."` / `"-."` while typing aren't snapped back — needed for negative bounds (CMF threshold etc.).

## Review process — surfaced core gaps

This PR went through **9 codex review rounds** and surfaced **19 real bugs**. Roughly half trace back to gaps in core's optimization API and registry schema:

- `ConditionParamSchema` has no `integer` / `precision` hints → Studio guesses from `default` / `min`, fails on edge cases (RSI thresholds with integer defaults but float usage, CMF threshold with `min: undefined`, etc.).
- `countCombinations` enumerates the full grid via `getParameterValues` → wide ranges + small decimal steps freeze the panel before the > 10,000 guard fires.
- No JSON-first `gridSearch` wrapper → Studio reimplements `buildFactoryStrategy` to walk + inject params back into a strategy spec.
- `validCombinations` only reflects constraint passes (not trade counts) → Studio re-filters and recomputes summary fields.
- `getParameterValues` FP epsilon semantics are non-trivial → Studio's combo count needed to mirror them exactly to avoid Run-button stalls.
- `gridSearch` factory drops strategy.backtest settings if the caller forgets → Studio passes the full options bundle through.

A follow-up `core` PR will add the missing schema metadata and safer entry points; the Studio panel's heuristics collapse once those land. Tracked in the epic memo as a blocker for `epic→main`.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — studio 70 (+18) / core 4888 / mcp 59 / chart 781 (1 known flaky perf)
- [x] `pnpm build` — workspace builds
- [x] Manual: empty before Run / param ranges auto-populate / combos counter accurate / Run produces top-10 / Replay disables Run / range edits clear stale results / metric change clears / negative bounds typeable

Carved out for PR13: StrategyDnaPanel.