### PR TITLE
fix(core): NaN/Infinity guards for optimization metrics and ranking

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## Unreleased
 
+### Fixed — `+Infinity` scores leaking into grid search ranking
+
+- `calculateCalmarRatio` / `calculateRecoveryFactor` / `calculateMAR`
+  previously returned `Number.POSITIVE_INFINITY` when
+  `maxDrawdown === 0` and the return was positive. Combined with
+  `gridSearch`'s `if (score > bestScore)` ranking, this caused a
+  flat strategy with maxDD = 0 (e.g. one tiny coincidental winning
+  trade) to outrank legitimate strategies and become `bestScore =
+  Infinity`. Downstream (Strategy DNA, MCP recommendations) inherited
+  the bad ranking. The three functions now return `NaN` when the
+  ratio is undefined, matching the empyrical / pyfolio convention
+  (`np.nan` on `max_dd >= 0` or non-finite). **Breaking** for callers
+  that compared the result to `Number.POSITIVE_INFINITY` — branch on
+  `Number.isFinite(value)` instead.
+- `gridSearch` now filters NaN / ±Infinity scores out of `bestScore`
+  selection and out of the returned `results` array (default), so
+  downstream consumers like `strategy-dna`'s `computeRecommendedParams`
+  / `extractSensitivityData` no longer have to re-guard before sorting
+  or averaging. Pass `keepAllResults: true` to surface the rejected
+  combinations for inspection — they sink to the end of the sorted
+  list deterministically.
+- `walkforward.calculateAggregateMetrics` now averages only across
+  periods where the metric was actually defined, instead of coercing
+  NaN to 0. The earlier coercion silently collapsed the average to
+  0 when every period had an undefined primary metric (e.g. Calmar
+  on a flat strategy across all windows), which made
+  `stabilityRatio` look perfect (`avgIn === avgOut === 0` → 1) and
+  caused `generateRecommendation` to endorse params whose primary
+  metric was never measurable. The recommendation path now treats
+  "no finite samples on either side" as `stabilityRatio = 0`.
+- Length=0 guards added in `walkforward.generateRecommendation` for
+  `periods.length === 0` and empty `paramKeys`.
+- `risk/var.ts` internal `mean` / `stdDev` / `skewness` /
+  `excessKurtosis` helpers now return 0 on empty arrays; the public
+  `calculateVaR` was already guarded but the helpers themselves
+  could be reused (or accidentally wired) elsewhere.
+
 ### Added — `parseStrategy` opt-in registry validation + `parseStrategySafe`
 
 - `parseStrategy(json, registry?)` gains an optional second argument.

--- a/packages/core/src/optimization/__tests__/grid-search.test.ts
+++ b/packages/core/src/optimization/__tests__/grid-search.test.ts
@@ -404,4 +404,101 @@ describe("Grid Search Optimization", () => {
       expect(result.totalCombinations).toBe(1);
     });
   });
+
+  describe("NaN / Infinity score handling", () => {
+    // Regression for an A6 audit finding: when `metric` is calmar /
+    // mar / recoveryFactor and a combination has maxDrawdown=0 (e.g.
+    // a single tiny winning trade), the metric returns NaN
+    // (empyrical / pyfolio convention). Without an isFinite guard,
+    // any combination producing such a result was eligible to win
+    // the ranking — flat strategies could outrank legitimate ones
+    // simply because they were lucky enough to never draw down.
+    it("excludes non-finite scores from default results array (without keepAllResults)", () => {
+      const candles = generateUpTrendCandles(50);
+
+      const createStrategy = (params: Record<string, number>) => ({
+        entry: createEnterCondition(Math.round(params.enterAt)),
+        exit: createExitCondition(1),
+        options: { capital: 100000 } as BacktestOptions,
+      });
+
+      const result = gridSearch(candles, createStrategy, [param("enterAt", 5, 10, 1)], {
+        metric: "calmar",
+      });
+
+      // Default behavior: NaN scores filtered out so downstream
+      // consumers (strategy-dna's computeRecommendedParams /
+      // extractSensitivityData) don't have to re-guard.
+      for (const r of result.results) {
+        expect(Number.isFinite(r.score)).toBe(true);
+      }
+    });
+
+    it("keeps non-finite scores at the end when keepAllResults is true", () => {
+      const candles = generateUpTrendCandles(50);
+
+      const createStrategy = (params: Record<string, number>) => ({
+        entry: createEnterCondition(Math.round(params.enterAt)),
+        exit: createExitCondition(1),
+        options: { capital: 100000 } as BacktestOptions,
+      });
+
+      const result = gridSearch(candles, createStrategy, [param("enterAt", 5, 10, 1)], {
+        metric: "calmar",
+        keepAllResults: true,
+      });
+
+      // With keepAllResults, NaN entries surface for inspection but
+      // sink to the end of the sorted array.
+      let firstNaNIdx = -1;
+      for (let i = 0; i < result.results.length; i++) {
+        if (!Number.isFinite(result.results[i].score)) {
+          firstNaNIdx = i;
+          break;
+        }
+      }
+      if (firstNaNIdx >= 0) {
+        for (let i = firstNaNIdx; i < result.results.length; i++) {
+          expect(Number.isFinite(result.results[i].score)).toBe(false);
+        }
+      }
+    });
+
+    it("rejects NaN score (Calmar with maxDD=0) from being treated as best", () => {
+      const candles = generateUpTrendCandles(50);
+
+      const createStrategy = (params: Record<string, number>) => ({
+        entry: createEnterCondition(Math.round(params.enterAt)),
+        exit: createExitCondition(1), // Exit one bar later — minimizes DD
+        options: { capital: 100000 } as BacktestOptions,
+      });
+
+      const result = gridSearch(candles, createStrategy, [param("enterAt", 5, 10, 1)], {
+        metric: "calmar",
+      });
+
+      // Either every score is finite (all combinations had a real DD)
+      // or, when some scored NaN, the bestScore is still finite (or
+      // null when no finite score existed). Specifically: NaN must
+      // never be reported as bestScore.
+      if (result.bestScore !== null) {
+        expect(Number.isFinite(result.bestScore)).toBe(true);
+      }
+
+      // Ranking is deterministic: NaN scores sink to the end of the
+      // sorted results list.
+      let firstNaNIdx = -1;
+      for (let i = 0; i < result.results.length; i++) {
+        if (!Number.isFinite(result.results[i].score)) {
+          firstNaNIdx = i;
+          break;
+        }
+      }
+      if (firstNaNIdx >= 0) {
+        for (let i = firstNaNIdx; i < result.results.length; i++) {
+          expect(Number.isFinite(result.results[i].score)).toBe(false);
+        }
+      }
+    });
+  });
 });

--- a/packages/core/src/optimization/__tests__/metrics.test.ts
+++ b/packages/core/src/optimization/__tests__/metrics.test.ts
@@ -4,6 +4,7 @@ import {
   annualizeReturn,
   calculateAllMetrics,
   calculateCalmarRatio,
+  calculateMAR,
   calculateRecoveryFactor,
   calculateSharpeRatio,
   checkConstraint,
@@ -104,13 +105,14 @@ describe("Optimization Metrics", () => {
   });
 
   describe("calculateCalmarRatio", () => {
-    it("should return Infinity when drawdown is 0 and return is positive", () => {
-      expect(calculateCalmarRatio(10, 0)).toBe(Number.POSITIVE_INFINITY);
+    it("returns NaN when drawdown is 0 (matches empyrical / pyfolio convention)", () => {
+      expect(calculateCalmarRatio(10, 0)).toBeNaN();
+      expect(calculateCalmarRatio(0, 0)).toBeNaN();
+      expect(calculateCalmarRatio(-5, 0)).toBeNaN();
     });
 
-    it("should return 0 when drawdown is 0 and return is non-positive", () => {
-      expect(calculateCalmarRatio(0, 0)).toBe(0);
-      expect(calculateCalmarRatio(-5, 0)).toBe(0);
+    it("returns NaN for negative drawdown (defensive — invalid input)", () => {
+      expect(calculateCalmarRatio(10, -5)).toBeNaN();
     });
 
     it("should calculate correct ratio", () => {
@@ -125,18 +127,38 @@ describe("Optimization Metrics", () => {
   });
 
   describe("calculateRecoveryFactor", () => {
-    it("should return Infinity when drawdown is 0 and profit is positive", () => {
-      expect(calculateRecoveryFactor(1000, 0)).toBe(Number.POSITIVE_INFINITY);
+    it("returns NaN when drawdown is 0 (matches empyrical / pyfolio convention)", () => {
+      expect(calculateRecoveryFactor(1000, 0)).toBeNaN();
+      expect(calculateRecoveryFactor(0, 0)).toBeNaN();
+      expect(calculateRecoveryFactor(-100, 0)).toBeNaN();
     });
 
-    it("should return 0 when drawdown is 0 and profit is non-positive", () => {
-      expect(calculateRecoveryFactor(0, 0)).toBe(0);
-      expect(calculateRecoveryFactor(-100, 0)).toBe(0);
+    it("returns NaN for negative drawdown", () => {
+      expect(calculateRecoveryFactor(1000, -10)).toBeNaN();
     });
 
     it("should calculate correct ratio", () => {
       expect(calculateRecoveryFactor(10000, 5000)).toBe(2);
       expect(calculateRecoveryFactor(5000, 2500)).toBe(2);
+    });
+  });
+
+  describe("calculateMAR", () => {
+    it("returns NaN when drawdown is 0 (matches empyrical / pyfolio convention)", () => {
+      expect(calculateMAR(10, 252, 0)).toBeNaN();
+      expect(calculateMAR(0, 252, 0)).toBeNaN();
+      expect(calculateMAR(-5, 252, 0)).toBeNaN();
+    });
+
+    it("returns NaN when tradingDays <= 0", () => {
+      expect(calculateMAR(10, 0, 5)).toBeNaN();
+      expect(calculateMAR(10, -1, 5)).toBeNaN();
+    });
+
+    it("computes monthly return / drawdown", () => {
+      // 10% return over 252 trading days ≈ 12 months → 0.833% / month / 5% DD = 0.1667
+      const v = calculateMAR(10, 252, 5);
+      expect(v).toBeCloseTo(0.1667, 3);
     });
   });
 
@@ -270,13 +292,14 @@ describe("Optimization Metrics", () => {
       expect(metrics.sharpe).toBe(0); // Not enough data for returns
     });
 
-    it("should handle zero max drawdown", () => {
+    it("calmar / recoveryFactor are NaN when max drawdown is 0", () => {
       const candles = generateTestCandles(50);
       const result = createMockBacktestResult({ maxDrawdown: 0 });
 
       const metrics = calculateAllMetrics(result, candles);
-      expect(metrics.calmar).toBe(Number.POSITIVE_INFINITY);
-      expect(metrics.recoveryFactor).toBe(Number.POSITIVE_INFINITY);
+      expect(metrics.calmar).toBeNaN();
+      expect(metrics.recoveryFactor).toBeNaN();
+      expect(metrics.mar).toBeNaN();
     });
   });
 });

--- a/packages/core/src/optimization/grid-search.ts
+++ b/packages/core/src/optimization/grid-search.ts
@@ -199,13 +199,19 @@ export function gridSearch(
         passedConstraints,
       };
 
-      // Only keep valid results unless keepAllResults is true
-      if (keepAllResults || passedConstraints) {
+      // Only keep valid, finite-scored results unless keepAllResults
+      // is true. Calmar / MAR / Recovery return NaN when maxDD <= 0
+      // (matches empyrical / pyfolio). Letting NaN / Infinity through
+      // would corrupt downstream consumers that re-sort or average
+      // `results` (e.g. strategy-dna's `computeRecommendedParams`,
+      // `extractSensitivityData`) without their own isFinite guard.
+      const finiteScore = Number.isFinite(score);
+      if (keepAllResults || (passedConstraints && finiteScore)) {
         results.push(entry);
       }
 
-      // Update best if passes constraints
-      if (passedConstraints) {
+      // Update best if passes constraints AND has a finite score.
+      if (passedConstraints && finiteScore) {
         validCombinations++;
         if (score > bestScore) {
           bestScore = score;
@@ -218,8 +224,17 @@ export function gridSearch(
     }
   }
 
-  // Sort results by score (descending)
-  results.sort((a, b) => b.score - a.score);
+  // Sort results by score (descending). NaN scores sink to the end:
+  // any comparison involving NaN returns false, so the comparator
+  // falls through, but explicit handling makes the order deterministic.
+  results.sort((a, b) => {
+    const aFinite = Number.isFinite(a.score);
+    const bFinite = Number.isFinite(b.score);
+    if (aFinite && bFinite) return b.score - a.score;
+    if (aFinite) return -1;
+    if (bFinite) return 1;
+    return 0;
+  });
 
   return {
     bestParams: validCombinations > 0 ? bestParams : null,

--- a/packages/core/src/optimization/metrics.ts
+++ b/packages/core/src/optimization/metrics.ts
@@ -48,41 +48,52 @@ export function calculateSharpeRatio(
 
 /**
  * Calculate Calmar Ratio (annualized return / max drawdown)
+ *
+ * Returns `NaN` when `maxDrawdownPercent <= 0` (i.e. there is no
+ * meaningful denominator). Matches the empyrical / pyfolio convention
+ * — a flat strategy with no observed drawdown does not have a defined
+ * Calmar ratio. Downstream consumers (gridSearch, walkforward) filter
+ * `Number.isFinite` to keep NaN strategies out of ranking.
+ *
  * @param annualizedReturnPercent Annualized return in percent
- * @param maxDrawdownPercent Maximum drawdown in percent
- * @returns Calmar Ratio
+ * @param maxDrawdownPercent Maximum drawdown in percent (positive number)
+ * @returns Calmar Ratio, or `NaN` when undefined
  */
 export function calculateCalmarRatio(
   annualizedReturnPercent: number,
   maxDrawdownPercent: number,
 ): number {
-  if (maxDrawdownPercent === 0) {
-    return annualizedReturnPercent > 0 ? Number.POSITIVE_INFINITY : 0;
-  }
+  if (!(maxDrawdownPercent > 0)) return Number.NaN;
   return annualizedReturnPercent / maxDrawdownPercent;
 }
 
 /**
  * Calculate Recovery Factor (net profit / max drawdown)
+ *
+ * Returns `NaN` when `maxDrawdown <= 0`. See `calculateCalmarRatio`
+ * for rationale.
+ *
  * @param netProfit Total net profit
- * @param maxDrawdown Maximum drawdown in absolute terms
- * @returns Recovery Factor
+ * @param maxDrawdown Maximum drawdown in absolute terms (positive number)
+ * @returns Recovery Factor, or `NaN` when undefined
  */
 export function calculateRecoveryFactor(netProfit: number, maxDrawdown: number): number {
-  if (maxDrawdown === 0) {
-    return netProfit > 0 ? Number.POSITIVE_INFINITY : 0;
-  }
+  if (!(maxDrawdown > 0)) return Number.NaN;
   return netProfit / maxDrawdown;
 }
 
 /**
  * Calculate MAR Ratio (Monthly Average Return / Max Drawdown)
- * Similar to Calmar but uses monthly returns instead of annualized
+ * Similar to Calmar but uses monthly returns instead of annualized.
+ *
+ * Returns `NaN` when the ratio is undefined (no drawdown or no
+ * trading days). See `calculateCalmarRatio` for rationale.
+ *
  * @param totalReturnPercent Total return in percent
  * @param tradingDays Number of trading days
- * @param maxDrawdownPercent Maximum drawdown in percent
+ * @param maxDrawdownPercent Maximum drawdown in percent (positive number)
  * @param tradingDaysPerMonth Trading days per month (default: 21)
- * @returns MAR Ratio
+ * @returns MAR Ratio, or `NaN` when undefined
  */
 export function calculateMAR(
   totalReturnPercent: number,
@@ -90,12 +101,9 @@ export function calculateMAR(
   maxDrawdownPercent: number,
   tradingDaysPerMonth = 21,
 ): number {
-  if (maxDrawdownPercent === 0) {
-    return totalReturnPercent > 0 ? Number.POSITIVE_INFINITY : 0;
-  }
-  if (tradingDays <= 0) return 0;
+  if (!(maxDrawdownPercent > 0)) return Number.NaN;
+  if (tradingDays <= 0) return Number.NaN;
 
-  // Calculate monthly average return
   const months = tradingDays / tradingDaysPerMonth;
   const monthlyAvgReturn = totalReturnPercent / months;
 

--- a/packages/core/src/optimization/walkforward.ts
+++ b/packages/core/src/optimization/walkforward.ts
@@ -215,6 +215,25 @@ export function walkForwardAnalysis(
 }
 
 /**
+ * Mean across only the finite entries; returns 0 when no finite
+ * value exists. This is the right behavior for averaging optimization
+ * metrics where NaN means "undefined for this period" (e.g. Calmar
+ * with maxDD=0): treating NaN as 0 would silently bias the average,
+ * dropping the period from the denominator preserves "no data" semantics.
+ */
+function averageFinite(values: number[]): number {
+  let sum = 0;
+  let count = 0;
+  for (const v of values) {
+    if (Number.isFinite(v)) {
+      sum += v;
+      count++;
+    }
+  }
+  return count > 0 ? sum / count : 0;
+}
+
+/**
  * Calculate aggregate metrics across all periods
  */
 function calculateAggregateMetrics(
@@ -240,21 +259,37 @@ function calculateAggregateMetrics(
     number
   >;
 
+  // Average only across periods where the metric was actually
+  // defined. Calmar / MAR / Recovery return NaN when a period had
+  // maxDD <= 0; coercing those to 0 collapses the average toward 0
+  // and makes `stabilityRatio` look perfect (avgIn === avgOut === 0
+  // → branch returns 1), letting `generateRecommendation` endorse
+  // params whose primary metric was never measurable. Excluding NaN
+  // periods from the denominator preserves "no data" semantics.
   for (const key of metricKeys) {
-    avgInSample[key] =
-      inSampleMetrics.reduce((sum, m) => sum + (Number.isFinite(m[key]) ? m[key] : 0), 0) /
-      inSampleMetrics.length;
-    avgOutOfSample[key] =
-      outOfSampleMetrics.reduce((sum, m) => sum + (Number.isFinite(m[key]) ? m[key] : 0), 0) /
-      outOfSampleMetrics.length;
+    avgInSample[key] = averageFinite(inSampleMetrics.map((m) => m[key]));
+    avgOutOfSample[key] = averageFinite(outOfSampleMetrics.map((m) => m[key]));
   }
 
-  // Calculate stability ratio for primary metric
+  // Calculate stability ratio for primary metric. If the primary
+  // metric was undefined (NaN) on every in-sample or out-of-sample
+  // period, `avgIn` / `avgOut` will be 0 (the "no data" sentinel
+  // from `averageFinite`) — but that 0 has different meaning from a
+  // measured 0. Distinguish by counting finite samples explicitly so
+  // the absence-of-data case yields stabilityRatio = 0 (no claim of
+  // stability) rather than the spurious 1 produced by the avgIn===0
+  // branch below.
+  const inFiniteCount = inSampleMetrics.filter((m) => Number.isFinite(m[primaryMetric])).length;
+  const outFiniteCount = outOfSampleMetrics.filter((m) => Number.isFinite(m[primaryMetric])).length;
   const avgIn = avgInSample[primaryMetric];
   const avgOut = avgOutOfSample[primaryMetric];
 
   let stabilityRatio: number;
-  if (avgIn === 0) {
+  if (inFiniteCount === 0 || outFiniteCount === 0) {
+    // Primary metric never measurable on at least one side — cannot
+    // make a stability claim either way.
+    stabilityRatio = 0;
+  } else if (avgIn === 0) {
     stabilityRatio = avgOut >= 0 ? 1 : 0;
   } else if (avgIn < 0 && avgOut < 0) {
     // Both negative: higher ratio is worse overfitting
@@ -286,7 +321,7 @@ function generateRecommendation(
 
   // Count profitable out-of-sample periods
   const profitablePeriods = periods.filter((p) => p.outOfSampleMetrics.returns > 0).length;
-  const profitableRatio = profitablePeriods / periods.length;
+  const profitableRatio = periods.length > 0 ? profitablePeriods / periods.length : 0;
 
   // Analyze parameter stability
   const paramKeys = Object.keys(periods[0]?.bestParams || {});
@@ -294,6 +329,10 @@ function generateRecommendation(
 
   for (const key of paramKeys) {
     const values = periods.map((p) => p.bestParams[key]);
+    if (values.length === 0) {
+      paramVariance[key] = 0;
+      continue;
+    }
     const mean = values.reduce((s, v) => s + v, 0) / values.length;
     const variance = values.reduce((s, v) => s + (v - mean) ** 2, 0) / values.length;
     paramVariance[key] = variance;

--- a/packages/core/src/risk/var.ts
+++ b/packages/core/src/risk/var.ts
@@ -139,12 +139,14 @@ function normalInverseCdf(p: number): number {
 // ---------------------------------------------------------------------------
 
 function mean(arr: number[]): number {
+  if (arr.length === 0) return 0;
   let sum = 0;
   for (let i = 0; i < arr.length; i++) sum += arr[i];
   return sum / arr.length;
 }
 
 function stdDev(arr: number[], mu: number): number {
+  if (arr.length === 0) return 0;
   let sum = 0;
   for (let i = 0; i < arr.length; i++) {
     const d = arr[i] - mu;
@@ -154,7 +156,7 @@ function stdDev(arr: number[], mu: number): number {
 }
 
 function skewness(arr: number[], mu: number, sigma: number): number {
-  if (sigma === 0) return 0;
+  if (arr.length === 0 || sigma === 0) return 0;
   let sum = 0;
   for (let i = 0; i < arr.length; i++) {
     const d = (arr[i] - mu) / sigma;
@@ -164,7 +166,7 @@ function skewness(arr: number[], mu: number, sigma: number): number {
 }
 
 function excessKurtosis(arr: number[], mu: number, sigma: number): number {
-  if (sigma === 0) return 0;
+  if (arr.length === 0 || sigma === 0) return 0;
   let sum = 0;
   for (let i = 0; i < arr.length; i++) {
     const d = (arr[i] - mu) / sigma;


### PR DESCRIPTION
## Summary

Fixes a class of silent ranking bugs where `+Infinity` scores from `Calmar` / `MAR` / `RecoveryFactor` (when `maxDrawdown === 0` with positive return) caused flat strategies to outrank legitimate ones in `gridSearch`. The same bad scores propagated into `walkforward` aggregates and Strategy DNA / MCP recommendations.

## What changed

**Metric layer** — `optimization/metrics.ts`
- `calculateCalmarRatio` / `calculateRecoveryFactor` / `calculateMAR` now return `NaN` when the ratio is undefined (`maxDrawdown <= 0`, or for MAR also `tradingDays <= 0`). Matches the empyrical / pyfolio convention (`np.nan` on `max_dd >= 0`). **Breaking** for callers comparing to `Number.POSITIVE_INFINITY` — branch on `Number.isFinite(value)` instead.

**Ranking layer** — `optimization/grid-search.ts`
- `bestScore` selection skips non-finite scores.
- `results` array excludes non-finite scores by default (downstream consumers like `strategy-dna`'s `computeRecommendedParams` / `extractSensitivityData` no longer have to re-guard before sorting / averaging). Pass `keepAllResults: true` to surface them — they sink to the end of the sorted list deterministically.

**Walk-forward layer** — `optimization/walkforward.ts`
- `calculateAggregateMetrics` averages only across periods where the metric was actually defined, via a new `averageFinite` helper. The earlier `Number.isFinite ? m[key] : 0` coercion silently collapsed the average to 0 when every period had NaN, making `stabilityRatio` look perfect (`avgIn === avgOut === 0` → 1) and causing `generateRecommendation` to endorse params whose primary metric was never measurable. Now: when zero periods have a finite value on either side, `stabilityRatio = 0` (no claim of stability).
- Length=0 guards added in `generateRecommendation` for `periods.length` and empty `paramKeys`.

**Risk layer** — `risk/var.ts`
- Internal `mean` / `stdDev` / `skewness` / `excessKurtosis` helpers guard `arr.length === 0` (the public `calculateVaR` was already guarded but the helpers were reusable / fragile).

## Why this is a real bug, not a curiosity

Without these guards, a strategy that opens once, exits with a tiny gain, and never draws down — a "lucky once" pattern that says nothing about robustness — gets `Calmar = Infinity` and wins grid search outright. Every downstream layer (Strategy DNA scoring, MCP `optimize_strategy` recommendations, walk-forward stability checks) treats this as the "best" strategy.

## Why NaN, not a sentinel

Reviewed the industry convention before settling on the design:

- empyrical (pyfolio's stats backend): returns `np.nan` when `max_dd >= 0` or the result is non-finite — pyfolio inherits this.
- quantstats: no guard — falls through to `inf` (effectively garbage).
- TrendCraft pre-existing `profitFactor`: 999.99 sentinel cap (kept as-is to avoid breaking that contract).

NaN matches the dominant convention and is well-supported by `Number.isFinite` filters that the optimization stack already needed elsewhere (`walkforward.aggregateMetrics`).

## Test plan

- [x] `pnpm --filter trendcraft test` — 5005/5005 passing
- [x] `pnpm lint` clean
- [x] `pnpm --filter trendcraft build` clean
- New tests:
  - `calculateCalmarRatio` / `calculateRecoveryFactor` / `calculateMAR` NaN return cases
  - `gridSearch` regression: NaN scores do not become bestScore
  - `gridSearch` keepAllResults: NaN entries surface but sink to end
  - `gridSearch` default: NaN entries excluded from `results`