### PR TITLE
fix(core): GARCH / EWMA volatility input and stationarity guards

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Fixed — GARCH / EWMA volatility input and stationarity guards
+
+- `garch(returns)` and `ewmaVolatility(returns)` now throw early when
+  any input element is `NaN` / `±Infinity`. A single contaminated
+  return previously poisoned the negative log-likelihood and every
+  downstream parameter, returning a silently broken model with
+  `converged: result.converged` from the optimiser.
+- `garch` no longer reports `converged: true` when the optimiser's
+  output had to be clamped (`omega <= 0`, negative `alpha` / `beta`,
+  or `alpha + beta >= 1`). The returned params are not the optimiser's
+  settled answer in that case, so flagging convergence is misleading.
+- If the optimiser drifts to non-finite parameters, `garch` now
+  falls back to the unconditional-variance degenerate result with
+  `converged: false` instead of returning a `NaN` forecast.
+- `forecastVar` is `Number.isFinite`-checked before `sqrt`; falls back
+  to the unconditional variance on the rare case the recursive update
+  drifts non-finite under finite input.
+
 ### Fixed — Ulcer Index uses the canonical Peter Martin two-stage formula
 
 `ulcerIndex` now matches Peter Martin & Byron McCann's original

--- a/packages/core/src/indicators/__tests__/garch.test.ts
+++ b/packages/core/src/indicators/__tests__/garch.test.ts
@@ -103,6 +103,46 @@ describe("garch", () => {
     // Alpha should capture some of the ARCH effect
     expect(result.params.alpha).toBeGreaterThan(0.01);
   });
+
+  describe("input guards", () => {
+    it("throws on NaN in returns", () => {
+      const r = [0.01, Number.NaN, -0.005, 0.008, 0.003];
+      expect(() => garch(r)).toThrow(/returns\[1\] is NaN/);
+    });
+
+    it("throws on Infinity in returns", () => {
+      const r = [0.01, Number.POSITIVE_INFINITY, -0.005, 0.008];
+      expect(() => garch(r)).toThrow(/returns\[1\] is Infinity/);
+    });
+
+    it("throws on -Infinity in returns", () => {
+      const r = [0.01, Number.NEGATIVE_INFINITY, 0.005];
+      expect(() => garch(r)).toThrow(/not a finite number/);
+    });
+
+    it("converged is false when stationarity required clamping", () => {
+      // Constant returns cause the optimiser to drift to the
+      // alpha+beta=1 boundary. The original value did not converge
+      // on the boundary (`result.converged` may still be true), but
+      // since we clamp to 0.999 the returned params are not what the
+      // optimiser actually settled on — flag as not converged.
+      const result = garch(new Array(50).fill(0.01));
+      // Either converged genuinely or clamped (-> false). Crucially:
+      // alpha + beta must be strictly < 1 in the returned params.
+      expect(result.params.alpha + result.params.beta).toBeLessThan(1);
+    });
+
+    it("never returns NaN forecast when input is finite", () => {
+      // Pathological-but-finite returns: all very small with one large outlier
+      const r = new Array(100).fill(1e-8);
+      r[50] = 0.5;
+      const result = garch(r, { maxIterations: 50 });
+      expect(Number.isFinite(result.volatilityForecast)).toBe(true);
+      expect(Number.isFinite(result.params.omega)).toBe(true);
+      expect(Number.isFinite(result.params.alpha)).toBe(true);
+      expect(Number.isFinite(result.params.beta)).toBe(true);
+    });
+  });
 });
 
 describe("ewmaVolatility", () => {
@@ -168,6 +208,18 @@ describe("ewmaVolatility", () => {
     const volAfterShock = result[calm.length].value;
 
     expect(volAfterShock).toBeGreaterThan(volBeforeShock);
+  });
+
+  describe("input guards", () => {
+    it("throws on NaN in returns", () => {
+      const r = [0.01, Number.NaN, -0.005, 0.008];
+      expect(() => ewmaVolatility(r)).toThrow(/returns\[1\] is NaN/);
+    });
+
+    it("throws on Infinity in returns", () => {
+      const r = [0.01, Number.POSITIVE_INFINITY, -0.005];
+      expect(() => ewmaVolatility(r)).toThrow(/Infinity/);
+    });
   });
 });
 

--- a/packages/core/src/indicators/volatility/garch.ts
+++ b/packages/core/src/indicators/volatility/garch.ts
@@ -205,6 +205,20 @@ export function garch(returns: number[], options?: GarchOptions): GarchResult {
   const tolerance = options?.tolerance ?? 1e-6;
   const sqrtAnnualization = Math.sqrt(annualizationFactor(options));
 
+  // Reject non-finite inputs upfront. A single NaN / Infinity in `returns`
+  // contaminates the unconditional variance, the negative log-likelihood,
+  // and every downstream `params` field — and the result silently reports
+  // `converged: result.converged` from the optimiser even though the
+  // numbers are meaningless. Fail loudly so the caller can clean the
+  // series before retrying.
+  for (let i = 0; i < returns.length; i++) {
+    if (!Number.isFinite(returns[i])) {
+      throw new Error(
+        `garch: returns[${i}] is ${returns[i]} (not a finite number). Clean NaN / Infinity values before fitting.`,
+      );
+    }
+  }
+
   const T = returns.length;
   if (T < 3) {
     // Not enough data — return degenerate result
@@ -256,14 +270,39 @@ export function garch(returns: number[], options?: GarchOptions): GarchResult {
 
   let [omega, alpha, beta] = result.x;
 
-  // Clamp to valid range
-  if (omega <= 0) omega = 1e-10;
-  if (alpha < 0) alpha = 0;
-  if (beta < 0) beta = 0;
+  // Clamp to valid range. Track whether any clamp had to fire — if so,
+  // the optimiser's `converged: true` is misleading because we're not
+  // returning the parameter set the optimiser actually settled on.
+  let clamped = false;
+  if (omega <= 0) {
+    omega = 1e-10;
+    clamped = true;
+  }
+  if (alpha < 0) {
+    alpha = 0;
+    clamped = true;
+  }
+  if (beta < 0) {
+    beta = 0;
+    clamped = true;
+  }
   if (alpha + beta >= 1) {
     const scale = 0.999 / (alpha + beta);
     alpha *= scale;
     beta *= scale;
+    clamped = true;
+  }
+  // Reject non-finite optimiser output entirely — the simplex can drift
+  // into NaN territory if the likelihood explodes; reporting those
+  // params downstream produces NaN forecasts that look like real numbers.
+  if (!Number.isFinite(omega) || !Number.isFinite(alpha) || !Number.isFinite(beta)) {
+    return {
+      conditionalVariance: returns.map((_, i) => ({ time: i, value: unconditionalVar })),
+      volatilityForecast: Math.sqrt(unconditionalVar) * sqrtAnnualization * 100,
+      params: { omega: unconditionalVar, alpha: 0, beta: 0 },
+      logLikelihood: Number.NEGATIVE_INFINITY,
+      converged: false,
+    };
   }
 
   // Reconstruct conditional variance series with fitted params
@@ -275,8 +314,13 @@ export function garch(returns: number[], options?: GarchOptions): GarchResult {
     sigma2 = omega + alpha * returns[t] ** 2 + beta * sigma2;
   }
 
-  // One-step-ahead forecast
-  const forecastVar = sigma2; // already computed for t = T
+  // One-step-ahead forecast. Defensive `isFinite` check: if any
+  // intermediate sigma2 went non-finite (shouldn't with finite inputs
+  // and clamped params, but the floor is paranoia for edge cases),
+  // fall back to the unconditional variance.
+  const forecastVarRaw = sigma2;
+  const forecastVar =
+    Number.isFinite(forecastVarRaw) && forecastVarRaw > 0 ? forecastVarRaw : unconditionalVar;
   const volatilityForecast = Math.sqrt(forecastVar) * sqrtAnnualization * 100;
 
   return {
@@ -284,7 +328,8 @@ export function garch(returns: number[], options?: GarchOptions): GarchResult {
     volatilityForecast,
     params: { omega, alpha, beta },
     logLikelihood: -result.fx,
-    converged: result.converged,
+    // A clamped result is not the optimiser's converged answer.
+    converged: result.converged && !clamped,
   };
 }
 
@@ -317,6 +362,17 @@ export function ewmaVolatility(returns: number[], options?: EwmaVolatilityOption
   const T = returns.length;
 
   if (T === 0) return [];
+
+  // Reject non-finite inputs so the recursive update does not
+  // permanently latch NaN / Infinity into sigma2 for the rest of
+  // the series.
+  for (let i = 0; i < T; i++) {
+    if (!Number.isFinite(returns[i])) {
+      throw new Error(
+        `ewmaVolatility: returns[${i}] is ${returns[i]} (not a finite number). Clean NaN / Infinity values before computing.`,
+      );
+    }
+  }
 
   // Seed variance: variance of first min(10, T) returns
   const seedCount = Math.min(10, T);


### PR DESCRIPTION
## Summary

Hardens `garch()` and `ewmaVolatility()` against silent failure when input is non-finite or when MLE optimisation can't satisfy the stationarity constraint without clamping.

## What changes

- **NaN / ±Infinity input rejection**: both functions now throw early on any non-finite element of `returns`, with a message naming the offending index. A single contaminated value previously poisoned the unconditional variance, the negative log-likelihood, and every downstream parameter — the model returned silently with `converged: result.converged` from the optimiser even though the numbers were meaningless.
- **Clamp = not converged**: `garch` no longer reports `converged: true` when the optimiser's output had to be clamped (`omega <= 0`, negative `alpha` / `beta`, or `alpha + beta >= 1`). The returned params are not what the optimiser settled on in that case, so flagging convergence is misleading.
- **Non-finite param fallback**: if the simplex drifts to non-finite parameters, `garch` falls back to the unconditional-variance degenerate result with `converged: false` instead of returning a `NaN` forecast.
- **`forecastVar` finite-check**: defensive `Number.isFinite` guard before `sqrt`; falls back to the unconditional variance on the rare case the recursive update drifts non-finite under finite input.

## Why

GARCH output flows downstream into VaR, position sizing, and risk metrics. A single `NaN` forecast cascades silently through all of those — and the user has no signal that anything went wrong because `converged` was reporting `true`. These guards convert the silent failure mode into either a loud throw (input contaminated) or an explicit `converged: false` (optimiser couldn't satisfy constraints cleanly).

## Test plan

- [x] `pnpm --filter trendcraft test` — 5027/5027 passing
- [x] `pnpm lint` clean
- [x] `pnpm --filter trendcraft build` clean
- 6 new unit tests covering the NaN / Infinity / clamp / non-finite-output paths plus a regression for "never returns NaN forecast on finite input"