### PR TITLE
feat(core): parseStrategy opt-in registry validation + parseStrategySafe

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+### Added — `parseStrategy` opt-in registry validation + `parseStrategySafe`
+
+- `parseStrategy(json, registry?)` gains an optional second argument.
+  When a `ConditionRegistry` is passed, the parser runs
+  `validateStrategyJSON` (structural shape) plus
+  `validateConditionSpec` on the entry / exit trees and aggregates
+  every finding into the thrown error message. Without a registry,
+  behavior is unchanged (back-compat: only `$schema` and `version`
+  are checked).
+- New `parseStrategySafe(json, registry?)` returns
+  `Result<StrategyJSON>` with one of five error codes —
+  `INVALID_JSON`, `INVALID_SCHEMA`, `UNSUPPORTED_VERSION`,
+  `INVALID_STRUCTURE`, `INVALID_CONDITION` — letting MCP / LLM
+  consumers branch on the failure reason instead of pattern-matching
+  on a thrown error message.
+- Surfaces unknown conditions / out-of-range params / malformed
+  `not` arity at parse time instead of deferring them to
+  `loadStrategy()` or runtime; aligned with the existing
+  `gridSearch` / `gridSearchFromJSON` `*Safe` pattern.
+
 ### Fixed — `detectOhlcErrors` now flags NaN / Infinity OHLCV fields
 
 - `detectOhlcErrors(candles)` previously only checked relational

--- a/packages/core/llms-full.txt
+++ b/packages/core/llms-full.txt
@@ -1737,7 +1737,13 @@ registry.register({
 ### Serialize / Parse
 
 ```typescript
-import { serializeStrategy, parseStrategy } from "trendcraft";
+import {
+  serializeStrategy,
+  parseStrategy,
+  parseStrategySafe,
+  backtestRegistry,
+  loadStrategy,
+} from "trendcraft";
 import type { StrategyJSON } from "trendcraft";
 
 const strategy: StrategyJSON = {
@@ -1763,6 +1769,17 @@ const strategy: StrategyJSON = {
 
 const jsonString = serializeStrategy(strategy); // → formatted JSON string
 const restored = parseStrategy(jsonString);      // → StrategyJSON (validates schema/version)
+
+// Strict mode — pass the registry to validate structure + conditions upfront.
+// Catches unknown conditions / out-of-range params / malformed `not` arity at
+// parse time instead of deferring them to loadStrategy() / runtime.
+const strict = parseStrategy(jsonString, backtestRegistry);
+
+// Result variant for MCP / LLM tooling. Error codes:
+//   INVALID_JSON | INVALID_SCHEMA | UNSUPPORTED_VERSION | INVALID_STRUCTURE | INVALID_CONDITION
+const result = parseStrategySafe(jsonString, backtestRegistry);
+if (result.ok) loadStrategy(result.value, backtestRegistry);
+else console.error(result.error.code, result.error.message);
 ```
 
 ### Hydrate / Load

--- a/packages/core/llms.txt
+++ b/packages/core/llms.txt
@@ -474,7 +474,8 @@ Declarative JSON representation for strategies — save, share, and version-cont
 - `backtestRegistry.list(category?)` — List conditions, optionally by category
 - `backtestRegistry.get(name)` — Get condition entry with param schema (for UI generation)
 - `serializeStrategy(strategy)` — Serialize StrategyJSON to formatted JSON string
-- `parseStrategy(json)` — Parse JSON string to StrategyJSON (validates schema/version)
+- `parseStrategy(json, registry?)` — Parse JSON string to StrategyJSON. Always checks `$schema` + `version`; pass a `ConditionRegistry` for full structure + condition validation upfront (catches unknown conditions / out-of-range params / malformed `not` arity at parse time).
+- `parseStrategySafe(json, registry?)` — Result variant. Error codes: `INVALID_JSON` / `INVALID_SCHEMA` / `UNSUPPORTED_VERSION` / `INVALID_STRUCTURE` / `INVALID_CONDITION`.
 - `hydrateCondition(spec, registry)` — Convert ConditionSpec JSON to executable Condition
 - `loadStrategy(json, registry)` — Load StrategyJSON → `{ entry, exit, backtestOptions }`
 - `validateConditionSpec(spec, registry)` — Validate condition spec (type/range/enum/required checks)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1202,7 +1202,7 @@ export { ConditionRegistry } from "./strategy";
 export { backtestRegistry } from "./strategy";
 export { streamingRegistry } from "./strategy";
 export { hydrateCondition, loadStrategy } from "./strategy";
-export { serializeStrategy, parseStrategy } from "./strategy";
+export { serializeStrategy, parseStrategy, parseStrategySafe } from "./strategy";
 export { validateConditionSpec, validateStrategyJSON } from "./strategy";
 export { applyParamOverrides, flattenStrategyLeaves, parseLeafPath } from "./strategy";
 export type { LeafInfo, ParsedLeafPath } from "./strategy";

--- a/packages/core/src/strategy/__tests__/serialize-hydrate.test.ts
+++ b/packages/core/src/strategy/__tests__/serialize-hydrate.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { NormalizedCandle, PresetCondition } from "../../types";
 import { hydrateCondition, loadStrategy } from "../hydrate";
 import { backtestRegistry } from "../registry-backtest";
-import { parseStrategy, serializeStrategy } from "../serialize";
+import { parseStrategy, parseStrategySafe, serializeStrategy } from "../serialize";
 import type { ConditionSpec, StrategyJSON } from "../types";
 
 // Helper: create minimal candle data for evaluation
@@ -69,10 +69,176 @@ describe("serializeStrategy / parseStrategy", () => {
     );
   });
 
+  it("parseStrategy rejects non-object JSON (null / array / primitive)", () => {
+    expect(() => parseStrategy("null")).toThrow(/expected JSON object.*null/);
+    expect(() => parseStrategy("[1,2,3]")).toThrow(/expected JSON object.*array/);
+    expect(() => parseStrategy('"just a string"')).toThrow(/expected JSON object.*string/);
+  });
+
   it("serialize produces formatted JSON", () => {
     const json = serializeStrategy(strategy);
     expect(json).toContain("\n"); // multi-line
     expect(json).toContain("  "); // indented
+  });
+
+  it("registry-less parse keeps current behavior — only schema/version checked", () => {
+    // Unknown condition slips through without registry. Verifies the
+    // back-compat path: existing callers that don't pass a registry
+    // see no behavior change.
+    const json = JSON.stringify({
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "x",
+      name: "x",
+      entry: { name: "thisDoesNotExist" },
+      exit: { name: "alsoMissing" },
+    });
+    expect(() => parseStrategy(json)).not.toThrow();
+  });
+
+  it("with registry, parseStrategy throws on unknown condition (regression — was deferred to hydration)", () => {
+    const json = JSON.stringify({
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "x",
+      name: "x",
+      entry: { name: "totallyMadeUpCondition" },
+      exit: { name: "deadCross" },
+    });
+    expect(() => parseStrategy(json, backtestRegistry)).toThrow(/unknown condition/i);
+  });
+
+  it("with registry, parseStrategy throws on out-of-range params", () => {
+    const json = JSON.stringify({
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "x",
+      name: "x",
+      // bollingerBreakout.stdDev has min: 0.1
+      entry: { name: "bollingerBreakout", params: { period: 20, stdDev: -1 } },
+      exit: { name: "deadCross" },
+    });
+    expect(() => parseStrategy(json, backtestRegistry)).toThrow(/below minimum/i);
+  });
+
+  it("with registry, parseStrategy throws on missing required fields", () => {
+    const json = JSON.stringify({
+      $schema: "trendcraft/strategy",
+      version: 1,
+      // id and name missing
+      entry: { name: "deadCross" },
+      exit: { name: "deadCross" },
+    });
+    expect(() => parseStrategy(json, backtestRegistry)).toThrow(/id|name/i);
+  });
+
+  it("with registry, parseStrategy aggregates multiple errors in one throw", () => {
+    const json = JSON.stringify({
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "x",
+      name: "x",
+      entry: { name: "thisDoesNotExist" },
+      exit: { name: "alsoMissing" },
+    });
+    let caught: Error | null = null;
+    try {
+      parseStrategy(json, backtestRegistry);
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).not.toBeNull();
+    // One bullet per error.
+    const message = caught?.message ?? "";
+    expect(message.match(/^\s*-\s/gm)?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("parseStrategySafe", () => {
+  const goodJson = JSON.stringify({
+    $schema: "trendcraft/strategy",
+    version: 1,
+    id: "test",
+    name: "Test",
+    entry: { name: "goldenCross" },
+    exit: { name: "deadCross" },
+  });
+
+  it("returns ok for a valid strategy with registry", () => {
+    const result = parseStrategySafe(goodJson, backtestRegistry);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.id).toBe("test");
+  });
+
+  it("returns INVALID_JSON for malformed JSON", () => {
+    const result = parseStrategySafe("{not valid json");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("INVALID_JSON");
+  });
+
+  it("returns INVALID_SCHEMA for wrong $schema", () => {
+    const json = JSON.stringify({ $schema: "other", version: 1 });
+    const result = parseStrategySafe(json);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("INVALID_SCHEMA");
+  });
+
+  it("returns UNSUPPORTED_VERSION for non-1 version", () => {
+    const json = JSON.stringify({ $schema: "trendcraft/strategy", version: 99 });
+    const result = parseStrategySafe(json);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("UNSUPPORTED_VERSION");
+  });
+
+  it("returns INVALID_STRUCTURE when registry is given and required fields missing", () => {
+    const json = JSON.stringify({ $schema: "trendcraft/strategy", version: 1 });
+    const result = parseStrategySafe(json, backtestRegistry);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("INVALID_STRUCTURE");
+  });
+
+  it("returns INVALID_CONDITION when registry catches unknown condition", () => {
+    const json = JSON.stringify({
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "x",
+      name: "x",
+      entry: { name: "unknownXyz" },
+      exit: { name: "deadCross" },
+    });
+    const result = parseStrategySafe(json, backtestRegistry);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INVALID_CONDITION");
+      expect(result.error.message).toMatch(/unknown condition/i);
+    }
+  });
+
+  it("returns INVALID_SCHEMA for JSON null (must not throw)", () => {
+    const result = parseStrategySafe("null");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INVALID_SCHEMA");
+      expect(result.error.message).toMatch(/null/);
+    }
+  });
+
+  it("returns INVALID_SCHEMA for JSON array", () => {
+    const result = parseStrategySafe("[1,2,3]");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INVALID_SCHEMA");
+      expect(result.error.message).toMatch(/array/);
+    }
+  });
+
+  it("returns INVALID_SCHEMA for JSON primitive", () => {
+    const result = parseStrategySafe('"just a string"');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INVALID_SCHEMA");
+      expect(result.error.message).toMatch(/string/);
+    }
   });
 });
 

--- a/packages/core/src/strategy/index.ts
+++ b/packages/core/src/strategy/index.ts
@@ -34,7 +34,7 @@ export { streamingRegistry } from "./registry-streaming";
 export { hydrateCondition, loadStrategy } from "./hydrate";
 
 // New: Serialization
-export { serializeStrategy, parseStrategy } from "./serialize";
+export { serializeStrategy, parseStrategy, parseStrategySafe } from "./serialize";
 
 // New: Validation
 export { validateConditionSpec, validateStrategyJSON } from "./validate";

--- a/packages/core/src/strategy/serialize.ts
+++ b/packages/core/src/strategy/serialize.ts
@@ -10,7 +10,10 @@
  * ```
  */
 
+import { type Result, err, ok, tcError } from "../types/result";
+import type { ConditionRegistry } from "./registry";
 import type { StrategyJSON } from "./types";
+import { validateConditionSpec, validateStrategyJSON } from "./validate";
 
 /**
  * Serialize a StrategyJSON to a formatted JSON string.
@@ -37,19 +40,46 @@ export function serializeStrategy(strategy: StrategyJSON): string {
 /**
  * Parse a JSON string into a StrategyJSON object.
  *
- * Validates the $schema and version fields.
+ * Always validates the `$schema` and `version` fields. When a
+ * `registry` is provided, additionally validates the structural
+ * shape (`validateStrategyJSON`) and the entry / exit
+ * `ConditionSpec` trees (`validateConditionSpec`) against the
+ * registry — surfacing unknown conditions, missing required params,
+ * out-of-range values, and malformed `not` arity at parse time
+ * instead of deferring them to `loadStrategy()` / runtime.
+ *
+ * Without a `registry`, behavior is unchanged: only schema and
+ * version are checked. Pass the registry whenever the caller has
+ * one available (most LLM / MCP / file-load paths do).
  *
  * @param json - JSON string to parse
+ * @param registry - Optional ConditionRegistry for full validation
  * @returns Parsed StrategyJSON
- * @throws Error if the JSON is invalid or has wrong schema/version
+ * @throws Error if the JSON is invalid, has wrong schema/version,
+ *   or (when `registry` is given) fails structural / condition
+ *   validation. Errors from registry validation are aggregated into
+ *   a single message with one bullet per finding.
  *
  * @example
  * ```ts
- * const strategy = parseStrategy('{"$schema":"trendcraft/strategy","version":1,...}');
+ * // Minimal parse (back-compat).
+ * const s = parseStrategy(jsonString);
+ *
+ * // Strict: catch unknown conditions / bad params upfront.
+ * const s2 = parseStrategy(jsonString, backtestRegistry);
  * ```
  */
-export function parseStrategy(json: string): StrategyJSON {
-  const obj = JSON.parse(json) as Record<string, unknown>;
+export function parseStrategy<T = unknown>(
+  json: string,
+  registry?: ConditionRegistry<T>,
+): StrategyJSON {
+  const parsed = JSON.parse(json);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `Invalid strategy: expected JSON object, got ${parsed === null ? "null" : Array.isArray(parsed) ? "array" : typeof parsed}`,
+    );
+  }
+  const obj = parsed as Record<string, unknown>;
 
   if (obj.$schema !== "trendcraft/strategy") {
     throw new Error(
@@ -61,5 +91,138 @@ export function parseStrategy(json: string): StrategyJSON {
     throw new Error(`Unsupported strategy version: ${String(obj.version)} (supported: 1)`);
   }
 
+  if (registry) {
+    const errors = collectValidationErrors(obj, registry);
+    if (errors.length > 0) {
+      throw new Error(`Invalid strategy:\n${errors.map((e) => `  - ${e}`).join("\n")}`);
+    }
+  }
+
   return obj as unknown as StrategyJSON;
+}
+
+/**
+ * Safe variant of `parseStrategy` that returns a `Result` instead of
+ * throwing. Distinguishes the failure mode via error code:
+ *
+ * - `INVALID_JSON` — `JSON.parse` failed
+ * - `INVALID_SCHEMA` — `$schema` is not `"trendcraft/strategy"`
+ * - `UNSUPPORTED_VERSION` — `version` is not `1`
+ * - `INVALID_STRUCTURE` — `validateStrategyJSON` flagged structural
+ *   issues (missing `id` / `name` / `entry` / `exit`, etc.)
+ * - `INVALID_CONDITION` — `validateConditionSpec` flagged registry
+ *   issues (unknown condition, bad params, malformed `not` arity)
+ *
+ * @example
+ * ```ts
+ * const result = parseStrategySafe(jsonString, backtestRegistry);
+ * if (result.ok) {
+ *   loadStrategy(result.value, backtestRegistry);
+ * } else {
+ *   console.error(result.error.code, result.error.message);
+ * }
+ * ```
+ */
+export function parseStrategySafe<T = unknown>(
+  json: string,
+  registry?: ConditionRegistry<T>,
+): Result<StrategyJSON> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return err(tcError("INVALID_JSON", `Failed to parse JSON: ${message}`));
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return err(
+      tcError(
+        "INVALID_SCHEMA",
+        `Invalid strategy: expected JSON object, got ${parsed === null ? "null" : Array.isArray(parsed) ? "array" : typeof parsed}`,
+      ),
+    );
+  }
+  const obj = parsed as Record<string, unknown>;
+
+  if (obj.$schema !== "trendcraft/strategy") {
+    return err(
+      tcError(
+        "INVALID_SCHEMA",
+        `Invalid strategy schema: expected "trendcraft/strategy", got "${String(obj.$schema)}"`,
+      ),
+    );
+  }
+
+  if (obj.version !== 1) {
+    return err(
+      tcError(
+        "UNSUPPORTED_VERSION",
+        `Unsupported strategy version: ${String(obj.version)} (supported: 1)`,
+      ),
+    );
+  }
+
+  if (registry) {
+    const structErrors = validateStrategyJSON(obj);
+    if (!structErrors.valid) {
+      return err(
+        tcError(
+          "INVALID_STRUCTURE",
+          `Invalid strategy structure:\n${structErrors.errors.map((e) => `  - ${e}`).join("\n")}`,
+        ),
+      );
+    }
+
+    const condErrors = collectConditionErrors(obj, registry);
+    if (condErrors.length > 0) {
+      return err(
+        tcError(
+          "INVALID_CONDITION",
+          `Invalid strategy conditions:\n${condErrors.map((e) => `  - ${e}`).join("\n")}`,
+        ),
+      );
+    }
+  }
+
+  return ok(obj as unknown as StrategyJSON);
+}
+
+/**
+ * Run both structural and condition validation against `registry`,
+ * returning the flat list of errors. Used by both `parseStrategy`
+ * (which collapses into a single throw) and `parseStrategySafe`
+ * (which classifies by structural vs condition).
+ */
+function collectValidationErrors<T>(
+  obj: Record<string, unknown>,
+  registry: ConditionRegistry<T>,
+): string[] {
+  const errors: string[] = [];
+
+  const struct = validateStrategyJSON(obj);
+  if (!struct.valid) {
+    errors.push(...struct.errors);
+    // Don't dive into condition validation if the structural shape
+    // is broken — `obj.entry` / `obj.exit` may not be ConditionSpec.
+    return errors;
+  }
+
+  errors.push(...collectConditionErrors(obj, registry));
+  return errors;
+}
+
+function collectConditionErrors<T>(
+  obj: Record<string, unknown>,
+  registry: ConditionRegistry<T>,
+): string[] {
+  const errors: string[] = [];
+  const strategy = obj as unknown as StrategyJSON;
+  for (const bucket of ["entry", "exit"] as const) {
+    const result = validateConditionSpec(strategy[bucket], registry);
+    if (!result.valid) {
+      errors.push(...result.errors.map((e) => `${bucket}.${e}`));
+    }
+  }
+  return errors;
 }

--- a/packages/core/src/types/result.ts
+++ b/packages/core/src/types/result.ts
@@ -59,7 +59,12 @@ export type TrendCraftErrorCode =
   | "BACKTEST_FAILED"
   | "SCREENING_FAILED"
   | "COMPUTATION_FAILED"
-  | "INDICATOR_ERROR";
+  | "INDICATOR_ERROR"
+  | "INVALID_JSON"
+  | "INVALID_SCHEMA"
+  | "UNSUPPORTED_VERSION"
+  | "INVALID_STRUCTURE"
+  | "INVALID_CONDITION";
 
 /**
  * Structured error with code, message, and optional context


### PR DESCRIPTION
## Summary

- `parseStrategy(json, registry?)` — opt-in: when a `ConditionRegistry` is passed, validates structural shape (`validateStrategyJSON`) and entry/exit `ConditionSpec` trees (`validateConditionSpec`) at parse time. Without `registry`, behavior is unchanged (only `\$schema` and `version` are checked) — full back-compat.
- `parseStrategySafe(json, registry?)` — new Result-returning companion. Classifies failures into `INVALID_JSON` / `INVALID_SCHEMA` / `UNSUPPORTED_VERSION` / `INVALID_STRUCTURE` / `INVALID_CONDITION`.
- Both variants reject non-object JSON (null / array / primitive) — relevant for MCP/LLM-facing callers.

## Why

Strategy Studio dogfooding (PR12 / #148) surfaced that unknown conditions and out-of-range params were silently accepted at parse time and only surfaced later inside `loadStrategy()` or hydration. LLM/MCP-facing callers want a single place to fail loudly when the JSON is broken. Registry-aware validation already exists (`validateConditionSpec`) but had to be invoked manually after parsing.

## Changes

- `packages/core/src/strategy/serialize.ts` — registry param + `parseStrategySafe`, null/array/primitive guards.
- `packages/core/src/types/result.ts` — added 5 new `TrendCraftErrorCode` literals.
- `packages/core/src/strategy/index.ts`, `packages/core/src/index.ts` — export `parseStrategySafe`.
- `packages/core/src/strategy/__tests__/serialize-hydrate.test.ts` — +15 tests covering the new validation paths and edge cases.
- CHANGELOG / llms.txt / llms-full.txt updated.

## Test plan

- [x] \`pnpm --filter trendcraft test\` — 4985/4985 passing
- [x] \`pnpm lint\` clean
- [x] \`pnpm --filter trendcraft build\` clean
- [x] \`/codex:review\` — 0 issues on the final patch (initial run flagged 2 P1s, both resolved before commit)

## Compatibility

- Additive only. Existing call sites that do `parseStrategy(json)` without a registry behave identically.
- New error codes are pure additions to the union — narrowing on previously-existing codes is unaffected.