### PR TITLE
fix(chart): track window.devicePixelRatio across resizes

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — chart now tracks `window.devicePixelRatio` across resizes
+
+The main `createChart` instance previously cached
+`window.devicePixelRatio` once at construction and never refreshed it.
+When the user dragged the browser window between displays of
+different DPR (e.g. an external 1× monitor ↔ a 2× Retina laptop
+display) or changed OS scaling mid-session, the canvas internal
+resolution stayed at the original DPR — the chart kept rendering at
+1× resolution on a 2× display, producing visibly blurry output.
+
+`_setSize` now re-reads `window.devicePixelRatio` on every resize
+when no explicit `options.pixelRatio` was pinned at construction.
+The pinned override path is unchanged — callers that supply
+`pixelRatio` keep full control. Sparkline already re-read DPR each
+frame and is unaffected.
+
 ### Fixed — non-finite value guards across render and layout paths
 
 Canvas silently swallows draw calls with `NaN` / `±Infinity`

--- a/packages/chart/src/__tests__/dpr-tracking.test.ts
+++ b/packages/chart/src/__tests__/dpr-tracking.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+/**
+ * DPR (devicePixelRatio) tracking — auto-update on resize.
+ *
+ * `window.devicePixelRatio` can change mid-session when the user drags
+ * the browser window between displays of different DPR (Retina ↔
+ * external monitor) or changes OS scaling. The chart's canvas internal
+ * resolution must follow that change to stay crisp on the new display.
+ *
+ * Without this guard, the chart caches the construction-time DPR and
+ * the canvas remains at the original internal resolution, producing
+ * blurry output after the move.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { createChart } from "../index";
+
+beforeAll(() => {
+  const noop = () => {};
+  const context2d = new Proxy(
+    {},
+    {
+      get: (_t, prop) => {
+        if (prop === "canvas") return null;
+        if (prop === "measureText") return () => ({ width: 0 }) as TextMetrics;
+        return noop;
+      },
+      set: () => true,
+    },
+  ) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as { getContext: () => unknown }).getContext = () =>
+    context2d;
+});
+
+function makeContainer(): HTMLElement {
+  const el = document.createElement("div");
+  el.style.width = "800px";
+  el.style.height = "400px";
+  document.body.appendChild(el);
+  return el;
+}
+
+describe("DPR tracking", () => {
+  it("re-reads window.devicePixelRatio on resize when no explicit pixelRatio is pinned", () => {
+    Object.defineProperty(window, "devicePixelRatio", { configurable: true, value: 1 });
+    const chart = createChart(makeContainer(), { width: 800, height: 400 });
+    const canvas = document.querySelector("canvas") as HTMLCanvasElement;
+
+    expect(canvas.width).toBe(800); // 800 css × 1 dpr
+    expect(canvas.height).toBe(400);
+
+    // Simulate moving the window to a Retina display (DPR 1 → 2).
+    Object.defineProperty(window, "devicePixelRatio", { configurable: true, value: 2 });
+    chart.resize(800, 400);
+
+    // Canvas internal resolution must follow the new DPR; CSS size unchanged.
+    expect(canvas.width).toBe(1600); // 800 × 2
+    expect(canvas.height).toBe(800);
+    expect(canvas.style.width).toBe("800px");
+    expect(canvas.style.height).toBe("400px");
+
+    chart.destroy();
+  });
+
+  it("honors explicit pixelRatio override (does not auto-track DPR)", () => {
+    Object.defineProperty(window, "devicePixelRatio", { configurable: true, value: 1 });
+    const chart = createChart(makeContainer(), { width: 800, height: 400, pixelRatio: 3 });
+    const canvas = document.querySelector("canvas") as HTMLCanvasElement;
+
+    expect(canvas.width).toBe(2400); // 800 × 3 (pinned)
+
+    // Even if the underlying DPR changes, the pinned value stays.
+    Object.defineProperty(window, "devicePixelRatio", { configurable: true, value: 2 });
+    chart.resize(800, 400);
+    expect(canvas.width).toBe(2400); // still 800 × 3
+
+    chart.destroy();
+  });
+
+  it("falls back to 1 when devicePixelRatio is 0 / undefined / non-finite", () => {
+    Object.defineProperty(window, "devicePixelRatio", { configurable: true, value: 0 });
+    const chart = createChart(makeContainer(), { width: 800, height: 400 });
+    const canvas = document.querySelector("canvas") as HTMLCanvasElement;
+
+    expect(canvas.width).toBe(800); // 800 × 1 fallback
+
+    chart.destroy();
+  });
+
+  it.each([
+    ["NaN", Number.NaN],
+    ["+Infinity", Number.POSITIVE_INFINITY],
+    ["-Infinity", Number.NEGATIVE_INFINITY],
+    ["negative", -2],
+  ])(
+    "rejects non-finite / negative DPR (%s) and falls back to 1 on subsequent resize",
+    (_label, badDpr) => {
+      Object.defineProperty(window, "devicePixelRatio", { configurable: true, value: 1 });
+      const chart = createChart(makeContainer(), { width: 800, height: 400 });
+      const canvas = document.querySelector("canvas") as HTMLCanvasElement;
+
+      Object.defineProperty(window, "devicePixelRatio", { configurable: true, value: badDpr });
+      chart.resize(800, 400);
+
+      expect(canvas.width).toBe(800); // 800 × 1 (clamped)
+      expect(canvas.height).toBe(400);
+      expect(Number.isFinite(canvas.width)).toBe(true);
+
+      chart.destroy();
+    },
+  );
+});

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -63,6 +63,18 @@ const DEFAULT_OPTIONS: Required<
   fontSize: 11,
 };
 
+/**
+ * Read `window.devicePixelRatio` and clamp to a finite positive value.
+ * Falls back to 1 when running outside a browser, when DPR is 0 / NaN /
+ * negative, or when DPR is `±Infinity` (the last is rare in practice
+ * but breaks `canvas.width = w * dpr` if it slips through).
+ */
+function safeDevicePixelRatio(): number {
+  if (typeof window === "undefined") return 1;
+  const dpr = window.devicePixelRatio;
+  return Number.isFinite(dpr) && dpr > 0 ? dpr : 1;
+}
+
 // ============================================
 // CanvasChart Class
 // ============================================
@@ -72,6 +84,16 @@ export class CanvasChart implements ChartInstance {
   private _canvas: HTMLCanvasElement;
   private _ctx: CanvasRenderingContext2D;
   private _pixelRatio: number;
+  /**
+   * `true` when the caller pinned `pixelRatio` via constructor options
+   * (or `applyOptions`). When pinned, we honor the caller's value and
+   * never auto-track `window.devicePixelRatio`. When false, every
+   * `_setSize` call re-reads `window.devicePixelRatio` so dragging the
+   * window between displays of different DPR (e.g. Retina ↔ external
+   * monitor) re-renders the canvas at the correct resolution instead
+   * of staying blurry at the original DPR.
+   */
+  private _pixelRatioPinned: boolean;
   private _theme: ThemeColors;
   private _fontSize: number;
   private _priceFormatter: (price: number) => string;
@@ -233,8 +255,10 @@ export class CanvasChart implements ChartInstance {
     this._sessionGapsOpts = resolveSessionGapsOptions(options?.timeScale?.sessionGaps);
     this._locale = mergeLocale(options?.locale);
     setMonthNames(this._locale.months);
-    this._pixelRatio =
-      options?.pixelRatio ?? (typeof window !== "undefined" ? window.devicePixelRatio : 1);
+    this._pixelRatioPinned = options?.pixelRatio !== undefined;
+    this._pixelRatio = this._pixelRatioPinned
+      ? (options?.pixelRatio as number)
+      : safeDevicePixelRatio();
 
     // Resolve theme
     if (typeof options?.theme === "object") {
@@ -1100,6 +1124,15 @@ export class CanvasChart implements ChartInstance {
     // Guard against zero/negative dimensions to prevent Infinity in layout math
     const w = Math.max(1, width);
     const h = Math.max(1, height);
+    // Re-read `window.devicePixelRatio` on every resize so dragging the
+    // window between displays of different DPR (e.g. moving from a
+    // 1× external monitor to a 2× Retina screen) re-renders at the
+    // correct resolution instead of staying blurry at the original
+    // construction-time DPR. Honor an explicit `options.pixelRatio`
+    // override by leaving `_pixelRatio` untouched when pinned.
+    if (!this._pixelRatioPinned) {
+      this._pixelRatio = safeDevicePixelRatio();
+    }
     const pr = this._pixelRatio;
     this._canvas.width = w * pr;
     this._canvas.height = h * pr;


### PR DESCRIPTION
## Summary

The main `createChart` instance cached `window.devicePixelRatio` once at construction and never refreshed it. Dragging the browser window between displays of different DPR (e.g. external 1× monitor → 2× Retina laptop display) or changing OS scaling mid-session left the canvas internal resolution stuck at the original DPR, producing visibly blurry output on the new display.

## Fix

`_setSize` now re-reads `window.devicePixelRatio` on every resize when no explicit `options.pixelRatio` was pinned at construction. The pinned override path is unchanged — callers that supply `pixelRatio` keep full control. Sparkline already re-read DPR each frame and is unaffected.

A new `safeDevicePixelRatio` helper clamps the value to a finite positive number — `0`, `NaN`, `±Infinity`, and negative DPR all fall back to `1` instead of producing a blank or garbage canvas.

## Why

Found via a targeted Phase B audit of the chart examples (agent-browser visual smoke tour). Setting DPR to 2 on a running chart and triggering resize confirmed the canvas internal dimensions stayed at the construction-time value while sparkline correctly tracked the new DPR — the gap between the two paths is the bug.

## Test plan

- [x] `pnpm --filter @trendcraft/chart test` — 797/797 passing (was 790; +7)
- [x] `pnpm lint` clean
- [x] `pnpm --filter @trendcraft/chart build` clean
- 7 new unit tests cover:
  - DPR 1 → 2 auto-track on resize
  - explicit `pixelRatio` pin (does not auto-track)
  - 0 fallback to 1 at construction
  - `NaN` / `+Infinity` / `-Infinity` / negative DPR all clamp to 1 on resize