### PR TITLE
feat(strategy-studio): StrategyDnaPanel with genome / sensitivity / robustness (PR13)

### DIFF
--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -6,6 +6,7 @@ import { indicatorPresets, parseStrategy, validateStrategyJSON } from "trendcraf
 import { useBacktestRunner } from "./hooks/useBacktestRunner";
 import { useRegime } from "./hooks/useRegime";
 import { type SimulatorHandle, createLiveSimulator } from "./lib/live-simulator";
+import type { OptimizationComputation } from "./lib/optimization";
 import { PLUGIN_BY_KIND, type PluginHandle } from "./lib/plugins";
 import { clampedSeedEnd, lastEmittedIdx } from "./lib/replay";
 import { sampleCandles } from "./lib/sample-data";
@@ -24,6 +25,7 @@ import { RiskPanel } from "./panels/RiskPanel";
 import { ScoringPanel } from "./panels/ScoringPanel";
 import { SignalsPanel } from "./panels/SignalsPanel";
 import { StrategyBuilder } from "./panels/StrategyBuilder";
+import { StrategyDnaPanel } from "./panels/StrategyDnaPanel";
 
 function resolvePresetId(kind: string): string {
   return localStudioAPI.resolvePresetKey(kind) ?? kind;
@@ -503,6 +505,15 @@ export function App() {
   const [jsonText, setJsonText] = useState<string>("");
   const [importError, setImportError] = useState<string | null>(null);
 
+  // Lifted from OptimizationPanel so StrategyDnaPanel can read the
+  // same computation state without duplicating the run trigger. Pass
+  // the full discriminated union — DNA panel surfaces empty/error
+  // states with their own messages instead of collapsing them to
+  // "Run a grid search...".
+  const [optimizationResult, setOptimizationResult] = useState<OptimizationComputation>({
+    kind: "idle",
+  });
+
   // Backtest snapshot against history up to the current playhead — what the
   // user sees on chart matches what backtest sees.
   const backtestCandles = useMemo(
@@ -703,7 +714,10 @@ export function App() {
           strategy={runner.state.lastResult?.json}
           candles={backtestCandles}
           isReplayPlaying={replay.mode === "live" && replay.status === "playing"}
+          onResult={setOptimizationResult}
         />
+        <div className="pane-divider" />
+        <StrategyDnaPanel optimizationResult={optimizationResult} />
       </aside>
 
       {popoverState && popoverInstance && (

--- a/packages/chart/examples/strategy-studio/src/panels/OptimizationPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/OptimizationPanel.tsx
@@ -23,6 +23,13 @@ type Props = {
   candles: StudioCandle[];
   /** True while Replay is actively playing — disables Run button. */
   isReplayPlaying: boolean;
+  /**
+   * Optional notifier for the latest optimization result. Lets sibling
+   * panels (e.g. StrategyDnaPanel) consume the same result without
+   * duplicating the run trigger. Result state stays panel-local; this
+   * is fire-and-forget broadcast on every change.
+   */
+  onResult?: (result: OptimizationComputation) => void;
 };
 
 type RangeMap = Record<string, { min: number; max: number; step: number }>;
@@ -36,12 +43,21 @@ function initRanges(tunables: Tunable[]): RangeMap {
   return out;
 }
 
-export function OptimizationPanel({ strategy, candles, isReplayPlaying }: Props) {
+export function OptimizationPanel({ strategy, candles, isReplayPlaying, onResult }: Props) {
   const tunables = useMemo<Tunable[]>(() => (strategy ? listTunables(strategy) : []), [strategy]);
 
   const [ranges, setRanges] = useState<RangeMap>(() => initRanges(tunables));
   const [metric, setMetric] = useState<OptimizationMetricUI>("returns");
   const [result, setResult] = useState<OptimizationComputation>({ kind: "idle" });
+
+  // Broadcast every result change so sibling panels (StrategyDnaPanel
+  // mounted in App) consume the same data without duplicating the
+  // run trigger. We fire on every change including idle so consumers
+  // see the empty/error state too and can clear their derived UI.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: onResult is a stable callback in practice; we don't want re-broadcasts when its identity changes.
+  useEffect(() => {
+    onResult?.(result);
+  }, [result]);
 
   // Anything that changes how `runGridSearch` would evaluate the strategy
   // must invalidate the panel state. Stringify the full entry/exit specs

--- a/packages/chart/examples/strategy-studio/src/panels/StrategyDnaPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/StrategyDnaPanel.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  buildGenomeSegments,
+  computeDnaGrade,
+  computeRecommendedParams,
+  extractSensitivityData,
+} from "trendcraft";
+import type { OptimizationComputation } from "../lib/optimization";
+import { GenomeVisualization } from "./dna/GenomeVisualization";
+import { RobustnessReport } from "./dna/RobustnessReport";
+import { SensitivityHeatmap } from "./dna/SensitivityHeatmap";
+
+type DnaTab = "genome" | "sensitivity" | "robustness";
+
+const TABS: { key: DnaTab; label: string }[] = [
+  { key: "genome", label: "Genome" },
+  { key: "sensitivity", label: "Sensitivity" },
+  { key: "robustness", label: "Robustness" },
+];
+
+type Props = {
+  /**
+   * Full optimization state from the sibling OptimizationPanel. Mirrored
+   * from `OptimizationComputation` so non-success states (`empty`,
+   * `error`) surface their own message instead of collapsing to "Run a
+   * grid search..." — that fallback would hide the fact that a run
+   * actually completed but produced no usable result.
+   */
+  optimizationResult: OptimizationComputation;
+};
+
+/**
+ * Strategy DNA panel — three-tab read-only visualization of an
+ * optimization run's genome, parameter sensitivity, and robustness
+ * grade. Display-only by design (no Apply button, no Compute Monte
+ * Carlo trigger): builder state is never mutated from this panel,
+ * matching PR12's OptimizationPanel philosophy. Walk-Forward and
+ * Monte Carlo dimensions on the grade card surface as
+ * `available: false` until Studio adds those workflows.
+ */
+export function StrategyDnaPanel({ optimizationResult }: Props) {
+  const gridSearchResult = optimizationResult.kind === "ok" ? optimizationResult.result : null;
+
+  const [activeTab, setActiveTab] = useState<DnaTab>("genome");
+  const [selectedParam, setSelectedParam] = useState<string | null>(null);
+  const [selectedParamPair, setSelectedParamPair] = useState<[string, string] | null>(null);
+
+  // Reset sensitivity selections when the grid result changes.
+  // Otherwise a second run with a different tunable set would leave
+  // selectedParam pointing at a name that no longer exists, and the
+  // Sensitivity tab would render blank (selector active but no body
+  // matches) until the user manually clicks another chip.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the result reference identity, which the parent invalidates whenever the run inputs change.
+  useEffect(() => {
+    setSelectedParam(null);
+    setSelectedParamPair(null);
+  }, [gridSearchResult]);
+
+  // Recompute analytics whenever the grid result changes. All four
+  // calls are pure data transforms; total cost is O(N · M) over
+  // results × params (~ms for typical 100-row grids).
+  const genomeSegments = useMemo(() => {
+    if (!gridSearchResult || gridSearchResult.bestParams === null) return null;
+    if (gridSearchResult.results.length === 0) return null;
+    // Derive ranges from the explored grid so the genome's [0, 1]
+    // axis matches the search space the user actually saw, not the
+    // nominal `paramRanges` they configured up front.
+    const paramNames = Object.keys(gridSearchResult.bestParams);
+    const paramRanges = paramNames.map((name) => {
+      const values = gridSearchResult.results.map((r) => r.params[name]);
+      return { name, min: Math.min(...values), max: Math.max(...values) };
+    });
+    return buildGenomeSegments(
+      gridSearchResult.bestParams,
+      paramRanges,
+      gridSearchResult.bestScore ?? 0,
+    );
+  }, [gridSearchResult]);
+
+  const sensitivityData = useMemo(() => {
+    if (!gridSearchResult) return null;
+    // Pass the full result set: pairwise aggregation is O(N · pairs)
+    // which on a 10,000-row, 10-param run is ~600k Map ops (~60ms on
+    // modern hardware). Capping to a top-N subset would bias the
+    // per-value histograms toward high scorers, hide values that
+    // never won, and break sensitivity-peak detection in
+    // `computeRecommendedParams` because dropped neighbors would no
+    // longer reveal a sharp drop.
+    return extractSensitivityData(gridSearchResult.results, gridSearchResult.metric);
+  }, [gridSearchResult]);
+
+  const recommendedParams = useMemo(() => {
+    if (!gridSearchResult) return null;
+    return computeRecommendedParams(gridSearchResult, null, sensitivityData);
+  }, [gridSearchResult, sensitivityData]);
+
+  const dnaGrade = useMemo(() => {
+    return computeDnaGrade(gridSearchResult, null, null);
+  }, [gridSearchResult]);
+
+  if (gridSearchResult === null) {
+    // Distinguish the three non-`ok` states. For `idle` (no run yet)
+    // we deliberately don't tell the user "Run a grid search" — the
+    // sibling Optimization panel may be unable to run (no strategy,
+    // no tunable params, etc.) and surfaces its own actionable
+    // reason. Pointing users at an action they can't perform from
+    // here would just be noise.
+    const message =
+      optimizationResult.kind === "empty"
+        ? optimizationResult.message
+        : optimizationResult.kind === "error"
+          ? `Optimization error: ${optimizationResult.message}`
+          : "No optimization data yet — see the Optimization panel above.";
+    return (
+      <div className="risk-panel">
+        <div className="pane-header">Strategy DNA</div>
+        <section className="risk-section">
+          <div className="meta-strategy-caption">{message}</div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="risk-panel">
+      <div className="pane-header">Strategy DNA</div>
+      <section className="risk-section">
+        <div style={{ display: "flex", gap: 0, marginBottom: 8 }}>
+          {TABS.map((tab, idx) => (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setActiveTab(tab.key)}
+              style={{
+                flex: 1,
+                padding: "5px 4px",
+                fontSize: 10,
+                borderWidth: 1,
+                borderStyle: "solid",
+                borderColor: "var(--border, #333)",
+                background:
+                  activeTab === tab.key ? "var(--accent, #4a9eff)" : "var(--bg-tertiary, #222)",
+                color: activeTab === tab.key ? "#fff" : "var(--text-secondary, #888)",
+                cursor: "pointer",
+                borderRadius:
+                  idx === 0 ? "4px 0 0 4px" : idx === TABS.length - 1 ? "0 4px 4px 0" : "0",
+              }}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {activeTab === "genome" &&
+          (genomeSegments && genomeSegments.length > 0 ? (
+            <GenomeVisualization
+              segments={genomeSegments}
+              onSegmentClick={(name) => {
+                setSelectedParam(name);
+                setSelectedParamPair(null);
+                setActiveTab("sensitivity");
+              }}
+            />
+          ) : (
+            <div className="meta-strategy-caption">No tunable parameters in this grid search.</div>
+          ))}
+
+        {activeTab === "sensitivity" &&
+          (sensitivityData && sensitivityData.singleParams.length > 0 ? (
+            <SensitivityHeatmap
+              data={sensitivityData}
+              selectedParam={selectedParam}
+              selectedParamPair={selectedParamPair}
+              onSelectParam={setSelectedParam}
+              onSelectParamPair={setSelectedParamPair}
+            />
+          ) : (
+            <div className="meta-strategy-caption">
+              No sensitivity data — grid search produced no results.
+            </div>
+          ))}
+
+        {activeTab === "robustness" && (
+          <RobustnessReport grade={dnaGrade} recommendedParams={recommendedParams} />
+        )}
+      </section>
+    </div>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/panels/dna/GenomeVisualization.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/dna/GenomeVisualization.tsx
@@ -1,0 +1,142 @@
+import { useState } from "react";
+import type { GenomeSegment } from "trendcraft";
+
+/**
+ * Format a genome value compactly without losing finer-step precision
+ * (`0.05`, `0.005`, etc.). `toFixed(1)` collapsed those into "0.1" /
+ * "0.0", which is misleading for strategies optimized at sub-decimal
+ * step sizes. Approach: integer values render as-is; fractional
+ * values show up to 4 decimals with trailing zeros trimmed.
+ */
+function formatGenomeValue(v: number): string {
+  if (Number.isInteger(v)) return String(v);
+  // Number(...) drops trailing zeros from "0.0500" → "0.05".
+  return String(Number(v.toFixed(4)));
+}
+
+/**
+ * Cool→hot gradient based on the segment's [0, 1] position within its
+ * declared search range. Pure math; no theme dependency.
+ */
+function positionToColor(position: number): string {
+  const r = Math.round(60 + position * 170);
+  const g = Math.round(120 - position * 80);
+  const b = Math.round(220 - position * 180);
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+type Props = {
+  segments: GenomeSegment[];
+  /** Click a segment to drive the panel state (e.g. switch to sensitivity tab). */
+  onSegmentClick?: (paramName: string) => void;
+};
+
+/**
+ * SVG bar chart showing each tunable parameter's `value` placed on a
+ * `[0, 1]` axis within its declared range. Hover surfaces the raw
+ * value plus the search range; click forwards the param name so the
+ * outer panel can react (e.g. switch to the sensitivity tab pre-
+ * filtered to that param).
+ */
+export function GenomeVisualization({ segments, onSegmentClick }: Props) {
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+
+  const segmentWidth = 36;
+  const segmentHeight = 48;
+  const gap = 4;
+  const totalWidth = segments.length * (segmentWidth + gap) - gap;
+  const svgWidth = Math.max(totalWidth + 16, 100);
+
+  return (
+    <div style={{ position: "relative" }}>
+      <svg
+        width="100%"
+        viewBox={`0 0 ${svgWidth} ${segmentHeight + 24}`}
+        style={{ display: "block" }}
+        role="img"
+        aria-label="Strategy genome parameter visualization"
+      >
+        {segments.map((seg, idx) => {
+          const x = 8 + idx * (segmentWidth + gap);
+          const isHovered = hoveredIdx === idx;
+          return (
+            <g
+              key={seg.name}
+              onMouseEnter={() => setHoveredIdx(idx)}
+              onMouseLeave={() => setHoveredIdx(null)}
+              onClick={() => onSegmentClick?.(seg.name)}
+              style={{ cursor: onSegmentClick ? "pointer" : "default" }}
+            >
+              <rect
+                x={x}
+                y={4}
+                width={segmentWidth}
+                height={segmentHeight}
+                rx={6}
+                ry={6}
+                fill={positionToColor(seg.position)}
+                stroke={isHovered ? "var(--accent, #4a9eff)" : "transparent"}
+                strokeWidth={2}
+                opacity={isHovered ? 1 : 0.85}
+              />
+              <text
+                x={x + segmentWidth / 2}
+                y={segmentHeight + 18}
+                textAnchor="middle"
+                fill="var(--text-secondary, #888)"
+                fontSize={9}
+              >
+                {seg.name.length > 6 ? `${seg.name.slice(0, 5)}..` : seg.name}
+              </text>
+              <text
+                x={x + segmentWidth / 2}
+                y={segmentHeight / 2 + 6}
+                textAnchor="middle"
+                fill="white"
+                fontSize={11}
+                fontWeight={600}
+              >
+                {formatGenomeValue(seg.value)}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      {hoveredIdx !== null && segments[hoveredIdx] && (
+        // Guard `segments[hoveredIdx]` against the case where a new
+        // optimization run replaces `segments` with a shorter array
+        // while a hover is active — `hoveredIdx` survives the prop
+        // change and `onMouseLeave` won't fire until the user moves,
+        // so we'd otherwise crash on `.name` before the tooltip can
+        // be dismissed.
+        <div
+          style={{
+            position: "absolute",
+            top: -4,
+            left: "50%",
+            transform: "translate(-50%, -100%)",
+            background: "var(--bg-primary, #1a1a1a)",
+            border: "1px solid var(--border, #333)",
+            borderRadius: 6,
+            padding: "6px 10px",
+            fontSize: "var(--font-xs)",
+            color: "var(--text-primary, #e0e0e0)",
+            whiteSpace: "nowrap",
+            zIndex: 10,
+            pointerEvents: "none",
+            boxShadow: "0 2px 8px rgba(0,0,0,0.3)",
+          }}
+        >
+          <div style={{ fontWeight: 600, marginBottom: 2 }}>{segments[hoveredIdx].name}</div>
+          <div>
+            Value: <strong>{segments[hoveredIdx].value}</strong>
+          </div>
+          <div style={{ color: "var(--text-secondary, #888)" }}>
+            Range: {segments[hoveredIdx].min} – {segments[hoveredIdx].max}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/panels/dna/RobustnessReport.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/dna/RobustnessReport.tsx
@@ -1,0 +1,245 @@
+import type { DnaGrade, DnaGradeReport, RecommendedParams } from "trendcraft";
+
+const GRADE_COLORS: Record<DnaGrade, string> = {
+  A: "#16a34a",
+  B: "#65a30d",
+  C: "#eab308",
+  D: "#ea580c",
+  F: "#dc2626",
+};
+
+const CONFIDENCE_COLORS: Record<RecommendedParams["confidence"], string> = {
+  high: "#16a34a",
+  medium: "#eab308",
+  low: "#dc2626",
+};
+
+type Props = {
+  grade: DnaGradeReport;
+  recommendedParams: RecommendedParams | null;
+};
+
+/**
+ * DNA grade report — overall A–F card plus per-dimension item list,
+ * followed by a recommended-params summary when grid-search results
+ * are available. Studio v1 is display-only (no "Apply to builder"
+ * button, no "Compute Monte Carlo" trigger): both callbacks live in
+ * the viewer because Studio doesn't yet wire walk-forward / Monte
+ * Carlo results into its panel state.
+ */
+export function RobustnessReport({ grade, recommendedParams }: Props) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {/* Overall grade */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 12,
+          padding: 12,
+          background: "var(--bg-primary, #1a1a1a)",
+          borderRadius: 8,
+        }}
+      >
+        <div
+          style={{
+            width: 48,
+            height: 48,
+            borderRadius: "50%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            background: GRADE_COLORS[grade.overall],
+            color: "#fff",
+            fontSize: 24,
+            fontWeight: 700,
+          }}
+        >
+          {grade.overall}
+        </div>
+        <div>
+          <div
+            style={{
+              fontSize: "var(--font-md)",
+              fontWeight: 600,
+              color: "var(--text-primary, #e0e0e0)",
+            }}
+          >
+            Overall Robustness
+          </div>
+          <div style={{ fontSize: "var(--font-xs)", color: "var(--text-secondary, #888)" }}>
+            Score: {grade.overallScore.toFixed(0)}/100
+          </div>
+        </div>
+      </div>
+
+      {/* Per-dimension items */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {grade.items.map((item) => (
+          <div
+            key={item.label}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              padding: "6px 8px",
+              background: "var(--bg-primary, #1a1a1a)",
+              borderRadius: 6,
+              opacity: item.available ? 1 : 0.5,
+            }}
+          >
+            <div
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: 4,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                background: item.available ? GRADE_COLORS[item.grade] : "var(--bg-tertiary, #222)",
+                color: item.available ? "#fff" : "var(--text-secondary, #888)",
+                fontSize: "var(--font-base)",
+                fontWeight: 700,
+                flexShrink: 0,
+              }}
+            >
+              {item.available ? item.grade : "—"}
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div
+                style={{
+                  fontSize: "var(--font-sm)",
+                  color: "var(--text-primary, #e0e0e0)",
+                  fontWeight: 500,
+                }}
+              >
+                {item.label}
+              </div>
+              <div
+                style={{
+                  fontSize: 9,
+                  color: "var(--text-secondary, #888)",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {item.description}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Recommended params summary */}
+      {recommendedParams && Object.keys(recommendedParams.params).length > 0 && (
+        <div
+          style={{
+            marginTop: 4,
+            padding: 10,
+            background: "var(--bg-primary, #1a1a1a)",
+            borderRadius: 8,
+            border: "1px solid var(--border, #333)",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              marginBottom: 8,
+            }}
+          >
+            <div
+              style={{
+                fontSize: "var(--font-sm)",
+                fontWeight: 600,
+                color: "var(--text-primary, #e0e0e0)",
+              }}
+            >
+              Recommended Parameters
+            </div>
+            <span
+              style={{
+                fontSize: 10,
+                fontWeight: 600,
+                padding: "2px 6px",
+                borderRadius: 4,
+                background: CONFIDENCE_COLORS[recommendedParams.confidence],
+                color: "#fff",
+                textTransform: "capitalize",
+              }}
+            >
+              {recommendedParams.confidence}
+            </span>
+          </div>
+
+          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            {Object.entries(recommendedParams.params).map(([name, value]) => {
+              const range = recommendedParams.ranges[name];
+              return (
+                <div
+                  key={name}
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "baseline",
+                    fontSize: "var(--font-xs)",
+                  }}
+                >
+                  <span
+                    style={{
+                      color: "var(--text-primary, #e0e0e0)",
+                      fontFamily: "monospace",
+                    }}
+                  >
+                    {name}
+                  </span>
+                  <span style={{ color: "var(--text-secondary, #888)" }}>
+                    <span
+                      style={{
+                        fontWeight: 600,
+                        color: "var(--text-primary, #e0e0e0)",
+                      }}
+                    >
+                      {value}
+                    </span>
+                    {range && (
+                      <span style={{ marginLeft: 4 }}>
+                        ({range.min}–{range.max})
+                      </span>
+                    )}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+
+          {recommendedParams.sources.length > 0 && (
+            <div
+              style={{
+                marginTop: 6,
+                fontSize: 9,
+                color: "var(--text-secondary, #888)",
+                lineHeight: 1.4,
+              }}
+            >
+              Based on: {recommendedParams.sources.join(" + ")}
+            </div>
+          )}
+          <div
+            style={{
+              marginTop: 2,
+              fontSize: 9,
+              color: "var(--text-secondary, #888)",
+              fontStyle: "italic",
+            }}
+          >
+            {recommendedParams.reason}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/panels/dna/SensitivityHeatmap.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/dna/SensitivityHeatmap.tsx
@@ -1,0 +1,346 @@
+import type { SensitivityData } from "trendcraft";
+
+/**
+ * Linear interpolation between blue (low) and red (high) for a metric
+ * value normalized to [0, 1]. Mirrors echarts-viewer's color palette
+ * but as plain CSS so this panel pulls in no charting dependency —
+ * keeps Studio's bundle small.
+ */
+function metricToColor(normalized: number): string {
+  // Normalized in [0, 1]: 0 = coldest, 1 = hottest.
+  const palette = [
+    [49, 54, 149], // #313695
+    [69, 117, 180], // #4575b4
+    [116, 173, 209], // #74add1
+    [171, 217, 233], // #abd9e9
+    [254, 224, 144], // #fee090
+    [253, 174, 97], // #fdae61
+    [244, 109, 67], // #f46d43
+    [215, 48, 39], // #d73027
+  ];
+  const t = Math.max(0, Math.min(1, normalized));
+  const idx = t * (palette.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  const frac = idx - lo;
+  const a = palette[lo];
+  const b = palette[hi];
+  const r = Math.round(a[0] + (b[0] - a[0]) * frac);
+  const g = Math.round(a[1] + (b[1] - a[1]) * frac);
+  const bl = Math.round(a[2] + (b[2] - a[2]) * frac);
+  return `rgb(${r}, ${g}, ${bl})`;
+}
+
+type Props = {
+  data: SensitivityData;
+  selectedParam: string | null;
+  selectedParamPair: [string, string] | null;
+  onSelectParam: (name: string | null) => void;
+  onSelectParamPair: (pair: [string, string] | null) => void;
+};
+
+/**
+ * Sensitivity visualization without an external chart library: a bar
+ * list for the 1D view and an HTML table for the 2D pairwise view.
+ * The viewer's panel uses echarts; Studio drops that dependency to
+ * keep the bundle compact and renders the same data with CSS.
+ */
+export function SensitivityHeatmap({
+  data,
+  selectedParam,
+  selectedParamPair,
+  onSelectParam,
+  onSelectParamPair,
+}: Props) {
+  const paramNames = data.singleParams.map((s) => s.paramName);
+  const showAny = selectedParam !== null || selectedParamPair !== null;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {/* Single-param selector */}
+      <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+        {paramNames.map((name) => (
+          <button
+            key={name}
+            type="button"
+            onClick={() => {
+              onSelectParamPair(null);
+              onSelectParam(selectedParam === name ? null : name);
+            }}
+            style={{
+              padding: "3px 8px",
+              fontSize: "var(--font-xs)",
+              background:
+                selectedParam === name ? "var(--accent, #4a9eff)" : "var(--bg-tertiary, #222)",
+              color: selectedParam === name ? "#fff" : "var(--text-secondary, #888)",
+              border: "1px solid var(--border, #333)",
+              borderRadius: 4,
+              cursor: "pointer",
+            }}
+          >
+            {name}
+          </button>
+        ))}
+      </div>
+
+      {/* Pairwise selector */}
+      {paramNames.length >= 2 && data.pairwise.length > 0 && (
+        <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+          <span style={{ fontSize: 9, color: "var(--text-secondary, #888)", alignSelf: "center" }}>
+            2D:
+          </span>
+          {data.pairwise.map((pair) => {
+            const isSelected =
+              selectedParamPair !== null &&
+              selectedParamPair[0] === pair.paramX &&
+              selectedParamPair[1] === pair.paramY;
+            return (
+              <button
+                key={`${pair.paramX}|${pair.paramY}`}
+                type="button"
+                onClick={() => {
+                  onSelectParam(null);
+                  onSelectParamPair(isSelected ? null : [pair.paramX, pair.paramY]);
+                }}
+                style={{
+                  padding: "2px 6px",
+                  fontSize: 9,
+                  background: isSelected
+                    ? "var(--accent-secondary, #ff9800)"
+                    : "var(--bg-tertiary, #222)",
+                  color: isSelected ? "#fff" : "var(--text-secondary, #888)",
+                  border: "1px solid var(--border, #333)",
+                  borderRadius: 3,
+                  cursor: "pointer",
+                }}
+              >
+                {pair.paramX} × {pair.paramY}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {!showAny && (
+        <div
+          style={{
+            textAlign: "center",
+            padding: 16,
+            color: "var(--text-secondary, #888)",
+            fontSize: "var(--font-xs)",
+          }}
+        >
+          Select a parameter to view sensitivity
+        </div>
+      )}
+
+      {/* 1D bar view */}
+      {selectedParam !== null && <SingleParamBars data={data} paramName={selectedParam} />}
+
+      {/* 2D heatmap table view */}
+      {selectedParamPair !== null && <PairHeatmapTable data={data} pair={selectedParamPair} />}
+    </div>
+  );
+}
+
+function SingleParamBars({
+  data,
+  paramName,
+}: {
+  data: SensitivityData;
+  paramName: string;
+}) {
+  const single = data.singleParams.find((s) => s.paramName === paramName);
+  const safeZone = data.safeZones.find((z) => z.paramName === paramName);
+  if (!single || single.data.length === 0) return null;
+
+  const max = Math.max(...single.data.map((d) => d.metric));
+  const min = Math.min(...single.data.map((d) => d.metric));
+  // Normalize bars against absolute span so negative metrics still
+  // render with a visible bar (drawdowns etc.).
+  const span = max - min || 1;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 2, marginTop: 4 }}>
+      {single.data.map((d) => {
+        const inSafeZone = safeZone && d.value >= safeZone.min && d.value <= safeZone.max;
+        const widthPct = ((d.metric - min) / span) * 100;
+        return (
+          <div
+            key={d.value}
+            style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 10 }}
+          >
+            <span
+              style={{
+                width: 36,
+                color: "var(--text-secondary, #888)",
+                fontFamily: "monospace",
+                textAlign: "right",
+                flexShrink: 0,
+              }}
+            >
+              {d.value}
+            </span>
+            <div
+              style={{
+                flex: 1,
+                height: 14,
+                background: "var(--bg-primary, #1a1a1a)",
+                borderRadius: 2,
+                position: "relative",
+                overflow: "hidden",
+              }}
+            >
+              <div
+                style={{
+                  width: `${Math.max(2, widthPct)}%`,
+                  height: "100%",
+                  background: inSafeZone ? "rgba(0, 200, 100, 0.55)" : "rgba(220, 100, 80, 0.45)",
+                }}
+              />
+            </div>
+            <span
+              style={{
+                width: 56,
+                color: "var(--text-primary, #e0e0e0)",
+                fontFamily: "monospace",
+                textAlign: "right",
+                flexShrink: 0,
+              }}
+            >
+              {d.metric.toFixed(3)}
+            </span>
+          </div>
+        );
+      })}
+      {safeZone && (
+        <div
+          style={{
+            marginTop: 4,
+            fontSize: 9,
+            color: "var(--text-secondary, #888)",
+            display: "flex",
+            gap: 6,
+            alignItems: "center",
+          }}
+        >
+          <span
+            style={{
+              width: 10,
+              height: 10,
+              background: "rgba(0, 200, 100, 0.55)",
+              borderRadius: 2,
+              display: "inline-block",
+            }}
+          />
+          Safe Zone: {safeZone.min}–{safeZone.max} (top 25%)
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PairHeatmapTable({
+  data,
+  pair: [x, y],
+}: {
+  data: SensitivityData;
+  pair: [string, string];
+}) {
+  const pair = data.pairwise.find((p) => p.paramX === x && p.paramY === y);
+  if (!pair || pair.data.length === 0) return null;
+
+  const metricByCell = new Map<string, number>();
+  for (const d of pair.data) metricByCell.set(`${d.x}|${d.y}`, d.metric);
+  const metricValues = pair.data.map((d) => d.metric);
+  const minM = Math.min(...metricValues);
+  const maxM = Math.max(...metricValues);
+  const span = maxM - minM || 1;
+
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <table
+        style={{
+          borderCollapse: "collapse",
+          fontSize: 9,
+          color: "var(--text-secondary, #888)",
+          marginTop: 4,
+        }}
+      >
+        <thead>
+          <tr>
+            <th
+              style={{
+                padding: 2,
+                textAlign: "right",
+                fontWeight: 400,
+                color: "var(--text-secondary, #888)",
+              }}
+            >
+              {y}↓ \ {x}→
+            </th>
+            {pair.xValues.map((xv) => (
+              <th
+                key={xv}
+                style={{
+                  padding: "2px 4px",
+                  fontFamily: "monospace",
+                  fontWeight: 400,
+                }}
+              >
+                {xv}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {pair.yValues.map((yv) => (
+            <tr key={yv}>
+              <th
+                scope="row"
+                style={{
+                  padding: "2px 4px",
+                  fontFamily: "monospace",
+                  fontWeight: 400,
+                  textAlign: "right",
+                  color: "var(--text-secondary, #888)",
+                }}
+              >
+                {yv}
+              </th>
+              {pair.xValues.map((xv) => {
+                const m = metricByCell.get(`${xv}|${yv}`);
+                if (m === undefined) {
+                  return (
+                    <td key={xv} style={{ padding: 0 }}>
+                      <div style={{ width: 44, height: 22, background: "transparent" }} />
+                    </td>
+                  );
+                }
+                const norm = (m - minM) / span;
+                return (
+                  <td
+                    key={xv}
+                    title={`${x}=${xv}, ${y}=${yv}: ${m.toFixed(3)}`}
+                    style={{
+                      padding: 0,
+                      width: 44,
+                      height: 22,
+                      background: metricToColor(norm),
+                      color: norm > 0.5 ? "#fff" : "#000",
+                      fontFamily: "monospace",
+                      textAlign: "center",
+                      fontSize: 9,
+                    }}
+                  >
+                    {m.toFixed(2)}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the Strategy DNA panel below OptimizationPanel in Strategy Studio. Three-tab visualization of an optimization run's parameter genome, sensitivity surface, and A–F robustness grade. All four core APIs (`buildGenomeSegments`, `extractSensitivityData`, `computeRecommendedParams`, `computeDnaGrade`) are consumed directly from PR-B2 — no Studio-side reimplementation.

This is the final panel in the Strategy Studio epic plan.

## Tabs

- **Genome** — SVG bar showing each tunable parameter's best value on a `[0, 1]` axis within its explored search range. Hover for raw value + range; click forwards the param name to the Sensitivity tab pre-filtered.
- **Sensitivity** — per-param histograms (HTML bars, safe-zone colored) and pairwise heatmap (CSS Grid table). No echarts dependency.
- **Robustness** — A–F overall grade plus per-dimension item list (WF stability, MC significance, parameter sensitivity, win-rate stability). Items lacking Studio inputs (WF / MC) render as `available: false`. Recommended-params summary attached.

Display-only by design — no Apply button, no Compute Monte Carlo trigger. Matches PR12's OptimizationPanel philosophy: builder state is never mutated from this panel.

## App wiring

- `OptimizationPanel` gains an optional `onResult` callback broadcasting every state change.
- `App` lifts the result into `optimizationResult` state so DNA panel renders the same data without duplicating the run trigger.
- DNA panel receives the full `OptimizationComputation` discriminated union; non-success states (`empty`, `error`) surface their own message instead of collapsing to "Run a grid search...".

## Defensive UX (Codex-driven)

- **Sensitivity selections** reset on grid result change so a second run with different tunables doesn't leave the selector pointing at a non-existent name.
- **Genome tooltip** guards `segments[hoveredIdx]` against bounds when a new run replaces segments mid-hover.
- **Genome value labels** preserve sub-decimal precision (`toFixed(4)` + trim trailing zeros) so optimized stdDev=0.05 doesn't display as "0.1".
- **Idle empty-state copy** points at the Optimization panel rather than instructing the user to run a search the UI may not let them start (e.g. no strategy or no tunable params).

## Test plan

- [x] `pnpm test` workspace green (4966 core, 781 chart, 80 strategy-studio, 59 mcp)
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] `npx tsc --noEmit` clean in `examples/strategy-studio/`
- [x] Codex review — 5 rounds, final round flagged no defects

## Notes

- DNA panel is pure UI composition over already-tested core APIs (PR-B2). No new Studio-side `lib/*` to test; the existing Studio test pattern is data-layer focused.
- echarts-viewer's DNA panel keeps its own UI (uses echarts for heatmaps); PR-B2 already lifted the analytics so both example apps share the same source of truth.