### PR TITLE
fix(chart): tick generation no longer drifts to ~1e-16 on symmetric ranges

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -26,6 +26,27 @@ mid-candle on slope-asymmetric crossings.
   by design — those would clutter at high marker count and don't
   share the "where does the line really cross?" ambiguity
 
+### Fixed — axis label "0.00000000" overflow on oscillator panes
+
+For oscillator-style indicators (QStick, CCI, ROC, etc.) the visible
+range is symmetric around zero. `PriceScale.getTicks` was generating
+the tick array by accumulating `v += niceStep` in a loop, which
+drifts after several iterations: what should be exactly 0 lands at
+~1e-16, and `autoFormatPrice` then renders that drifted value as
+"0.00000000" (8 decimals) — visibly overflowing the axis label area
+and colliding with neighbouring ticks.
+
+`PriceScale.getTicks` now computes ticks as integer multiples of
+`niceStep` (`m * niceStep` for each integer `m` in the visible
+range), so the 0 tick lands at exactly 0. A small upward tolerance
+on the upper-bound floor handles the case where the max lands
+exactly on a step boundary but the divided quotient lands at
+`n - ε`. The lower bound stays strict (no downward tolerance) so
+ranges whose endpoints are merely near a step boundary don't
+generate ticks outside the visible range. Each computed tick is
+also bounds-checked before being emitted as a final guard against
+multiplicative FP drift.
+
 ### Fixed — chart now tracks `window.devicePixelRatio` across resizes
 
 The main `createChart` instance previously cached

--- a/packages/chart/src/__tests__/format.test.ts
+++ b/packages/chart/src/__tests__/format.test.ts
@@ -50,6 +50,11 @@ describe("autoFormatPrice", () => {
   it("handles zero", () => {
     expect(autoFormatPrice(0)).toBe("0");
   });
+
+  it("preserves genuinely tiny values (the formatter is reused outside axis ticks — crosshair / overlay / drawings — where rewriting them as 0 would lose data)", () => {
+    expect(autoFormatPrice(1e-12)).toBe("0.00000000");
+    expect(autoFormatPrice(1e-9)).toBe("0.00000000");
+  });
 });
 
 describe("autoFormatTime", () => {

--- a/packages/chart/src/__tests__/scale.test.ts
+++ b/packages/chart/src/__tests__/scale.test.ts
@@ -124,6 +124,49 @@ describe("PriceScale", () => {
     }
   });
 
+  it("does not produce floating-point drift on symmetric-around-zero ranges (regression: '0.00000000' label)", () => {
+    // For oscillator-style indicators (QStick, CCI, etc.) the visible
+    // range is symmetric around zero and `start + niceStep * n` should
+    // land exactly on 0. Accumulating with `v += niceStep` in a loop
+    // drifts after several iterations — the "0" tick lands at ~1e-16
+    // and `autoFormatPrice` then renders it as "0.00000000".
+    const ps = new PriceScale();
+    ps.setHeight(400);
+    ps.setDataRange(-0.6, 0.6);
+
+    const ticks = ps.getTicks();
+    // The 0 tick should be exactly 0 (no drift).
+    const zeroTick = ticks.find((t) => Math.abs(t) < 1e-6);
+    expect(zeroTick).toBeDefined();
+    expect(zeroTick).toBe(0);
+  });
+
+  it("includes the top tick when max lands on a step boundary (regression: dropped last tick)", () => {
+    // `max - start` divided by `niceStep` is mathematically an integer
+    // here, but FP can represent it as `n - ε`. A naive
+    // `Math.floor + 1` count drops the final tick; an integer-multiple
+    // approach with a small epsilon tolerance keeps it.
+    const ps = new PriceScale();
+    ps.setHeight(400);
+    ps.setDataRange(-1, -0.4);
+
+    const ticks = ps.getTicks();
+    const topTick = ticks[ticks.length - 1];
+    expect(topTick).toBeCloseTo(-0.4, 9);
+  });
+
+  it("emitted ticks always lie within [min, max] (no out-of-range labels from FP drift)", () => {
+    const ps = new PriceScale();
+    ps.setHeight(400);
+    ps.setDataRange(-0.6, 0.6);
+
+    const ticks = ps.getTicks();
+    for (const t of ticks) {
+      expect(t).toBeGreaterThanOrEqual(ps.min - 1e-12);
+      expect(t).toBeLessThanOrEqual(ps.max + 1e-12);
+    }
+  });
+
   it("log mode maps correctly", () => {
     const ps = new PriceScale();
     ps.setMode("log");

--- a/packages/chart/src/core/scale.ts
+++ b/packages/chart/src/core/scale.ts
@@ -696,8 +696,26 @@ export class PriceScale {
     niceStep *= magnitude;
 
     const ticks: number[] = [];
-    const start = Math.ceil(this._min / niceStep) * niceStep;
-    for (let v = start; v <= this._max; v += niceStep) {
+    // Compute ticks as integer multiples of `niceStep` rather than
+    // accumulating `v += niceStep` in a loop. Accumulating drifts
+    // after several iterations — what should be exactly 0 lands at
+    // ~1e-16, which then formats as "0.00000000" because
+    // `autoFormatPrice` enters its smallest-magnitude branch.
+    //
+    // The ceil/floor handle the lower / upper boundary respectively.
+    // A small upward tolerance is applied only on the upper bound
+    // because `max - n*niceStep` can land at `n - ε` even when the
+    // mathematical answer is `n` exactly, and a naive `Math.floor`
+    // would then drop the visible top tick. The lower bound is NOT
+    // tolerated downward — that would generate ticks below `min`
+    // for ranges whose endpoints are only near a step boundary.
+    const startMul = Math.ceil(this._min / niceStep);
+    const maxMul = Math.floor(this._max / niceStep + 1e-9);
+    for (let m = startMul; m <= maxMul; m++) {
+      const v = m * niceStep;
+      // Defensive bounds: floating-point multiplication may push the
+      // computed value just outside the actual [min, max] range.
+      if (v < this._min - 1e-12 || v > this._max + 1e-12) continue;
       ticks.push(v);
     }
 


### PR DESCRIPTION
## Summary

Oscillator-style indicators (QStick, CCI, ROC, etc.) render their reference value in a pane whose y-axis runs symmetrically around 0. The "0" tick was visibly overflowing the axis label area and colliding with neighbouring ticks like "0.6000" / "-0.2000".

## Root cause

`PriceScale.getTicks` was generating ticks by accumulating `v += niceStep` in a loop. Floating-point error accumulates on each step — what should be exactly 0 lands at ~1e-16. Then `autoFormatPrice` enters its smallest-magnitude branch and returns `toFixed(8)` → `"0.00000000"` (8 decimals). The label is wider than the rest, overflows the axis padding, and visually collides with the neighbouring ticks.

## Fix

`PriceScale.getTicks` now computes ticks as integer multiples of `niceStep` (`m * niceStep` for each integer `m` in the visible range), so the 0 tick lands at exactly 0.

- A small upward tolerance on the upper-bound floor (`Math.floor(max / niceStep + 1e-9)`) handles the case where the max lands exactly on a step boundary but the divided quotient lands at `n - ε` — without it the visible top tick disappears for boundary-aligned ranges like `[-1, -0.4]`.
- The lower bound stays strict (no downward tolerance) so ranges whose endpoints are merely near a step boundary don't generate ticks outside the visible range.
- Each computed tick is bounds-checked (`v < min - 1e-12 || v > max + 1e-12`) before being emitted as a final guard against multiplicative FP drift.

`autoFormatPrice` is intentionally not changed — it's reused outside axis tick formatting (crosshair, overlays, drawings, pattern labels) and a snap-to-zero shortcut would rewrite legitimate tiny values to `0` at those call sites.

## Test plan

- [x] `pnpm --filter @trendcraft/chart test` — 801/801 passing (was 797 + 3 new + 1 existing renamed)
- [x] `pnpm lint` clean
- [x] `pnpm --filter @trendcraft/chart build` clean
- 3 new tests cover:
  - 0 tick lands at exactly 0 on a symmetric `[-0.6, 0.6]` range
  - Top tick is preserved when max lands on a step boundary (`[-1, -0.4]`)
  - All emitted ticks lie within the visible `[min, max]`