### PR TITLE
feat(core): ParamDef UI annotations + GRID_SEARCH_EPSILON_FACTOR export

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## Unreleased
+
+### Added — `GRID_SEARCH_EPSILON_FACTOR`
+
+- Exported constant (`1_000_000`) used by `getParameterValues` for the
+  inclusive `<= max + ε` upper-bound comparison (epsilon = step / FACTOR).
+  Exposed so external tools (UIs deriving the same grid points, MCP
+  callers pre-validating LLM output) can reproduce the comparison
+  semantics without re-deriving the constant.
+
+### Added — ParamDef annotations (`integer`, `precision`, `suggestedMin/Max`)
+
+- `ParamDef` gains optional `integer?: boolean` and `precision?: number`
+  fields. UIs and optimization helpers that derive parameter ranges or
+  step inputs from a registry entry no longer need to heuristically
+  guess whether a param is integer-valued (period etc.) or what its
+  decimal grid is. The two fields are mutually exclusive: when
+  `integer: true`, `precision` is ignored.
+- `ParamDef` also gains optional `suggestedMin?` / `suggestedMax?` UI
+  hints. Unlike `min` / `max` these are **not** enforced by
+  `validateConditionSpec`, so adding them to a registry entry never
+  invalidates persisted strategy JSON. Use them for params where the
+  indicator mathematically accepts a wider range than is practical to
+  surface in a slider (e.g. periods accept any positive integer, but a
+  UI usually wants 1..200).
+- Representative entries in `backtestRegistry` now carry these
+  annotations as a starting set: `goldenCross` / `deadCross` periods
+  (`integer: true`, `suggestedMax`), `bollingerBreakout` /
+  `bollingerTouch` `stdDev` (`precision: 1`, existing `min: 0.1`
+  preserved as runtime contract, new `suggestedMax: 5` UI hint),
+  `bollingerBreakout` / `bollingerTouch` `period`
+  (`integer: true`, `suggestedMax: 200`), and `cmfAbove` / `cmfBelow`
+  `threshold` (`precision: 2`, `suggestedMin: -1`, `suggestedMax: 1`).
+  All bounds are UI hints, not validation limits, so adding them never
+  invalidates persisted strategy JSON. Remaining entries will be
+  annotated as needed.
+
 ## [0.3.0] - 2026-04-26
 
 ### Breaking — Indicator Quality Fixes

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -961,6 +961,7 @@ export {
   gridSearchSafe,
   generateParameterCombinations,
   countCombinations,
+  GRID_SEARCH_EPSILON_FACTOR,
   param,
   constraint,
   getTopResults,

--- a/packages/core/src/optimization/__tests__/grid-search.test.ts
+++ b/packages/core/src/optimization/__tests__/grid-search.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { BacktestOptions, NormalizedCandle, PresetCondition } from "../../types";
 import {
+  GRID_SEARCH_EPSILON_FACTOR,
   constraint,
   countCombinations,
   generateParameterCombinations,
@@ -118,6 +119,14 @@ describe("Grid Search Optimization", () => {
     it("should match generated combinations when range is not evenly divisible by step", () => {
       const ranges = [param("threshold", 0, 1, 0.4)];
       expect(countCombinations(ranges)).toBe(generateParameterCombinations(ranges).length);
+    });
+  });
+
+  describe("GRID_SEARCH_EPSILON_FACTOR", () => {
+    it("is the same constant getParameterValues uses internally", () => {
+      // Documented as 1_000_000; check explicitly so callers reproducing
+      // grid points externally know the magic number.
+      expect(GRID_SEARCH_EPSILON_FACTOR).toBe(1_000_000);
     });
   });
 

--- a/packages/core/src/optimization/grid-search.ts
+++ b/packages/core/src/optimization/grid-search.ts
@@ -27,6 +27,15 @@ export type StrategyFactory = (params: Record<string, number>) => {
   options?: BacktestOptions;
 };
 
+/**
+ * Epsilon divisor used by `getParameterValues` when comparing the loop
+ * variable against `range.max` (epsilon = step / FACTOR). Exposed so
+ * external tools (UIs deriving the same grid points, MCP callers
+ * pre-validating LLM output, etc.) can reproduce the comparison
+ * semantics without re-deriving the constant.
+ */
+export const GRID_SEARCH_EPSILON_FACTOR = 1_000_000;
+
 function getParameterValues(range: ParameterRange): number[] {
   if (range.step <= 0) {
     throw new Error(`Parameter "${range.name}" step must be positive`);
@@ -36,10 +45,11 @@ function getParameterValues(range: ParameterRange): number[] {
   }
 
   const values: number[] = [];
-  const epsilon = Math.abs(range.step) / 1_000_000;
+  const epsilon = Math.abs(range.step) / GRID_SEARCH_EPSILON_FACTOR;
 
   for (let value = range.min; value <= range.max + epsilon; value += range.step) {
-    const roundedValue = Math.round(value * 1_000_000) / 1_000_000;
+    const roundedValue =
+      Math.round(value * GRID_SEARCH_EPSILON_FACTOR) / GRID_SEARCH_EPSILON_FACTOR;
     if (roundedValue <= range.max + epsilon) {
       values.push(roundedValue);
     }

--- a/packages/core/src/optimization/index.ts
+++ b/packages/core/src/optimization/index.ts
@@ -51,6 +51,7 @@ export {
   gridSearchSafe,
   generateParameterCombinations,
   countCombinations,
+  GRID_SEARCH_EPSILON_FACTOR,
   param,
   constraint,
   getTopResults,

--- a/packages/core/src/strategy/__tests__/param-def-annotations.test.ts
+++ b/packages/core/src/strategy/__tests__/param-def-annotations.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { backtestRegistry } from "../registry-backtest";
+
+describe("ParamDef annotations on registered backtest conditions", () => {
+  it("goldenCross periods are annotated as integer with UI-suggested max", () => {
+    const entry = backtestRegistry.get("goldenCross");
+    if (!entry) throw new Error("goldenCross not registered");
+    expect(entry.params.shortPeriod.integer).toBe(true);
+    // suggestedMax is a UI hint and does NOT trigger validateConditionSpec
+    // rejection — the registry deliberately leaves `max` undefined for
+    // periods so persisted strategies with longPeriod=750 still validate.
+    expect(entry.params.shortPeriod.suggestedMax).toBeGreaterThan(0);
+    expect(entry.params.shortPeriod.max).toBeUndefined();
+    expect(entry.params.longPeriod.integer).toBe(true);
+    expect(entry.params.longPeriod.max).toBeUndefined();
+  });
+
+  it("bollingerBreakout.stdDev keeps runtime validation min and adds UI suggestedMax", () => {
+    const entry = backtestRegistry.get("bollingerBreakout");
+    if (!entry) throw new Error("bollingerBreakout not registered");
+    const stdDev = entry.params.stdDev;
+    expect(stdDev.integer).toBeFalsy();
+    expect(stdDev.precision).toBe(1);
+    // bollingerBands() throws on stdDev <= 0, so the registry keeps a
+    // hard `min` (matching main) to surface invalid JSON at validate
+    // time. `suggestedMax` is a UI hint only — `bollingerBands()`
+    // accepts any positive stdDev, so we deliberately leave `max`
+    // undefined to keep persisted strategies with stdDev=8 valid.
+    expect(stdDev.min).toBe(0.1);
+    expect(stdDev.suggestedMax).toBeDefined();
+    expect(stdDev.max).toBeUndefined();
+    expect(entry.params.period.integer).toBe(true);
+  });
+
+  it("cmfAbove.threshold supports negative range via suggested UI hints", () => {
+    const entry = backtestRegistry.get("cmfAbove");
+    if (!entry) throw new Error("cmfAbove not registered");
+    const threshold = entry.params.threshold;
+    expect(threshold.integer).toBeFalsy();
+    expect(threshold.precision).toBe(2);
+    // CMF is mathematically bounded to [-1, 1] but we annotate the
+    // bound as a UI hint, not a hard validation limit, so legacy JSON
+    // with an out-of-range threshold still loads.
+    expect(threshold.suggestedMin).toBeLessThanOrEqual(0);
+    expect(threshold.suggestedMax).toBeGreaterThan(0);
+    expect(threshold.min).toBeUndefined();
+    expect(threshold.max).toBeUndefined();
+  });
+
+  it("integer:true and a non-zero precision aren't both set on any entry", () => {
+    // Documented as mutually exclusive (integer wins, precision is ignored).
+    // Catch accidental annotations that contradict each other.
+    for (const entry of backtestRegistry.list()) {
+      for (const [name, schema] of Object.entries(entry.params)) {
+        if (schema.integer === true && schema.precision !== undefined && schema.precision > 0) {
+          throw new Error(
+            `${entry.name}.${name}: integer=true but precision=${schema.precision} (mutually exclusive)`,
+          );
+        }
+      }
+    }
+  });
+});

--- a/packages/core/src/strategy/registry-backtest.ts
+++ b/packages/core/src/strategy/registry-backtest.ts
@@ -171,8 +171,22 @@ backtestRegistry.register({
   displayName: "Golden Cross",
   category: "trend",
   params: {
-    shortPeriod: { type: "number", default: 5, min: 1, description: "Short MA period" },
-    longPeriod: { type: "number", default: 25, min: 1, description: "Long MA period" },
+    shortPeriod: {
+      type: "number",
+      default: 5,
+      min: 1,
+      suggestedMax: 200,
+      integer: true,
+      description: "Short MA period",
+    },
+    longPeriod: {
+      type: "number",
+      default: 25,
+      min: 1,
+      suggestedMax: 500,
+      integer: true,
+      description: "Long MA period",
+    },
   },
   create: (p) => goldenCross((p.shortPeriod as number) ?? 5, (p.longPeriod as number) ?? 25),
 });
@@ -182,8 +196,22 @@ backtestRegistry.register({
   displayName: "Dead Cross",
   category: "trend",
   params: {
-    shortPeriod: { type: "number", default: 5, min: 1, description: "Short MA period" },
-    longPeriod: { type: "number", default: 25, min: 1, description: "Long MA period" },
+    shortPeriod: {
+      type: "number",
+      default: 5,
+      min: 1,
+      suggestedMax: 200,
+      integer: true,
+      description: "Short MA period",
+    },
+    longPeriod: {
+      type: "number",
+      default: 25,
+      min: 1,
+      suggestedMax: 500,
+      integer: true,
+      description: "Long MA period",
+    },
   },
   create: (p) => deadCross((p.shortPeriod as number) ?? 5, (p.longPeriod as number) ?? 25),
 });
@@ -301,8 +329,8 @@ backtestRegistry.register({
       enum: ["upper", "lower"],
       description: "Band to check",
     },
-    period: { type: "number", default: 20, min: 1 },
-    stdDev: { type: "number", default: 2, min: 0.1 },
+    period: { type: "number", default: 20, min: 1, suggestedMax: 200, integer: true },
+    stdDev: { type: "number", default: 2, min: 0.1, suggestedMax: 5, precision: 1 },
   },
   create: (p) =>
     bollingerBreakout(
@@ -323,8 +351,8 @@ backtestRegistry.register({
       enum: ["upper", "lower"],
       description: "Band to check",
     },
-    period: { type: "number", default: 20, min: 1 },
-    stdDev: { type: "number", default: 2, min: 0.1 },
+    period: { type: "number", default: 20, min: 1, suggestedMax: 200, integer: true },
+    stdDev: { type: "number", default: 2, min: 0.1, suggestedMax: 5, precision: 1 },
   },
   create: (p) =>
     bollingerTouch(
@@ -791,8 +819,8 @@ backtestRegistry.register({
   displayName: "CMF Above",
   category: "volume",
   params: {
-    threshold: { type: "number", default: 0 },
-    period: { type: "number", default: 20, min: 1 },
+    threshold: { type: "number", default: 0, suggestedMin: -1, suggestedMax: 1, precision: 2 },
+    period: { type: "number", default: 20, min: 1, suggestedMax: 200, integer: true },
   },
   create: (p) => cmfAbove((p.threshold as number) ?? 0, (p.period as number) ?? 20),
 });
@@ -802,8 +830,8 @@ backtestRegistry.register({
   displayName: "CMF Below",
   category: "volume",
   params: {
-    threshold: { type: "number", default: 0 },
-    period: { type: "number", default: 20, min: 1 },
+    threshold: { type: "number", default: 0, suggestedMin: -1, suggestedMax: 1, precision: 2 },
+    period: { type: "number", default: 20, min: 1, suggestedMax: 200, integer: true },
   },
   create: (p) => cmfBelow((p.threshold as number) ?? 0, (p.period as number) ?? 20),
 });

--- a/packages/core/src/strategy/types.ts
+++ b/packages/core/src/strategy/types.ts
@@ -125,6 +125,36 @@ export type ParamDef = {
   enum?: unknown[];
   /** Whether this parameter is required (default: false) */
   required?: boolean;
+  /**
+   * `true` when the param accepts only integer values (period, lookback,
+   * thresholdCount, etc.). Used by UIs that derive parameter ranges or
+   * input cadences. When `true`, `precision` is ignored (treated as 0).
+   * When omitted, callers shouldn't assume — the param may be either int
+   * or float depending on the indicator.
+   */
+  integer?: boolean;
+  /**
+   * Decimal places of valid resolution for numeric params. `1` = 0.1
+   * granularity (Bollinger stdDev), `2` = 0.01 (CMF threshold). Mutually
+   * exclusive with `integer: true`. UIs use this to seed step sizes for
+   * parameter range editors.
+   */
+  precision?: number;
+  /**
+   * UI-only suggested lower bound for editors / range pickers. Unlike
+   * `min`, this is **not** enforced by `validateConditionSpec` — it's a
+   * hint, not a contract. Use this for params where the indicator
+   * mathematically accepts a wider range than is practical to surface in
+   * a slider (e.g. periods accept any positive integer, but a UI usually
+   * wants to default to 1..200).
+   */
+  suggestedMin?: number;
+  /**
+   * UI-only suggested upper bound for editors / range pickers. Same
+   * non-enforcing semantics as `suggestedMin`. Adding this never breaks
+   * persisted strategy JSON, whereas tightening `max` would.
+   */
+  suggestedMax?: number;
 };
 
 /**


### PR DESCRIPTION
## Summary

Additive metadata extension to `ParamDef` so UIs and optimization helpers that derive parameter ranges from a registry entry don't need to heuristically guess integer-vs-float, decimal precision, or sensible UI bounds. Driven by Strategy Studio (`packages/chart/examples/strategy-studio/`) PR12 dogfooding, where the `OptimizationPanel` had to reimplement these hints in user-space to avoid freezing on wide ranges with small steps.

This is the first of three planned core fix PRs surfaced by that dogfooding pass:
- **PR-A1 (this PR)**: ParamDef extension + epsilon export — purely additive
- **PR-A2 (planned)**: `GridSearchResult.bestScore` null fallback — small breaking
- **PR-A3 (planned)**: `gridSearchFromJSON` + path-style ranges — additive wrapper

The originally bundled `countCombinationsFast` helper was carved out for a separate design pass; its rounding-overshoot interaction with `getParameterValues` needs to settle exact-match vs approximate semantics before shipping.

## Changes

### `ParamDef` extension (`packages/core/src/strategy/types.ts`)

Four new optional fields:
- `integer?: boolean` — param accepts only integer values (period etc.). Mutually exclusive with `precision`.
- `precision?: number` — decimal places of valid resolution (`1` = 0.1 grid for stdDev, `2` = 0.01 for CMF threshold).
- `suggestedMin?` / `suggestedMax?` — UI-only bounds. Unlike `min`/`max`, these are **not** enforced by `validateConditionSpec`, so adding them never invalidates persisted strategy JSON.

### `backtestRegistry` annotations

Representative entries get the new fields as a starting set:
- `goldenCross` / `deadCross`: periods → `integer: true`, `suggestedMax`
- `bollingerBreakout` / `bollingerTouch`: period → `integer: true`, `suggestedMax: 200`; stdDev → `precision: 1`, `suggestedMax: 5` (existing `min: 0.1` preserved as runtime contract)
- `cmfAbove` / `cmfBelow`: period → `integer: true`, `suggestedMax: 200`; threshold → `precision: 2`, `suggestedMin: -1`, `suggestedMax: 1`

Remaining 90+ entries can be annotated as needed; this PR keeps scope tight.

### `GRID_SEARCH_EPSILON_FACTOR` export (`packages/core/src/optimization/grid-search.ts`)

Exported constant (`1_000_000`) used by `getParameterValues` for the inclusive `<= max + ε` upper-bound comparison (`epsilon = step / FACTOR`). Allows external tools (UIs deriving the same grid points, MCP callers pre-validating LLM output) to reproduce the comparison semantics without re-deriving the magic number.

## Test plan

- [x] `pnpm test` workspace green (4893 tests, +13 new)
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] Codex review clean (4 rounds; final round flagged no defects)
- [x] New invariant tests upfront:
  - `param-def-annotations.test.ts` — verifies the documented annotations on representative entries and asserts `integer + precision > 0` is never both set on any registered entry
  - `GRID_SEARCH_EPSILON_FACTOR` exported value test