### PR TITLE
feat(core)!: nullable bestScore / bestParams for empty optimization results

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## Unreleased
 
+### Breaking — `bestScore` / `bestParams` are now `number | null`
+
+- `GridSearchResult.bestScore` and `CombinationSearchResult.bestScore` are
+  now `number | null`. Previously they fell back to `0` when no parameter
+  combination satisfied all constraints (or no combination produced
+  trades), which callers mistook as "the optimum is zero" instead of
+  "no valid result". Update consumers to handle `null` explicitly:
+
+  ```ts
+  // Before
+  console.log(`Best Sharpe: ${result.bestScore.toFixed(3)}`);
+
+  // After (preserve prior behavior)
+  console.log(`Best Sharpe: ${(result.bestScore ?? 0).toFixed(3)}`);
+
+  // Or branch
+  if (result.bestScore !== null) {
+    console.log(`Best Sharpe: ${result.bestScore.toFixed(3)}`);
+  } else {
+    console.log("No combination passed constraints");
+  }
+  ```
+
+- `GridSearchResult.bestParams` is now `Record<string, number> | null`
+  for the same reason — the legacy `{}` fallback was indistinguishable
+  from the legitimate "no params to optimize" case (empty
+  `parameterRanges`). `result.validCombinations > 0` and
+  `result.bestParams !== null` are now equivalent guards.
+- `CombinationSearchResult.bestEntry` / `bestExit` keep their `string[]`
+  type (empty arrays unambiguously signal "no entry/exit conditions"),
+  so this breaking change is limited to `bestScore` and `bestParams`.
+
 ### Added — `GRID_SEARCH_EPSILON_FACTOR`
 
 - Exported constant (`1_000_000`) used by `getParameterValues` for the

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -3346,9 +3346,12 @@ console.log('シャープレシオ:', result.results[0].metrics.sharpeRatio);
 interface GridSearchResult {
   results: OptimizationResultEntry[];
   totalCombinations: number;
-  passedConstraints: number;
-  bestParameters: Record<string, number>;
-  bestMetrics: Record<string, number>;
+  validCombinations: number;
+  /** 制約を満たす組み合わせがない場合は null */
+  bestParams: Record<string, number> | null;
+  /** 制約を満たす組み合わせがない場合は null */
+  bestScore: number | null;
+  metric: OptimizationMetric;
 }
 ```
 

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -3876,9 +3876,12 @@ console.log('Sharpe ratio:', result.results[0].metrics.sharpeRatio);
 interface GridSearchResult {
   results: OptimizationResultEntry[];
   totalCombinations: number;
-  passedConstraints: number;
-  bestParameters: Record<string, number>;
-  bestMetrics: Record<string, number>;
+  validCombinations: number;
+  /** Best parameters found, or null if no combination passed constraints */
+  bestParams: Record<string, number> | null;
+  /** Best score achieved, or null if no combination passed constraints */
+  bestScore: number | null;
+  metric: OptimizationMetric;
 }
 ```
 

--- a/packages/core/examples/echarts-viewer/src/components/optimization/OptimizationPanel.tsx
+++ b/packages/core/examples/echarts-viewer/src/components/optimization/OptimizationPanel.tsx
@@ -570,22 +570,27 @@ export function OptimizationPanel() {
                   <MetricCell label="Valid" value={String(gridSearchResult.validCombinations)} />
                   <MetricCell
                     label="Best Score"
-                    value={gridSearchResult.bestScore.toFixed(3)}
+                    value={
+                      gridSearchResult.bestScore !== null
+                        ? gridSearchResult.bestScore.toFixed(3)
+                        : "—"
+                    }
                     color="var(--success)"
                   />
                 </div>
-                {Object.keys(gridSearchResult.bestParams).length > 0 && (
-                  <div
-                    style={{
-                      fontSize: "var(--font-xs)",
-                      color: "var(--warning)",
-                      marginTop: 6,
-                      textAlign: "center",
-                    }}
-                  >
-                    Best: {JSON.stringify(gridSearchResult.bestParams)}
-                  </div>
-                )}
+                {gridSearchResult.bestParams !== null &&
+                  Object.keys(gridSearchResult.bestParams).length > 0 && (
+                    <div
+                      style={{
+                        fontSize: "var(--font-xs)",
+                        color: "var(--warning)",
+                        marginTop: 6,
+                        textAlign: "center",
+                      }}
+                    >
+                      Best: {JSON.stringify(gridSearchResult.bestParams)}
+                    </div>
+                  )}
               </div>
 
               {/* Results Table */}

--- a/packages/core/examples/echarts-viewer/src/hooks/useStrategyDna.ts
+++ b/packages/core/examples/echarts-viewer/src/hooks/useStrategyDna.ts
@@ -37,7 +37,15 @@ export function useStrategyDna() {
 
   // Genome segments — lightweight, only uses bestParams + params from results
   const genomeSegments: GenomeSegment[] | null = useMemo(() => {
-    if (!gridSearchResult || Object.keys(gridSearchResult.bestParams).length === 0) return null;
+    // bestParams/bestScore are null when no combination passed constraints —
+    // there's no genome to render in that case.
+    if (
+      !gridSearchResult ||
+      gridSearchResult.bestParams === null ||
+      gridSearchResult.bestScore === null ||
+      Object.keys(gridSearchResult.bestParams).length === 0
+    )
+      return null;
     const paramNames = Object.keys(gridSearchResult.bestParams);
     // Extract min/max per param without creating intermediate arrays
     const ranges = paramNames.map((name) => {

--- a/packages/core/examples/echarts-viewer/src/utils/strategyDna.ts
+++ b/packages/core/examples/echarts-viewer/src/utils/strategyDna.ts
@@ -394,7 +394,10 @@ export function computeRecommendedParams(
   walkForward?: WalkForwardResult | null,
   sensitivityData?: SensitivityData | null,
 ): RecommendedParams {
-  const paramNames = Object.keys(gridSearch.bestParams);
+  // gridSearch.bestParams is null when no combination passed constraints.
+  // Use the candidate space (results[0]) as a fallback so we still recommend
+  // something based on the explored grid even when no result was "best".
+  const paramNames = Object.keys(gridSearch.bestParams ?? gridSearch.results[0]?.params ?? {});
   const sources: string[] = [];
 
   // Step 1: Safe Zone center (top 25% median)

--- a/packages/core/examples/quick-start/03-optimization.ts
+++ b/packages/core/examples/quick-start/03-optimization.ts
@@ -71,6 +71,10 @@ top5.forEach((r, i) => {
   );
 });
 
-console.log(
-  `\nBest: RSI entry<${result.bestParams.entryThreshold}, exit>${result.bestParams.exitThreshold}, SL=${result.bestParams.stopLoss}%  (Sharpe: ${result.bestScore.toFixed(3)})`,
-);
+if (result.bestParams !== null && result.bestScore !== null) {
+  console.log(
+    `\nBest: RSI entry<${result.bestParams.entryThreshold}, exit>${result.bestParams.exitThreshold}, SL=${result.bestParams.stopLoss}%  (Sharpe: ${result.bestScore.toFixed(3)})`,
+  );
+} else {
+  console.log("\nNo parameter combination passed the configured constraints.");
+}

--- a/packages/core/llms-full.txt
+++ b/packages/core/llms-full.txt
@@ -811,7 +811,7 @@ const result = gridSearch(candles, (params) => ({
 });
 ```
 
-Returns `GridSearchResult` with `results[]`, `bestParameters`, `bestMetrics`.
+Returns `GridSearchResult` with `results[]`, `totalCombinations`, `validCombinations`, `bestParams: Record<string, number> | null`, `bestScore: number | null`, `metric`. `bestParams`/`bestScore` are `null` when no combination passed constraints — guard with `result.bestScore ?? 0` or `result.validCombinations > 0`.
 
 ### `walkForwardAnalysis(candles, strategyFactory, paramRanges, options?)`
 Out-of-sample validation. Options: `inSampleRatio` (0.7), `periods` (5), `metric`.

--- a/packages/core/src/optimization/__tests__/grid-search.test.ts
+++ b/packages/core/src/optimization/__tests__/grid-search.test.ts
@@ -334,6 +334,46 @@ describe("Grid Search Optimization", () => {
     });
   });
 
+  describe("null fallback when no valid combinations", () => {
+    // Documents the contract that bestScore / bestParams are `null`
+    // (not `0` / `{}`) when no combination satisfies the constraints.
+    // The legacy `0` fallback was indistinguishable from an actual
+    // optimum of zero — callers couldn't tell "no result" from "result
+    // is exactly zero". null is the explicit empty-state signal.
+    it("returns null bestScore and bestParams when no combination passes constraints", () => {
+      const candles = generateUpTrendCandles(50);
+      const createStrategy = (params: Record<string, number>) => ({
+        entry: createEnterCondition(Math.round(params.enterAt)),
+        exit: createExitCondition(10),
+        options: { capital: 100000 } as BacktestOptions,
+      });
+      const result = gridSearch(
+        candles,
+        createStrategy,
+        [param("enterAt", 5, 10, 5)],
+        // Impossible constraint — no combination will pass.
+        { constraints: [constraint("sharpe", ">=", 9999)] },
+      );
+      expect(result.validCombinations).toBe(0);
+      expect(result.bestScore).toBeNull();
+      expect(result.bestParams).toBeNull();
+    });
+
+    it("returns non-null bestScore and bestParams when at least one combination is valid", () => {
+      const candles = generateUpTrendCandles(50);
+      const createStrategy = (params: Record<string, number>) => ({
+        entry: createEnterCondition(Math.round(params.enterAt)),
+        exit: createExitCondition(10),
+        options: { capital: 100000 } as BacktestOptions,
+      });
+      const result = gridSearch(candles, createStrategy, [param("enterAt", 5, 10, 5)]);
+      // No constraints, so every combination "passes" trivially.
+      expect(result.validCombinations).toBeGreaterThan(0);
+      expect(result.bestScore).not.toBeNull();
+      expect(result.bestParams).not.toBeNull();
+    });
+  });
+
   describe("edge cases", () => {
     it("should handle empty parameter ranges", () => {
       const candles = generateUpTrendCandles(50);

--- a/packages/core/src/optimization/combination-search.ts
+++ b/packages/core/src/optimization/combination-search.ts
@@ -54,10 +54,16 @@ export type CombinationResultEntry = {
  * Combination search result
  */
 export type CombinationSearchResult = {
-  /** Best combination found */
+  /** Best combination found (empty arrays when no valid combination) */
   bestEntry: string[];
   bestExit: string[];
-  bestScore: number;
+  /**
+   * Best score achieved, or `null` if no combination satisfied the
+   * configured constraints. Previously fell back to `0`, which callers
+   * mistook as "the optimum is zero". Use `result.bestScore ?? 0` to
+   * preserve the prior behavior.
+   */
+  bestScore: number | null;
   /** Metric used for optimization */
   metric: OptimizationMetric;
   /** Total combinations tested */
@@ -368,7 +374,7 @@ export function combinationSearch(
   return {
     bestEntry,
     bestExit,
-    bestScore: bestScore === Number.NEGATIVE_INFINITY ? 0 : bestScore,
+    bestScore: bestScore === Number.NEGATIVE_INFINITY ? null : bestScore,
     metric,
     totalCombinations,
     validCombinations,

--- a/packages/core/src/optimization/condition-pools.ts
+++ b/packages/core/src/optimization/condition-pools.ts
@@ -56,7 +56,7 @@ export function summarizeCombinationSearch(result: CombinationSearchResult): {
   validPercent: number;
   bestEntry: string;
   bestExit: string;
-  bestScore: number;
+  bestScore: number | null;
   metric: OptimizationMetric;
 } {
   return {

--- a/packages/core/src/optimization/grid-search.ts
+++ b/packages/core/src/optimization/grid-search.ts
@@ -157,7 +157,7 @@ export function gridSearch(
   // Run backtests and collect results
   const results: OptimizationResultEntry[] = [];
   let bestScore = Number.NEGATIVE_INFINITY;
-  let bestParams: Record<string, number> = {};
+  let bestParams: Record<string, number> | null = null;
   let validCombinations = 0;
 
   for (let i = 0; i < combinations.length; i++) {
@@ -222,8 +222,8 @@ export function gridSearch(
   results.sort((a, b) => b.score - a.score);
 
   return {
-    bestParams,
-    bestScore: bestScore === Number.NEGATIVE_INFINITY ? 0 : bestScore,
+    bestParams: validCombinations > 0 ? bestParams : null,
+    bestScore: bestScore === Number.NEGATIVE_INFINITY ? null : bestScore,
     metric,
     totalCombinations,
     validCombinations,
@@ -284,8 +284,8 @@ export function summarizeGridSearch(result: GridSearchResult): {
   totalTested: number;
   validCount: number;
   validPercent: number;
-  bestParams: Record<string, number>;
-  bestScore: number;
+  bestParams: Record<string, number> | null;
+  bestScore: number | null;
   metric: OptimizationMetric;
 } {
   return {

--- a/packages/core/src/optimization/walkforward.ts
+++ b/packages/core/src/optimization/walkforward.ts
@@ -151,9 +151,11 @@ export function walkForwardAnalysis(
       maxCombinations: 10000,
     });
 
-    // Use best parameters or fallback to first valid result
-    const bestParams =
-      gridResult.validCombinations > 0
+    // Use best parameters or fallback to range minima.
+    // When validCombinations > 0, gridSearch guarantees bestParams is non-null,
+    // but TypeScript can't infer that across the boundary, so assert here.
+    const bestParams: Record<string, number> =
+      gridResult.validCombinations > 0 && gridResult.bestParams !== null
         ? gridResult.bestParams
         : parameterRanges.reduce(
             (acc, r) => {

--- a/packages/core/src/types/optimization.ts
+++ b/packages/core/src/types/optimization.ts
@@ -66,10 +66,22 @@ export type OptimizationResultEntry = {
  * Grid search result
  */
 export type GridSearchResult = {
-  /** Best parameters found */
-  bestParams: Record<string, number>;
-  /** Best score achieved */
-  bestScore: number;
+  /**
+   * Best parameters found, or `null` if no combination satisfied the
+   * configured constraints. Previously fell back to `{}`, which was
+   * indistinguishable from the legitimate "no params to optimize"
+   * case (empty `parameterRanges`). Use `result.bestParams ?? {}` to
+   * preserve the prior behavior in callers that don't care about the
+   * distinction.
+   */
+  bestParams: Record<string, number> | null;
+  /**
+   * Best score achieved, or `null` if no combination satisfied the
+   * configured constraints. Previously fell back to `0`, which callers
+   * mistook as "the optimum is zero". Use `result.bestScore ?? 0` to
+   * preserve the prior behavior.
+   */
+  bestScore: number | null;
   /** Metric used for optimization */
   metric: OptimizationMetric;
   /** Total number of parameter combinations */


### PR DESCRIPTION
## Summary

Breaking change to `GridSearchResult` and `CombinationSearchResult`: when no parameter combination satisfies all configured constraints, `bestScore` and `bestParams` now return `null` instead of the legacy `0` / `{}` fallback. The previous fallback was indistinguishable from an actual optimum of zero, causing UIs (echarts-viewer / Strategy Studio) to render "Best Sharpe: 0" as if it were a real result.

This is the second of three planned core fix PRs surfaced by Strategy Studio dogfooding:
- **PR-A1** ✅ merged — `ParamDef` extension + `GRID_SEARCH_EPSILON_FACTOR` export
- **PR-A2 (this PR)** — `bestScore` / `bestParams` null fallback
- **PR-A3 (planned)** — `gridSearchFromJSON` + path-style ranges

## Migration

```ts
// Preserve prior behavior (0 / {} fallback)
const score = result.bestScore ?? 0;
const params = result.bestParams ?? {};

// Or branch on the nullable value
if (result.bestScore !== null) {
  console.log(`Best: ${result.bestScore.toFixed(3)}`);
} else {
  console.log("No combination passed constraints");
}
```

`result.validCombinations > 0` and `result.bestParams !== null` are now equivalent guards.

`CombinationSearchResult.bestEntry` / `bestExit` keep their `string[]` type — empty arrays unambiguously signal "no entry/exit conditions", unlike `bestScore: 0` which collides with a real result. The breaking change is limited to the two ambiguous fields.

## Changes

### Type contract (`packages/core/src/types/optimization.ts`, `combination-search.ts`)

- `GridSearchResult.bestScore: number → number | null`
- `GridSearchResult.bestParams: Record<string, number> → Record<string, number> | null`
- `CombinationSearchResult.bestScore: number → number | null`

### Implementation

- `gridSearch` / `combinationSearch` return `null` when `bestScore === Number.NEGATIVE_INFINITY` (no combination beat the initial sentinel)
- `summarizeGridSearch` / `summarizeCombinationSearch` return types widened
- `walkforward.ts` adds a non-null assertion under its existing `validCombinations > 0` guard

### In-repo consumer updates

- `examples/quick-start/03-optimization.ts` — null branch
- `examples/echarts-viewer/utils/strategyDna.ts` — fallback to `results[0].params` when no best
- `examples/echarts-viewer/hooks/useStrategyDna.ts` — null guard before genome render
- `examples/echarts-viewer/components/optimization/OptimizationPanel.tsx` — render "—" instead of `0.000` when null

### Tests

Two invariant tests added upfront:
- `gridSearch` with impossible constraint → `validCombinations === 0 && bestScore === null && bestParams === null`
- `gridSearch` no constraints → `bestScore !== null && bestParams !== null`

### Docs

- `CHANGELOG.md` — Breaking changes section with migration snippets
- `docs/API.md` / `docs/API.ja.md` — `GridSearchResult` interface refreshed (also fixes the long-standing `bestParameters/bestMetrics` typo)
- `llms-full.txt` — `GridSearchResult` description updated with null guard hint

## Test plan

- [x] `pnpm test` — 4895 passed (+2 new invariant tests)
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] `npx tsc --noEmit` clean in `examples/echarts-viewer/`
- [x] Codex review clean (3 rounds; final round flagged no defects)

## Notes for downstream consumers

- **Strategy Studio (`packages/chart/examples/strategy-studio/`)**: PR12 (`feat/strategy-studio-optimization` → `epic/strategy-studio`, PR #148) is still open. After this PR merges main, the epic rebase will surface a `result.bestScore.toFixed(2)` site at `panels/OptimizationPanel.tsx:264`. Will be fixed as part of the rebase or its own follow-up commit.