### PR TITLE
feat(chart): markers option on scalar line series

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `markers` option on scalar line series for "discrete-per-bar" affordance
+
+`SeriesConfig.markers?: boolean | { radius?: number; color?: string }`
+draws a filled circle at each bar's value point on **scalar line
+series** (i.e. `Series<number>` such as SMA, EMA, RSI, CCI). This
+makes it visually obvious that the underlying data is one value
+per bar and the line connecting consecutive points is just linear
+interpolation — particularly useful for backtest signal
+interpretation, where the cross's visual x-position can land
+mid-candle on slope-asymmetric crossings.
+
+- `markers: true` → default radius 2.5 px, filled with the series color
+- `markers: { radius: 4, color: "#fff" }` → custom override
+- Auto-skipped when `barSpacing < 5 px` to avoid the dots smearing
+  into a solid mass at high zoom-out
+- No-op on multi-channel series (`band`, MACD, Stochastics, etc.)
+  by design — those would clutter at high marker count and don't
+  share the "where does the line really cross?" ambiguity
+
 ### Fixed — chart now tracks `window.devicePixelRatio` across resizes
 
 The main `createChart` instance previously cached

--- a/packages/chart/src/__tests__/series-renderers.test.ts
+++ b/packages/chart/src/__tests__/series-renderers.test.ts
@@ -111,6 +111,57 @@ describe("renderLine", () => {
     renderLine(ctx, data, ts, ps, ts.startIndex, { color: "#000", lineWidth: 1, dash: [4, 2] });
     expect(ctx.setLineDash).toHaveBeenCalledWith([4, 2]);
   });
+
+  it("draws a marker dot at every non-null bar when markers option is set", () => {
+    const { ctx, ts, ps } = setup(5);
+    const data = [
+      { time: 1, value: 100 },
+      { time: 2, value: 105 },
+      { time: 3, value: null },
+      { time: 4, value: 102 },
+      { time: 5, value: 99 },
+    ];
+    renderLine(ctx, data, ts, ps, ts.startIndex, {
+      color: "#2196F3",
+      lineWidth: 1,
+      markers: { radius: 2.5, color: "#2196F3" },
+    });
+    // arc() called once per non-null point (4 of 5 here)
+    expect(ctx.arc).toHaveBeenCalledTimes(4);
+    // Each arc uses the configured radius
+    const arcCalls = (ctx.arc as unknown as { mock: { calls: number[][] } }).mock.calls;
+    for (const call of arcCalls) {
+      expect(call[2]).toBe(2.5); // 3rd arg is radius
+    }
+  });
+
+  it("does not draw markers when markers option is omitted", () => {
+    const { ctx, ts, ps } = setup(3);
+    const data = [
+      { time: 1, value: 100 },
+      { time: 2, value: 105 },
+      { time: 3, value: 98 },
+    ];
+    renderLine(ctx, data, ts, ps, ts.startIndex, { color: "#000", lineWidth: 1 });
+    expect(ctx.arc).not.toHaveBeenCalled();
+  });
+
+  it("skips markers when bar spacing is below the legibility threshold", () => {
+    const ctx = mockCtx();
+    // Tight bar spacing — 200 bars in 800 px → 4 px each, below the 5 px floor
+    const tightTs = makeTimeScale(200, 800);
+    const ps = makePriceScale(400, 90, 120);
+    const data = Array.from({ length: 200 }, (_, i) => ({ time: i, value: 100 + (i % 10) }));
+    renderLine(ctx, data, tightTs, ps, tightTs.startIndex, {
+      color: "#000",
+      lineWidth: 1,
+      markers: { radius: 2.5, color: "#000" },
+    });
+    // Smaller-than-threshold spacing → no markers drawn even though the
+    // line itself is still rendered.
+    expect(ctx.arc).not.toHaveBeenCalled();
+    expect(ctx.stroke).toHaveBeenCalled();
+  });
 });
 
 describe("renderChannelLine", () => {

--- a/packages/chart/src/core/types/series.ts
+++ b/packages/chart/src/core/types/series.ts
@@ -48,6 +48,24 @@ export type SeriesConfig = {
    * (wrapping), so stacking e.g. multiple SMAs produces distinct colors.
    */
   colorPalette?: readonly string[];
+  /**
+   * Draw a small filled circle at each bar's value on **scalar
+   * line series** (i.e. `Series<number>`), making it visually
+   * obvious that the underlying data is one value per bar and the
+   * line between bars is just linear interpolation. Useful for
+   * SMA / EMA / RSI etc. where the exact bar position of a crossing
+   * matters more than the line shape.
+   *
+   * Pass `true` for default styling (radius 2.5 px, filled with the
+   * series color), or an object to customize. Markers are skipped
+   * when `barSpacing` is too tight to render them legibly (< 5 px).
+   *
+   * Currently a no-op on multi-channel series (`band`, MACD,
+   * Stochastics, etc.) — those would clutter at high marker count
+   * and don't share the "where does the line really cross?"
+   * ambiguity that motivates this option.
+   */
+  markers?: boolean | { radius?: number; color?: string };
 };
 
 export type SeriesHandle = {

--- a/packages/chart/src/renderer/series-dispatcher.ts
+++ b/packages/chart/src/renderer/series-dispatcher.ts
@@ -95,6 +95,15 @@ export function dispatchSeries(
 
   const color = s.config.color ?? "#2196F3";
   const lineWidth = s.config.lineWidth ?? 1.5;
+  // Resolve `markers` config — `true` becomes default style, an object
+  // overrides; `undefined` / `false` skip marker rendering entirely.
+  const markersConfig = s.config.markers;
+  const markers =
+    markersConfig === true
+      ? { radius: 2.5, color }
+      : markersConfig && typeof markersConfig === "object"
+        ? { radius: markersConfig.radius ?? 2.5, color: markersConfig.color ?? color }
+        : undefined;
 
   if (rule.name === "number") {
     // Honor explicit type override (e.g., volume as histogram)
@@ -162,7 +171,7 @@ export function dispatchSeries(
       timeScale,
       priceScale,
       timeScale.startIndex,
-      { color, lineWidth },
+      { color, lineWidth, markers },
       origIndices,
     );
     return;

--- a/packages/chart/src/series/line.ts
+++ b/packages/chart/src/series/line.ts
@@ -13,7 +13,21 @@ export type LineRenderOptions = {
   lineWidth: number;
   /** Dash pattern (e.g., [4, 2] for dashed) */
   dash?: number[];
+  /**
+   * Draw a filled circle at each bar's value point. Makes it explicit
+   * that the underlying data is discrete-per-bar and the line is just
+   * linear interpolation — useful for SMA / EMA / RSI etc. where the
+   * exact bar position of a crossing matters. Pass radius and color
+   * (default radius = 2.5 px, color = `options.color`).
+   *
+   * Skipped when `barSpacing < 5` to avoid the dots smearing into a
+   * solid mass at high zoom-out.
+   */
+  markers?: { radius: number; color: string };
 };
+
+/** Minimum bar spacing (px) at which marker dots are still drawn. */
+const MARKER_MIN_BAR_SPACING = 5;
 
 /**
  * Render a line series on the canvas.
@@ -67,6 +81,22 @@ export function renderLine(
   }
   ctx.stroke();
   ctx.setLineDash([]);
+
+  // Marker dots — drawn after the stroke so they sit on top of the line.
+  // Skipped at high zoom-out (small bar spacing) to avoid a solid smear.
+  if (options.markers && timeScale.barSpacing >= MARKER_MIN_BAR_SPACING) {
+    const radius = options.markers.radius;
+    ctx.fillStyle = options.markers.color;
+    for (let i = iStart; i < iEnd; i++) {
+      const point = data[i];
+      if (!point || point.value === null || point.value === undefined) continue;
+      const x = timeScale.indexToX(bucketed ? originalIndices[i] : i);
+      const y = priceScale.priceToY(point.value);
+      ctx.beginPath();
+      ctx.arc(x, y, radius, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds `SeriesConfig.markers` to draw a filled circle at each bar's value point on scalar line series (SMA, EMA, RSI, CCI, etc.). Makes the per-bar nature of indicator data visible at a glance, so users can read "this bar above / this bar below" instead of squinting at where two interpolated lines cross.

## Why

Recurring question during Strategy Studio dogfooding: when SMA(5) crosses SMA(25), the visual cross point can land mid-bar or in the gap between bars **depending on the slope ratio** of the two SMAs around the crossing — purely an artifact of linear interpolation, not a shift in actual signal timing.

Concrete example from the sample data:

| Event | bar N-1 diff | bar N diff | t (cross x position) | Looks like |
|-------|--------------|------------|----------------------|------------|
| GC 2025-07-17 | -0.108 | +0.131 | 0.45 (mid-segment) | cross at mid-bar |
| DC 2025-08-29 | +0.041 | -0.850 | 0.05 (right after N-1) | cross between bars |

Same `barSpacing`, different visual cross location — entirely slope-driven. Adding marker dots removes the ambiguity by showing the actual per-bar values.

## API

```ts
chart.addSeries(smaData, { color: "#FF6E40", markers: true });
chart.addSeries(emaData, { color: "#00BCD4", markers: { radius: 4, color: "#fff" } });
```

- `markers: true` → default style: radius 2.5 px, fill = series color
- `markers: { radius, color }` → custom override
- Auto-skipped when `barSpacing < 5 px` to avoid the dots smearing into a solid mass at high zoom-out
- No-op on multi-channel series (`band`, MACD, Stochastics) by design — those would clutter at high marker count and don't share the "where does the line really cross?" ambiguity

## Test plan

- [x] `pnpm --filter @trendcraft/chart test` — 800/800 passing (was 797; +3)
- [x] `pnpm lint` clean
- [x] `pnpm --filter @trendcraft/chart build` clean
- 3 new tests cover: marker count matches non-null bar count, omitted option = no markers drawn, tight bar spacing skips markers but still draws line