### PR TITLE
test(core): strategy JSON round-trip depth coverage

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+### Added — strategy JSON round-trip depth tests
+
+`serialize / parse` is now pinned across:
+
+- all condition shapes (preset leaf, `and`, `or`, `not`)
+- 3- and 4-level nesting
+- presence and absence of optional fields (`tags`, `metadata`,
+  `description`, `backtest.*`, `params`)
+- unicode / quotes / backslashes / newlines in `id` / `name` /
+  `description`; long descriptions; 20-element tag arrays
+- every entry in `backtestRegistry`: each preset's default-param
+  shape round-trips through `serialize → parse → serialize` to
+  byte-identical JSON
+
+The contract enforced is `serialize(parse(serialize(s))) === serialize(s)`
+plus structural equality after parse. No production behavior change;
+this is regression coverage for the JSON layer that downstream
+consumers (MCP, Strategy Studio, Strategy DNA) all build on.
+
 ### Fixed — GARCH / EWMA volatility input and stationarity guards
 
 - `garch(returns)` and `ewmaVolatility(returns)` now throw early when

--- a/packages/core/src/strategy/__tests__/serialize-round-trip.test.ts
+++ b/packages/core/src/strategy/__tests__/serialize-round-trip.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Round-trip depth tests for the strategy JSON layer.
+ *
+ * Pins the contract that `serialize(parse(serialize(s)))` is
+ * idempotent across:
+ * - all condition shapes (preset leaf, `and`, `or`, `not`)
+ * - deep nesting (3-4 levels)
+ * - presence and absence of optional fields (`tags`, `metadata`,
+ *   `description`, `backtest.*`, `params`)
+ * - special characters in `id` / `name` / preset names
+ * - empty arrays / empty objects
+ *
+ * Plus a registry-driven test: every entry in `backtestRegistry`
+ * round-trips through default-param hydration → serialize → parse →
+ * value equality.
+ */
+
+import { describe, expect, it } from "vitest";
+import { loadStrategy } from "../hydrate";
+import { backtestRegistry } from "../registry-backtest";
+import { parseStrategy, serializeStrategy } from "../serialize";
+import type { ConditionSpec, StrategyJSON } from "../types";
+import { validateConditionSpec, validateStrategyJSON } from "../validate";
+
+function assertIdempotent(strategy: StrategyJSON): void {
+  // Top-level structural shape (id / name / entry / exit / backtest …).
+  const topLevel = validateStrategyJSON(strategy);
+  expect(topLevel).toEqual({ valid: true, errors: [] });
+
+  // Recursive condition-tree validation against the registry. This is
+  // the bit that catches malformed combinators like `not` with the
+  // wrong arity, unknown preset names, or out-of-range params.
+  // `validateStrategyJSON` does NOT recurse into the condition tree,
+  // so without this step a fixture like `{ op: "not", conditions: [] }`
+  // would silently pass.
+  for (const bucket of ["entry", "exit"] as const) {
+    const result = validateConditionSpec(strategy[bucket], backtestRegistry);
+    expect({
+      bucket,
+      result,
+    }).toEqual({ bucket, result: { valid: true, errors: [] } });
+  }
+
+  // The fixture must also hydrate cleanly under the backtest
+  // registry — otherwise we are testing the JSON layer in isolation
+  // from the consumers that actually run the strategy.
+  expect(() => loadStrategy(strategy, backtestRegistry)).not.toThrow();
+
+  const first = serializeStrategy(strategy);
+  const reparsed = parseStrategy(first);
+  const second = serializeStrategy(reparsed);
+  expect(second).toBe(first);
+  expect(reparsed).toEqual(strategy);
+}
+
+const baseStrategy = (entry: ConditionSpec, exit: ConditionSpec): StrategyJSON => ({
+  $schema: "trendcraft/strategy",
+  version: 1,
+  id: "round-trip-test",
+  name: "Round Trip Test",
+  entry,
+  exit,
+});
+
+describe("serialize / parse round-trip — condition shapes", () => {
+  it("preset leaf with no params", () => {
+    assertIdempotent(baseStrategy({ name: "goldenCross" }, { name: "deadCross" }));
+  });
+
+  it("preset leaf with full params", () => {
+    assertIdempotent(
+      baseStrategy(
+        { name: "goldenCross", params: { shortPeriod: 5, longPeriod: 25 } },
+        { name: "rsiAbove", params: { threshold: 70 } },
+      ),
+    );
+  });
+
+  it("and() of two leaves", () => {
+    assertIdempotent(
+      baseStrategy(
+        {
+          op: "and",
+          conditions: [
+            { name: "goldenCross", params: { shortPeriod: 5, longPeriod: 25 } },
+            { name: "rsiBelow", params: { threshold: 30 } },
+          ],
+        },
+        { name: "deadCross" },
+      ),
+    );
+  });
+
+  it("or() of three leaves", () => {
+    assertIdempotent(
+      baseStrategy(
+        {
+          op: "or",
+          conditions: [
+            { name: "goldenCross" },
+            { name: "rsiBelow", params: { threshold: 30 } },
+            { name: "rsiAbove", params: { threshold: 50 } },
+          ],
+        },
+        { name: "deadCross" },
+      ),
+    );
+  });
+
+  it("not() of a leaf", () => {
+    assertIdempotent(
+      baseStrategy(
+        {
+          op: "not",
+          conditions: [{ name: "rsiAbove", params: { threshold: 70 } }],
+        },
+        { name: "deadCross" },
+      ),
+    );
+  });
+
+  it("nested and(or(not(leaf)))", () => {
+    assertIdempotent(
+      baseStrategy(
+        {
+          op: "and",
+          conditions: [
+            { name: "goldenCross", params: { shortPeriod: 5, longPeriod: 25 } },
+            {
+              op: "or",
+              conditions: [
+                { name: "rsiBelow", params: { threshold: 30 } },
+                {
+                  op: "not",
+                  conditions: [{ name: "rsiAbove", params: { threshold: 80 } }],
+                },
+              ],
+            },
+          ],
+        },
+        { name: "deadCross" },
+      ),
+    );
+  });
+
+  it("4-level deep nesting (and(or(and(not(leaf)))))", () => {
+    assertIdempotent(
+      baseStrategy(
+        {
+          op: "and",
+          conditions: [
+            { name: "goldenCross" },
+            {
+              op: "or",
+              conditions: [
+                {
+                  op: "and",
+                  conditions: [
+                    { name: "rsiBelow", params: { threshold: 30 } },
+                    {
+                      op: "not",
+                      conditions: [{ name: "rsiAbove", params: { threshold: 70 } }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        { name: "deadCross" },
+      ),
+    );
+  });
+});
+
+describe("serialize / parse round-trip — optional fields", () => {
+  it("strategy without description / tags / metadata", () => {
+    assertIdempotent({
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "minimal",
+      name: "Minimal",
+      entry: { name: "goldenCross" },
+      exit: { name: "deadCross" },
+    });
+  });
+
+  it("strategy with empty tags array", () => {
+    assertIdempotent({
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "empty-tags",
+      name: "Empty Tags",
+      tags: [],
+      entry: { name: "goldenCross" },
+      exit: { name: "deadCross" },
+    });
+  });
+
+  it("strategy with empty metadata object", () => {
+    assertIdempotent({
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "empty-meta",
+      name: "Empty Metadata",
+      metadata: {},
+      entry: { name: "goldenCross" },
+      exit: { name: "deadCross" },
+    });
+  });
+
+  it("strategy with full backtest options", () => {
+    assertIdempotent({
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "full-bt",
+      name: "Full BT",
+      entry: { name: "goldenCross" },
+      exit: { name: "deadCross" },
+      backtest: {
+        capital: 1_000_000,
+        stopLoss: 5,
+        takeProfit: 10,
+        fillMode: "next-bar-open",
+      },
+    });
+  });
+
+  it("strategy with empty backtest object", () => {
+    assertIdempotent({
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "empty-bt",
+      name: "Empty BT",
+      entry: { name: "goldenCross" },
+      exit: { name: "deadCross" },
+      backtest: {},
+    });
+  });
+});
+
+describe("serialize / parse round-trip — special characters", () => {
+  it("preserves unicode in id / name / description", () => {
+    assertIdempotent({
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "戦略-α-2026",
+      name: "ゴールデンクロス × RSI",
+      description: "日本語の説明 — 全角ハイフン / 半角 / emoji 🎯",
+      entry: { name: "goldenCross" },
+      exit: { name: "deadCross" },
+    });
+  });
+
+  it("preserves quotes / backslashes in description", () => {
+    assertIdempotent({
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "esc",
+      name: "Escapes",
+      description: 'Line 1 with "double quotes" and \\backslash\\ — newline\nhere.',
+      entry: { name: "goldenCross" },
+      exit: { name: "deadCross" },
+    });
+  });
+
+  it("preserves long descriptions and tag arrays", () => {
+    const longText = "lorem ipsum ".repeat(50).trim();
+    const manyTags = Array.from({ length: 20 }, (_, i) => `tag-${i}`);
+    assertIdempotent({
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "long",
+      name: "Long",
+      description: longText,
+      tags: manyTags,
+      entry: { name: "goldenCross" },
+      exit: { name: "deadCross" },
+    });
+  });
+});
+
+describe("serialize / parse round-trip — all backtestRegistry conditions", () => {
+  // Build a strategy whose entry/exit each cycle through every
+  // registry entry's name with its declared default params. If
+  // serialize → parse drops a default param or a nested structure
+  // for any specific preset, this loop catches it.
+  it("every registered preset round-trips with its default params", () => {
+    const entries = backtestRegistry.list();
+    expect(entries.length).toBeGreaterThan(20);
+
+    for (const entry of entries) {
+      const key = entry.name;
+      const params: Record<string, unknown> = {};
+      for (const [paramName, schema] of Object.entries(entry.params)) {
+        if (schema.default !== undefined) params[paramName] = schema.default;
+      }
+
+      const strategy: StrategyJSON = {
+        $schema: "trendcraft/strategy",
+        version: 1,
+        id: `roundtrip-${key}`,
+        name: `Round-trip ${key}`,
+        entry: Object.keys(params).length > 0 ? { name: key, params } : { name: key },
+        exit: { name: "deadCross" },
+      };
+
+      const serialized = serializeStrategy(strategy);
+      const reparsed = parseStrategy(serialized);
+      expect(reparsed).toEqual(strategy);
+      expect(serializeStrategy(reparsed)).toBe(serialized);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Pins `serialize` / `parse` idempotency across all combinator shapes, optional-field combinations, and every `backtestRegistry` entry. The JSON layer is the substrate every downstream consumer (MCP, Strategy Studio, Strategy DNA) builds on, but coverage was previously limited to two happy-path cases.

## What the new helper enforces

For each fixture, `assertIdempotent` runs:

1. `validateStrategyJSON` — top-level field shape (id / name / entry / exit / backtest …)
2. `validateConditionSpec` on `entry` and `exit` — registry-aware recursion that catches malformed combinators (`not` with empty / multiple children), unknown preset names, and out-of-range params
3. `loadStrategy(strategy, backtestRegistry)` — must hydrate cleanly; ensures the JSON-layer test stays in sync with the consumers that actually run it
4. `serialize(parse(serialize(s))) === serialize(s)` — byte-identical idempotency
5. `parse(serialize(s))` is structurally equal to the input

## Coverage

16 new fixtures across:

- preset leaf with and without params
- `and` / `or` combinators
- `not` (canonical `{ op: "not", conditions: [child] }` shape)
- 3- and 4-level nested combinators
- presence / absence of every optional field (`tags`, `metadata`, `description`, `backtest.*`, `params`)
- unicode / quotes / backslashes / newlines / long strings / 20-element tag arrays in `id` / `name` / `description`
- a loop over every entry in `backtestRegistry`: each preset's default-param shape round-trips through `serialize → parse → serialize` to byte-identical JSON

## Why now

Several recent JSON-layer fixes (`parseStrategy` opt-in registry validation, `+Infinity` ranking guard, Ulcer Index canonical formula) all touched the surrounding code without breaking. That's reassuring, but the existing two round-trip tests can't actually prove the JSON contract. This is the regression net for that contract.

## Test plan

- [x] `pnpm --filter trendcraft test` — 5043/5043 passing
- [x] `pnpm lint` clean
- [x] `pnpm --filter trendcraft build` clean
- Sanity-checked the helper rejects malformed `{ op: "not", conditions: [] }`, `{ op: "not", conditions: [a, b] }`, and unknown preset names