### PR TITLE
feat(mcp): upfront params shape guard for calc_indicator / detect_signal

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+### Added — upfront `params` shape guard for `calc_indicator` / `detect_signal`
+
+`validateIndicatorParams` rejects structurally broken `params`
+objects before the underlying function runs, returning
+`INVALID_PARAMETER` with actionable hints:
+
+- non-object / array / `null` `params` → reject with the actual type
+- nested-object values → reject (`{ period: { value: 14 } }`)
+- `NaN` / `±Infinity` numbers → reject
+- arrays containing nested arrays / `null` / `NaN` / non-primitive
+  elements → reject; flat `number[]` / `string[]` / `boolean[]` are
+  accepted (used by KST `rocPeriods`, candlestick `patterns`, etc.)
+- string-where-number-expected on numeric-style keys → reject
+  (`{ period: "14" }`); we deliberately do not auto-coerce because
+  the string form is more often a serialization bug than intent
+
+Per-parameter range and type contracts are still owned by the
+indicator itself; this guard only catches obvious wrong shapes that
+would otherwise turn into a downstream NaN or a silent default
+fallback.
+
 ### Added
 
 - **`load_candles` tool + `candlesRef` input** — cache OHLCV candles in the

--- a/packages/mcp/src/__tests__/validation-params.test.ts
+++ b/packages/mcp/src/__tests__/validation-params.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { validateIndicatorParams } from "../validation/params";
+
+describe("validateIndicatorParams", () => {
+  it("returns silently when params is undefined", () => {
+    expect(() => validateIndicatorParams("rsi", undefined)).not.toThrow();
+  });
+
+  it("rejects non-object params", () => {
+    expect(() => validateIndicatorParams("rsi", 14 as unknown)).toThrow(/must be a plain object/);
+    expect(() => validateIndicatorParams("rsi", "{}" as unknown)).toThrow(/must be a plain object/);
+    expect(() => validateIndicatorParams("rsi", null as unknown)).toThrow(/must be a plain object/);
+    expect(() => validateIndicatorParams("rsi", [14] as unknown)).toThrow(/must be a plain object/);
+  });
+
+  it("rejects null leaf values", () => {
+    expect(() => validateIndicatorParams("rsi", { period: null })).toThrow(/is null/);
+  });
+
+  it("rejects nested objects", () => {
+    expect(() => validateIndicatorParams("rsi", { period: { value: 14 } })).toThrow(
+      /nested object/,
+    );
+  });
+
+  it("accepts flat number arrays (e.g. KST rocPeriods)", () => {
+    expect(() => validateIndicatorParams("kst", { rocPeriods: [10, 15, 20, 30] })).not.toThrow();
+  });
+
+  it("accepts flat string arrays (e.g. candlestickPatterns patterns)", () => {
+    expect(() =>
+      validateIndicatorParams("candlestickPatterns", { patterns: ["hammer", "doji"] }),
+    ).not.toThrow();
+  });
+
+  it("accepts flat boolean arrays", () => {
+    expect(() => validateIndicatorParams("dummy", { flags: [true, false, true] })).not.toThrow();
+  });
+
+  it("rejects nested arrays", () => {
+    expect(() => validateIndicatorParams("kst", { rocPeriods: [[10], [15]] as unknown[] })).toThrow(
+      /array of primitives/,
+    );
+  });
+
+  it("rejects arrays containing NaN", () => {
+    expect(() =>
+      validateIndicatorParams("kst", { rocPeriods: [10, Number.NaN] as number[] }),
+    ).toThrow(/array of primitives/);
+  });
+
+  it("rejects arrays containing null", () => {
+    expect(() => validateIndicatorParams("kst", { rocPeriods: [10, null] as unknown[] })).toThrow(
+      /array of primitives/,
+    );
+  });
+
+  it("rejects NaN / Infinity numbers", () => {
+    expect(() => validateIndicatorParams("rsi", { period: Number.NaN })).toThrow(/NaN/);
+    expect(() => validateIndicatorParams("rsi", { period: Number.POSITIVE_INFINITY })).toThrow(
+      /Infinity/,
+    );
+  });
+
+  it("rejects string-where-number-expected on numeric-style keys", () => {
+    expect(() => validateIndicatorParams("rsi", { period: "14" })).toThrow(
+      /string \("14"\) but a number is expected/,
+    );
+  });
+
+  it("does not auto-coerce numeric-style strings", () => {
+    expect(() => validateIndicatorParams("macd", { fastPeriod: "12" })).toThrow();
+  });
+
+  it("accepts generic options not listed in manifest paramHints", () => {
+    // SMA's manifest paramHints lists only `period`, but the indicator
+    // accepts `source` (hl2 / hlc3 / etc.). The guard must not reject
+    // it just because the manifest is curated rather than exhaustive.
+    expect(() => validateIndicatorParams("sma", { period: 20, source: "hlc3" })).not.toThrow();
+  });
+
+  it("accepts known params with valid values (regression)", () => {
+    expect(() => validateIndicatorParams("rsi", { period: 14 })).not.toThrow();
+    expect(() =>
+      validateIndicatorParams("macd", { fastPeriod: 12, slowPeriod: 26, signalPeriod: 9 }),
+    ).not.toThrow();
+  });
+});

--- a/packages/mcp/src/tools/calc.ts
+++ b/packages/mcp/src/tools/calc.ts
@@ -8,6 +8,7 @@ import {
   candlesInputShape,
   resolveCandlesInput,
 } from "../schemas/candle";
+import { validateIndicatorParams } from "../validation/params";
 
 export const calcIndicatorInputShape = {
   kind: z.string().min(1),
@@ -70,6 +71,11 @@ export function calcIndicatorHandler(
       `UNSUPPORTED_KIND: "${input.kind}" has no calc wrapper. Call list_indicators({ calcSupported: true }) to discover all ${total} computable kinds, or get_indicator_manifest("${input.kind}") to confirm whether the kind exists at all.`,
     );
   }
+
+  // Reject typo'd keys / wrong-type values upfront so the caller gets a
+  // clear `INVALID_PARAMETER` instead of a downstream NaN or default
+  // fallback that masquerades as a successful call.
+  validateIndicatorParams(input.kind, input.params);
 
   const raw = (fn as (c: Candle[], p?: unknown) => unknown)(candles, input.params);
 

--- a/packages/mcp/src/tools/detect-signal.ts
+++ b/packages/mcp/src/tools/detect-signal.ts
@@ -6,6 +6,7 @@ import {
   listSupportedSignals,
 } from "../dispatcher/signal-map";
 import { type CandlesInput, candlesInputShape, resolveCandlesInput } from "../schemas/candle";
+import { validateIndicatorParams } from "../validation/params";
 
 export const detectSignalInputShape = {
   kind: z.string().min(1),
@@ -64,6 +65,11 @@ export function detectSignalHandler(
       `UNSUPPORTED_SIGNAL: "${input.kind}" is not a supported detect_signal kind. Supported (${supported.length}): ${supported.join(", ")}.`,
     );
   }
+
+  // Structural / wrong-type check (NaN, nested object, string-where-
+  // number-expected). Per-signal contracts are still enforced by the
+  // underlying signal function.
+  validateIndicatorParams(input.kind, input.params);
 
   let raw: unknown;
   try {

--- a/packages/mcp/src/validation/params.ts
+++ b/packages/mcp/src/validation/params.ts
@@ -1,0 +1,93 @@
+/**
+ * MCP-side input parameter guard.
+ *
+ * Indicator / signal calls accept a free-form `params: Record<string, unknown>`
+ * because the underlying functions are heterogeneous. That flexibility is also
+ * the main silent-failure surface for LLM-driven callers: a stringified
+ * number, an `NaN` leaked into JSON, or a nested option blob is silently
+ * consumed by the factory and the indicator falls back to defaults (or
+ * NaN-out without throwing).
+ *
+ * This module catches the structural / wrong-type shapes upfront and turns
+ * them into `INVALID_PARAMETER` errors. It is intentionally conservative:
+ *
+ * - Per-parameter range and type contracts stay with the indicator.
+ * - Unknown / typo'd keys are NOT rejected — manifest `paramHints` is a
+ *   curated tuning-knob hint, not an exhaustive option list (e.g. `source`
+ *   is accepted by most indicators but rarely listed). Rejecting unknown
+ *   keys here would block valid generic options like `source: "hlc3"`.
+ *
+ * The goal is to flag wrong shapes that would otherwise turn into a
+ * downstream NaN or a default fallback that masquerades as success.
+ */
+
+const NUMBER_LIKE_KEY_RE =
+  /period$|periods$|length$|signalPeriod$|smoothPeriod$|window$|threshold$|multiplier$|sigma$|stdDev$|kPeriod$|dPeriod$|fastPeriod$|slowPeriod$|shortPeriod$|longPeriod$|cyclePeriod$|step$|max$/i;
+
+function isPlainObject(x: unknown): x is Record<string, unknown> {
+  if (x === null || typeof x !== "object") return false;
+  if (Array.isArray(x)) return false;
+  return true;
+}
+
+/**
+ * Throws `INVALID_PARAMETER: ...` when `params` is structurally broken.
+ *
+ * Specifically:
+ * - non-object / array / primitive → reject
+ * - `null` leaf value → reject
+ * - nested object value → reject
+ * - array containing a nested array, `null`, `NaN`, or a non-primitive
+ *   element → reject (flat `number[]` / `string[]` / `boolean[]` are OK)
+ * - finite-number requirement for any numeric value
+ * - string-where-number-expected on a numeric-style key
+ *   (`{ period: "14" }`) → reject; we don't auto-coerce because the
+ *   string form is more often a serialization bug than intent
+ */
+export function validateIndicatorParams(kind: string, params: unknown): void {
+  if (params === undefined) return;
+  if (!isPlainObject(params)) {
+    throw new Error(
+      `INVALID_PARAMETER: params for "${kind}" must be a plain object, got ${describeValue(params)}.`,
+    );
+  }
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === null) {
+      throw new Error(`INVALID_PARAMETER: params.${key} for "${kind}" is null.`);
+    }
+    if (typeof value === "object") {
+      if (Array.isArray(value)) {
+        for (const v of value) {
+          if (
+            v === null ||
+            (typeof v === "number" && !Number.isFinite(v)) ||
+            (typeof v !== "number" && typeof v !== "string" && typeof v !== "boolean")
+          ) {
+            throw new Error(
+              `INVALID_PARAMETER: params.${key} for "${kind}" must be an array of primitives (number / string / boolean).`,
+            );
+          }
+        }
+      } else {
+        throw new Error(
+          `INVALID_PARAMETER: params.${key} for "${kind}" is a nested object — pass primitives only.`,
+        );
+      }
+    } else if (typeof value === "number" && !Number.isFinite(value)) {
+      throw new Error(
+        `INVALID_PARAMETER: params.${key} for "${kind}" is ${value} (not a finite number).`,
+      );
+    } else if (typeof value === "string" && NUMBER_LIKE_KEY_RE.test(key)) {
+      throw new Error(
+        `INVALID_PARAMETER: params.${key} for "${kind}" is a string ("${value}") but a number is expected.`,
+      );
+    }
+  }
+}
+
+function describeValue(v: unknown): string {
+  if (v === null) return "null";
+  if (Array.isArray(v)) return "array";
+  return typeof v;
+}


### PR DESCRIPTION
## Summary

Adds `validateIndicatorParams` that rejects structurally broken `params` objects upfront, turning silent NaN-out / default-fallback failure modes into actionable `INVALID_PARAMETER` errors.

Wired into:
- `calc_indicator` (every indicator kind)
- `detect_signal` (every signal kind)

## What gets rejected

| Input shape | Why |
|-------------|-----|
| non-object / array / `null` `params` | Wrong root shape |
| `null` leaf value | Indicator can't make sense of `null` |
| Nested object value (`{ period: { value: 14 } }`) | Almost always a serialization bug |
| Array with nested arrays / `null` / `NaN` / non-primitive elements | Same |
| `NaN` / `±Infinity` numbers | Would propagate into the output |
| `{ period: "14" }` (string on numeric-style key) | Deliberate non-coercion — usually a serialization bug, not intent |

Flat `number[]` / `string[]` / `boolean[]` arrays are accepted (KST `rocPeriods`, candlestick `patterns`, etc.).

## What stays unchanged

- Per-parameter ranges / required fields are still validated by the indicator itself (this is a shape guard, not a schema validator).
- Manifest `paramHints` is intentionally NOT used as an exhaustive option allowlist. It's a curated tuning hint, and many indicators accept generic options (e.g. `source`) that aren't documented there. Rejecting unknown keys would block valid calls like `sma({ period: 20, source: "hlc3" })`.

## Why

LLM-driven callers are the main silent-failure surface — typo'd or stringified params get destructured silently and the indicator either uses defaults or NaN-outs. The guard converts these into a clear `INVALID_PARAMETER` so the model can correct course.

## Test plan

- [x] `pnpm test` — core 5020 / mcp 74 / chart 785 passing
- [x] `pnpm lint` clean
- [x] `pnpm build` clean
- 14 new unit tests covering each rejection path plus a regression for valid calls (including generic options not in `paramHints`)