### PR TITLE
feat(core): strategy DNA primitives

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ## Unreleased
 
+### Added — Strategy DNA primitives (`optimization/strategy-dna`)
+
+- New `optimization/strategy-dna.ts` module exposing post-optimization
+  analytics that previously lived only as user-space helpers in
+  example apps:
+  - `buildGenomeSegments(bestParams, paramRanges, bestScore)` — maps
+    each best-param value onto a `[0, 1]` position within its declared
+    search range, for "where in the space did the optimizer land"
+    visualizations.
+  - `extractSensitivityData(results, metric)` — aggregates per-param
+    and pairwise mean-metric tables plus top-25% safe zones from a
+    grid search's `results[]`.
+  - `computeRecommendedParams(grid, walkForward?, sensitivity?)` —
+    three-step recommendation: safe-zone median → walk-forward
+    stable-period median override → sensitivity-peak penalty. Returns
+    `{ params, ranges, confidence, reason, sources }` with
+    `confidence: "high" | "medium" | "low"`. Handles
+    `gridSearch.bestParams === null` (PR-A2 contract) by falling back
+    to `results[0]?.params` so the explored grid still informs a
+    recommendation.
+  - `computeDnaGrade(grid?, walkForward?, monteCarlo?)` — A–F grade
+    across four dimensions (WF stability 30%, MC significance 30%,
+    parameter sensitivity 20%, win-rate stability 20%). Items whose
+    inputs are missing are marked `available: false` and excluded
+    from the renormalized weighted average — distinct from
+    `robustness/calculateRobustnessScore` which runs new backtests.
+- New types: `GenomeSegment`, `SensitivitySingle`, `SensitivityPair`,
+  `SafeZone`, `SensitivityData`, `RecommendedParams`, `DnaGrade`,
+  `DnaGradeItem`, `DnaGradeReport`. The `Dna` prefix avoids collision
+  with `robustness/RobustnessGrade`.
+- `core.examples.echarts-viewer` cleaned up: its
+  `utils/strategyDna.ts` (574 lines) is now an ~80-line shim that
+  re-exports the core APIs (with backwards-compatible aliases) plus
+  the viewer-specific URL codec.
+
 ### Added — `percentile` / `median` / `quartiles` statistics utilities
 
 - New `packages/core/src/core/statistics.ts` with three exported

--- a/packages/core/examples/echarts-viewer/src/utils/strategyDna.ts
+++ b/packages/core/examples/echarts-viewer/src/utils/strategyDna.ts
@@ -1,510 +1,49 @@
 /**
- * Strategy DNA utilities
+ * Strategy DNA — viewer-side glue.
  *
- * Genome visualization, sensitivity analysis, robustness grading,
- * and share URL encoding/decoding for backtest strategies.
+ * Re-exports the post-optimization analytics that now live in core
+ * (`buildGenomeSegments`, `extractSensitivityData`,
+ * `computeRecommendedParams`, `computeDnaGrade`) plus the
+ * viewer-only URL codec for sharing strategies via the address bar.
+ *
+ * Names are aliased back to the viewer's prior local exports
+ * (`Grade`, `RobustnessGrade`, `computeRobustnessGrade`) so the
+ * UI components don't need to change imports.
  */
 
-import type {
-  GridSearchResult,
-  MonteCarloResult,
-  OptimizationMetric,
-  OptimizationResultEntry,
-  WalkForwardResult,
-} from "trendcraft";
+import type { DnaGrade, DnaGradeItem, DnaGradeReport } from "trendcraft";
+import { computeDnaGrade } from "trendcraft";
 import type { BacktestConfig } from "../types/chart";
 
-// ── Types ──────────────────────────────────────────────────────────
+// ── Core re-exports ────────────────────────────────────────────────
 
-export interface GenomeSegment {
-  name: string;
-  value: number;
-  min: number;
-  max: number;
-  /** 0-1 position within the range */
-  position: number;
-  /** Metric score for this parameter value */
-  score: number;
-}
+export type {
+  GenomeSegment,
+  SensitivitySingle,
+  SensitivityPair,
+  SafeZone,
+  SensitivityData,
+  RecommendedParams,
+} from "trendcraft";
+export {
+  buildGenomeSegments,
+  extractSensitivityData,
+  computeRecommendedParams,
+} from "trendcraft";
 
-export interface SensitivitySingle {
-  paramName: string;
-  data: { value: number; metric: number }[];
-}
-
-export interface SensitivityPair {
-  paramX: string;
-  paramY: string;
-  data: { x: number; y: number; metric: number }[];
-  xValues: number[];
-  yValues: number[];
-}
-
-export interface SafeZone {
-  paramName: string;
-  min: number;
-  max: number;
-}
-
-export interface SensitivityData {
-  singleParams: SensitivitySingle[];
-  pairwise: SensitivityPair[];
-  safeZones: SafeZone[];
-}
-
-export type Grade = "A" | "B" | "C" | "D" | "F";
-
-export interface GradeItem {
-  label: string;
-  grade: Grade;
-  score: number;
-  description: string;
-  available: boolean;
-}
-
-export interface RobustnessGrade {
-  items: GradeItem[];
-  overall: Grade;
-  overallScore: number;
-}
-
-// ── Genome ─────────────────────────────────────────────────────────
-
-/**
- * Build genome segments from grid search best parameters and ranges
- */
-export function buildGenomeSegments(
-  bestParams: Record<string, number>,
-  paramRanges: { name: string; min: number; max: number }[],
-  bestScore: number,
-): GenomeSegment[] {
-  return paramRanges
-    .filter((r) => bestParams[r.name] !== undefined)
-    .map((r) => {
-      const value = bestParams[r.name];
-      const range = r.max - r.min;
-      const position = range > 0 ? (value - r.min) / range : 0.5;
-      return {
-        name: r.name,
-        value,
-        min: r.min,
-        max: r.max,
-        position: Math.max(0, Math.min(1, position)),
-        score: bestScore,
-      };
-    });
-}
-
-// ── Sensitivity ────────────────────────────────────────────────────
-
-/**
- * Extract sensitivity data from grid search results
- */
-export function extractSensitivityData(
-  results: OptimizationResultEntry[],
-  metric: OptimizationMetric,
-): SensitivityData {
-  if (results.length === 0) {
-    return { singleParams: [], pairwise: [], safeZones: [] };
-  }
-
-  // Discover parameter names
-  const paramNames = Object.keys(results[0].params);
-
-  // Single-parameter sensitivity: aggregate by parameter value
-  const singleParams: SensitivitySingle[] = paramNames.map((paramName) => {
-    const byValue = new Map<number, number[]>();
-    for (const r of results) {
-      const v = r.params[paramName];
-      if (!byValue.has(v)) byValue.set(v, []);
-      byValue.get(v)?.push(r.metrics[metric]);
-    }
-    const data = Array.from(byValue.entries())
-      .sort((a, b) => a[0] - b[0])
-      .map(([value, metrics]) => ({
-        value,
-        metric: metrics.reduce((s, m) => s + m, 0) / metrics.length,
-      }));
-    return { paramName, data };
-  });
-
-  // Pairwise sensitivity (for 2-param combos)
-  const pairwise: SensitivityPair[] = [];
-  for (let i = 0; i < paramNames.length; i++) {
-    for (let j = i + 1; j < paramNames.length; j++) {
-      const paramX = paramNames[i];
-      const paramY = paramNames[j];
-      const byPair = new Map<string, number[]>();
-      const xSet = new Set<number>();
-      const ySet = new Set<number>();
-
-      for (const r of results) {
-        const x = r.params[paramX];
-        const y = r.params[paramY];
-        xSet.add(x);
-        ySet.add(y);
-        const key = `${x}|${y}`;
-        if (!byPair.has(key)) byPair.set(key, []);
-        byPair.get(key)?.push(r.metrics[metric]);
-      }
-
-      const data: { x: number; y: number; metric: number }[] = [];
-      for (const [key, metrics] of byPair) {
-        const [xs, ys] = key.split("|");
-        data.push({
-          x: Number(xs),
-          y: Number(ys),
-          metric: metrics.reduce((s, m) => s + m, 0) / metrics.length,
-        });
-      }
-
-      pairwise.push({
-        paramX,
-        paramY,
-        data,
-        xValues: Array.from(xSet).sort((a, b) => a - b),
-        yValues: Array.from(ySet).sort((a, b) => a - b),
-      });
-    }
-  }
-
-  // Safe zones: top 25% results, find parameter ranges
-  const sorted = [...results].sort((a, b) => b.metrics[metric] - a.metrics[metric]);
-  const top25 = sorted.slice(0, Math.max(1, Math.ceil(sorted.length * 0.25)));
-
-  const safeZones: SafeZone[] = paramNames.map((paramName) => {
-    const values = top25.map((r) => r.params[paramName]);
-    return {
-      paramName,
-      min: Math.min(...values),
-      max: Math.max(...values),
-    };
-  });
-
-  return { singleParams, pairwise, safeZones };
-}
-
-// ── Robustness Grading ─────────────────────────────────────────────
-
-function scoreToGrade(score: number): Grade {
-  if (score >= 80) return "A";
-  if (score >= 60) return "B";
-  if (score >= 40) return "C";
-  if (score >= 20) return "D";
-  return "F";
-}
-
-function wfStabilityScore(stabilityRatio: number): number {
-  if (stabilityRatio >= 0.8) return 100;
-  if (stabilityRatio >= 0.6) return 75;
-  if (stabilityRatio >= 0.4) return 50;
-  if (stabilityRatio >= 0.2) return 25;
-  return 0;
-}
-
-function mcSignificanceScore(pValue: number): number {
-  if (pValue < 0.01) return 100;
-  if (pValue < 0.05) return 75;
-  if (pValue < 0.1) return 50;
-  if (pValue < 0.2) return 25;
-  return 0;
-}
-
-function paramSensitivityScore(cv: number): number {
-  if (cv < 0.1) return 100;
-  if (cv < 0.2) return 75;
-  if (cv < 0.3) return 50;
-  if (cv < 0.5) return 25;
-  return 0;
-}
-
-function winRateStabilityScore(stdDev: number): number {
-  if (stdDev < 5) return 100;
-  if (stdDev < 10) return 75;
-  if (stdDev < 15) return 50;
-  if (stdDev < 20) return 25;
-  return 0;
-}
-
-/**
- * Compute coefficient of variation from grid search results
- */
-function computeCV(results: OptimizationResultEntry[], metric: OptimizationMetric): number {
-  if (results.length < 2) return 0;
-  const values = results.map((r) => r.metrics[metric]);
-  const mean = values.reduce((s, v) => s + v, 0) / values.length;
-  if (Math.abs(mean) < 1e-10) return 1;
-  const variance = values.reduce((s, v) => s + (v - mean) ** 2, 0) / values.length;
-  return Math.sqrt(variance) / Math.abs(mean);
-}
-
-/**
- * Compute win rate standard deviation across WF periods
- */
-function computeWinRateStdDev(wf: WalkForwardResult): number {
-  if (wf.periods.length < 2) return 0;
-  const winRates = wf.periods.map((p) => p.outOfSampleMetrics.winRate);
-  const mean = winRates.reduce((s, v) => s + v, 0) / winRates.length;
-  const variance = winRates.reduce((s, v) => s + (v - mean) ** 2, 0) / winRates.length;
-  return Math.sqrt(variance);
-}
-
-/**
- * Compute robustness grade from available optimization results
- */
-export function computeRobustnessGrade(
-  gridSearch?: GridSearchResult | null,
-  walkForward?: WalkForwardResult | null,
-  monteCarlo?: MonteCarloResult | null,
-): RobustnessGrade {
-  const items: GradeItem[] = [];
-
-  // Walk-Forward stability
-  if (walkForward) {
-    const s = wfStabilityScore(walkForward.aggregateMetrics.stabilityRatio);
-    items.push({
-      label: "Walk-Forward Stability",
-      grade: scoreToGrade(s),
-      score: s,
-      description: `Stability ratio: ${(walkForward.aggregateMetrics.stabilityRatio * 100).toFixed(1)}%`,
-      available: true,
-    });
-  } else {
-    items.push({
-      label: "Walk-Forward Stability",
-      grade: "F",
-      score: 0,
-      description: "Run Walk-Forward analysis first",
-      available: false,
-    });
-  }
-
-  // Monte Carlo significance
-  if (monteCarlo) {
-    const pVal = Math.min(monteCarlo.pValue.sharpe, monteCarlo.pValue.returns);
-    const s = mcSignificanceScore(pVal);
-    items.push({
-      label: "Monte Carlo Significance",
-      grade: scoreToGrade(s),
-      score: s,
-      description: `p-value: ${pVal.toFixed(3)}`,
-      available: true,
-    });
-  } else {
-    items.push({
-      label: "Monte Carlo Significance",
-      grade: "F",
-      score: 0,
-      description: 'Click "Compute Grade" to run',
-      available: false,
-    });
-  }
-
-  // Parameter sensitivity (from grid search)
-  if (gridSearch && gridSearch.results.length > 1) {
-    const cv = computeCV(gridSearch.results, gridSearch.metric);
-    const s = paramSensitivityScore(cv);
-    items.push({
-      label: "Parameter Sensitivity",
-      grade: scoreToGrade(s),
-      score: s,
-      description: `CV: ${cv.toFixed(3)} (lower = more robust)`,
-      available: true,
-    });
-  } else {
-    items.push({
-      label: "Parameter Sensitivity",
-      grade: "F",
-      score: 0,
-      description: "Run Grid Search first",
-      available: false,
-    });
-  }
-
-  // Win rate stability (from WF periods)
-  if (walkForward && walkForward.periods.length >= 2) {
-    const stdDev = computeWinRateStdDev(walkForward);
-    const s = winRateStabilityScore(stdDev);
-    items.push({
-      label: "Win Rate Stability",
-      grade: scoreToGrade(s),
-      score: s,
-      description: `Std dev: ${stdDev.toFixed(1)}% across ${walkForward.periods.length} periods`,
-      available: true,
-    });
-  } else {
-    items.push({
-      label: "Win Rate Stability",
-      grade: "F",
-      score: 0,
-      description: "Run Walk-Forward analysis first",
-      available: false,
-    });
-  }
-
-  // Overall grade: weighted average of available items
-  // MC 30%, WF 30%, Param 20%, WinRate 20%
-  const weights = [0.3, 0.3, 0.2, 0.2];
-  const availableItems = items.filter((it) => it.available);
-
-  let overallScore = 0;
-  if (availableItems.length > 0) {
-    let totalWeight = 0;
-    for (let i = 0; i < items.length; i++) {
-      if (items[i].available) {
-        overallScore += items[i].score * weights[i];
-        totalWeight += weights[i];
-      }
-    }
-    overallScore = totalWeight > 0 ? overallScore / totalWeight : 0;
-  }
-
-  return {
-    items,
-    overall: scoreToGrade(overallScore),
-    overallScore,
-  };
-}
-
-// ── Recommended Parameters ────────────────────────────────────────
-
-export interface RecommendedParams {
-  params: Record<string, number>;
-  ranges: Record<string, { min: number; max: number }>;
-  confidence: "high" | "medium" | "low";
-  reason: string;
-  sources: string[];
-}
-
-/**
- * Compute recommended parameters from grid search + walk-forward results.
- *
- * 3-step scoring:
- * 1. Safe Zone center from top 25% grid search results
- * 2. Walk-forward stable period filter (OOS profitable periods only)
- * 3. Sensitivity penalty for sharp peaks
- *
- * @example
- * const rec = computeRecommendedParams(gridResult, wfResult, sensitivityData);
- * // rec.params = { fastPeriod: 7, slowPeriod: 30 }
- * // rec.confidence = "high"
- */
-export function computeRecommendedParams(
-  gridSearch: GridSearchResult,
-  walkForward?: WalkForwardResult | null,
-  sensitivityData?: SensitivityData | null,
-): RecommendedParams {
-  // gridSearch.bestParams is null when no combination passed constraints.
-  // Use the candidate space (results[0]) as a fallback so we still recommend
-  // something based on the explored grid even when no result was "best".
-  const paramNames = Object.keys(gridSearch.bestParams ?? gridSearch.results[0]?.params ?? {});
-  const sources: string[] = [];
-
-  // Step 1: Safe Zone center (top 25% median)
-  const sorted = [...gridSearch.results].sort(
-    (a, b) => b.metrics[gridSearch.metric] - a.metrics[gridSearch.metric],
-  );
-  const top25 = sorted.slice(0, Math.max(1, Math.ceil(sorted.length * 0.25)));
-
-  const params: Record<string, number> = {};
-  const ranges: Record<string, { min: number; max: number }> = {};
-
-  for (const name of paramNames) {
-    const values = top25.map((r) => r.params[name]).sort((a, b) => a - b);
-    const min = values[0];
-    const max = values[values.length - 1];
-    // Median
-    const mid = Math.floor(values.length / 2);
-    const median =
-      values.length % 2 === 0 ? Math.round((values[mid - 1] + values[mid]) / 2) : values[mid];
-    params[name] = median;
-    ranges[name] = { min, max };
-  }
-  sources.push("Safe Zone center");
-
-  // Step 2: Walk-Forward stable period filter
-  let wfStablePeriods = 0;
-  let wfTotalPeriods = 0;
-
-  if (walkForward && walkForward.periods.length > 0) {
-    wfTotalPeriods = walkForward.periods.length;
-    // Filter: OOS returns > 0
-    const stablePeriods = walkForward.periods.filter((p) => p.outOfSampleMetrics.returns > 0);
-    wfStablePeriods = stablePeriods.length;
-
-    if (stablePeriods.length > 0) {
-      // Override with median of stable periods' bestParams
-      for (const name of paramNames) {
-        const values = stablePeriods
-          .map((p) => p.bestParams[name])
-          .filter((v) => v !== undefined)
-          .sort((a, b) => a - b);
-        if (values.length > 0) {
-          const mid = Math.floor(values.length / 2);
-          params[name] =
-            values.length % 2 === 0 ? Math.round((values[mid - 1] + values[mid]) / 2) : values[mid];
-        }
-      }
-      sources.push(`${stablePeriods.length}/${wfTotalPeriods} stable WF periods`);
-    }
-  }
-
-  // Step 3: Sensitivity penalty — check if recommended params sit on a sharp peak
-  let hasSensitivityPenalty = false;
-
-  if (sensitivityData && sensitivityData.singleParams.length > 0) {
-    for (const sp of sensitivityData.singleParams) {
-      const recValue = params[sp.paramName];
-      if (recValue === undefined || sp.data.length < 3) continue;
-
-      // Find the metric at the recommended value
-      const atRec = sp.data.find((d) => d.value === recValue);
-      if (!atRec) continue;
-
-      // Check neighbors: if metric drops >50% within 1 step, it's a sharp peak
-      const idx = sp.data.findIndex((d) => d.value === recValue);
-      const neighbors = [sp.data[idx - 1], sp.data[idx + 1]].filter(Boolean);
-
-      if (neighbors.length > 0 && atRec.metric > 0) {
-        const avgNeighbor = neighbors.reduce((s, n) => s + n.metric, 0) / neighbors.length;
-        const dropRatio = 1 - avgNeighbor / atRec.metric;
-        if (dropRatio > 0.5) {
-          hasSensitivityPenalty = true;
-          break;
-        }
-      }
-    }
-  }
-
-  // Determine confidence
-  let confidence: "high" | "medium" | "low";
-  const hasWfData = wfStablePeriods > 0;
-  const wfMajorityStable = wfStablePeriods >= wfTotalPeriods / 2;
-
-  if (hasSensitivityPenalty) {
-    confidence = "low";
-  } else if (hasWfData && wfMajorityStable && !hasSensitivityPenalty) {
-    confidence = "high";
-  } else {
-    confidence = "medium";
-  }
-
-  // Build reason string
-  const reason =
-    confidence === "high"
-      ? "Safe Zone center confirmed by stable Walk-Forward periods with low sensitivity"
-      : confidence === "medium"
-        ? hasWfData
-          ? `Only ${wfStablePeriods}/${wfTotalPeriods} WF periods were profitable`
-          : "Based on Grid Search Safe Zone only (no Walk-Forward data)"
-        : "Parameters sit on a sharp sensitivity peak — use with caution";
-
-  return { params, ranges, confidence, reason, sources };
-}
+// Aliases preserving the viewer's prior local names.
+export type Grade = DnaGrade;
+export type GradeItem = DnaGradeItem;
+export type RobustnessGrade = DnaGradeReport;
+export const computeRobustnessGrade = computeDnaGrade;
 
 // ── Share URL ──────────────────────────────────────────────────────
+//
+// URL encoding stays viewer-side: `BacktestConfig` is a viewer-local
+// shape and the short-key map is shared only between this codec and
+// the address-bar consumers. Lifting to core would force every other
+// app to know about Studio/echarts-specific config field names.
 
-/** Short keys for URL encoding */
 const KEY_MAP: Record<string, string> = {
   entryCondition: "e",
   exitCondition: "x",
@@ -525,7 +64,6 @@ const REVERSE_KEY_MAP: Record<string, string> = Object.fromEntries(
   Object.entries(KEY_MAP).map(([k, v]) => [v, k]),
 );
 
-/** Numeric fields that should be parsed as numbers */
 const NUMERIC_FIELDS = new Set([
   "capital",
   "stopLoss",
@@ -539,9 +77,6 @@ const NUMERIC_FIELDS = new Set([
   "taxRate",
 ]);
 
-/**
- * Encode a BacktestConfig into URL query parameters
- */
 export function encodeBacktestConfig(config: BacktestConfig): string {
   const params = new URLSearchParams();
   for (const [key, shortKey] of Object.entries(KEY_MAP)) {
@@ -553,9 +88,6 @@ export function encodeBacktestConfig(config: BacktestConfig): string {
   return params.toString();
 }
 
-/**
- * Decode URL query parameters into a partial BacktestConfig
- */
 export function decodeBacktestConfig(params: URLSearchParams): Partial<BacktestConfig> {
   const config: Record<string, unknown> = {};
   for (const [shortKey, value] of params.entries()) {

--- a/packages/core/llms-full.txt
+++ b/packages/core/llms-full.txt
@@ -816,6 +816,9 @@ Returns `GridSearchResult` with `results[]`, `totalCombinations`, `validCombinat
 ### `gridSearchFromJSON(candles, strategy, ranges, registry, options?)`
 JSON-first variant. `strategy: StrategyJSON`, `ranges: PathParameterRange[]` where each range is `{ path: "entry.0.shortPeriod", min, max, step }`. Path syntax is `<bucket>.<leafIndex>.<paramName>` — `bucket` is `"entry"` or `"exit"`, `leafIndex` is depth-first leaf order across AND/OR/NOT, `paramName` is the registry param key. Returns the same `GridSearchResult` shape, with `bestParams` keyed by path so callers plug it back into `applyParamOverrides(strategy, bestParams)` to get the tuned strategy. Throws on invalid paths (use `gridSearchFromJSONSafe` for `Result`-returning variant).
 
+### Strategy DNA — post-optimization analytics
+`buildGenomeSegments(bestParams, paramRanges, bestScore)` — values mapped to `[0, 1]` within ranges. `extractSensitivityData(results, metric)` — per-param + pairwise mean-metric tables + top-25% safe zones. `computeRecommendedParams(grid, walkForward?, sensitivity?)` — 3-step robust recommendation (safe-zone median → WF stable-period override → sensitivity-peak penalty), returns `{ params, ranges, confidence: "high" | "medium" | "low", reason, sources }`. `computeDnaGrade(grid?, walkForward?, monteCarlo?)` — A-F grade across WF stability / MC significance / parameter sensitivity / win-rate stability; missing inputs are excluded from the renormalized weighted overall. Distinct from `robustness/calculateRobustnessScore` which runs new backtests.
+
 ### `flattenStrategyLeaves(strategy)` / `applyParamOverrides(strategy, overrides)`
 Pure utilities for walking and rewriting `StrategyJSON`. `flattenStrategyLeaves` returns `LeafInfo[]` (depth-first), `applyParamOverrides` returns a new strategy with the addressed leaves' params updated. Both share the same path syntax as `gridSearchFromJSON`.
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1008,6 +1008,11 @@ export {
   fastNonDominatedSort,
   crowdingDistance,
   summarizeParetoResult,
+  // Strategy DNA — post-optimization analytics
+  buildGenomeSegments,
+  extractSensitivityData,
+  computeRecommendedParams,
+  computeDnaGrade,
 } from "./optimization";
 
 export type {
@@ -1041,6 +1046,16 @@ export type {
   ParetoOptions,
   ParetoResultEntry,
   ParetoResult,
+  // Strategy DNA types
+  GenomeSegment,
+  SensitivitySingle,
+  SensitivityPair,
+  SafeZone,
+  SensitivityData,
+  RecommendedParams,
+  DnaGrade,
+  DnaGradeItem,
+  DnaGradeReport,
 } from "./optimization";
 
 // Screening (browser-compatible exports only - no fs dependency)

--- a/packages/core/src/optimization/__tests__/strategy-dna.test.ts
+++ b/packages/core/src/optimization/__tests__/strategy-dna.test.ts
@@ -1,0 +1,486 @@
+import { describe, expect, it } from "vitest";
+import type {
+  GridSearchResult,
+  MonteCarloResult,
+  OptimizationResultEntry,
+  WalkForwardResult,
+} from "../../types/optimization";
+import {
+  buildGenomeSegments,
+  computeDnaGrade,
+  computeRecommendedParams,
+  extractSensitivityData,
+} from "../strategy-dna";
+
+// ── Fixtures ──────────────────────────────────────────────────────
+
+const makeEntry = (
+  params: Record<string, number>,
+  score: number,
+  trades = 5,
+): OptimizationResultEntry => ({
+  params,
+  score,
+  metrics: {
+    sharpe: score,
+    returns: score * 10,
+    profitFactor: score,
+    winRate: score * 5,
+    maxDrawdown: -score / 2,
+    calmar: score,
+    recoveryFactor: score,
+  },
+  // Backtest field is required for OptimizationResultEntry but DNA
+  // analytics only read params + metrics + score, so a minimal stub is
+  // fine here. Tests that need real backtest data construct it inline.
+  backtest: {
+    initialCapital: 100_000,
+    finalCapital: 100_000 + score * 1000,
+    trades: Array.from({ length: trades }, (_, i) => ({
+      side: "long",
+      entryTime: i,
+      entryPrice: 100,
+      exitTime: i + 1,
+      exitPrice: 100 + i,
+      pnl: i,
+      pnlPercent: i / 100,
+      reason: "exit",
+      barsHeld: 1,
+    })),
+    settings: { capital: 100_000 },
+    equityCurve: [],
+  } as unknown as OptimizationResultEntry["backtest"],
+  passedConstraints: true,
+});
+
+const baseGridResult: GridSearchResult = {
+  bestParams: { fast: 5, slow: 25 },
+  bestScore: 1.5,
+  metric: "sharpe",
+  totalCombinations: 12,
+  validCombinations: 12,
+  results: [
+    makeEntry({ fast: 5, slow: 25 }, 1.5),
+    makeEntry({ fast: 5, slow: 30 }, 1.4),
+    makeEntry({ fast: 7, slow: 25 }, 1.3),
+    makeEntry({ fast: 7, slow: 30 }, 1.2),
+    makeEntry({ fast: 9, slow: 25 }, 1.0),
+    makeEntry({ fast: 9, slow: 30 }, 0.9),
+    makeEntry({ fast: 5, slow: 35 }, 0.8),
+    makeEntry({ fast: 7, slow: 35 }, 0.7),
+    makeEntry({ fast: 9, slow: 35 }, 0.6),
+    makeEntry({ fast: 5, slow: 40 }, 0.5),
+    makeEntry({ fast: 7, slow: 40 }, 0.3),
+    makeEntry({ fast: 9, slow: 40 }, 0.1),
+  ],
+};
+
+// ── buildGenomeSegments ───────────────────────────────────────────
+
+describe("buildGenomeSegments", () => {
+  it("normalizes values to [0, 1] within their declared range", () => {
+    const segments = buildGenomeSegments(
+      { fast: 7, slow: 30 },
+      [
+        { name: "fast", min: 5, max: 15 },
+        { name: "slow", min: 20, max: 50 },
+      ],
+      1.0,
+    );
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toMatchObject({ name: "fast", value: 7, position: 0.2 });
+    expect(segments[1]).toMatchObject({
+      name: "slow",
+      value: 30,
+      position: (30 - 20) / (50 - 20),
+    });
+  });
+
+  it("clamps position to [0, 1] for out-of-range values", () => {
+    const segments = buildGenomeSegments({ fast: 100 }, [{ name: "fast", min: 5, max: 10 }], 1.0);
+    expect(segments[0].position).toBe(1);
+  });
+
+  it("collapses to position=0.5 when range is zero (min === max)", () => {
+    const segments = buildGenomeSegments({ fast: 7 }, [{ name: "fast", min: 7, max: 7 }], 1.0);
+    expect(segments[0].position).toBe(0.5);
+  });
+
+  it("filters out params not in bestParams", () => {
+    const segments = buildGenomeSegments(
+      { fast: 5 },
+      [
+        { name: "fast", min: 1, max: 10 },
+        { name: "slow", min: 10, max: 50 },
+      ],
+      1.0,
+    );
+    expect(segments).toHaveLength(1);
+    expect(segments[0].name).toBe("fast");
+  });
+
+  it("returns [] for an empty paramRanges array", () => {
+    expect(buildGenomeSegments({ fast: 5 }, [], 1.0)).toEqual([]);
+  });
+});
+
+// ── extractSensitivityData ────────────────────────────────────────
+
+describe("extractSensitivityData", () => {
+  it("returns empty data for empty results", () => {
+    const out = extractSensitivityData([], "sharpe");
+    expect(out.singleParams).toEqual([]);
+    expect(out.pairwise).toEqual([]);
+    expect(out.safeZones).toEqual([]);
+  });
+
+  it("aggregates single-parameter sensitivity by averaging metrics", () => {
+    // fast=5 appears in entries with sharpe 1.5, 1.4, 0.8, 0.5 — average = 1.05
+    const out = extractSensitivityData(baseGridResult.results, "sharpe");
+    const fast = out.singleParams.find((sp) => sp.paramName === "fast");
+    expect(fast).toBeDefined();
+    const fast5 = fast?.data.find((d) => d.value === 5);
+    expect(fast5?.metric).toBeCloseTo((1.5 + 1.4 + 0.8 + 0.5) / 4, 5);
+  });
+
+  it("emits pairwise data for every param pair (combinatorially)", () => {
+    const out = extractSensitivityData(baseGridResult.results, "sharpe");
+    expect(out.pairwise).toHaveLength(1); // fast × slow = 1 pair
+    const pair = out.pairwise[0];
+    expect(pair.paramX).toBe("fast");
+    expect(pair.paramY).toBe("slow");
+    expect(pair.xValues).toEqual([5, 7, 9]);
+    expect(pair.yValues).toEqual([25, 30, 35, 40]);
+  });
+
+  it("treats `maxDrawdown` as a minimizing metric for safe zones (regression)", () => {
+    // trendcraft reports `maxDrawdown` as a positive percentage (1 = 1%
+    // drawdown, 20 = 20% drawdown), so smaller = better. Top 25% must
+    // be the smallest drawdowns, not the largest.
+    const results: OptimizationResultEntry[] = [
+      makeEntry({ p: 1 }, 0),
+      makeEntry({ p: 2 }, 0),
+      makeEntry({ p: 3 }, 0),
+      makeEntry({ p: 4 }, 0),
+    ];
+    results[0].metrics.maxDrawdown = 1;
+    results[1].metrics.maxDrawdown = 2;
+    results[2].metrics.maxDrawdown = 10;
+    results[3].metrics.maxDrawdown = 20;
+    const out = extractSensitivityData(results, "maxDrawdown");
+    const zone = out.safeZones.find((z) => z.paramName === "p");
+    // Top 25% (1 entry) = p=1 (drawdown 1%, the best).
+    expect(zone).toEqual({ paramName: "p", min: 1, max: 1 });
+  });
+
+  it("safe zones cover the top-25% range for each param", () => {
+    const out = extractSensitivityData(baseGridResult.results, "sharpe");
+    // top 25% of 12 entries = 3 entries with highest sharpe = 1.5, 1.4, 1.3
+    // → fast values (5, 5, 7) → range [5, 7]
+    // → slow values (25, 30, 25) → range [25, 30]
+    const fastZone = out.safeZones.find((z) => z.paramName === "fast");
+    const slowZone = out.safeZones.find((z) => z.paramName === "slow");
+    expect(fastZone).toEqual({ paramName: "fast", min: 5, max: 7 });
+    expect(slowZone).toEqual({ paramName: "slow", min: 25, max: 30 });
+  });
+});
+
+// ── computeRecommendedParams ──────────────────────────────────────
+
+describe("computeRecommendedParams", () => {
+  it("uses safe-zone median for params and tags Safe Zone center as a source", () => {
+    const rec = computeRecommendedParams(baseGridResult);
+    // Top 25% (3 entries) for `fast` = [5, 5, 7] → median 5
+    // Top 25% (3 entries) for `slow` = [25, 25, 30] → median 25
+    expect(rec.params).toEqual({ fast: 5, slow: 25 });
+    expect(rec.sources).toContain("Safe Zone center");
+  });
+
+  it("falls back to results[0].params when bestParams is null (PR-A2 contract)", () => {
+    const rec = computeRecommendedParams({ ...baseGridResult, bestParams: null });
+    // Should still produce a recommendation based on the explored grid
+    expect(Object.keys(rec.params)).toEqual(expect.arrayContaining(["fast", "slow"]));
+  });
+
+  it("overrides safe-zone median with WF-stable period median when available", () => {
+    const wf: WalkForwardResult = {
+      periods: [
+        {
+          trainStart: 0,
+          trainEnd: 50,
+          testStart: 50,
+          testEnd: 100,
+          bestParams: { fast: 9, slow: 35 },
+          inSampleMetrics: {
+            sharpe: 1.5,
+            returns: 15,
+            profitFactor: 1.5,
+            winRate: 60,
+            maxDrawdown: -5,
+            calmar: 1.5,
+            recoveryFactor: 1.5,
+          },
+          outOfSampleMetrics: {
+            sharpe: 1.0,
+            returns: 10, // > 0 → stable
+            profitFactor: 1.2,
+            winRate: 55,
+            maxDrawdown: -8,
+            calmar: 1.0,
+            recoveryFactor: 1.0,
+          },
+          testBacktest: {} as never,
+        },
+      ],
+      aggregateMetrics: {
+        avgInSample: {} as never,
+        avgOutOfSample: {} as never,
+        stabilityRatio: 0.7,
+      },
+      recommendation: { useOptimizedParams: true, suggestedParams: {}, reason: "" },
+    };
+    const rec = computeRecommendedParams(baseGridResult, wf);
+    // WF stable period had fast=9, slow=35 → median override
+    expect(rec.params).toEqual({ fast: 9, slow: 35 });
+    expect(rec.sources.some((s) => s.includes("stable WF"))).toBe(true);
+  });
+
+  it("recomputes ranges from WF stable periods when the override applies (regression)", () => {
+    // WF override picks fast=9 (outside the top-25% safe zone of 5..7).
+    // Without recomputing `ranges`, the viewer would show fast=9 with
+    // range (5..7), which is internally inconsistent.
+    const wf: WalkForwardResult = {
+      periods: [
+        {
+          trainStart: 0,
+          trainEnd: 50,
+          testStart: 50,
+          testEnd: 100,
+          bestParams: { fast: 9, slow: 35 },
+          inSampleMetrics: {} as never,
+          outOfSampleMetrics: { returns: 5 } as never,
+          testBacktest: {} as never,
+        },
+      ],
+      aggregateMetrics: {
+        avgInSample: {} as never,
+        avgOutOfSample: {} as never,
+        stabilityRatio: 0.6,
+      },
+      recommendation: { useOptimizedParams: true, suggestedParams: {}, reason: "" },
+    };
+    const rec = computeRecommendedParams(baseGridResult, wf);
+    expect(rec.params.fast).toBe(9);
+    expect(rec.ranges.fast.min).toBe(9);
+    expect(rec.ranges.fast.max).toBe(9);
+    expect(rec.ranges.slow.min).toBe(35);
+    expect(rec.ranges.slow.max).toBe(35);
+  });
+
+  it("treats `maxDrawdown` as a minimizing metric in recommendations (regression)", () => {
+    // Mirror of the safe-zone test. Recommendations must surface
+    // p=1 (drawdown 1%) — not p=4 with the worst drawdown.
+    const results: OptimizationResultEntry[] = [
+      makeEntry({ p: 1 }, 0),
+      makeEntry({ p: 2 }, 0),
+      makeEntry({ p: 3 }, 0),
+      makeEntry({ p: 4 }, 0),
+    ];
+    results[0].metrics.maxDrawdown = 1;
+    results[1].metrics.maxDrawdown = 2;
+    results[2].metrics.maxDrawdown = 10;
+    results[3].metrics.maxDrawdown = 20;
+    const grid: GridSearchResult = {
+      bestParams: { p: 1 },
+      bestScore: 1,
+      metric: "maxDrawdown",
+      totalCombinations: 4,
+      validCombinations: 4,
+      results,
+    };
+    const rec = computeRecommendedParams(grid);
+    expect(rec.params.p).toBe(1);
+  });
+
+  it("snaps recommended values to an explored candidate (no 7.5 for integer params; regression)", () => {
+    // Top-25% bucket with an even number of candidates would otherwise
+    // produce a linearly-interpolated median like 7.5 — that re-enters
+    // the next optimization run as a fractional value the strategy
+    // never saw on an integer-only param. The recommendation must
+    // always be one of the actually-explored values.
+    const evenCountGrid: GridSearchResult = {
+      bestParams: { period: 7 },
+      bestScore: 1.5,
+      metric: "sharpe",
+      totalCombinations: 8,
+      validCombinations: 8,
+      results: [
+        makeEntry({ period: 5 }, 1.6),
+        makeEntry({ period: 6 }, 1.5),
+        makeEntry({ period: 7 }, 1.4),
+        makeEntry({ period: 8 }, 1.3),
+        makeEntry({ period: 9 }, 1.2),
+        makeEntry({ period: 10 }, 1.1),
+        makeEntry({ period: 11 }, 1.0),
+        makeEntry({ period: 12 }, 0.9),
+      ],
+    };
+    // Top 25% of 8 = 2 entries → period values [5, 6] → linear median 5.5
+    // Without snapping, recommended period = 5.5 (invalid integer).
+    // With snapping, must round to either 5 or 6 (both explored).
+    const rec = computeRecommendedParams(evenCountGrid);
+    expect([5, 6]).toContain(rec.params.period);
+    expect(Number.isInteger(rec.params.period)).toBe(true);
+  });
+
+  it("returns an empty recommendation for a 0-result grid (regression)", () => {
+    // An empty results[] should not silently produce a `Safe Zone center` source
+    // — no data means no recommendation.
+    const empty: GridSearchResult = {
+      bestParams: null,
+      bestScore: null,
+      metric: "sharpe",
+      totalCombinations: 0,
+      validCombinations: 0,
+      results: [],
+    };
+    const rec = computeRecommendedParams(empty);
+    expect(rec.params).toEqual({});
+    expect(rec.ranges).toEqual({});
+    expect(rec.sources).toEqual([]);
+    expect(rec.confidence).toBe("low");
+  });
+
+  it("detects sharp peaks for minimize metrics like maxDrawdown (regression)", () => {
+    // Drawdown at rec=2 with neighbors at 10 → rise ratio (10-2)/2 = 4 > 0.5
+    // → confidence should be downgraded for minimize-direction sensitivity peaks
+    // (not just maximize ones).
+    const grid: GridSearchResult = {
+      bestParams: { p: 5 },
+      bestScore: 2,
+      metric: "maxDrawdown",
+      totalCombinations: 3,
+      validCombinations: 3,
+      results: [makeEntry({ p: 3 }, 0), makeEntry({ p: 5 }, 0), makeEntry({ p: 7 }, 0)],
+    };
+    grid.results[0].metrics.maxDrawdown = 10;
+    grid.results[1].metrics.maxDrawdown = 2; // peak (best)
+    grid.results[2].metrics.maxDrawdown = 10;
+    const sensitivity = {
+      singleParams: [
+        {
+          paramName: "p",
+          data: [
+            { value: 3, metric: 10 },
+            { value: 5, metric: 2 },
+            { value: 7, metric: 10 },
+          ],
+        },
+      ],
+      pairwise: [],
+      safeZones: [],
+    };
+    const rec = computeRecommendedParams(grid, null, sensitivity);
+    expect(rec.confidence).toBe("low");
+    expect(rec.reason).toMatch(/sharp/i);
+  });
+
+  it("flags `confidence: low` when sensitivity shows a sharp peak", () => {
+    // Construct a sensitivity dataset where the recommended value sits
+    // on a peak that drops > 50% to its neighbors.
+    const sensitivity = {
+      singleParams: [
+        {
+          paramName: "fast",
+          data: [
+            { value: 3, metric: 0.1 },
+            { value: 5, metric: 1.5 }, // peak
+            { value: 7, metric: 0.2 },
+          ],
+        },
+      ],
+      pairwise: [],
+      safeZones: [],
+    };
+    const rec = computeRecommendedParams(baseGridResult, null, sensitivity);
+    expect(rec.confidence).toBe("low");
+    expect(rec.reason).toMatch(/sharp/i);
+  });
+});
+
+// ── computeDnaGrade ───────────────────────────────────────────────
+
+describe("computeDnaGrade", () => {
+  const wfStable: WalkForwardResult = {
+    periods: [
+      {
+        trainStart: 0,
+        trainEnd: 50,
+        testStart: 50,
+        testEnd: 100,
+        bestParams: {},
+        inSampleMetrics: {} as never,
+        outOfSampleMetrics: { winRate: 60 } as never,
+        testBacktest: {} as never,
+      },
+      {
+        trainStart: 50,
+        trainEnd: 100,
+        testStart: 100,
+        testEnd: 150,
+        bestParams: {},
+        inSampleMetrics: {} as never,
+        outOfSampleMetrics: { winRate: 62 } as never,
+        testBacktest: {} as never,
+      },
+    ],
+    aggregateMetrics: {
+      avgInSample: {} as never,
+      avgOutOfSample: {} as never,
+      stabilityRatio: 0.85, // → A
+    },
+    recommendation: { useOptimizedParams: true, suggestedParams: {}, reason: "" },
+  };
+
+  const mc: MonteCarloResult = {
+    pValue: { sharpe: 0.005, returns: 0.005 } as never,
+  } as MonteCarloResult;
+
+  it("returns overall='F' with all items unavailable when no inputs are provided", () => {
+    const out = computeDnaGrade(null, null, null);
+    expect(out.overall).toBe("F");
+    expect(out.overallScore).toBe(0);
+    expect(out.items.every((it) => !it.available)).toBe(true);
+  });
+
+  it("includes WF stability when walkForward is provided", () => {
+    const out = computeDnaGrade(null, wfStable, null);
+    const wfItem = out.items.find((it) => it.label === "Walk-Forward Stability");
+    expect(wfItem?.available).toBe(true);
+    expect(wfItem?.grade).toBe("A");
+  });
+
+  it("includes MC significance when monteCarlo is provided", () => {
+    const out = computeDnaGrade(null, null, mc);
+    const mcItem = out.items.find((it) => it.label === "Monte Carlo Significance");
+    expect(mcItem?.available).toBe(true);
+    expect(mcItem?.grade).toBe("A");
+  });
+
+  it("computes parameter sensitivity from grid search results when available", () => {
+    const out = computeDnaGrade(baseGridResult, null, null);
+    const psItem = out.items.find((it) => it.label === "Parameter Sensitivity");
+    expect(psItem?.available).toBe(true);
+  });
+
+  it("renormalizes the weighted overall by available items", () => {
+    // Only WF and MC available — overall should equal weighted average
+    // of those two items, not penalize for missing items.
+    const out = computeDnaGrade(null, wfStable, mc);
+    const wfScore = out.items.find((it) => it.label === "Walk-Forward Stability")?.score ?? 0;
+    const mcScore = out.items.find((it) => it.label === "Monte Carlo Significance")?.score ?? 0;
+    // weights: WF 0.3, MC 0.3 → renormalized to 0.5 each
+    const expected = (wfScore * 0.3 + mcScore * 0.3) / 0.6;
+    expect(out.overallScore).toBeCloseTo(expected, 5);
+  });
+});

--- a/packages/core/src/optimization/index.ts
+++ b/packages/core/src/optimization/index.ts
@@ -124,3 +124,22 @@ export {
   crowdingDistance,
   summarizeParetoResult,
 } from "./pareto";
+
+// Strategy DNA — post-optimization analytics
+export {
+  buildGenomeSegments,
+  extractSensitivityData,
+  computeRecommendedParams,
+  computeDnaGrade,
+} from "./strategy-dna";
+export type {
+  GenomeSegment,
+  SensitivitySingle,
+  SensitivityPair,
+  SafeZone,
+  SensitivityData,
+  RecommendedParams,
+  DnaGrade,
+  DnaGradeItem,
+  DnaGradeReport,
+} from "./strategy-dna";

--- a/packages/core/src/optimization/strategy-dna.ts
+++ b/packages/core/src/optimization/strategy-dna.ts
@@ -1,0 +1,619 @@
+/**
+ * Strategy DNA — post-optimization analytics.
+ *
+ * Analyzes already-computed optimization results (no new backtests
+ * needed) to produce visualizations and recommendations:
+ *
+ * - **Genome segments** — best params placed on a 0..1 axis within
+ *   their search ranges, for at-a-glance "where in the space did the
+ *   optimizer land" panels.
+ * - **Sensitivity data** — per-param and pairwise score distributions,
+ *   plus top-25% safe zones, used by sensitivity heatmaps.
+ * - **Recommended params** — three-step heuristic: safe-zone median,
+ *   walk-forward stable-period override, sensitivity-peak penalty.
+ * - **DNA grade report** — A–F summary across WF stability / MC
+ *   significance / parameter sensitivity / win-rate stability.
+ *
+ * This is intentionally separate from the comprehensive
+ * `robustness/` module: that one runs new backtests across regime
+ * splits, this one only crunches outputs the user already produced.
+ *
+ * @example
+ * ```ts
+ * import {
+ *   buildGenomeSegments,
+ *   extractSensitivityData,
+ *   computeRecommendedParams,
+ *   computeDnaGrade,
+ *   gridSearch,
+ * } from "trendcraft";
+ *
+ * const grid = gridSearch(...);
+ * const sensitivity = extractSensitivityData(grid.results, grid.metric);
+ * const recommendation = computeRecommendedParams(grid, walkForwardResult, sensitivity);
+ * const grade = computeDnaGrade(grid, walkForwardResult, monteCarloResult);
+ * ```
+ */
+
+import { median } from "../core/statistics";
+import type {
+  GridSearchResult,
+  MonteCarloResult,
+  OptimizationMetric,
+  OptimizationResultEntry,
+  WalkForwardResult,
+} from "../types/optimization";
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface GenomeSegment {
+  name: string;
+  value: number;
+  min: number;
+  max: number;
+  /** Position within the [min, max] range, clamped to [0, 1]. 0.5 when min === max. */
+  position: number;
+  /** Best score for this segment's strategy run. */
+  score: number;
+}
+
+export interface SensitivitySingle {
+  paramName: string;
+  /** Sorted by `value`. `metric` is the mean across all entries that share the same value. */
+  data: { value: number; metric: number }[];
+}
+
+export interface SensitivityPair {
+  paramX: string;
+  paramY: string;
+  /** Mean metric per (x, y) cell. */
+  data: { x: number; y: number; metric: number }[];
+  /** Sorted unique x and y values from the grid. */
+  xValues: number[];
+  yValues: number[];
+}
+
+export interface SafeZone {
+  paramName: string;
+  min: number;
+  max: number;
+}
+
+export interface SensitivityData {
+  singleParams: SensitivitySingle[];
+  pairwise: SensitivityPair[];
+  safeZones: SafeZone[];
+}
+
+export interface RecommendedParams {
+  params: Record<string, number>;
+  ranges: Record<string, { min: number; max: number }>;
+  confidence: "high" | "medium" | "low";
+  reason: string;
+  /** Human-readable list of inputs the recommendation drew from (Safe Zone, WF, etc.). */
+  sources: string[];
+}
+
+/** DNA grade letter, simpler than `robustness/RobustnessGrade` (no `+` half-grades). */
+export type DnaGrade = "A" | "B" | "C" | "D" | "F";
+
+export interface DnaGradeItem {
+  label: string;
+  grade: DnaGrade;
+  /** 0..100 score; weighted by `available: true` items into the overall grade. */
+  score: number;
+  description: string;
+  /** `false` when the input that would produce this item wasn't supplied. */
+  available: boolean;
+}
+
+export interface DnaGradeReport {
+  items: DnaGradeItem[];
+  overall: DnaGrade;
+  overallScore: number;
+}
+
+// ── Metric Direction ───────────────────────────────────────────────
+
+/**
+ * Metrics where smaller is better (notably `maxDrawdown`, where -2%
+ * is preferable to -5%). Everything else in `OptimizationMetric`
+ * follows max-is-better. Without this, top-25% / safe-zone / WF
+ * stable filtering would surface the *worst* drawdown configurations
+ * as recommendations.
+ */
+const MINIMIZING_METRICS: ReadonlySet<OptimizationMetric> = new Set(["maxDrawdown"]);
+
+function compareDescByMetric(metric: OptimizationMetric) {
+  const minimize = MINIMIZING_METRICS.has(metric);
+  return (a: OptimizationResultEntry, b: OptimizationResultEntry) =>
+    minimize ? a.metrics[metric] - b.metrics[metric] : b.metrics[metric] - a.metrics[metric];
+}
+
+// ── Genome ─────────────────────────────────────────────────────────
+
+/**
+ * Map best parameter values onto a normalized [0, 1] axis within their
+ * declared search ranges. Filters out params not present in `bestParams`.
+ *
+ * @example
+ * ```ts
+ * const segments = buildGenomeSegments(
+ *   { fast: 7, slow: 30 },
+ *   [{ name: "fast", min: 5, max: 15 }, { name: "slow", min: 20, max: 50 }],
+ *   bestScore,
+ * );
+ * // segments[0] = { name: "fast", value: 7, position: 0.2, ... }
+ * ```
+ */
+export function buildGenomeSegments(
+  bestParams: Record<string, number>,
+  paramRanges: { name: string; min: number; max: number }[],
+  bestScore: number,
+): GenomeSegment[] {
+  return paramRanges
+    .filter((r) => bestParams[r.name] !== undefined)
+    .map((r) => {
+      const value = bestParams[r.name];
+      const range = r.max - r.min;
+      const position = range > 0 ? (value - r.min) / range : 0.5;
+      return {
+        name: r.name,
+        value,
+        min: r.min,
+        max: r.max,
+        position: Math.max(0, Math.min(1, position)),
+        score: bestScore,
+      };
+    });
+}
+
+// ── Sensitivity ────────────────────────────────────────────────────
+
+/**
+ * Aggregate per-parameter and pairwise metric distributions plus
+ * top-25% safe zones from a grid search's results.
+ *
+ * - `singleParams[i]`: param × value → mean metric across all combos
+ *   with that value.
+ * - `pairwise[ij]`: (param_i, param_j) × (value_i, value_j) → mean
+ *   metric. One entry per unordered pair.
+ * - `safeZones[i]`: min/max value of param_i across the top-25%
+ *   results by `metric`.
+ *
+ * Empty results returns an empty `SensitivityData` (no throw).
+ */
+export function extractSensitivityData(
+  results: OptimizationResultEntry[],
+  metric: OptimizationMetric,
+): SensitivityData {
+  if (results.length === 0) {
+    return { singleParams: [], pairwise: [], safeZones: [] };
+  }
+
+  const paramNames = Object.keys(results[0].params);
+
+  const singleParams: SensitivitySingle[] = paramNames.map((paramName) => {
+    const byValue = new Map<number, number[]>();
+    for (const r of results) {
+      const v = r.params[paramName];
+      if (!byValue.has(v)) byValue.set(v, []);
+      byValue.get(v)?.push(r.metrics[metric]);
+    }
+    const data = Array.from(byValue.entries())
+      .sort((a, b) => a[0] - b[0])
+      .map(([value, metrics]) => ({
+        value,
+        metric: metrics.reduce((s, m) => s + m, 0) / metrics.length,
+      }));
+    return { paramName, data };
+  });
+
+  const pairwise: SensitivityPair[] = [];
+  for (let i = 0; i < paramNames.length; i++) {
+    for (let j = i + 1; j < paramNames.length; j++) {
+      const paramX = paramNames[i];
+      const paramY = paramNames[j];
+      const byPair = new Map<string, number[]>();
+      const xSet = new Set<number>();
+      const ySet = new Set<number>();
+      for (const r of results) {
+        const x = r.params[paramX];
+        const y = r.params[paramY];
+        xSet.add(x);
+        ySet.add(y);
+        const key = `${x}|${y}`;
+        if (!byPair.has(key)) byPair.set(key, []);
+        byPair.get(key)?.push(r.metrics[metric]);
+      }
+      const data: { x: number; y: number; metric: number }[] = [];
+      for (const [key, metrics] of byPair) {
+        const [xs, ys] = key.split("|");
+        data.push({
+          x: Number(xs),
+          y: Number(ys),
+          metric: metrics.reduce((s, m) => s + m, 0) / metrics.length,
+        });
+      }
+      pairwise.push({
+        paramX,
+        paramY,
+        data,
+        xValues: Array.from(xSet).sort((a, b) => a - b),
+        yValues: Array.from(ySet).sort((a, b) => a - b),
+      });
+    }
+  }
+
+  // Safe zones: top 25% results by metric (direction-aware so
+  // minimizing metrics like `maxDrawdown` surface the smallest, not
+  // the largest, drawdowns), find param ranges.
+  const sorted = [...results].sort(compareDescByMetric(metric));
+  const top25 = sorted.slice(0, Math.max(1, Math.ceil(sorted.length * 0.25)));
+  const safeZones: SafeZone[] = paramNames.map((paramName) => {
+    const values = top25.map((r) => r.params[paramName]);
+    return {
+      paramName,
+      min: Math.min(...values),
+      max: Math.max(...values),
+    };
+  });
+
+  return { singleParams, pairwise, safeZones };
+}
+
+// ── Recommended Parameters ─────────────────────────────────────────
+
+/**
+ * Snap an interpolated median back to the nearest explored candidate
+ * so the recommendation is always a value the user actually tested.
+ * Without this, the recommendation can be `7.5` for an integer-only
+ * param (when the top-25% has an even count and median linearly
+ * interpolates `7` and `8`), which then re-enters the next
+ * optimization run as a fractional value the strategy never saw.
+ */
+function snapToNearest(target: number, candidates: number[]): number {
+  let best = candidates[0];
+  let bestDist = Math.abs(target - best);
+  for (let i = 1; i < candidates.length; i++) {
+    const d = Math.abs(target - candidates[i]);
+    if (d < bestDist) {
+      best = candidates[i];
+      bestDist = d;
+    }
+  }
+  return best;
+}
+
+/**
+ * Produce a "robust" parameter recommendation from a grid search,
+ * optionally refined by walk-forward and sensitivity inputs.
+ *
+ * Three-step pipeline (each step optionally narrows the previous
+ * step's choice):
+ *
+ * 1. **Safe Zone center** — median of the top-25% grid-search results
+ *    per param. Always runs.
+ * 2. **WF stability override** — if any walk-forward periods
+ *    out-of-sample-profitably, override Step 1 with the median of
+ *    those periods' `bestParams`.
+ * 3. **Sensitivity penalty** — when the recommended value sits on a
+ *    sharp peak (≥50% drop to nearest neighbors in the sensitivity
+ *    plot), the recommendation is downgraded to `confidence: "low"`.
+ *
+ * Confidence rules:
+ * - `low` if any param sits on a sharp sensitivity peak.
+ * - `high` if WF data exists, ≥half its periods were profitable, and
+ *   no sharp peak was found.
+ * - `medium` otherwise.
+ *
+ * Handles `gridSearch.bestParams === null` (PR-A2 contract) by
+ * falling back to `results[0]?.params` so a recommendation can still
+ * be produced from the explored space.
+ */
+export function computeRecommendedParams(
+  gridSearch: GridSearchResult,
+  walkForward?: WalkForwardResult | null,
+  sensitivityData?: SensitivityData | null,
+): RecommendedParams {
+  // 0-result guard: an empty grid produces no recommendation rather
+  // than a partially-formed object whose params/ranges are vacuously
+  // empty but sources still claim a "Safe Zone center" was found.
+  if (gridSearch.results.length === 0) {
+    return {
+      params: {},
+      ranges: {},
+      confidence: "low",
+      reason: "No optimization results to recommend from",
+      sources: [],
+    };
+  }
+
+  const paramNames = Object.keys(gridSearch.bestParams ?? gridSearch.results[0]?.params ?? {});
+  const sources: string[] = [];
+
+  // Step 1: Safe Zone center (top-25% median). Direction-aware so
+  // minimizing metrics like `maxDrawdown` recommend params near the
+  // smallest drawdowns, not the largest.
+  const sorted = [...gridSearch.results].sort(compareDescByMetric(gridSearch.metric));
+  const top25 = sorted.slice(0, Math.max(1, Math.ceil(sorted.length * 0.25)));
+
+  const params: Record<string, number> = {};
+  const ranges: Record<string, { min: number; max: number }> = {};
+
+  for (const name of paramNames) {
+    const values = top25.map((r) => r.params[name]);
+    if (values.length === 0) continue;
+    params[name] = snapToNearest(median(values), values);
+    ranges[name] = { min: Math.min(...values), max: Math.max(...values) };
+  }
+  sources.push("Safe Zone center");
+
+  // Step 2: Walk-Forward stable period override.
+  let wfStablePeriods = 0;
+  let wfTotalPeriods = 0;
+
+  if (walkForward && walkForward.periods.length > 0) {
+    wfTotalPeriods = walkForward.periods.length;
+    const stablePeriods = walkForward.periods.filter((p) => p.outOfSampleMetrics.returns > 0);
+    wfStablePeriods = stablePeriods.length;
+
+    if (stablePeriods.length > 0) {
+      for (const name of paramNames) {
+        const values = stablePeriods
+          .map((p) => p.bestParams[name])
+          .filter((v): v is number => v !== undefined);
+        if (values.length > 0) {
+          params[name] = snapToNearest(median(values), values);
+          // Recompute the displayed range from the same source as the
+          // override so consumers don't get a self-contradictory
+          // `fast=9` with `(5..7)` when WF stable values lie outside
+          // the original safe zone.
+          ranges[name] = { min: Math.min(...values), max: Math.max(...values) };
+        }
+      }
+      sources.push(`${stablePeriods.length}/${wfTotalPeriods} stable WF periods`);
+    }
+  }
+
+  // Step 3: Sensitivity penalty for sharp peaks. Direction-aware so
+  // it works for both maximizing metrics (rec value much higher than
+  // neighbors → drop ratio > 50%) and minimizing metrics like
+  // `maxDrawdown` (rec value much lower than neighbors → rise ratio
+  // > 50%, since smaller drawdowns are better).
+  let hasSensitivityPenalty = false;
+  const minimize = MINIMIZING_METRICS.has(gridSearch.metric);
+  if (sensitivityData && sensitivityData.singleParams.length > 0) {
+    for (const sp of sensitivityData.singleParams) {
+      const recValue = params[sp.paramName];
+      if (recValue === undefined || sp.data.length < 3) continue;
+
+      const idx = sp.data.findIndex((d) => d.value === recValue);
+      if (idx === -1) continue;
+      const atRec = sp.data[idx];
+
+      const neighbors = [sp.data[idx - 1], sp.data[idx + 1]].filter(Boolean);
+      if (neighbors.length === 0) continue;
+      const avgNeighbor = neighbors.reduce((s, n) => s + n.metric, 0) / neighbors.length;
+
+      let peakRatio = 0;
+      if (minimize) {
+        // Minimize: rec is "smaller is better" — peak means avgNeighbor
+        // is meaningfully larger. Use magnitude of `atRec.metric` as
+        // the denominator so a 50% rise from rec to neighbors triggers.
+        if (Math.abs(atRec.metric) > 0) {
+          peakRatio = (avgNeighbor - atRec.metric) / Math.abs(atRec.metric);
+        }
+      } else if (atRec.metric > 0) {
+        peakRatio = 1 - avgNeighbor / atRec.metric;
+      }
+      if (peakRatio > 0.5) {
+        hasSensitivityPenalty = true;
+        break;
+      }
+    }
+  }
+
+  const hasWfData = wfStablePeriods > 0;
+  const wfMajorityStable = wfStablePeriods >= wfTotalPeriods / 2;
+
+  let confidence: "high" | "medium" | "low";
+  if (hasSensitivityPenalty) {
+    confidence = "low";
+  } else if (hasWfData && wfMajorityStable) {
+    confidence = "high";
+  } else {
+    confidence = "medium";
+  }
+
+  const reason =
+    confidence === "high"
+      ? "Safe Zone center confirmed by stable Walk-Forward periods with low sensitivity"
+      : confidence === "medium"
+        ? hasWfData
+          ? `Only ${wfStablePeriods}/${wfTotalPeriods} WF periods were profitable`
+          : "Based on Grid Search Safe Zone only (no Walk-Forward data)"
+        : "Parameters sit on a sharp sensitivity peak — use with caution";
+
+  return { params, ranges, confidence, reason, sources };
+}
+
+// ── DNA Grading ────────────────────────────────────────────────────
+
+function scoreToDnaGrade(score: number): DnaGrade {
+  if (score >= 80) return "A";
+  if (score >= 60) return "B";
+  if (score >= 40) return "C";
+  if (score >= 20) return "D";
+  return "F";
+}
+
+function wfStabilityScore(stabilityRatio: number): number {
+  if (stabilityRatio >= 0.8) return 100;
+  if (stabilityRatio >= 0.6) return 75;
+  if (stabilityRatio >= 0.4) return 50;
+  if (stabilityRatio >= 0.2) return 25;
+  return 0;
+}
+
+function mcSignificanceScore(pValue: number): number {
+  if (pValue < 0.01) return 100;
+  if (pValue < 0.05) return 75;
+  if (pValue < 0.1) return 50;
+  if (pValue < 0.2) return 25;
+  return 0;
+}
+
+function paramSensitivityScore(cv: number): number {
+  if (cv < 0.1) return 100;
+  if (cv < 0.2) return 75;
+  if (cv < 0.3) return 50;
+  if (cv < 0.5) return 25;
+  return 0;
+}
+
+function winRateStabilityScore(stdDev: number): number {
+  if (stdDev < 5) return 100;
+  if (stdDev < 10) return 75;
+  if (stdDev < 15) return 50;
+  if (stdDev < 20) return 25;
+  return 0;
+}
+
+/** Coefficient of variation of grid-search scores: a unit-free measure of metric spread. */
+function computeCV(results: OptimizationResultEntry[], metric: OptimizationMetric): number {
+  if (results.length < 2) return 0;
+  const values = results.map((r) => r.metrics[metric]);
+  const mean = values.reduce((s, v) => s + v, 0) / values.length;
+  if (Math.abs(mean) < 1e-10) return 1;
+  const variance = values.reduce((s, v) => s + (v - mean) ** 2, 0) / values.length;
+  return Math.sqrt(variance) / Math.abs(mean);
+}
+
+/** Stddev of out-of-sample win rates across walk-forward periods. */
+function computeWinRateStdDev(wf: WalkForwardResult): number {
+  if (wf.periods.length < 2) return 0;
+  const winRates = wf.periods.map((p) => p.outOfSampleMetrics.winRate);
+  const mean = winRates.reduce((s, v) => s + v, 0) / winRates.length;
+  const variance = winRates.reduce((s, v) => s + (v - mean) ** 2, 0) / winRates.length;
+  return Math.sqrt(variance);
+}
+
+/**
+ * Compute an A–F robustness grade across four dimensions, using only
+ * the inputs supplied. Items whose corresponding input is missing are
+ * marked `available: false` and excluded from the weighted-average
+ * overall (the remaining weights renormalize to 1, so a one-input
+ * grade isn't penalized for the missing dimensions).
+ *
+ * Weights: WF stability 30%, MC significance 30%, parameter
+ * sensitivity 20%, win-rate stability 20%.
+ *
+ * Distinct from the `robustness/` module's `RobustnessGrade` (which
+ * uses A+/B+/... half-grades and runs new backtests). This grade only
+ * crunches inputs the user already produced.
+ */
+export function computeDnaGrade(
+  gridSearch?: GridSearchResult | null,
+  walkForward?: WalkForwardResult | null,
+  monteCarlo?: MonteCarloResult | null,
+): DnaGradeReport {
+  const items: DnaGradeItem[] = [];
+
+  if (walkForward) {
+    const s = wfStabilityScore(walkForward.aggregateMetrics.stabilityRatio);
+    items.push({
+      label: "Walk-Forward Stability",
+      grade: scoreToDnaGrade(s),
+      score: s,
+      description: `Stability ratio: ${(walkForward.aggregateMetrics.stabilityRatio * 100).toFixed(1)}%`,
+      available: true,
+    });
+  } else {
+    items.push({
+      label: "Walk-Forward Stability",
+      grade: "F",
+      score: 0,
+      description: "Run Walk-Forward analysis first",
+      available: false,
+    });
+  }
+
+  if (monteCarlo) {
+    const pVal = Math.min(monteCarlo.pValue.sharpe, monteCarlo.pValue.returns);
+    const s = mcSignificanceScore(pVal);
+    items.push({
+      label: "Monte Carlo Significance",
+      grade: scoreToDnaGrade(s),
+      score: s,
+      description: `p-value: ${pVal.toFixed(3)}`,
+      available: true,
+    });
+  } else {
+    items.push({
+      label: "Monte Carlo Significance",
+      grade: "F",
+      score: 0,
+      description: "Run Monte Carlo first",
+      available: false,
+    });
+  }
+
+  if (gridSearch && gridSearch.results.length > 1) {
+    const cv = computeCV(gridSearch.results, gridSearch.metric);
+    const s = paramSensitivityScore(cv);
+    items.push({
+      label: "Parameter Sensitivity",
+      grade: scoreToDnaGrade(s),
+      score: s,
+      description: `CV: ${cv.toFixed(3)} (lower = more robust)`,
+      available: true,
+    });
+  } else {
+    items.push({
+      label: "Parameter Sensitivity",
+      grade: "F",
+      score: 0,
+      description: "Run Grid Search first",
+      available: false,
+    });
+  }
+
+  if (walkForward && walkForward.periods.length >= 2) {
+    const stdDev = computeWinRateStdDev(walkForward);
+    const s = winRateStabilityScore(stdDev);
+    items.push({
+      label: "Win Rate Stability",
+      grade: scoreToDnaGrade(s),
+      score: s,
+      description: `Std dev: ${stdDev.toFixed(1)}% across ${walkForward.periods.length} periods`,
+      available: true,
+    });
+  } else {
+    items.push({
+      label: "Win Rate Stability",
+      grade: "F",
+      score: 0,
+      description: "Run Walk-Forward analysis first",
+      available: false,
+    });
+  }
+
+  // Renormalize available weights so a one-input grade isn't dragged down by missing items.
+  const weights = [0.3, 0.3, 0.2, 0.2];
+  let overallScore = 0;
+  let totalWeight = 0;
+  for (let i = 0; i < items.length; i++) {
+    if (items[i].available) {
+      overallScore += items[i].score * weights[i];
+      totalWeight += weights[i];
+    }
+  }
+  overallScore = totalWeight > 0 ? overallScore / totalWeight : 0;
+
+  return {
+    items,
+    overall: scoreToDnaGrade(overallScore),
+    overallScore,
+  };
+}


### PR DESCRIPTION
## Summary

Lifts post-optimization analytics from echarts-viewer into core as a reusable `optimization/strategy-dna` module. Foundation for Strategy Studio PR13 (StrategyDnaPanel) and any future MCP tools that surface "robust parameter recommendation" / "strategy grading".

This is the second of two core fix PRs surfaced by PR13 dogfooding:

- **PR-B1** ✅ merged (#152) — `percentile` / `median` / `quartiles` public utility
- **PR-B2 (this PR)** — strategy DNA primitives (lift + cleanup viewer)

After this lands, Strategy Studio PR13 can build on top of these APIs without re-implementing them in user-space.

## New API

### `optimization/strategy-dna.ts`

```ts
buildGenomeSegments(bestParams, paramRanges, bestScore): GenomeSegment[]
extractSensitivityData(results, metric): SensitivityData
computeRecommendedParams(grid, walkForward?, sensitivity?): RecommendedParams
computeDnaGrade(grid?, walkForward?, monteCarlo?): DnaGradeReport
```

### Types

`GenomeSegment`, `SensitivitySingle`, `SensitivityPair`, `SafeZone`, `SensitivityData`, `RecommendedParams`, `DnaGrade` (`"A" | "B" | "C" | "D" | "F"`), `DnaGradeItem`, `DnaGradeReport`.

The `Dna` prefix avoids collision with the comprehensive `robustness/RobustnessGrade` (`A+ | A | B+ | B | C+ | C | D | F`) — that module runs new backtests, this one only crunches existing optimization outputs.

## Correctness highlights

Surfaced through 4 rounds of Codex review:

- **Snap-to-nearest** — recommendations always land on an explored grid value (no `period: 7.5` for integer-only params).
- **Range/param sync** — when WF override changes the recommended value, `ranges` is recomputed from the same source so consumers never see `fast=9` with displayed range `(5..7)`.
- **Direction-aware metrics** — `maxDrawdown` (smaller-is-better) is sorted ascending in safe-zone extraction and recommendation, with symmetric sensitivity-peak detection.
- **0-result guard** — empty grid returns `{ params: {}, sources: [], confidence: "low" }` rather than a partially-formed object claiming a "Safe Zone center".

## echarts-viewer cleanup

`utils/strategyDna.ts`: 574 → 110 lines. Now re-exports the core APIs with backwards-compat aliases (`Grade`, `RobustnessGrade`, `computeRobustnessGrade`) plus the viewer-specific URL codec. No consumer file (`hooks/useStrategyDna.ts`, `panels/StrategyDnaPanel.tsx`, etc.) needs to change imports.

## Test plan

- [x] 24 new tests in `optimization/__tests__/strategy-dna.test.ts`
- [x] `pnpm test` workspace green (4966 core tests)
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] `npx tsc --noEmit` clean in `examples/echarts-viewer/`
- [x] Codex review clean (R4: no defects flagged)