### PR TITLE
feat(strategy-studio): real-data mode via Alpaca

### DIFF
--- a/packages/chart/examples/strategy-studio/.env.example
+++ b/packages/chart/examples/strategy-studio/.env.example
@@ -1,0 +1,7 @@
+# Alpaca Markets API credentials. When both are set, Strategy Studio enables
+# real-data mode (symbol search, timeframe switcher, IEX feed). Without them
+# the studio falls back to synthetic sample data.
+#
+# Get yours at https://app.alpaca.markets/signup (paper account is enough).
+ALPACA_API_KEY=
+ALPACA_API_SECRET=

--- a/packages/chart/examples/strategy-studio/README.md
+++ b/packages/chart/examples/strategy-studio/README.md
@@ -54,6 +54,25 @@ pnpm dev
 
 Visit the URL Vite prints (typically <http://localhost:5173>).
 
+## Real data (Alpaca, optional)
+
+By default Studio runs on synthetic sample data. If you have an Alpaca account, you can switch to real OHLCV with timeframe selection (1m / 5m / 15m / 1H / 1D).
+
+1. Copy `.env.example` to `.env`
+2. Fill in your `ALPACA_API_KEY` and `ALPACA_API_SECRET` (paper account is enough — get them at <https://app.alpaca.markets/signup>)
+3. Restart `pnpm dev`
+
+A `Source · Symbol · TF` toolbar appears in the header. The Symbol field autocompletes against Alpaca's full US-equity asset list — search by ticker (`SPY`) or company name (`Apple`). Without the keys, the toolbar stays hidden and Studio behaves exactly as before.
+
+**Security**: keys live only in the dev server process. The vite proxy attaches them as request headers; client bundles never see the credentials.
+
+**Notes**:
+
+- Free-tier `feed=iex`. Intraday volume coverage is lower than SIP but bar shapes are accurate.
+- Adjustment is `split` to align with TradingView's default chart behaviour.
+- Lookback per timeframe is sized so all timeframes return ~2,000–2,500 bars (enough warmup for SMA(200) / Ichimoku).
+- Per-symbol/timeframe results are cached in memory for the session; use `Reload` to bust the cache.
+
 ## Current PR2 capabilities
 
 - **Regime detection**: live `detectMarketRegime` on the loaded candles → 4-bucket classification (`trending` / `ranging` / `volatile` / `low-volatility`)

--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -3,13 +3,15 @@ import { registerTrendCraftPresets } from "@trendcraft/chart/presets";
 import { useTrendChart } from "@trendcraft/chart/react";
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { indicatorPresets, parseStrategy, validateStrategyJSON } from "trendcraft";
+import { DataSourcePanel } from "./components/DataSourcePanel";
 import { useBacktestRunner } from "./hooks/useBacktestRunner";
+import { useDataSource } from "./hooks/useDataSource";
 import { useRegime } from "./hooks/useRegime";
+import { dataSourceKey } from "./lib/data-sources";
 import { type SimulatorHandle, createLiveSimulator } from "./lib/live-simulator";
 import type { OptimizationComputation } from "./lib/optimization";
 import { PLUGIN_BY_KIND, type PluginHandle } from "./lib/plugins";
 import { clampedSeedEnd, lastEmittedIdx } from "./lib/replay";
-import { sampleCandles } from "./lib/sample-data";
 import { SIGNAL_BY_KIND } from "./lib/signals";
 import { builderReducer, initialBuilderState, strategyJSONToState } from "./lib/strategy-state";
 import { localStudioAPI } from "./lib/studio-api";
@@ -60,7 +62,14 @@ export const SPEED_MS: Record<SpeedTier, number> = {
 };
 
 export function App() {
-  const candles = sampleCandles;
+  const {
+    candles,
+    source: dataSource,
+    setSource: setDataSource,
+    reload: reloadDataSource,
+    loading: dataLoading,
+    error: dataError,
+  } = useDataSource();
   const regime = useRegime(candles);
 
   const [instances, setInstances] = useState<IndicatorInstance[]>([]);
@@ -79,6 +88,19 @@ export function App() {
   const [progress, setProgress] = useState(0);
   const replayRef = useRef(replay);
   replayRef.current = replay;
+
+  // Reset replay whenever the underlying candle series changes (different
+  // symbol / timeframe / source). A live cursorIndex against stale data
+  // would render bars from the previous series.
+  const dataKey = dataSourceKey(dataSource);
+  const lastDataKeyRef = useRef(dataKey);
+  useEffect(() => {
+    if (lastDataKeyRef.current !== dataKey) {
+      lastDataKeyRef.current = dataKey;
+      setReplay({ mode: "static" });
+      setProgress(0);
+    }
+  }, [dataKey]);
 
   const newInstance = useCallback(
     (kind: string): IndicatorInstance => ({
@@ -491,10 +513,13 @@ export function App() {
     chart?.addSignals(visibleSignalMarkers);
   }, [chart, visibleSignalMarkers]);
 
-  const headerInfo = useMemo(
-    () => `${candles.length} bars · LLM-free · regime-aware`,
-    [candles.length],
-  );
+  const headerInfo = useMemo(() => {
+    const base = `${candles.length} bars · LLM-free · regime-aware`;
+    if (dataSource.kind === "alpaca") {
+      return `${dataSource.symbol} ${dataSource.timeframe} · ${base}`;
+    }
+    return `synthetic · ${base}`;
+  }, [candles.length, dataSource]);
 
   // ---- PR3: strategy builder + backtest runner ----
   const [builderState, builderDispatch] = useReducer(
@@ -638,6 +663,13 @@ export function App() {
       <header className="studio-header">
         <span className="studio-title">TrendCraft — Strategy Studio</span>
         <span className="studio-tag">@trendcraft/chart</span>
+        <DataSourcePanel
+          source={dataSource}
+          loading={dataLoading}
+          error={dataError}
+          onChange={setDataSource}
+          onReload={reloadDataSource}
+        />
         <span style={{ marginLeft: "auto", fontSize: 11, color: "#787b86" }}>{headerInfo}</span>
       </header>
 

--- a/packages/chart/examples/strategy-studio/src/components/DataSourcePanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/components/DataSourcePanel.tsx
@@ -1,0 +1,159 @@
+import {
+  ALPACA_ENABLED,
+  DEFAULT_SYMBOL,
+  DEFAULT_TIMEFRAME,
+  type DataSource,
+  POPULAR_SYMBOLS,
+  TIMEFRAME_LABEL,
+  TIMEFRAME_ORDER,
+  type Timeframe,
+} from "../lib/data-sources";
+import { SymbolSearch } from "./SymbolSearch";
+
+interface DataSourcePanelProps {
+  source: DataSource;
+  loading: boolean;
+  error: Error | null;
+  onChange: (source: DataSource) => void;
+  onReload: () => void;
+}
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 10,
+  textTransform: "uppercase",
+  letterSpacing: 0.6,
+  color: "#787b86",
+};
+
+const buttonStyle: React.CSSProperties = {
+  padding: "3px 8px",
+  fontSize: 11,
+  background: "#1e222d",
+  border: "1px solid #2a2e39",
+  borderRadius: 3,
+  color: "#d1d4dc",
+  cursor: "pointer",
+};
+
+const activeButtonStyle: React.CSSProperties = {
+  ...buttonStyle,
+  background: "#2196f3",
+  borderColor: "#2196f3",
+  color: "#fff",
+};
+
+/**
+ * Toolbar mounted in the studio header. Renders nothing when Alpaca is
+ * disabled at the dev-server layer (no key) — synthetic data is the only
+ * option in that case and the existing UI already conveys it.
+ */
+export function DataSourcePanel({
+  source,
+  loading,
+  error,
+  onChange,
+  onReload,
+}: DataSourcePanelProps) {
+  if (!ALPACA_ENABLED) return null;
+
+  const isAlpaca = source.kind === "alpaca";
+  const currentSymbol = isAlpaca ? source.symbol : DEFAULT_SYMBOL;
+  const currentTimeframe: Timeframe = isAlpaca ? source.timeframe : DEFAULT_TIMEFRAME;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        flexWrap: "wrap",
+      }}
+      role="toolbar"
+      aria-label="Data source"
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+        <span style={labelStyle}>Source</span>
+        <button
+          type="button"
+          style={!isAlpaca ? activeButtonStyle : buttonStyle}
+          onClick={() => onChange({ kind: "synthetic" })}
+        >
+          Synthetic
+        </button>
+        <button
+          type="button"
+          style={isAlpaca ? activeButtonStyle : buttonStyle}
+          onClick={() =>
+            onChange({
+              kind: "alpaca",
+              symbol: currentSymbol,
+              timeframe: currentTimeframe,
+            })
+          }
+        >
+          Alpaca
+        </button>
+      </div>
+
+      {isAlpaca && (
+        <>
+          <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+            <span style={labelStyle}>Symbol</span>
+            <SymbolSearch
+              symbol={source.symbol}
+              onSelect={(sym) =>
+                onChange({ kind: "alpaca", symbol: sym, timeframe: currentTimeframe })
+              }
+            />
+            {POPULAR_SYMBOLS.map((sym) => (
+              <button
+                key={sym}
+                type="button"
+                style={source.symbol === sym ? activeButtonStyle : buttonStyle}
+                onClick={() =>
+                  onChange({ kind: "alpaca", symbol: sym, timeframe: currentTimeframe })
+                }
+              >
+                {sym}
+              </button>
+            ))}
+          </div>
+
+          <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+            <span style={labelStyle}>TF</span>
+            {TIMEFRAME_ORDER.map((tf) => (
+              <button
+                key={tf}
+                type="button"
+                style={currentTimeframe === tf ? activeButtonStyle : buttonStyle}
+                onClick={() => onChange({ kind: "alpaca", symbol: source.symbol, timeframe: tf })}
+              >
+                {TIMEFRAME_LABEL[tf]}
+              </button>
+            ))}
+          </div>
+
+          <button type="button" style={buttonStyle} onClick={onReload} disabled={loading}>
+            {loading ? "Loading…" : "Reload"}
+          </button>
+        </>
+      )}
+
+      {error && (
+        <span
+          style={{
+            fontSize: 11,
+            color: "#ef5350",
+            background: "#3a1a1a",
+            padding: "3px 8px",
+            borderRadius: 3,
+            border: "1px solid #ef5350",
+          }}
+          role="alert"
+        >
+          {error.message}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/components/DataSourcePanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/components/DataSourcePanel.tsx
@@ -29,7 +29,11 @@ const buttonStyle: React.CSSProperties = {
   padding: "3px 8px",
   fontSize: 11,
   background: "#1e222d",
-  border: "1px solid #2a2e39",
+  // Long-hand border properties only — mixing `border` shorthand with
+  // `borderColor` overrides triggers a React rerender warning.
+  borderWidth: 1,
+  borderStyle: "solid",
+  borderColor: "#2a2e39",
   borderRadius: 3,
   color: "#d1d4dc",
   cursor: "pointer",

--- a/packages/chart/examples/strategy-studio/src/components/SymbolSearch.tsx
+++ b/packages/chart/examples/strategy-studio/src/components/SymbolSearch.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { type AlpacaAsset, fetchAssetList, searchAssets } from "../lib/data-sources";
+
+interface SymbolSearchProps {
+  symbol: string;
+  onSelect: (symbol: string) => void;
+}
+
+const inputStyle: React.CSSProperties = {
+  width: 180,
+  padding: "3px 6px",
+  fontSize: 11,
+  background: "#0e1320",
+  border: "1px solid #2a2e39",
+  borderRadius: 3,
+  color: "#d1d4dc",
+};
+
+const dropdownStyle: React.CSSProperties = {
+  position: "absolute",
+  top: "calc(100% + 2px)",
+  left: 0,
+  width: 320,
+  maxHeight: 300,
+  overflowY: "auto",
+  background: "#1e222d",
+  border: "1px solid #2a2e39",
+  borderRadius: 3,
+  boxShadow: "0 4px 12px rgba(0,0,0,0.5)",
+  zIndex: 100,
+};
+
+const itemStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "6px 10px",
+  fontSize: 11,
+  color: "#d1d4dc",
+  cursor: "pointer",
+  borderBottom: "1px solid #2a2e39",
+};
+
+const itemHoverStyle: React.CSSProperties = {
+  ...itemStyle,
+  background: "#2a2e39",
+};
+
+/**
+ * Symbol picker with inline autocomplete. Fetches the Alpaca asset list
+ * (US equities, ~10k entries) once per session and filters locally on
+ * symbol-prefix → name-prefix → substring. Empty query shows popular
+ * tickers as quick picks.
+ */
+export function SymbolSearch({ symbol, onSelect }: SymbolSearchProps) {
+  const [assets, setAssets] = useState<AlpacaAsset[]>([]);
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+  const [loadError, setLoadError] = useState<Error | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listboxId = useId();
+
+  // Lazy-load asset list on first focus.
+  const ensureLoaded = () => {
+    if (assets.length > 0 || loadError) return;
+    fetchAssetList()
+      .then(setAssets)
+      .catch((err: unknown) => setLoadError(err instanceof Error ? err : new Error(String(err))));
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const suggestions = searchAssets(assets, query);
+
+  const commit = (sym: string) => {
+    onSelect(sym);
+    setQuery("");
+    setOpen(false);
+    inputRef.current?.blur();
+  };
+
+  return (
+    <div ref={containerRef} style={{ position: "relative" }}>
+      <input
+        ref={inputRef}
+        type="text"
+        value={open ? query : symbol}
+        placeholder="Symbol or company name…"
+        onFocus={() => {
+          setOpen(true);
+          setQuery("");
+          setHighlight(0);
+          ensureLoaded();
+        }}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setHighlight(0);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowDown") {
+            e.preventDefault();
+            setHighlight((h) => Math.min(h + 1, suggestions.length - 1));
+          } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            setHighlight((h) => Math.max(h - 1, 0));
+          } else if (e.key === "Enter") {
+            e.preventDefault();
+            const pick = suggestions[highlight];
+            if (pick) commit(pick.symbol);
+            else if (query.trim()) commit(query.trim().toUpperCase());
+          } else if (e.key === "Escape") {
+            setOpen(false);
+            inputRef.current?.blur();
+          }
+        }}
+        style={inputStyle}
+        aria-label="Symbol search"
+        aria-autocomplete="list"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+      />
+      {open && (
+        <div id={listboxId} role="listbox" tabIndex={-1} style={dropdownStyle}>
+          {loadError && (
+            <div style={{ ...itemStyle, color: "#ef5350" }}>
+              Failed to load asset list: {loadError.message}
+            </div>
+          )}
+          {!loadError && assets.length === 0 && (
+            <div style={{ ...itemStyle, color: "#787b86" }}>Loading assets…</div>
+          )}
+          {assets.length > 0 && suggestions.length === 0 && (
+            <div style={{ ...itemStyle, color: "#787b86" }}>No matches</div>
+          )}
+          {suggestions.map((s, i) => (
+            <div
+              key={s.symbol}
+              role="option"
+              tabIndex={-1}
+              aria-selected={i === highlight}
+              style={i === highlight ? itemHoverStyle : itemStyle}
+              onMouseDown={(e) => {
+                // mousedown (not click) so we beat the input's blur, which
+                // would otherwise close the dropdown before onClick fires.
+                e.preventDefault();
+                commit(s.symbol);
+              }}
+              onMouseEnter={() => setHighlight(i)}
+            >
+              <span style={{ fontWeight: 600, minWidth: 60 }}>{s.symbol}</span>
+              <span
+                style={{
+                  flex: 1,
+                  color: "#a3a6af",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {s.name}
+              </span>
+              <span style={{ fontSize: 9, color: "#787b86" }}>{s.exchange}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/hooks/useDataSource.ts
+++ b/packages/chart/examples/strategy-studio/src/hooks/useDataSource.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ALPACA_ENABLED,
+  DEFAULT_SYMBOL,
+  DEFAULT_TIMEFRAME,
+  type DataSource,
+  dataSourceKey,
+  fetchAlpacaBars,
+} from "../lib/data-sources";
+import { type StudioCandle, sampleCandles } from "../lib/sample-data";
+
+/**
+ * Initial source: Alpaca (SPY 1D) when credentials are configured, otherwise
+ * synthetic. Initial candles match the source — when Alpaca is selected we
+ * start empty (with `loading=true`) instead of flashing synthetic data
+ * before the fetch resolves.
+ */
+const INITIAL_SOURCE: DataSource = ALPACA_ENABLED
+  ? { kind: "alpaca", symbol: DEFAULT_SYMBOL, timeframe: DEFAULT_TIMEFRAME }
+  : { kind: "synthetic" };
+
+export interface UseDataSourceResult {
+  candles: StudioCandle[];
+  source: DataSource;
+  setSource: (source: DataSource) => void;
+  reload: () => void;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useDataSource(): UseDataSourceResult {
+  const [source, setSourceState] = useState<DataSource>(INITIAL_SOURCE);
+  const [candles, setCandles] = useState<StudioCandle[]>(() =>
+    INITIAL_SOURCE.kind === "synthetic" ? sampleCandles : [],
+  );
+  const [loading, setLoading] = useState<boolean>(INITIAL_SOURCE.kind === "alpaca");
+  const [error, setError] = useState<Error | null>(null);
+  // Per-(symbol, tf) candle cache. Lives for the lifetime of the studio
+  // session — reloads bypass it via `reload()`.
+  const cacheRef = useRef<Map<string, StudioCandle[]>>(new Map());
+  const reloadCounterRef = useRef(0);
+  const [reloadTick, setReloadTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (source.kind === "synthetic") {
+      setCandles(sampleCandles);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const key = dataSourceKey(source);
+    const cached = cacheRef.current.get(key);
+    if (cached && reloadTick === reloadCounterRef.current) {
+      setCandles(cached);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    fetchAlpacaBars(source.symbol, source.timeframe)
+      .then((next) => {
+        if (cancelled) return;
+        cacheRef.current.set(key, next);
+        setCandles(next);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [source, reloadTick]);
+
+  const setSource = useCallback((next: DataSource) => {
+    setSourceState(next);
+  }, []);
+
+  const reload = useCallback(() => {
+    if (source.kind === "alpaca") {
+      cacheRef.current.delete(dataSourceKey(source));
+    }
+    reloadCounterRef.current += 1;
+    setReloadTick(reloadCounterRef.current);
+  }, [source]);
+
+  return { candles, source, setSource, reload, loading, error };
+}

--- a/packages/chart/examples/strategy-studio/src/lib/data-sources/__tests__/alpaca.test.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/data-sources/__tests__/alpaca.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type AlpacaAsset, fetchAlpacaBars, searchAssets } from "../alpaca";
+import { dataSourceKey } from "../types";
+
+interface PageBars {
+  bars: { t: string; o: number; h: number; l: number; c: number; v: number }[];
+  next_page_token?: string | null;
+}
+
+function jsonResponse(body: PageBars, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Bad",
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+describe("fetchAlpacaBars", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns normalized candles for a single page", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        bars: [
+          { t: "2026-01-01T00:00:00Z", o: 100, h: 101, l: 99, c: 100.5, v: 1000 },
+          { t: "2026-01-02T00:00:00Z", o: 100.5, h: 102, l: 100, c: 101.5, v: 1500 },
+        ],
+        next_page_token: null,
+      }),
+    );
+
+    const candles = await fetchAlpacaBars("SPY", "1Day");
+    expect(candles).toHaveLength(2);
+    expect(candles[0]).toEqual({
+      time: new Date("2026-01-01T00:00:00Z").getTime(),
+      open: 100,
+      high: 101,
+      low: 99,
+      close: 100.5,
+      volume: 1000,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("paginates via next_page_token", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          bars: [{ t: "2026-01-01T00:00:00Z", o: 1, h: 1, l: 1, c: 1, v: 1 }],
+          next_page_token: "abc",
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          bars: [{ t: "2026-01-02T00:00:00Z", o: 2, h: 2, l: 2, c: 2, v: 2 }],
+          next_page_token: null,
+        }),
+      );
+
+    const candles = await fetchAlpacaBars("SPY", "1Day");
+    expect(candles).toHaveLength(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const secondCallUrl = fetchMock.mock.calls[1]?.[0] as string;
+    expect(secondCallUrl).toContain("page_token=abc");
+  });
+
+  it("encodes the symbol and includes feed=iex with split adjustment", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ bars: [], next_page_token: null }));
+    await fetchAlpacaBars("BRK.B", "1Hour");
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    expect(url).toContain("/v2/stocks/BRK.B/bars");
+    expect(url).toContain("timeframe=1Hour");
+    expect(url).toContain("feed=iex");
+    expect(url).toContain("adjustment=split");
+  });
+
+  it("throws on non-OK response with status in the message", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ bars: [] }, false, 422));
+    await expect(fetchAlpacaBars("SPY", "1Day")).rejects.toThrow(/422/);
+  });
+
+  it("handles missing bars array as empty", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ bars: [], next_page_token: null }));
+    const candles = await fetchAlpacaBars("SPY", "5Min");
+    expect(candles).toEqual([]);
+  });
+});
+
+describe("dataSourceKey", () => {
+  it("returns 'synthetic' for synthetic source", () => {
+    expect(dataSourceKey({ kind: "synthetic" })).toBe("synthetic");
+  });
+
+  it("includes symbol and timeframe for alpaca source", () => {
+    expect(dataSourceKey({ kind: "alpaca", symbol: "SPY", timeframe: "1Day" })).toBe(
+      "alpaca:SPY:1Day",
+    );
+    expect(dataSourceKey({ kind: "alpaca", symbol: "QQQ", timeframe: "5Min" })).toBe(
+      "alpaca:QQQ:5Min",
+    );
+  });
+});
+
+describe("searchAssets", () => {
+  const assets: AlpacaAsset[] = [
+    { symbol: "AAPL", name: "Apple Inc Common Stock", exchange: "NASDAQ" },
+    { symbol: "MSFT", name: "Microsoft Corporation Common Stock", exchange: "NASDAQ" },
+    { symbol: "SPY", name: "SPDR S&P 500 ETF Trust", exchange: "ARCA" },
+    { symbol: "QQQ", name: "Invesco QQQ Trust", exchange: "NASDAQ" },
+    { symbol: "NVDA", name: "NVIDIA Corp", exchange: "NASDAQ" },
+    { symbol: "GOOGL", name: "Alphabet Inc Class A", exchange: "NASDAQ" },
+    { symbol: "TSLA", name: "Tesla Inc Common Stock", exchange: "NASDAQ" },
+  ];
+
+  it("returns popular symbols when query is empty", () => {
+    const result = searchAssets(assets, "");
+    expect(result.map((a) => a.symbol)).toEqual(["SPY", "QQQ", "AAPL", "NVDA", "MSFT"]);
+  });
+
+  it("matches by symbol prefix with priority", () => {
+    const result = searchAssets(assets, "AA");
+    expect(result[0]?.symbol).toBe("AAPL");
+  });
+
+  it("matches by company name", () => {
+    const result = searchAssets(assets, "tesla");
+    expect(result.map((a) => a.symbol)).toContain("TSLA");
+  });
+
+  it("matches by name prefix even when symbol does not start with query", () => {
+    const result = searchAssets(assets, "alphabet");
+    expect(result[0]?.symbol).toBe("GOOGL");
+  });
+
+  it("ranks symbol prefix above name prefix", () => {
+    const result = searchAssets(assets, "S");
+    // "SPY" starts with S (symbol prefix) — should appear before any
+    // pure-name-prefix-only matches.
+    expect(result[0]?.symbol).toBe("SPY");
+  });
+
+  it("is case insensitive", () => {
+    const lower = searchAssets(assets, "apple");
+    const upper = searchAssets(assets, "APPLE");
+    expect(lower.map((a) => a.symbol)).toEqual(upper.map((a) => a.symbol));
+  });
+
+  it("respects the limit option", () => {
+    const result = searchAssets(assets, "", { limit: 2 });
+    expect(result).toHaveLength(2);
+  });
+
+  it("returns no matches as empty array", () => {
+    const result = searchAssets(assets, "ZZZNOMATCH");
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/chart/examples/strategy-studio/src/lib/data-sources/alpaca.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/data-sources/alpaca.ts
@@ -1,0 +1,178 @@
+import type { StudioCandle } from "../sample-data";
+import { TIMEFRAME_LOOKBACK_DAYS, type Timeframe } from "./types";
+
+interface AlpacaBar {
+  t: string;
+  o: number;
+  h: number;
+  l: number;
+  c: number;
+  v: number;
+}
+
+interface AlpacaBarsResponse {
+  bars?: AlpacaBar[];
+  next_page_token?: string | null;
+}
+
+export interface AlpacaAsset {
+  symbol: string;
+  name: string;
+  exchange: string;
+}
+
+interface AlpacaAssetRaw {
+  symbol: string;
+  name: string;
+  exchange: string;
+  tradable: boolean;
+}
+
+/**
+ * Whether the dev server has Alpaca credentials configured. When `false`,
+ * studio uses synthetic data only. The flag is injected by `vite.config.ts`
+ * via `define`; the actual API keys never reach client code.
+ */
+export const ALPACA_ENABLED: boolean = import.meta.env.VITE_ALPACA_ENABLED === "true";
+
+/** Default symbols offered as quick-pick buttons in DataSourcePanel. */
+export const POPULAR_SYMBOLS = ["SPY", "QQQ", "AAPL", "NVDA", "MSFT"];
+
+export const DEFAULT_SYMBOL = "SPY";
+export const DEFAULT_TIMEFRAME: Timeframe = "1Day";
+
+/**
+ * Fetch historical bars for a given symbol/timeframe via the dev-server proxy.
+ * Pagination is handled internally; returns a chronologically ordered array
+ * of `StudioCandle`. Adjustment is `split` to align with TradingView's default
+ * chart behaviour for sanity comparisons.
+ */
+export async function fetchAlpacaBars(
+  symbol: string,
+  timeframe: Timeframe,
+): Promise<StudioCandle[]> {
+  const lookbackDays = TIMEFRAME_LOOKBACK_DAYS[timeframe];
+  const start = new Date();
+  start.setUTCDate(start.getUTCDate() - lookbackDays);
+  const startStr = start.toISOString();
+
+  const out: StudioCandle[] = [];
+  let pageToken: string | null = null;
+
+  do {
+    const params = new URLSearchParams({
+      timeframe,
+      start: startStr,
+      limit: "10000",
+      feed: "iex",
+      adjustment: "split",
+    });
+    if (pageToken) params.set("page_token", pageToken);
+
+    const url = `/api/alpaca/data/v2/stocks/${encodeURIComponent(symbol)}/bars?${params}`;
+    const res = await fetch(url);
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`Alpaca API ${res.status}: ${text || res.statusText}`);
+    }
+
+    const data = (await res.json()) as AlpacaBarsResponse;
+    const bars = data.bars ?? [];
+
+    for (const bar of bars) {
+      out.push({
+        time: new Date(bar.t).getTime(),
+        open: bar.o,
+        high: bar.h,
+        low: bar.l,
+        close: bar.c,
+        volume: bar.v,
+      });
+    }
+
+    pageToken = data.next_page_token ?? null;
+  } while (pageToken);
+
+  return out;
+}
+
+// ── Asset list (lazy, session-cached) ──────────────────────────────────────
+
+let assetCache: AlpacaAsset[] | null = null;
+let assetFetchPromise: Promise<AlpacaAsset[]> | null = null;
+
+/**
+ * Fetch the full list of tradable US equities from Alpaca's trading API.
+ * Cached for the lifetime of the page — concurrent callers share a single
+ * in-flight request. Returns symbol + company name + exchange for each
+ * entry, enabling search by either symbol or name.
+ */
+export async function fetchAssetList(): Promise<AlpacaAsset[]> {
+  if (assetCache) return assetCache;
+  if (assetFetchPromise) return assetFetchPromise;
+
+  assetFetchPromise = (async () => {
+    const res = await fetch("/api/alpaca/trading/v2/assets?status=active&asset_class=us_equity");
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`Alpaca asset list ${res.status}: ${text || res.statusText}`);
+    }
+    const raw = (await res.json()) as AlpacaAssetRaw[];
+    assetCache = raw
+      .filter((a) => a.tradable)
+      .map((a) => ({ symbol: a.symbol, name: a.name, exchange: a.exchange }));
+    return assetCache;
+  })();
+
+  try {
+    return await assetFetchPromise;
+  } catch (err) {
+    assetFetchPromise = null;
+    throw err;
+  }
+}
+
+export interface SearchOptions {
+  /** Maximum suggestions to return. */
+  limit?: number;
+}
+
+/**
+ * Filter and rank assets by a query string. Matches against symbol prefix
+ * (highest priority), name prefix, then symbol/name substring. Empty query
+ * returns the popular symbols list resolved against the asset cache.
+ */
+export function searchAssets(
+  assets: AlpacaAsset[],
+  query: string,
+  { limit = 20 }: SearchOptions = {},
+): AlpacaAsset[] {
+  const q = query.trim().toUpperCase();
+  if (!q) {
+    const map = new Map(assets.map((a) => [a.symbol, a]));
+    const out: AlpacaAsset[] = [];
+    for (const sym of POPULAR_SYMBOLS) {
+      const hit = map.get(sym);
+      if (hit) out.push(hit);
+    }
+    return out.slice(0, limit);
+  }
+
+  const symbolPrefix: AlpacaAsset[] = [];
+  const namePrefix: AlpacaAsset[] = [];
+  const symbolSubstr: AlpacaAsset[] = [];
+  const nameSubstr: AlpacaAsset[] = [];
+
+  for (const asset of assets) {
+    const sym = asset.symbol.toUpperCase();
+    const name = asset.name.toUpperCase();
+    if (sym.startsWith(q)) symbolPrefix.push(asset);
+    else if (name.startsWith(q)) namePrefix.push(asset);
+    else if (sym.includes(q)) symbolSubstr.push(asset);
+    else if (name.includes(q)) nameSubstr.push(asset);
+    if (symbolPrefix.length + namePrefix.length >= limit * 2) break;
+  }
+
+  return [...symbolPrefix, ...namePrefix, ...symbolSubstr, ...nameSubstr].slice(0, limit);
+}

--- a/packages/chart/examples/strategy-studio/src/lib/data-sources/index.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/data-sources/index.ts
@@ -1,0 +1,19 @@
+export {
+  ALPACA_ENABLED,
+  DEFAULT_SYMBOL,
+  DEFAULT_TIMEFRAME,
+  POPULAR_SYMBOLS,
+  fetchAlpacaBars,
+  fetchAssetList,
+  searchAssets,
+  type AlpacaAsset,
+} from "./alpaca";
+export {
+  TIMEFRAME_LABEL,
+  TIMEFRAME_LOOKBACK_DAYS,
+  TIMEFRAME_ORDER,
+  dataSourceKey,
+  type DataSource,
+  type LoadResult,
+  type Timeframe,
+} from "./types";

--- a/packages/chart/examples/strategy-studio/src/lib/data-sources/types.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/data-sources/types.ts
@@ -1,0 +1,40 @@
+import type { StudioCandle } from "../sample-data";
+
+export type Timeframe = "1Min" | "5Min" | "15Min" | "1Hour" | "1Day";
+
+export type DataSource =
+  | { kind: "synthetic" }
+  | { kind: "alpaca"; symbol: string; timeframe: Timeframe };
+
+export type LoadResult = {
+  candles: StudioCandle[];
+  source: DataSource;
+};
+
+export const TIMEFRAME_ORDER: Timeframe[] = ["1Min", "5Min", "15Min", "1Hour", "1Day"];
+
+export const TIMEFRAME_LABEL: Record<Timeframe, string> = {
+  "1Min": "1m",
+  "5Min": "5m",
+  "15Min": "15m",
+  "1Hour": "1H",
+  "1Day": "1D",
+};
+
+/**
+ * Lookback window per timeframe, sized to land near ~2,000-2,500 bars so that
+ * indicators with long warm-up (SMA(200), Ichimoku, etc.) have enough history
+ * regardless of which timeframe the user picks.
+ */
+export const TIMEFRAME_LOOKBACK_DAYS: Record<Timeframe, number> = {
+  "1Min": 5,
+  "5Min": 30,
+  "15Min": 90,
+  "1Hour": 365,
+  "1Day": 3650,
+};
+
+export function dataSourceKey(source: DataSource): string {
+  if (source.kind === "synthetic") return "synthetic";
+  return `alpaca:${source.symbol}:${source.timeframe}`;
+}

--- a/packages/chart/examples/strategy-studio/tsconfig.json
+++ b/packages/chart/examples/strategy-studio/tsconfig.json
@@ -19,5 +19,5 @@
       "trendcraft/manifest": ["../../../core/src/manifest/index.ts"]
     }
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "vite-env.d.ts"]
 }

--- a/packages/chart/examples/strategy-studio/vite-env.d.ts
+++ b/packages/chart/examples/strategy-studio/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_ALPACA_ENABLED: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/packages/chart/examples/strategy-studio/vite.config.ts
+++ b/packages/chart/examples/strategy-studio/vite.config.ts
@@ -1,42 +1,77 @@
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const useDist = process.env.USE_DIST === "1";
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    // Order matters: longer / more specific keys must come first so
-    // `@trendcraft/chart/react/sparkline` doesn't get re-mapped through the
-    // generic `@trendcraft/chart/react` alias before its own entry runs.
-    alias: [
-      {
-        find: "@trendcraft/chart/react/sparkline",
-        replacement: resolve(__dirname, useDist ? "../../dist/react/sparkline.js" : "../../react/sparkline.tsx"),
-      },
-      {
-        find: "@trendcraft/chart/react",
-        replacement: resolve(__dirname, useDist ? "../../dist/react/TrendChart.js" : "../../react/TrendChart.tsx"),
-      },
-      {
-        find: "@trendcraft/chart/presets",
-        replacement: resolve(__dirname, useDist ? "../../dist/presets.js" : "../../src/presets.ts"),
-      },
-      {
-        find: "@trendcraft/chart",
-        replacement: resolve(__dirname, useDist ? "../../dist/index.js" : "../../src/index.ts"),
-      },
-      {
-        find: "trendcraft/manifest",
-        replacement: resolve(__dirname, useDist ? "../../../core/dist/manifest/index.js" : "../../../core/src/manifest/index.ts"),
-      },
-      {
-        find: "trendcraft",
-        replacement: resolve(__dirname, useDist ? "../../../core/dist/index.js" : "../../../core/src/index.ts"),
-      },
-    ],
-  },
+export default defineConfig(({ mode }) => {
+  // ALPACA_ env vars stay in the dev server process; the proxy below injects
+  // them as request headers so browser bundles never see the keys.
+  const env = loadEnv(mode, process.cwd(), "ALPACA_");
+  const hasAlpaca = !!(env.ALPACA_API_KEY && env.ALPACA_API_SECRET);
+
+  const authHeaders = hasAlpaca
+    ? {
+        "APCA-API-KEY-ID": env.ALPACA_API_KEY,
+        "APCA-API-SECRET-KEY": env.ALPACA_API_SECRET,
+      }
+    : {};
+
+  return {
+    plugins: [react()],
+    define: {
+      "import.meta.env.VITE_ALPACA_ENABLED": JSON.stringify(hasAlpaca ? "true" : ""),
+    },
+    server: {
+      proxy: hasAlpaca
+        ? {
+            "/api/alpaca/data": {
+              target: "https://data.alpaca.markets",
+              changeOrigin: true,
+              rewrite: (path) => path.replace(/^\/api\/alpaca\/data/, ""),
+              headers: authHeaders,
+            },
+            "/api/alpaca/trading": {
+              target: "https://paper-api.alpaca.markets",
+              changeOrigin: true,
+              rewrite: (path) => path.replace(/^\/api\/alpaca\/trading/, ""),
+              headers: authHeaders,
+            },
+          }
+        : {},
+    },
+    resolve: {
+      // Order matters: longer / more specific keys must come first so
+      // `@trendcraft/chart/react/sparkline` doesn't get re-mapped through the
+      // generic `@trendcraft/chart/react` alias before its own entry runs.
+      alias: [
+        {
+          find: "@trendcraft/chart/react/sparkline",
+          replacement: resolve(__dirname, useDist ? "../../dist/react/sparkline.js" : "../../react/sparkline.tsx"),
+        },
+        {
+          find: "@trendcraft/chart/react",
+          replacement: resolve(__dirname, useDist ? "../../dist/react/TrendChart.js" : "../../react/TrendChart.tsx"),
+        },
+        {
+          find: "@trendcraft/chart/presets",
+          replacement: resolve(__dirname, useDist ? "../../dist/presets.js" : "../../src/presets.ts"),
+        },
+        {
+          find: "@trendcraft/chart",
+          replacement: resolve(__dirname, useDist ? "../../dist/index.js" : "../../src/index.ts"),
+        },
+        {
+          find: "trendcraft/manifest",
+          replacement: resolve(__dirname, useDist ? "../../../core/dist/manifest/index.js" : "../../../core/src/manifest/index.ts"),
+        },
+        {
+          find: "trendcraft",
+          replacement: resolve(__dirname, useDist ? "../../../core/dist/index.js" : "../../../core/src/index.ts"),
+        },
+      ],
+    },
+  };
 });


### PR DESCRIPTION
## Summary

Adds an opt-in real-data mode to Strategy Studio. When `ALPACA_API_KEY` and `ALPACA_API_SECRET` are set in `.env`, the studio switches its underlying candle stream from synthetic sample data to real Alpaca bars. Without the keys, Studio behaves exactly as before — the new toolbar stays hidden.

## What changes when enabled

- **Source toggle**: Synthetic ↔ Alpaca
- **Timeframe selector**: 1m / 5m / 15m / 1H / 1D. Per-TF lookback is sized so all timeframes return ~2,000–2,500 bars (enough warmup for SMA(200) / Ichimoku regardless of TF)
- **Symbol search**: autocomplete against Alpaca's full US-equity asset list. Search by ticker (`SPY`) or company name (`Apple`). Keyboard navigation (↑/↓/Enter/Esc)
- **Popular quick-picks**: SPY / QQQ / AAPL / NVDA / MSFT buttons alongside the search
- **Reload**: bypasses the in-memory per-(symbol, TF) cache
- **Replay reset**: switching symbol/timeframe resets replay state to avoid a stale cursor on a different series

## Security

Credentials live only in the dev server process. The vite proxy attaches them as request headers; the client bundle and browser DevTools see only `/api/alpaca/...` URLs, never the keys.

## Notes

- Free-tier `feed=iex`. Adjustment is `split` to align with TradingView's default chart behaviour for sanity comparison.
- Initial render with Alpaca enabled is empty + `Loading…` so users don't see a synthetic flash before the first fetch resolves.
- `PortfolioPanel` continues to use its existing 3-symbol synthetic dataset (out of scope; multi-symbol Alpaca can be a follow-on PR).

## Files

- New: `data-sources/` lib (`types.ts`, `alpaca.ts`, `index.ts`), `useDataSource` hook, `DataSourcePanel`, `SymbolSearch`, `vite-env.d.ts`, `.env.example`
- Modified: `vite.config.ts` (proxy + `loadEnv`), `App.tsx` (sampleCandles → useDataSource), `tsconfig.json` (include vite-env.d.ts), `README.md`

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm build` green for all packages + studio individually
- [x] `pnpm test` — studio 95/95 (8 new searchAssets tests + 7 fetchAlpacaBars/dataSourceKey tests), core 5043/5043, chart 811/811, mcp 74/74
- [x] Manual: run `pnpm dev` without `.env` → toolbar hidden, synthetic data displayed (existing behaviour preserved)
- [x] Manual: run `pnpm dev` with valid Alpaca keys → toolbar appears, SPY 1Day loads on startup
- [x] Manual: switch symbol via search ("apple" → AAPL), via popular button (NVDA), via timeframe buttons
- [x] Manual: Reload bypasses cache; error displayed inline on bad symbol