### PR TITLE
chore(strategy-studio): polish epic — anchor mode, indicator search, real portfolio, etc.

### DIFF
--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -3,6 +3,7 @@ import { registerTrendCraftPresets } from "@trendcraft/chart/presets";
 import { useTrendChart } from "@trendcraft/chart/react";
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { indicatorPresets, parseStrategy, validateStrategyJSON } from "trendcraft";
+import { ChartToolbar } from "./components/ChartToolbar";
 import { DataSourcePanel } from "./components/DataSourcePanel";
 import { useBacktestRunner } from "./hooks/useBacktestRunner";
 import { useDataSource } from "./hooks/useDataSource";
@@ -69,6 +70,7 @@ export function App() {
     reload: reloadDataSource,
     loading: dataLoading,
     error: dataError,
+    reloadTick: dataReloadTick,
   } = useDataSource();
   const regime = useRegime(candles);
 
@@ -88,6 +90,24 @@ export function App() {
   const [progress, setProgress] = useState(0);
   const replayRef = useRef(replay);
   replayRef.current = replay;
+
+  // Anchor mode — when on, the next chart click starts Replay at that bar.
+  // Shift+click is also recognized as anchor (regardless of mode). Driven via
+  // a ref so the chart click handler reads it without re-binding on every
+  // toggle.
+  const [anchorMode, setAnchorMode] = useState(false);
+  const anchorModeRef = useRef(anchorMode);
+  anchorModeRef.current = anchorMode;
+  const toggleAnchor = useCallback(() => setAnchorMode((v) => !v), []);
+  // Esc cancels anchor mode.
+  useEffect(() => {
+    if (!anchorMode) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setAnchorMode(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [anchorMode]);
 
   // Reset replay whenever the underlying candle series changes (different
   // symbol / timeframe / source). A live cursorIndex against stale data
@@ -409,22 +429,27 @@ export function App() {
       if (instId) setInstances((prev) => prev.filter((i) => i.id !== instId));
     };
     const onClick = (data: unknown) => {
-      const payload = data as { index: number | null } | null;
+      const payload = data as { index: number | null; shiftKey?: boolean } | null;
       if (payload?.index == null) return;
-      // Static-mode click anchors Replay at the clicked bar (TradingView's
-      // signature UX). Live-mode clicks are ignored — re-anchoring mid-replay
-      // would surprise the user; use Exit ✕ first.
+      // A click anchors Replay only when the user has explicitly opted in:
+      // either by arming anchor-mode via the toolbar button, or by holding
+      // Shift while clicking. Plain clicks do nothing so users can interact
+      // with the chart without accidentally entering Replay. Live-mode
+      // clicks are ignored — re-anchoring mid-replay would surprise the
+      // user; use Exit ✕ first.
       // `cursorIndex` becomes seedEnd downstream and the seed is
       // `candles[0..seedEnd-1]`, so add 1 to include the clicked candle in
       // the snapshot rather than treating it as the first queued bar.
-      if (replayRef.current.mode === "static") {
-        setReplay({
-          mode: "live",
-          cursorIndex: payload.index + 1,
-          status: "idle",
-          speed: "1x",
-        });
-      }
+      const wantAnchor = anchorModeRef.current || payload.shiftKey === true;
+      if (!wantAnchor) return;
+      if (replayRef.current.mode !== "static") return;
+      setReplay({
+        mode: "live",
+        cursorIndex: payload.index + 1,
+        status: "idle",
+        speed: "1x",
+      });
+      setAnchorMode(false);
     };
     chart.on("seriesEditRequest", onEdit);
     chart.on("seriesRemoveRequest", onRemove);
@@ -695,10 +720,13 @@ export function App() {
       </aside>
 
       <main className="pane center">
+        <ChartToolbar chart={chart} />
         <ReplayControls
           replay={replay}
           progress={progress}
           cursorTime={cursorCandle?.time ?? null}
+          anchorMode={anchorMode}
+          onToggleAnchor={toggleAnchor}
           onPlay={replayPlay}
           onPause={replayPause}
           onStep={replayStep}
@@ -733,8 +761,11 @@ export function App() {
         <PortfolioPanel
           strategy={runner.state.lastResult?.json}
           lastResult={runner.state.lastResult?.result}
-          sliceLength={backtestCandles.length}
+          sliceStartTime={backtestCandles[0]?.time ?? null}
+          sliceEndTime={backtestCandles[backtestCandles.length - 1]?.time ?? null}
           isReplayPlaying={replay.mode === "live" && replay.status === "playing"}
+          dataSource={dataSource}
+          reloadTick={dataReloadTick}
         />
         <div className="pane-divider" />
         <ScoringPanel

--- a/packages/chart/examples/strategy-studio/src/components/ChartToolbar.tsx
+++ b/packages/chart/examples/strategy-studio/src/components/ChartToolbar.tsx
@@ -1,0 +1,136 @@
+import type { ChartInstance, ChartType, DrawingType } from "@trendcraft/chart";
+import { useEffect, useState } from "react";
+
+interface ChartToolbarProps {
+  chart: ChartInstance | null;
+}
+
+const CHART_TYPES: ReadonlyArray<{ id: ChartType; label: string }> = [
+  { id: "candlestick", label: "Candle" },
+  { id: "line", label: "Line" },
+  { id: "mountain", label: "Mountain" },
+  { id: "ohlc", label: "OHLC" },
+];
+
+const DRAWING_TOOLS: ReadonlyArray<{ id: DrawingType; label: string; title: string }> = [
+  { id: "hline", label: "H-Line", title: "Horizontal line" },
+  { id: "vline", label: "V-Line", title: "Vertical line" },
+  { id: "ray", label: "Trend", title: "Trend line / ray" },
+  { id: "arrow", label: "Arrow", title: "Arrow" },
+  { id: "rectangle", label: "Rect", title: "Rectangle" },
+  { id: "channel", label: "Channel", title: "Parallel channel" },
+  { id: "fibRetracement", label: "Fib", title: "Fibonacci retracement" },
+  { id: "fibExtension", label: "Fib+", title: "Fibonacci extension" },
+  { id: "textLabel", label: "Text", title: "Text label" },
+];
+
+/**
+ * Toolbar pinned above the chart. Exposes the chart-type switcher, drawing
+ * tools, and Fit content — the controls a user expects from a "complete"
+ * chart demo. Studio is the flagship example, so feature parity with
+ * simple-chart's drawing affordances and indicator-showcase's chart-type
+ * cycle is intentional here.
+ */
+export function ChartToolbar({ chart }: ChartToolbarProps) {
+  const [chartType, setChartType] = useState<ChartType>("candlestick");
+  const [activeTool, setActiveTool] = useState<DrawingType | null>(null);
+
+  // Sync chart type. Kept separate from the drawing-tool sync so changing
+  // the chart type mid-drawing doesn't cascade through `setDrawingTool` and
+  // clear the in-progress anchor of a two-click drawing.
+  useEffect(() => {
+    if (!chart) return;
+    chart.setChartType(chartType);
+  }, [chart, chartType]);
+
+  // Sync the active drawing tool only when it actually changes. Calling
+  // `setDrawingTool` with the same value would still reset the in-progress
+  // gesture (by design — see DrawingTool.setTool), so we must avoid firing
+  // it for unrelated state changes (chart type, theme, etc.).
+  useEffect(() => {
+    if (!chart) return;
+    chart.setDrawingTool(activeTool);
+  }, [chart, activeTool]);
+
+  // Mirror DrawingTool state changes (drawing completion, Escape hotkey,
+  // any other path that clears or re-arms the tool) so the highlighted
+  // button always matches the chart's actual active tool. Without this,
+  // pressing Escape mid-drawing leaves the toolbar stuck and a follow-up
+  // click would deactivate instead of re-arm.
+  useEffect(() => {
+    if (!chart) return;
+    const onChange = (data: unknown) => {
+      const next = (data as { tool: DrawingType | null } | null)?.tool ?? null;
+      setActiveTool(next);
+    };
+    chart.on("drawingToolChanged", onChange);
+    return () => chart.off("drawingToolChanged", onChange);
+  }, [chart]);
+
+  const onChartType = (id: ChartType) => {
+    setChartType(id);
+  };
+
+  const onDrawingTool = (id: DrawingType) => {
+    setActiveTool((prev) => (prev === id ? null : id));
+  };
+
+  const onClearDrawings = () => {
+    setActiveTool(null);
+    if (!chart) return;
+    for (const d of chart.getDrawings()) chart.removeDrawing(d.id);
+  };
+
+  return (
+    <div className="chart-toolbar" role="toolbar" aria-label="Chart controls">
+      <div className="chart-toolbar-group" aria-label="Chart type">
+        {CHART_TYPES.map((t) => (
+          <button
+            type="button"
+            key={t.id}
+            className={`chart-toolbar-btn${chartType === t.id ? " active" : ""}`}
+            onClick={() => onChartType(t.id)}
+            title={`Chart type: ${t.label}`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      <span className="chart-toolbar-sep" aria-hidden="true" />
+
+      <div className="chart-toolbar-group" aria-label="Drawing tools">
+        {DRAWING_TOOLS.map((t) => (
+          <button
+            type="button"
+            key={t.id}
+            className={`chart-toolbar-btn${activeTool === t.id ? " active" : ""}`}
+            onClick={() => onDrawingTool(t.id)}
+            title={`${t.title} — click chart to place`}
+          >
+            {t.label}
+          </button>
+        ))}
+        <button
+          type="button"
+          className="chart-toolbar-btn"
+          onClick={onClearDrawings}
+          title="Clear all drawings"
+        >
+          Clear
+        </button>
+      </div>
+
+      <span className="chart-toolbar-sep" aria-hidden="true" />
+
+      <button
+        type="button"
+        className="chart-toolbar-btn"
+        onClick={() => chart?.fitContent()}
+        title="Fit visible range to data"
+      >
+        Fit
+      </button>
+    </div>
+  );
+}

--- a/packages/chart/examples/strategy-studio/src/hooks/useDataSource.ts
+++ b/packages/chart/examples/strategy-studio/src/hooks/useDataSource.ts
@@ -26,6 +26,12 @@ export interface UseDataSourceResult {
   reload: () => void;
   loading: boolean;
   error: Error | null;
+  /**
+   * Monotonic counter incremented every time `reload()` fires. Other hooks
+   * that own independent fetches (e.g. PortfolioPanel's symbol set) should
+   * key on this so they refresh in lockstep with the main candle stream.
+   */
+  reloadTick: number;
 }
 
 export function useDataSource(): UseDataSourceResult {
@@ -92,5 +98,5 @@ export function useDataSource(): UseDataSourceResult {
     setReloadTick(reloadCounterRef.current);
   }, [source]);
 
-  return { candles, source, setSource, reload, loading, error };
+  return { candles, source, setSource, reload, loading, error, reloadTick };
 }

--- a/packages/chart/examples/strategy-studio/src/hooks/usePortfolioSymbols.ts
+++ b/packages/chart/examples/strategy-studio/src/hooks/usePortfolioSymbols.ts
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  type DataSource,
+  PORTFOLIO_SYMBOLS,
+  type Timeframe,
+  fetchAlpacaBars,
+} from "../lib/data-sources";
+import { type SampleSymbol, sampleSymbols } from "../lib/sample-data";
+
+export interface UsePortfolioSymbolsResult {
+  symbols: SampleSymbol[];
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Returns the symbol set PortfolioPanel renders. Mirrors `useDataSource`'s
+ * lifecycle for consistency: synthetic mode returns the bundled three
+ * (BASE / STEADY / VOLAT); Alpaca mode fetches PORTFOLIO_SYMBOLS in parallel
+ * at the active timeframe and caches per timeframe in memory for the
+ * session.
+ *
+ * `reloadTick` is the counter exposed by `useDataSource` — incrementing it
+ * (e.g. when the user clicks the toolbar Reload button) busts this hook's
+ * timeframe cache so the portfolio backtest stays aligned with the main
+ * chart's freshly-fetched bars.
+ */
+export function usePortfolioSymbols(source: DataSource, reloadTick = 0): UsePortfolioSymbolsResult {
+  const isAlpaca = source.kind === "alpaca";
+  const [symbols, setSymbols] = useState<SampleSymbol[]>(() => (isAlpaca ? [] : sampleSymbols));
+  const [loading, setLoading] = useState<boolean>(isAlpaca);
+  const [error, setError] = useState<Error | null>(null);
+  const cacheRef = useRef<Map<Timeframe, SampleSymbol[]>>(new Map());
+  const lastReloadTickRef = useRef(reloadTick);
+
+  useEffect(() => {
+    if (source.kind !== "alpaca") {
+      setSymbols(sampleSymbols);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    if (lastReloadTickRef.current !== reloadTick) {
+      lastReloadTickRef.current = reloadTick;
+      cacheRef.current.clear();
+    }
+
+    const tf = source.timeframe;
+    const cached = cacheRef.current.get(tf);
+    if (cached) {
+      setSymbols(cached);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    Promise.all(
+      PORTFOLIO_SYMBOLS.map(async (p) => ({
+        symbol: p.symbol,
+        label: p.label,
+        candles: await fetchAlpacaBars(p.symbol, tf),
+      })),
+    )
+      .then((next) => {
+        if (cancelled) return;
+        cacheRef.current.set(tf, next);
+        setSymbols(next);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [source, reloadTick]);
+
+  return { symbols, loading, error };
+}

--- a/packages/chart/examples/strategy-studio/src/lib/data-sources/alpaca.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/data-sources/alpaca.ts
@@ -42,6 +42,17 @@ export const DEFAULT_SYMBOL = "SPY";
 export const DEFAULT_TIMEFRAME: Timeframe = "1Day";
 
 /**
+ * Symbols used by PortfolioPanel when Alpaca is enabled — picked to span the
+ * volatility / cap-size spectrum so the BASE / STEADY / VOLAT semantics still
+ * read clearly with real data.
+ */
+export const PORTFOLIO_SYMBOLS: ReadonlyArray<{ symbol: string; label: string }> = [
+  { symbol: "SPY", label: "SPDR S&P 500 ETF" },
+  { symbol: "AAPL", label: "Apple Inc." },
+  { symbol: "NVDA", label: "NVIDIA Corp" },
+];
+
+/**
  * Fetch historical bars for a given symbol/timeframe via the dev-server proxy.
  * Pagination is handled internally; returns a chronologically ordered array
  * of `StudioCandle`. Adjustment is `split` to align with TradingView's default

--- a/packages/chart/examples/strategy-studio/src/lib/data-sources/index.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/data-sources/index.ts
@@ -3,6 +3,7 @@ export {
   DEFAULT_SYMBOL,
   DEFAULT_TIMEFRAME,
   POPULAR_SYMBOLS,
+  PORTFOLIO_SYMBOLS,
   fetchAlpacaBars,
   fetchAssetList,
   searchAssets,

--- a/packages/chart/examples/strategy-studio/src/panels/OptimizationPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/OptimizationPanel.tsx
@@ -293,37 +293,39 @@ function ResultBody({
         constraints · best {result.metric}:{" "}
         {result.result.bestScore !== null ? result.result.bestScore.toFixed(2) : "—"}
       </div>
-      <table className="optimization-result-table">
-        <thead>
-          <tr>
-            <th>#</th>
-            {tunables.map((t) => (
-              // Prefix the bucket so a strategy with the same param name on
-              // both legs (goldenCross.shortPeriod / deadCross.shortPeriod)
-              // doesn't collapse to two indistinguishable columns.
-              <th key={t.key} className="num">
-                {t.bucket === "entry" ? "in" : "out"}.{t.paramName}
-              </th>
-            ))}
-            <th className="num">Score</th>
-            <th className="num">Trades</th>
-          </tr>
-        </thead>
-        <tbody>
-          {top.map((entry, i) => (
-            <tr key={`${i}-${entry.score}`} className={i === 0 ? "optimization-best" : undefined}>
-              <td>{i + 1}</td>
+      <div className="optimization-result-scroll">
+        <table className="optimization-result-table">
+          <thead>
+            <tr>
+              <th>#</th>
               {tunables.map((t) => (
-                <td key={t.key} className="num">
-                  {entry.params[t.key] ?? "—"}
-                </td>
+                // Prefix the bucket so a strategy with the same param name on
+                // both legs (goldenCross.shortPeriod / deadCross.shortPeriod)
+                // doesn't collapse to two indistinguishable columns.
+                <th key={t.key} className="num">
+                  {t.bucket === "entry" ? "in" : "out"}.{t.paramName}
+                </th>
               ))}
-              <td className="num">{entry.score.toFixed(2)}</td>
-              <td className="num">{entry.backtest.trades.length}</td>
+              <th className="num">Score</th>
+              <th className="num">Trades</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {top.map((entry, i) => (
+              <tr key={`${i}-${entry.score}`} className={i === 0 ? "optimization-best" : undefined}>
+                <td>{i + 1}</td>
+                {tunables.map((t) => (
+                  <td key={t.key} className="num">
+                    {entry.params[t.key] ?? "—"}
+                  </td>
+                ))}
+                <td className="num">{entry.score.toFixed(2)}</td>
+                <td className="num">{entry.backtest.trades.length}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </>
   );
 }

--- a/packages/chart/examples/strategy-studio/src/panels/PortfolioPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/PortfolioPanel.tsx
@@ -2,6 +2,8 @@ import { Sparkline, SparklineList } from "@trendcraft/chart/react/sparkline";
 import { useEffect, useMemo, useState } from "react";
 import type { BacktestResult, StrategyJSON } from "trendcraft";
 import { NumInput } from "../components/NumInput";
+import { usePortfolioSymbols } from "../hooks/usePortfolioSymbols";
+import type { DataSource } from "../lib/data-sources";
 import { overridesFromResult } from "../lib/meta-strategy";
 import {
   type AllocationMode,
@@ -10,7 +12,6 @@ import {
   runPortfolio,
   symbolEquityCurve,
 } from "../lib/portfolio";
-import { sampleSymbols } from "../lib/sample-data";
 
 type Props = {
   /** Builder JSON to apply to all symbols. */
@@ -18,15 +19,25 @@ type Props = {
   /** Most recent solo backtest, used to inherit settings (stops, fees, etc.). */
   lastResult: BacktestResult | undefined;
   /**
-   * Active candle range — `backtestCandles.length` from the host. Used to
-   * slice every synthetic symbol to the same horizon so portfolio metrics
-   * track the same window the solo backtest and chart show. The synthetic
-   * symbols share the parent candle stream's time axis 1:1, so a single
-   * length is enough.
+   * Calendar time window — the first and last `time` values of the host's
+   * `backtestCandles`. Each portfolio symbol is filtered to bars whose
+   * `time` falls inside this range so the multi-symbol backtest runs on
+   * the same wall-clock window the chart and solo backtest show. Slicing
+   * by bar count instead would misalign symbols with different listing
+   * dates / histories (e.g. an IPO ticker on the main chart vs. SPY/AAPL/
+   * NVDA in the portfolio).
+   *
+   * `null` means "use each symbol's full history" — appropriate when the
+   * host has no candles loaded yet.
    */
-  sliceLength: number;
+  sliceStartTime: number | null;
+  sliceEndTime: number | null;
   /** Replay playing → freeze recompute (multi-symbol backtest is heavy). */
   isReplayPlaying: boolean;
+  /** Drives synthetic vs real-data symbol selection. */
+  dataSource: DataSource;
+  /** Reload counter from `useDataSource` — busts the symbol cache in lockstep. */
+  reloadTick: number;
 };
 
 const ALLOCATIONS: ReadonlyArray<{ id: AllocationMode; label: string }> = [
@@ -34,18 +45,49 @@ const ALLOCATIONS: ReadonlyArray<{ id: AllocationMode; label: string }> = [
   { id: "custom", label: "Custom" },
 ];
 
-export function PortfolioPanel({ strategy, lastResult, sliceLength, isReplayPlaying }: Props) {
+export function PortfolioPanel({
+  strategy,
+  lastResult,
+  sliceStartTime,
+  sliceEndTime,
+  isReplayPlaying,
+  dataSource,
+  reloadTick,
+}: Props) {
+  const {
+    symbols: portfolioSymbols,
+    loading: symbolsLoading,
+    error: symbolsError,
+  } = usePortfolioSymbols(dataSource, reloadTick);
+
   const [inputs, setInputs] = useState<PortfolioInputs>(() =>
-    defaultPortfolioInputs(sampleSymbols),
+    defaultPortfolioInputs(portfolioSymbols),
   );
+
+  // When the symbol set changes (synthetic ↔ alpaca, or Alpaca timeframe
+  // switch), reset weights to a valid equal-weight default for the new keys.
+  // Without this, custom weights from the previous symbol set carry over and
+  // sum to the wrong value.
+  const symbolKey = portfolioSymbols.map((s) => s.symbol).join(",");
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only react to symbol identity changes.
+  useEffect(() => {
+    setInputs((prev) => ({
+      ...defaultPortfolioInputs(portfolioSymbols),
+      capital: prev.capital,
+      allocation: prev.allocation,
+    }));
+  }, [symbolKey]);
 
   const slicedSymbols = useMemo(
     () =>
-      sampleSymbols.map((s) => ({
-        ...s,
-        candles: sliceLength > 0 ? s.candles.slice(0, sliceLength) : s.candles,
-      })),
-    [sliceLength],
+      portfolioSymbols.map((s) => {
+        if (sliceStartTime == null || sliceEndTime == null) return s;
+        return {
+          ...s,
+          candles: s.candles.filter((c) => c.time >= sliceStartTime && c.time <= sliceEndTime),
+        };
+      }),
+    [portfolioSymbols, sliceStartTime, sliceEndTime],
   );
 
   // Recompute on strategy / inputs / settings change. We don't need to key on
@@ -66,12 +108,40 @@ export function PortfolioPanel({ strategy, lastResult, sliceLength, isReplayPlay
     .map(([k, v]) => `${k}=${v}`)
     .join(",")}`;
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: strategyKey + inputsKey + overridesKey + sliceLength are content hashes; raw `strategy`/`slicedSymbols` references shift on every render so we key on hashes instead.
+  // Content hash of the symbol payload itself — `symbolKey` only carries the
+  // ticker identity, so a timeframe switch that returns the same three
+  // tickers with similar bar counts (1Day vs 1Hour both ~2,000 bars) would
+  // not invalidate this effect on its own. Including bar count + last-bar
+  // time + last-bar close + first-bar close catches every realistic refresh
+  // path: TF/source switches, intraday reloads where the still-open bar's
+  // OHLC moved without changing count or endpoint timestamp, and split
+  // adjustments that preserve bar count and timestamps.
+  const symbolContentKey = portfolioSymbols
+    .map((s) => {
+      const last = s.candles[s.candles.length - 1];
+      const first = s.candles[0];
+      return `${s.symbol}:${s.candles.length}:${last?.time ?? 0}:${last?.close ?? 0}:${first?.close ?? 0}`;
+    })
+    .join("|");
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: strategyKey + inputsKey + overridesKey + sliceStartTime + sliceEndTime + symbolKey + symbolContentKey are content hashes; raw `strategy`/`slicedSymbols` references shift on every render so we key on hashes instead.
   useEffect(() => {
     if (isReplayPlaying) return;
+    if (symbolsLoading) return;
+    if (slicedSymbols.length === 0) return;
     const overrides = lastResult ? overridesFromResult(lastResult) : {};
     setComputation(runPortfolio(strategy, slicedSymbols, inputs, overrides));
-  }, [strategyKey, inputsKey, isReplayPlaying, overridesKey, sliceLength]);
+  }, [
+    strategyKey,
+    inputsKey,
+    isReplayPlaying,
+    overridesKey,
+    sliceStartTime,
+    sliceEndTime,
+    symbolKey,
+    symbolContentKey,
+    symbolsLoading,
+  ]);
 
   const customWeightSum = useMemo(
     () => Object.values(inputs.customWeights).reduce((s, w) => s + w, 0),
@@ -113,7 +183,7 @@ export function PortfolioPanel({ strategy, lastResult, sliceLength, isReplayPlay
         {inputs.allocation === "custom" && (
           <>
             <div className="risk-inputs">
-              {sampleSymbols.map((s) => (
+              {portfolioSymbols.map((s) => (
                 <NumInput
                   key={s.symbol}
                   label={`${s.symbol} weight`}
@@ -139,7 +209,15 @@ export function PortfolioPanel({ strategy, lastResult, sliceLength, isReplayPlay
           </>
         )}
 
-        <PortfolioBody computation={computation} customWeightsValid={customWeightsValid} />
+        {symbolsLoading && (
+          <div className="meta-strategy-caption">
+            Loading {portfolioSymbols.length || 3} symbols…
+          </div>
+        )}
+        {symbolsError && <div className="risk-error">{symbolsError.message}</div>}
+        {!symbolsLoading && !symbolsError && (
+          <PortfolioBody computation={computation} customWeightsValid={customWeightsValid} />
+        )}
         {isReplayPlaying && (
           <div className="meta-strategy-caption">Frozen during replay playback.</div>
         )}
@@ -165,7 +243,7 @@ function PortfolioBody({
   const { result } = computation;
   return (
     <>
-      <SparklineList hover className="symbol-list">
+      <SparklineList hover={{ format: formatEquityHover }} className="symbol-list">
         {result.symbols.map((s) => {
           const equity = symbolEquityCurve(s);
           const ret = s.result.totalReturnPercent;
@@ -231,4 +309,17 @@ function PortfolioMetric({
       <div className="metric-value">{value}</div>
     </div>
   );
+}
+
+const EQUITY_FORMATTER = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+function formatEquityHover(d: { value: number }): string {
+  // Prefixed with `Equity` so the number isn't mistaken for a price. The
+  // sparkline plots accumulated capital (initialCapital + Σ trade P&L), not
+  // the underlying ticker's price.
+  return `Equity ${EQUITY_FORMATTER.format(d.value)}`;
 }

--- a/packages/chart/examples/strategy-studio/src/panels/PresetSelector.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/PresetSelector.tsx
@@ -16,6 +16,19 @@ const CATEGORIES: IndicatorCategory[] = [
   "wyckoff",
 ];
 
+const CATEGORY_LABEL: Record<IndicatorCategory, string> = {
+  "moving-average": "Moving Averages",
+  momentum: "Momentum",
+  volatility: "Volatility",
+  trend: "Trend",
+  volume: "Volume",
+  price: "Price",
+  session: "Session",
+  regime: "Regime",
+  smc: "SMC",
+  wyckoff: "Wyckoff",
+};
+
 type Props = {
   regime: RegimeSummary;
   /** How many instances of each kind are currently mounted. */
@@ -26,19 +39,71 @@ type Props = {
   onAdd: (kind: string) => void;
 };
 
+function matchesQuery(m: IndicatorManifest, q: string): boolean {
+  if (!q) return true;
+  const haystack = [m.displayName, m.kind, m.oneLiner, m.whenToUse.join(" "), m.signals.join(" ")]
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(q);
+}
+
 export function PresetSelector({ regime, instanceCountsByKind, onToggle, onAdd }: Props) {
-  const [category, setCategory] = useState<IndicatorCategory | "all">("all");
+  const [search, setSearch] = useState("");
   const [hovered, setHovered] = useState<string | null>(null);
+  // Default: regime suggestions expanded; browse categories collapsed (the
+  // user opens what they need). Search overrides — when active every
+  // category with a match is expanded.
+  const [expandedCats, setExpandedCats] = useState<Set<IndicatorCategory>>(() => new Set());
+  const [suggestionsOpen, setSuggestionsOpen] = useState(true);
 
   const suggestions = useMemo(
     () => localStudioAPI.suggestPresets(regime.manifestRegime),
     [regime.manifestRegime],
   );
 
-  const browse = useMemo(() => {
-    const filter = category === "all" ? undefined : { category };
-    return localStudioAPI.listIndicators(filter);
-  }, [category]);
+  const allByCategory = useMemo(() => {
+    const map = new Map<IndicatorCategory, IndicatorManifest[]>();
+    for (const cat of CATEGORIES) map.set(cat, []);
+    for (const m of localStudioAPI.listIndicators()) {
+      map.get(m.category)?.push(m);
+    }
+    return map;
+  }, []);
+
+  const q = search.trim().toLowerCase();
+  const isSearching = q.length > 0;
+
+  const filteredSuggestions = useMemo(
+    () => suggestions.filter((m) => matchesQuery(m, q)),
+    [suggestions, q],
+  );
+
+  const filteredByCategory = useMemo(() => {
+    const out = new Map<IndicatorCategory, IndicatorManifest[]>();
+    for (const cat of CATEGORIES) {
+      const items = allByCategory.get(cat) ?? [];
+      out.set(
+        cat,
+        items.filter((m) => matchesQuery(m, q)),
+      );
+    }
+    return out;
+  }, [allByCategory, q]);
+
+  const totalMatches = useMemo(() => {
+    let n = 0;
+    for (const items of filteredByCategory.values()) n += items.length;
+    return n;
+  }, [filteredByCategory]);
+
+  const toggleCat = (cat: IndicatorCategory) => {
+    setExpandedCats((prev) => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat);
+      else next.add(cat);
+      return next;
+    });
+  };
 
   return (
     <>
@@ -56,40 +121,89 @@ export function PresetSelector({ regime, instanceCountsByKind, onToggle, onAdd }
         </div>
       </div>
 
-      <div className="section-title">Suggested for this regime</div>
-      <PresetList
-        items={suggestions}
-        instanceCountsByKind={instanceCountsByKind}
-        hovered={hovered}
-        onHover={setHovered}
-        onToggle={onToggle}
-        onAdd={onAdd}
-        emptyText="No manifest entries match this regime yet."
-      />
+      <div className="preset-search">
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search indicators…"
+          aria-label="Search indicators"
+        />
+        {isSearching && (
+          <span className="preset-search-count">
+            {totalMatches} match{totalMatches === 1 ? "" : "es"}
+          </span>
+        )}
+      </div>
 
-      <div className="section-title">Browse all indicators</div>
-      <select
-        className="category-select"
-        value={category}
-        onChange={(e) => setCategory(e.target.value as IndicatorCategory | "all")}
-      >
-        <option value="all">All categories</option>
-        {CATEGORIES.map((c) => (
-          <option key={c} value={c}>
-            {c}
-          </option>
-        ))}
-      </select>
-      <PresetList
-        items={browse}
-        instanceCountsByKind={instanceCountsByKind}
-        hovered={hovered}
-        onHover={setHovered}
-        onToggle={onToggle}
-        onAdd={onAdd}
-        emptyText="No indicators in this category."
+      <CategoryHeader
+        label={`Suggested for ${regime.manifestRegime}`}
+        count={filteredSuggestions.length}
+        expanded={suggestionsOpen}
+        onToggle={() => setSuggestionsOpen((v) => !v)}
       />
+      {suggestionsOpen && (
+        <PresetList
+          items={filteredSuggestions}
+          instanceCountsByKind={instanceCountsByKind}
+          hovered={hovered}
+          onHover={setHovered}
+          onToggle={onToggle}
+          onAdd={onAdd}
+          emptyText={
+            isSearching
+              ? "No matches in regime suggestions."
+              : "No manifest entries match this regime yet."
+          }
+        />
+      )}
+
+      {CATEGORIES.map((cat) => {
+        const items = filteredByCategory.get(cat) ?? [];
+        if (isSearching && items.length === 0) return null;
+        const expanded = isSearching || expandedCats.has(cat);
+        return (
+          <div key={cat}>
+            <CategoryHeader
+              label={CATEGORY_LABEL[cat]}
+              count={items.length}
+              expanded={expanded}
+              onToggle={() => toggleCat(cat)}
+            />
+            {expanded && (
+              <PresetList
+                items={items}
+                instanceCountsByKind={instanceCountsByKind}
+                hovered={hovered}
+                onHover={setHovered}
+                onToggle={onToggle}
+                onAdd={onAdd}
+                emptyText="No indicators in this category."
+              />
+            )}
+          </div>
+        );
+      })}
     </>
+  );
+}
+
+type CategoryHeaderProps = {
+  label: string;
+  count: number;
+  expanded: boolean;
+  onToggle: () => void;
+};
+
+function CategoryHeader({ label, count, expanded, onToggle }: CategoryHeaderProps) {
+  return (
+    <button type="button" className="preset-cat-header" onClick={onToggle} aria-expanded={expanded}>
+      <span className="preset-cat-label">
+        <span className="preset-cat-chevron">{expanded ? "▼" : "▶"}</span>
+        {label}
+      </span>
+      <span className="preset-cat-count">{count}</span>
+    </button>
   );
 }
 
@@ -140,8 +254,11 @@ function PresetList({
               aria-pressed={count > 0}
               title={tip}
             >
-              <span className="preset-name">{m.displayName}</span>
-              <span className="preset-kind">{m.kind}</span>
+              <span className="preset-name-row">
+                <span className="preset-name">{m.displayName}</span>
+                <span className="preset-kind">{m.kind}</span>
+              </span>
+              <span className="preset-oneliner">{m.oneLiner}</span>
             </button>
             {renderable && count > 0 && (
               <button

--- a/packages/chart/examples/strategy-studio/src/panels/ReplayControls.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/ReplayControls.tsx
@@ -7,6 +7,9 @@ type Props = {
   replay: ReplayState;
   progress: number;
   cursorTime: number | null;
+  /** Whether the host is in "anchor mode" (next chart click anchors Replay). */
+  anchorMode: boolean;
+  onToggleAnchor: () => void;
   onPlay: () => void;
   onPause: () => void;
   onStep: () => void;
@@ -15,14 +18,18 @@ type Props = {
 };
 
 /**
- * Toolbar pinned to the top of the chart pane. In static mode it shows a hint
- * inviting the user to click any candle to anchor a Replay. In live mode it
- * exposes Play/Pause/Step, speed presets, a progress bar, and a REPLAY badge.
+ * Toolbar pinned to the top of the chart pane. In static mode it exposes the
+ * Anchor button (clicking it arms anchor-mode; the next chart click starts
+ * Replay) and surfaces the Shift+click shortcut as a desktop accelerator. In
+ * live mode it exposes Play/Pause/Step, speed presets, a progress bar, and a
+ * REPLAY badge.
  */
 export function ReplayControls({
   replay,
   progress,
   cursorTime,
+  anchorMode,
+  onToggleAnchor,
   onPlay,
   onPause,
   onStep,
@@ -32,9 +39,29 @@ export function ReplayControls({
   if (replay.mode === "static") {
     return (
       <div className="replay-toolbar replay-toolbar--ghost">
+        <button
+          type="button"
+          className={`replay-btn small${anchorMode ? " active" : ""}`}
+          onClick={onToggleAnchor}
+          aria-pressed={anchorMode}
+          title="Arm anchor mode — next chart click starts Replay from that bar"
+        >
+          🎯 Anchor
+        </button>
         <span className="replay-hint">
-          <span className="replay-hint-icon">▶</span>
-          Click any candle to start <strong>Replay</strong> from there
+          {anchorMode ? (
+            <>
+              <span className="replay-hint-icon">▶</span>
+              Click any candle to start <strong>Replay</strong> from there
+              <span className="replay-hint-sub">(Esc to cancel)</span>
+            </>
+          ) : (
+            <>
+              <span className="replay-hint-icon">▶</span>
+              Press <strong>🎯 Anchor</strong> or <strong>Shift+click</strong> any candle to start
+              Replay
+            </>
+          )}
         </span>
       </div>
     );
@@ -111,14 +138,16 @@ export function ReplayControls({
   );
 }
 
-const FORMATTER = new Intl.DateTimeFormat(undefined, {
-  year: "numeric",
-  month: "short",
-  day: "numeric",
-  hour: "2-digit",
-  minute: "2-digit",
-});
-
+// Hand-rolled ISO-style formatter so the cursor label is fixed-width: every
+// component is zero-padded and locale-independent. Using `Intl.DateTimeFormat`
+// with month: "short" / hour12 made the label width jitter as the playhead
+// advanced (May vs September, 1 vs 12, AM vs PM), shifting the toolbar.
 function formatCursor(time: number): string {
-  return FORMATTER.format(new Date(time));
+  const d = new Date(time);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mi = String(d.getMinutes()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd} ${hh}:${mi}`;
 }

--- a/packages/chart/examples/strategy-studio/src/panels/StrategyDnaPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/StrategyDnaPanel.tsx
@@ -153,14 +153,42 @@ export function StrategyDnaPanel({ optimizationResult }: Props) {
 
         {activeTab === "genome" &&
           (genomeSegments && genomeSegments.length > 0 ? (
-            <GenomeVisualization
-              segments={genomeSegments}
-              onSegmentClick={(name) => {
-                setSelectedParam(name);
-                setSelectedParamPair(null);
-                setActiveTab("sensitivity");
-              }}
-            />
+            <>
+              <div className="meta-strategy-caption" style={{ marginBottom: 6 }}>
+                Each block is a tunable parameter at its best value. Color shows where that value
+                sits in the search range — hover for details, click to inspect sensitivity.
+              </div>
+              <GenomeVisualization
+                segments={genomeSegments}
+                onSegmentClick={(name) => {
+                  setSelectedParam(name);
+                  setSelectedParamPair(null);
+                  setActiveTab("sensitivity");
+                }}
+              />
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  marginTop: 6,
+                  fontSize: 10,
+                  color: "#787b86",
+                }}
+              >
+                <span>Range</span>
+                <span
+                  aria-hidden="true"
+                  style={{
+                    flex: 1,
+                    height: 6,
+                    borderRadius: 3,
+                    background: "linear-gradient(90deg, rgb(60,120,220), rgb(230,40,40))",
+                  }}
+                />
+                <span>low → high</span>
+              </div>
+            </>
           ) : (
             <div className="meta-strategy-caption">No tunable parameters in this grid search.</div>
           ))}

--- a/packages/chart/examples/strategy-studio/src/panels/dna/GenomeVisualization.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/dna/GenomeVisualization.tsx
@@ -38,10 +38,45 @@ type Props = {
  * outer panel can react (e.g. switch to the sensitivity tab pre-
  * filtered to that param).
  */
+/**
+ * Compact label: keep the distinguishing parts of a dotted param path
+ * (`entry.0.shortPeriod` → `in.short`). Plain `slice(0, 5)` collapsed
+ * `entry.shortPeriod` and `entry.longPeriod` to the same `entry..`,
+ * which made the genome unreadable for multi-leg strategies.
+ *
+ * Drops the redundant `Period` suffix and the leg index (`0`) when the
+ * strategy only has a single leg per bucket — including it would just
+ * waste pixels. Multi-leg cases still surface the index so two `entry`
+ * legs don't collide.
+ */
+function compactLabel(name: string, max = 12): string {
+  if (name.length <= max) return name;
+  const parts = name.split(".");
+  const renameBucket = (b: string): string =>
+    b === "entry" ? "in" : b === "exit" ? "out" : b.slice(0, 3);
+  const trimParam = (p: string): string =>
+    p
+      .replace(/Period$/, "")
+      .replace(/^short/i, "short")
+      .replace(/^long/i, "long");
+
+  let compact = name;
+  if (parts.length === 2) {
+    compact = `${renameBucket(parts[0])}.${trimParam(parts[1])}`;
+  } else if (parts.length === 3) {
+    // `entry.0.shortPeriod` → `in.short` when leg index is 0; keep it
+    // otherwise so multi-leg strategies stay distinguishable.
+    const [bucket, leg, param] = parts;
+    const legSuffix = leg === "0" ? "" : `${leg}.`;
+    compact = `${renameBucket(bucket)}.${legSuffix}${trimParam(param)}`;
+  }
+  return compact.length <= max ? compact : `${compact.slice(0, max - 1)}…`;
+}
+
 export function GenomeVisualization({ segments, onSegmentClick }: Props) {
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
 
-  const segmentWidth = 36;
+  const segmentWidth = 52;
   const segmentHeight = 48;
   const gap = 4;
   const totalWidth = segments.length * (segmentWidth + gap) - gap;
@@ -86,7 +121,7 @@ export function GenomeVisualization({ segments, onSegmentClick }: Props) {
                 fill="var(--text-secondary, #888)"
                 fontSize={9}
               >
-                {seg.name.length > 6 ? `${seg.name.slice(0, 5)}..` : seg.name}
+                {compactLabel(seg.name)}
               </text>
               <text
                 x={x + segmentWidth / 2}

--- a/packages/chart/examples/strategy-studio/src/styles.css
+++ b/packages/chart/examples/strategy-studio/src/styles.css
@@ -1633,12 +1633,31 @@ button.ghost.danger:hover {
   margin-bottom: 8px;
 }
 
+.optimization-result-scroll {
+  /* Many-column results (e.g. multi-leg strategies with `in.shortPeriod`,
+   * `out.longPeriod`, score, trades) overflow the right pane's width.
+   * Confine the overflow to this wrapper so the rest of the panel
+   * (caption, controls below) stays properly bounded. */
+  overflow-x: auto;
+  margin-top: 6px;
+  scrollbar-width: thin;
+}
+
+.optimization-result-scroll::-webkit-scrollbar {
+  height: 4px;
+}
+
+.optimization-result-scroll::-webkit-scrollbar-thumb {
+  background: #2a2e39;
+  border-radius: 2px;
+}
+
 .optimization-result-table {
   width: 100%;
   border-collapse: collapse;
   font-size: 11px;
   font-variant-numeric: tabular-nums;
-  margin-top: 6px;
+  white-space: nowrap;
 }
 
 .optimization-result-table th,

--- a/packages/chart/examples/strategy-studio/src/styles.css
+++ b/packages/chart/examples/strategy-studio/src/styles.css
@@ -137,9 +137,88 @@ body,
   color: #787b86;
 }
 
+.preset-search {
+  position: relative;
+  padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid #2a2e39;
+}
+
+.preset-search input {
+  flex: 1 1 auto;
+  padding: 6px 10px;
+  background: #0e1320;
+  border: 1px solid #2a2e39;
+  border-radius: 4px;
+  color: #d1d4dc;
+  font: inherit;
+  font-size: 12px;
+  outline: none;
+}
+
+.preset-search input:focus {
+  border-color: #2196f3;
+}
+
+.preset-search-count {
+  font-size: 10px;
+  color: #787b86;
+  white-space: nowrap;
+}
+
+.preset-cat-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  background: #181c27;
+  border: none;
+  border-top: 1px solid #1e222d;
+  border-bottom: 1px solid #1e222d;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.preset-cat-header:hover {
+  background: #1e222d;
+}
+
+.preset-cat-header:focus-visible {
+  outline: 2px solid #2196f3;
+  outline-offset: -2px;
+}
+
+.preset-cat-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.preset-cat-chevron {
+  display: inline-block;
+  width: 10px;
+  font-size: 9px;
+  color: #787b86;
+}
+
+.preset-cat-count {
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  color: #787b86;
+}
+
 .preset-list {
   list-style: none;
-  padding: 0 8px 12px;
+  padding: 0 8px 8px;
 }
 
 .preset-item {
@@ -161,10 +240,10 @@ body,
 .preset-toggle {
   flex: 1 1 auto;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 8px 10px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 2px;
+  padding: 6px 10px;
   background: none;
   border: none;
   color: inherit;
@@ -173,6 +252,29 @@ body,
   text-align: left;
   cursor: pointer;
   border-radius: 4px;
+  min-width: 0;
+}
+
+.preset-name-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.preset-oneliner {
+  font-size: 11px;
+  color: #787b86;
+  line-height: 1.3;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.preset-item.active .preset-oneliner {
+  color: #a3a6af;
 }
 
 .preset-toggle:focus-visible {
@@ -753,6 +855,71 @@ button.ghost.danger:hover {
   min-height: 36px;
 }
 
+.chart-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: #131722;
+  border-bottom: 1px solid #2a2e39;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.chart-toolbar::-webkit-scrollbar {
+  height: 4px;
+}
+
+.chart-toolbar::-webkit-scrollbar-thumb {
+  background: #2a2e39;
+  border-radius: 2px;
+}
+
+.chart-toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.chart-toolbar-sep {
+  width: 1px;
+  height: 16px;
+  background: #2a2e39;
+  flex-shrink: 0;
+}
+
+.chart-toolbar-btn {
+  flex-shrink: 0;
+  padding: 3px 8px;
+  font-size: 11px;
+  background: #1e222d;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #2a2e39;
+  border-radius: 3px;
+  color: #d1d4dc;
+  cursor: pointer;
+  font-family: inherit;
+  white-space: nowrap;
+}
+
+.chart-toolbar-btn:hover {
+  border-color: #3a3e49;
+}
+
+.chart-toolbar-btn:focus-visible {
+  outline: 2px solid #2196f3;
+  outline-offset: -2px;
+}
+
+.chart-toolbar-btn.active {
+  background: #2196f3;
+  border-color: #2196f3;
+  color: #fff;
+}
+
 .replay-toolbar--ghost {
   background: transparent;
   color: #787b86;
@@ -767,6 +934,11 @@ button.ghost.danger:hover {
 
 .replay-hint strong {
   color: #d1d4dc;
+}
+
+.replay-hint-sub {
+  color: #585b66;
+  font-size: 10px;
 }
 
 .replay-hint-icon {
@@ -1030,10 +1202,27 @@ button.ghost.danger:hover {
   display: flex;
   gap: 4px;
   margin-bottom: 8px;
+  /* Confine overflow to the row itself; otherwise wide rows (e.g. Scoring's
+   * 6 presets) push the whole right pane wider than its clientWidth and
+   * the rest of the panel content gets clipped on the left edge. */
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.risk-tabs::-webkit-scrollbar {
+  height: 4px;
+}
+
+.risk-tabs::-webkit-scrollbar-thumb {
+  background: #2a2e39;
+  border-radius: 2px;
 }
 
 .risk-tab {
-  flex: 1;
+  flex: 1 0 auto;
+  /* Never shrink below the natural label width — clipped tab labels are
+   * worse than horizontal scroll. */
+  min-width: max-content;
   padding: 4px 6px;
   font-size: 11px;
   background: #0e1320;

--- a/packages/chart/src/__tests__/click-event.test.ts
+++ b/packages/chart/src/__tests__/click-event.test.ts
@@ -41,13 +41,23 @@ const sampleCandles = Array.from({ length: 50 }, (_, i) => ({
   volume: 1000,
 }));
 
-function clickCanvas(canvas: HTMLCanvasElement, x: number, y: number): void {
+function clickCanvas(
+  canvas: HTMLCanvasElement,
+  x: number,
+  y: number,
+  init: MouseEventInit = {},
+): void {
   const rect = canvas.getBoundingClientRect();
   canvas.dispatchEvent(
     new MouseEvent("mousedown", { clientX: rect.left + x, clientY: rect.top + y, bubbles: true }),
   );
   canvas.dispatchEvent(
-    new MouseEvent("click", { clientX: rect.left + x, clientY: rect.top + y, bubbles: true }),
+    new MouseEvent("click", {
+      clientX: rect.left + x,
+      clientY: rect.top + y,
+      bubbles: true,
+      ...init,
+    }),
   );
 }
 
@@ -73,11 +83,37 @@ describe("chart click event", () => {
       y: number;
       index: number | null;
       time: number | null;
+      shiftKey: boolean;
     };
     expect(payload.x).toBeGreaterThanOrEqual(0);
     expect(payload.y).toBeGreaterThanOrEqual(0);
     expect(payload.index).not.toBeNull();
     expect(payload.time).not.toBeNull();
+    expect(payload.shiftKey).toBe(false);
+    chart.destroy();
+  });
+
+  it("forwards modifier keys in the click payload", () => {
+    const container = makeContainer();
+    const chart = createChart(container, { width: 800, height: 400 });
+    chart.setCandles(sampleCandles);
+
+    const handler = vi.fn();
+    chart.on("click", handler);
+
+    const canvas = container.querySelector("canvas") as HTMLCanvasElement;
+    clickCanvas(canvas, 200, 100, { shiftKey: true, altKey: true });
+
+    const payload = handler.mock.calls[0][0] as {
+      shiftKey: boolean;
+      altKey: boolean;
+      metaKey: boolean;
+      ctrlKey: boolean;
+    };
+    expect(payload.shiftKey).toBe(true);
+    expect(payload.altKey).toBe(true);
+    expect(payload.metaKey).toBe(false);
+    expect(payload.ctrlKey).toBe(false);
     chart.destroy();
   });
 
@@ -115,6 +151,145 @@ describe("chart click event", () => {
     clickCanvas(canvas, 9000, 9000);
 
     expect(handler).not.toHaveBeenCalled();
+    chart.destroy();
+  });
+
+  it("emits drawingToolChanged when the tool is set, completed, or cancelled", () => {
+    // Toolbar UIs sync their highlighted state via this event so they don't
+    // drift when the chart clears the tool internally (drawing completion,
+    // Escape hotkey, etc.).
+    const container = makeContainer();
+    const chart = createChart(container, { width: 800, height: 400 });
+    chart.setCandles(sampleCandles);
+
+    const handler = vi.fn();
+    chart.on("drawingToolChanged", handler);
+
+    // Setting a tool emits with the new tool name.
+    chart.setDrawingTool("hline");
+    expect(handler).toHaveBeenLastCalledWith({ tool: "hline" });
+
+    // Setting the same tool is a no-op (no extra emit).
+    const callsBefore = handler.mock.calls.length;
+    chart.setDrawingTool("hline");
+    expect(handler.mock.calls.length).toBe(callsBefore);
+
+    // Clearing emits null.
+    chart.setDrawingTool(null);
+    expect(handler).toHaveBeenLastCalledWith({ tool: null });
+
+    chart.destroy();
+  });
+
+  it("emits drawingToolChanged with null after a drawing completes", () => {
+    const container = makeContainer();
+    const chart = createChart(container, { width: 800, height: 400 });
+    chart.setCandles(sampleCandles);
+
+    const handler = vi.fn();
+    chart.on("drawingToolChanged", handler);
+
+    chart.setDrawingTool("hline");
+    handler.mockClear();
+
+    // hline is one-click — first click completes immediately
+    const canvas = container.querySelector("canvas") as HTMLCanvasElement;
+    clickCanvas(canvas, 200, 100);
+
+    expect(handler).toHaveBeenCalledWith({ tool: null });
+    chart.destroy();
+  });
+
+  it("does not fire doubleClick when a two-click drawing completes (same spot)", () => {
+    // After the second click of a two-click drawing (rectangle, ray, etc.)
+    // DrawingTool clears its internal active flag before the browser
+    // dispatches the trailing native `dblclick`. The plain isActive() guard
+    // would let that dblclick through and hosts (Strategy Studio) would
+    // anchor Replay on the drawing's end-point.
+    const container = makeContainer();
+    const chart = createChart(container, { width: 800, height: 400 });
+    chart.setCandles(sampleCandles);
+
+    const handler = vi.fn();
+    chart.on("doubleClick", handler);
+    chart.setDrawingTool("rectangle");
+
+    const canvas = container.querySelector("canvas") as HTMLCanvasElement;
+    // First click — starts the rectangle
+    clickCanvas(canvas, 200, 100);
+    // Second click — completes the rectangle and clears _activeTool
+    clickCanvas(canvas, 300, 200);
+    // Browser then fires the trailing dblclick at the completing-click spot
+    const rect = canvas.getBoundingClientRect();
+    canvas.dispatchEvent(
+      new MouseEvent("dblclick", {
+        clientX: rect.left + 300,
+        clientY: rect.top + 200,
+        bubbles: true,
+      }),
+    );
+
+    expect(handler).not.toHaveBeenCalled();
+    chart.destroy();
+  });
+
+  it("re-arming the same multi-click tool clears the in-progress anchor", () => {
+    // Regression: after the first click of a two-click drawing, re-selecting
+    // the same tool (toolbar click, hotkey, etc.) must restart the gesture
+    // rather than completing a stale rectangle from the previous start to
+    // the new tap.
+    const container = makeContainer();
+    const chart = createChart(container, { width: 800, height: 400 });
+    chart.setCandles(sampleCandles);
+
+    chart.setDrawingTool("rectangle");
+    const canvas = container.querySelector("canvas") as HTMLCanvasElement;
+    // First click — sets the in-progress anchor (rectangle is two-click).
+    clickCanvas(canvas, 200, 100);
+    expect(chart.getDrawings()).toHaveLength(0);
+
+    // Re-arm the same tool — should clear the in-progress anchor.
+    chart.setDrawingTool("rectangle");
+
+    // Confirm a second click fires a fresh first-anchor (no completion from
+    // the abandoned start). The pre-fix bug would have closed a rectangle
+    // here using the (200, 100) anchor, producing 1 drawing.
+    clickCanvas(canvas, 250, 100);
+    expect(chart.getDrawings()).toHaveLength(0);
+
+    chart.destroy();
+  });
+
+  it("still fires doubleClick when the user double-clicks elsewhere after a one-click drawing", () => {
+    // Regression: a pure time-based guard would drop *any* doubleClick
+    // arriving within the guard window after a drawing tap, even when the
+    // user intentionally double-clicks a far-away spot. The position match
+    // ensures only the trailing dblclick paired with the drawing's
+    // completing click is suppressed.
+    const container = makeContainer();
+    const chart = createChart(container, { width: 800, height: 400 });
+    chart.setCandles(sampleCandles);
+
+    const handler = vi.fn();
+    chart.on("doubleClick", handler);
+
+    // Place a one-click hline at one location.
+    chart.setDrawingTool("hline");
+    const canvas = container.querySelector("canvas") as HTMLCanvasElement;
+    clickCanvas(canvas, 200, 100);
+    // Drawing tool should have cleared itself.
+    // Now the user double-clicks at a different location — the dblclick
+    // for that gesture must NOT be suppressed.
+    const rect = canvas.getBoundingClientRect();
+    canvas.dispatchEvent(
+      new MouseEvent("dblclick", {
+        clientX: rect.left + 600,
+        clientY: rect.top + 300,
+        bubbles: true,
+      }),
+    );
+
+    expect(handler).toHaveBeenCalledTimes(1);
     chart.destroy();
   });
 });

--- a/packages/chart/src/__tests__/pointer.test.ts
+++ b/packages/chart/src/__tests__/pointer.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getPointerPos, onTap } from "../core/pointer";
+import { getPointerPos, onDoubleTap, onTap } from "../core/pointer";
 
 function makeEl(rect: Partial<DOMRect> = {}): HTMLElement {
   const el = document.createElement("div");
@@ -21,18 +21,34 @@ function makeEl(rect: Partial<DOMRect> = {}): HTMLElement {
 }
 
 describe("getPointerPos", () => {
-  it("subtracts rect offset for MouseEvent", () => {
+  it("subtracts rect offset for MouseEvent and reads modifiers", () => {
     const el = makeEl();
-    const ev = new MouseEvent("click", { clientX: 110, clientY: 120 });
+    const ev = new MouseEvent("click", { clientX: 110, clientY: 120, shiftKey: true });
     const p = getPointerPos(ev, el);
-    expect(p).toEqual({ x: 100, y: 100, isTouch: false });
+    expect(p).toEqual({
+      x: 100,
+      y: 100,
+      isTouch: false,
+      shiftKey: true,
+      altKey: false,
+      metaKey: false,
+      ctrlKey: false,
+    });
   });
 
-  it("treats Touch-like object (no button) as isTouch=true", () => {
+  it("treats Touch-like object (no button) as isTouch=true with no modifiers", () => {
     const el = makeEl();
     const touch = { clientX: 50, clientY: 40 } as unknown as Touch;
     const p = getPointerPos(touch, el);
-    expect(p).toEqual({ x: 40, y: 20, isTouch: true });
+    expect(p).toEqual({
+      x: 40,
+      y: 20,
+      isTouch: true,
+      shiftKey: false,
+      altKey: false,
+      metaKey: false,
+      ctrlKey: false,
+    });
   });
 });
 
@@ -44,11 +60,21 @@ describe("onTap", () => {
     handler = vi.fn();
   });
 
-  it("fires on short click", () => {
+  it("fires on short click and forwards modifier keys", () => {
     const off = onTap(el, handler);
     el.dispatchEvent(new MouseEvent("mousedown", { clientX: 100, clientY: 100 }));
-    el.dispatchEvent(new MouseEvent("click", { clientX: 101, clientY: 101 }));
-    expect(handler).toHaveBeenCalledWith({ x: 91, y: 81, isTouch: false });
+    el.dispatchEvent(
+      new MouseEvent("click", { clientX: 101, clientY: 101, shiftKey: true, altKey: true }),
+    );
+    expect(handler).toHaveBeenCalledWith({
+      x: 91,
+      y: 81,
+      isTouch: false,
+      shiftKey: true,
+      altKey: true,
+      metaKey: false,
+      ctrlKey: false,
+    });
     off();
   });
 
@@ -135,5 +161,181 @@ describe("onTap", () => {
     off();
     el.dispatchEvent(new MouseEvent("click", { clientX: 100, clientY: 100 }));
     expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe("onDoubleTap", () => {
+  let el: HTMLElement;
+  let handler: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    el = makeEl();
+    handler = vi.fn();
+  });
+
+  function tapAt(el: HTMLElement, x: number, y: number): void {
+    const start = new Event("touchstart") as unknown as TouchEvent;
+    Object.defineProperty(start, "touches", { value: [{ clientX: x, clientY: y }] });
+    el.dispatchEvent(start);
+    const end = new Event("touchend") as unknown as TouchEvent;
+    Object.defineProperty(end, "changedTouches", { value: [{ clientX: x, clientY: y }] });
+    el.dispatchEvent(end);
+  }
+
+  it("fires on native dblclick (mouse path) with modifier keys", () => {
+    const off = onDoubleTap(el, handler);
+    el.dispatchEvent(new MouseEvent("dblclick", { clientX: 110, clientY: 120, shiftKey: true }));
+    expect(handler).toHaveBeenCalledWith({
+      x: 100,
+      y: 100,
+      isTouch: false,
+      shiftKey: true,
+      altKey: false,
+      metaKey: false,
+      ctrlKey: false,
+    });
+    off();
+  });
+
+  it("fires on two close touchend events", () => {
+    const off = onDoubleTap(el, handler);
+    tapAt(el, 50, 60);
+    expect(handler).not.toHaveBeenCalled();
+    tapAt(el, 51, 61);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0].isTouch).toBe(true);
+    off();
+  });
+
+  it("does not fire when second tap lands far from the first", () => {
+    const off = onDoubleTap(el, handler);
+    tapAt(el, 50, 60);
+    tapAt(el, 200, 200);
+    expect(handler).not.toHaveBeenCalled();
+    off();
+  });
+
+  it("does not fire when taps are too far apart in time", async () => {
+    const off = onDoubleTap(el, handler);
+    vi.useFakeTimers();
+    try {
+      tapAt(el, 50, 60);
+      vi.advanceTimersByTime(500);
+      tapAt(el, 51, 61);
+      expect(handler).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      off();
+    }
+  });
+
+  it("ignores touchend with empty changedTouches", () => {
+    const off = onDoubleTap(el, handler);
+    const start = new Event("touchstart") as unknown as TouchEvent;
+    Object.defineProperty(start, "touches", { value: [{ clientX: 50, clientY: 50 }] });
+    el.dispatchEvent(start);
+    const end = new Event("touchend") as unknown as TouchEvent;
+    Object.defineProperty(end, "changedTouches", { value: [] });
+    expect(() => el.dispatchEvent(end)).not.toThrow();
+    expect(handler).not.toHaveBeenCalled();
+    off();
+  });
+
+  it("ignores touch sequences that pan beyond the tap threshold", () => {
+    const off = onDoubleTap(el, handler);
+    const swipe = (sx: number, sy: number, ex: number, ey: number) => {
+      const start = new Event("touchstart") as unknown as TouchEvent;
+      Object.defineProperty(start, "touches", { value: [{ clientX: sx, clientY: sy }] });
+      el.dispatchEvent(start);
+      const end = new Event("touchend") as unknown as TouchEvent;
+      Object.defineProperty(end, "changedTouches", { value: [{ clientX: ex, clientY: ey }] });
+      el.dispatchEvent(end);
+    };
+    swipe(20, 60, 100, 60);
+    swipe(20, 60, 100, 60);
+    expect(handler).not.toHaveBeenCalled();
+    off();
+  });
+
+  it("ignores multi-touch gestures (pinch / two-finger pan)", () => {
+    const off = onDoubleTap(el, handler);
+    const start = new Event("touchstart") as unknown as TouchEvent;
+    Object.defineProperty(start, "touches", {
+      value: [
+        { clientX: 30, clientY: 60 },
+        { clientX: 80, clientY: 60 },
+      ],
+    });
+    el.dispatchEvent(start);
+    const end = new Event("touchend") as unknown as TouchEvent;
+    Object.defineProperty(end, "changedTouches", { value: [{ clientX: 31, clientY: 61 }] });
+    el.dispatchEvent(end);
+    tapAt(el, 32, 62);
+    expect(handler).not.toHaveBeenCalled();
+    off();
+  });
+
+  it("cancels a pending first tap when an invalid gesture follows", () => {
+    const off = onDoubleTap(el, handler);
+    tapAt(el, 50, 60);
+    const swStart = new Event("touchstart") as unknown as TouchEvent;
+    Object.defineProperty(swStart, "touches", { value: [{ clientX: 50, clientY: 60 }] });
+    el.dispatchEvent(swStart);
+    const swEnd = new Event("touchend") as unknown as TouchEvent;
+    Object.defineProperty(swEnd, "changedTouches", { value: [{ clientX: 200, clientY: 60 }] });
+    el.dispatchEvent(swEnd);
+    tapAt(el, 51, 61);
+    expect(handler).not.toHaveBeenCalled();
+    off();
+  });
+
+  it("cleanup removes all listeners", () => {
+    const off = onDoubleTap(el, handler);
+    off();
+    el.dispatchEvent(new MouseEvent("dblclick", { clientX: 100, clientY: 100 }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("suppresses synthesized mouse dblclick at the same spot after a touch double-tap", () => {
+    // Mobile browsers (iOS Safari, Android WebView) generate compatibility
+    // mouse events for touch gestures, including a synthesized `dblclick`
+    // at the same coordinates as the touch end. Suppress that copy so the
+    // host's handler doesn't fire twice for one gesture.
+    const off = onDoubleTap(el, handler);
+    tapAt(el, 50, 60);
+    tapAt(el, 51, 61);
+    expect(handler).toHaveBeenCalledTimes(1);
+    el.dispatchEvent(new MouseEvent("dblclick", { clientX: 51, clientY: 61, bubbles: true }));
+    expect(handler).toHaveBeenCalledTimes(1); // still 1, not 2
+    off();
+  });
+
+  it("still fires mouse dblclick at a different spot within the compat window", () => {
+    // Hybrid devices (touch + trackpad) can produce a real mouse double-
+    // click shortly after a touch double-tap. As long as the position
+    // doesn't match, the de-dup must not swallow it.
+    const off = onDoubleTap(el, handler);
+    tapAt(el, 50, 60);
+    tapAt(el, 51, 61);
+    expect(handler).toHaveBeenCalledTimes(1);
+    el.dispatchEvent(new MouseEvent("dblclick", { clientX: 400, clientY: 300, bubbles: true }));
+    expect(handler).toHaveBeenCalledTimes(2);
+    off();
+  });
+
+  it("re-allows synthesized dblclick once the touch compat window expires", async () => {
+    const off = onDoubleTap(el, handler);
+    vi.useFakeTimers();
+    try {
+      tapAt(el, 50, 60);
+      tapAt(el, 51, 61);
+      expect(handler).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(800);
+      // Same spot, but the window has expired.
+      el.dispatchEvent(new MouseEvent("dblclick", { clientX: 51, clientY: 61, bubbles: true }));
+      expect(handler).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+      off();
+    }
   });
 });

--- a/packages/chart/src/__tests__/viewport-attach.test.ts
+++ b/packages/chart/src/__tests__/viewport-attach.test.ts
@@ -61,6 +61,7 @@ function setup(
     longPress?: boolean;
     wheelInertia?: boolean;
     total?: number;
+    isDrawingActive?: () => boolean;
   } = {},
 ): Setup {
   const el = makeEl();
@@ -89,6 +90,7 @@ function setup(
       wheelInertia: opts.wheelInertia ?? true,
       hotkeys: opts.hotkeys,
       onAction: dispatch,
+      isDrawingActive: opts.isDrawingActive,
     },
   );
   return { el, vp, ts, detach, resizePanes, dispatch, onUpdate };
@@ -349,6 +351,31 @@ describe("Viewport.attach() — touch", () => {
     vi.advanceTimersByTime(100);
     fireTouch(s.el, "touchstart", [makeTouch(400, 200)]);
     expect(s.ts.startIndex).toBe(0);
+  });
+
+  it("suppresses double-tap fitContent while a drawing tool is active", () => {
+    // Two-click drawings (rectangle / ray / channel / fib) on touch devices
+    // would otherwise fire the chart's built-in double-tap fit on the second
+    // tap. Hosts that arm a drawing tool expose `isDrawingActive: () => true`
+    // so the gesture default backs off and the drawing completes cleanly.
+    s.detach();
+    s = setup({ isDrawingActive: () => true });
+    // makeTimeScale defaults visible range to [100, 200] of 500 total — fit
+    // would snap startIndex to 0 if the guard didn't fire.
+    const startBefore = s.ts.startIndex;
+    fireTouch(s.el, "touchstart", [makeTouch(400, 200)]);
+    fireTouch(s.el, "touchend", []);
+    vi.advanceTimersByTime(100);
+    fireTouch(s.el, "touchstart", [makeTouch(400, 200)]);
+    expect(s.ts.startIndex).toBe(startBefore);
+  });
+
+  it("suppresses long-press crosshair lock while a drawing tool is active", () => {
+    s.detach();
+    s = setup({ isDrawingActive: () => true });
+    fireTouch(s.el, "touchstart", [makeTouch(400, 200)]);
+    vi.advanceTimersByTime(600);
+    expect(s.vp.state.crosshairIndex).toBe(null);
   });
 
   it("long-press locks crosshair after 500ms", () => {

--- a/packages/chart/src/core/interaction/touch-handler.ts
+++ b/packages/chart/src/core/interaction/touch-handler.ts
@@ -30,17 +30,23 @@ export function attachTouchHandlers(
         return;
       }
 
+      // While a drawing tool is armed, suppress the gesture defaults so the
+      // second tap of a two-click drawing (rectangle, ray, channel, fib...)
+      // doesn't double-up as a viewport reset, and a long press doesn't
+      // lock the crosshair instead of placing the start point.
+      const drawingActive = ctx.isDrawingActive?.() ?? false;
+
       // Double-tap detection
-      if (now - ctx.touch.lastTapTime < 300) {
+      if (!drawingActive && now - ctx.touch.lastTapTime < 300) {
         timeScale.fitContent();
         ctx.onUpdate();
         ctx.touch.lastTapTime = 0;
         return;
       }
-      ctx.touch.lastTapTime = now;
+      ctx.touch.lastTapTime = drawingActive ? 0 : now;
 
-      // Long-press detection (disabled when option is off)
-      if (longPressEnabled) {
+      // Long-press detection (disabled when option is off, or while drawing).
+      if (longPressEnabled && !drawingActive) {
         ctx.touch.longPressTimer = setTimeout(() => {
           ctx.touch.longPressCrosshairLocked = true;
           const r = el.getBoundingClientRect();

--- a/packages/chart/src/core/interaction/types.ts
+++ b/packages/chart/src/core/interaction/types.ts
@@ -110,4 +110,12 @@ export type InteractionContext = {
   // Scrollbar-press helpers (kept on Viewport to preserve their docstrings).
   applyScrollbarDrag: (mouseX: number, sb: ScrollbarRect) => void;
   beginScrollbarDrag: (mouseX: number, sb: ScrollbarRect) => void;
+
+  /**
+   * Whether a drawing tool is currently armed in the host. Touch gesture
+   * defaults (double-tap fitContent, long-press crosshair lock) consult this
+   * so two-click drawings can complete without the second tap also being
+   * interpreted as a viewport gesture.
+   */
+  isDrawingActive?: () => boolean;
 };

--- a/packages/chart/src/core/pointer.ts
+++ b/packages/chart/src/core/pointer.ts
@@ -8,15 +8,39 @@ export type PointerInfo = {
   x: number;
   y: number;
   isTouch: boolean;
+  /** Modifier keys at the time of the event. False for synthetic events
+   *  that don't carry modifier state. */
+  shiftKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  ctrlKey: boolean;
 };
+
+type ModifierSource = Pick<MouseEvent, "shiftKey" | "altKey" | "metaKey" | "ctrlKey">;
+
+function readModifiers(e: ModifierSource | undefined): {
+  shiftKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  ctrlKey: boolean;
+} {
+  return {
+    shiftKey: !!e?.shiftKey,
+    altKey: !!e?.altKey,
+    metaKey: !!e?.metaKey,
+    ctrlKey: !!e?.ctrlKey,
+  };
+}
 
 /** Extract canvas-local coordinates from a MouseEvent or Touch */
 export function getPointerPos(e: MouseEvent | Touch, el: HTMLElement): PointerInfo {
   const rect = el.getBoundingClientRect();
+  const isMouse = "button" in e;
   return {
     x: e.clientX - rect.left,
     y: e.clientY - rect.top,
-    isTouch: !("button" in e),
+    isTouch: !isMouse,
+    ...readModifiers(isMouse ? (e as MouseEvent) : undefined),
   };
 }
 
@@ -44,7 +68,7 @@ export function onTap(el: HTMLElement, handler: (pos: PointerInfo) => void): () 
       const dy = y - downPos.y;
       if (dx * dx + dy * dy > TAP_THRESHOLD) return;
     }
-    handler({ x, y, isTouch: false });
+    handler({ x, y, isTouch: false, ...readModifiers(e) });
   };
 
   let touchStartPos: { x: number; y: number } | null = null;
@@ -71,7 +95,7 @@ export function onTap(el: HTMLElement, handler: (pos: PointerInfo) => void): () 
     const dy = y - touchStartPos.y;
     touchStartPos = null;
     if (dx * dx + dy * dy > TAP_THRESHOLD) return;
-    handler({ x, y, isTouch: true });
+    handler({ x, y, isTouch: true, ...readModifiers(e) });
   };
 
   el.addEventListener("mousedown", onMouseDown);
@@ -82,6 +106,134 @@ export function onTap(el: HTMLElement, handler: (pos: PointerInfo) => void): () 
   return () => {
     el.removeEventListener("mousedown", onMouseDown);
     el.removeEventListener("click", onClick);
+    el.removeEventListener("touchstart", onTouchStart);
+    el.removeEventListener("touchend", onTouchEnd);
+  };
+}
+
+const DOUBLE_TAP_MS = 350;
+const DOUBLE_TAP_THRESHOLD = TAP_THRESHOLD;
+
+/**
+ * After a real touch double-tap, mobile browsers (iOS Safari, most Android
+ * WebViews) synthesize a mouse `dblclick` for the same gesture as part of
+ * their touch→mouse compatibility layer. Suppress the synthesized event
+ * within this window so subscribers don't see the same double-tap twice.
+ */
+const TOUCH_TO_MOUSE_COMPAT_MS = 700;
+
+function pointerNowMs(): number {
+  return typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+}
+
+/**
+ * Attach a "double-tap" listener that fires on mouse `dblclick` and on two
+ * finger taps within ~350 ms at near-identical positions. The chart emits
+ * this as a generic event; whether the chart also runs a built-in default
+ * action (e.g. `fitContent` on touch double-tap via `attachTouchHandlers`)
+ * is independent — hosts can subscribe and add their own action layer.
+ *
+ * Touch path mirrors `onTap`'s gesture discrimination:
+ *   - Multi-touch starts (pinch / two-finger pan) are ignored.
+ *   - touchends whose finger moved more than `TAP_THRESHOLD` are rejected
+ *     (pan/swipe, not a tap).
+ *   - Any invalid intervening gesture cancels the pending first tap so a
+ *     `tap → invalid → tap` sequence doesn't pair as a double-tap.
+ *
+ * Returns a cleanup function to remove all listeners.
+ */
+export function onDoubleTap(el: HTMLElement, handler: (pos: PointerInfo) => void): () => void {
+  // Stamped whenever the touch path successfully fires the handler. The
+  // mouse `dblclick` listener checks both timestamp and position: only the
+  // synthesized dblclick generated for the *same* gesture is suppressed.
+  // A real trackpad / mouse double-click somewhere else within the compat
+  // window must still fire normally on hybrid devices.
+  let lastTouchDoubleTapAt = Number.NEGATIVE_INFINITY;
+  let lastTouchDoubleTapPos: { x: number; y: number } | null = null;
+
+  const onDblClick = (e: MouseEvent) => {
+    const rect = el.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    if (lastTouchDoubleTapPos && pointerNowMs() - lastTouchDoubleTapAt < TOUCH_TO_MOUSE_COMPAT_MS) {
+      const dx = x - lastTouchDoubleTapPos.x;
+      const dy = y - lastTouchDoubleTapPos.y;
+      if (dx * dx + dy * dy <= DOUBLE_TAP_THRESHOLD) return;
+    }
+    handler({ x, y, isTouch: false, ...readModifiers(e) });
+  };
+
+  let lastTapTime = 0;
+  let lastTapPos: { x: number; y: number } | null = null;
+  let touchStartPos: { x: number; y: number } | null = null;
+  let multiTouch = false;
+
+  const onTouchStart = (e: TouchEvent) => {
+    if (e.touches.length > 1) {
+      multiTouch = true;
+      touchStartPos = null;
+      return;
+    }
+    multiTouch = false;
+    const rect = el.getBoundingClientRect();
+    const t = e.touches[0];
+    touchStartPos = { x: t.clientX - rect.left, y: t.clientY - rect.top };
+  };
+
+  const onTouchEnd = (e: TouchEvent) => {
+    const wasMulti = multiTouch;
+    const startPos = touchStartPos;
+    multiTouch = false;
+    touchStartPos = null;
+    if (wasMulti || !startPos) {
+      lastTapTime = 0;
+      lastTapPos = null;
+      return;
+    }
+
+    const t = e.changedTouches[0];
+    if (!t) {
+      lastTapTime = 0;
+      lastTapPos = null;
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    const x = t.clientX - rect.left;
+    const y = t.clientY - rect.top;
+
+    const moveDx = x - startPos.x;
+    const moveDy = y - startPos.y;
+    if (moveDx * moveDx + moveDy * moveDy > TAP_THRESHOLD) {
+      lastTapTime = 0;
+      lastTapPos = null;
+      return;
+    }
+
+    const now = pointerNowMs();
+    if (lastTapPos && now - lastTapTime < DOUBLE_TAP_MS) {
+      const dx = x - lastTapPos.x;
+      const dy = y - lastTapPos.y;
+      if (dx * dx + dy * dy <= DOUBLE_TAP_THRESHOLD) {
+        lastTapTime = 0;
+        lastTapPos = null;
+        lastTouchDoubleTapAt = now;
+        lastTouchDoubleTapPos = { x, y };
+        handler({ x, y, isTouch: true, ...readModifiers(e) });
+        return;
+      }
+    }
+    lastTapTime = now;
+    lastTapPos = { x, y };
+  };
+
+  el.addEventListener("dblclick", onDblClick);
+  el.addEventListener("touchstart", onTouchStart, { passive: true });
+  el.addEventListener("touchend", onTouchEnd, { passive: true });
+
+  return () => {
+    el.removeEventListener("dblclick", onDblClick);
     el.removeEventListener("touchstart", onTouchStart);
     el.removeEventListener("touchend", onTouchEnd);
   };

--- a/packages/chart/src/core/types/event.ts
+++ b/packages/chart/src/core/types/event.ts
@@ -8,6 +8,7 @@ export type ChartEvent =
   | "crosshairMove"
   | "visibleRangeChange"
   | "click"
+  | "doubleClick"
   | "resize"
   | "paneResize"
   | "seriesAdded"
@@ -16,6 +17,7 @@ export type ChartEvent =
   | "seriesRemoveRequest"
   | "dataFiltered"
   | "drawingComplete"
+  | "drawingToolChanged"
   | "error";
 
 /**
@@ -43,16 +45,23 @@ export type CrosshairMoveData = {
 };
 
 /**
- * Payload for the chart-wide `click` event. Fires on any pointer tap that
- * isn't consumed by the drawing tool. `index` and `time` resolve to the
- * candle nearest the click; `null` when the click landed outside the
- * data range.
+ * Payload for the chart-wide `click` and `doubleClick` events. Fires on
+ * pointer taps (mouse or touch) and double-clicks / double-taps that
+ * aren't consumed by the drawing tool. `index` and `time` resolve to the
+ * candle nearest the pointer; `null` when the pointer landed outside the
+ * data range. Modifier keys carry the keyboard state at click time (always
+ * `false` on touch unless the platform pairs a hardware keyboard) so hosts
+ * can branch on Shift/Alt/Meta/Ctrl without attaching their own listeners.
  */
 export type ChartClickData = {
   x: number;
   y: number;
   index: number | null;
   time: TimeValue | null;
+  shiftKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  ctrlKey: boolean;
 };
 
 export type VisibleRangeChangeData = {

--- a/packages/chart/src/core/viewport.ts
+++ b/packages/chart/src/core/viewport.ts
@@ -39,6 +39,13 @@ export type ViewportAttachOptions = {
   hotkeys?: HotkeyMap | false;
   /** Called when a hotkey fires (drawing tool, 'cancel', 'toggleOverlays'). */
   onAction?: (action: HotkeyAction) => void;
+  /**
+   * Returns whether a drawing tool is currently armed. When `true`, touch
+   * handlers suppress gesture defaults (double-tap fitContent, long-press
+   * crosshair lock) so the second tap of a two-click drawing isn't also
+   * interpreted as a viewport reset.
+   */
+  isDrawingActive?: () => boolean;
 };
 
 export class Viewport {
@@ -182,6 +189,7 @@ export class Viewport {
       },
       applyScrollbarDrag: (mouseX, sb) => this._applyScrollbarDrag(mouseX, sb, timeScale),
       beginScrollbarDrag: (mouseX, sb) => this._beginScrollbarDrag(mouseX, sb, timeScale),
+      isDrawingActive: opts?.isDrawingActive,
     };
 
     const inertia = new InertiaController(timeScale, ctx.pan, ctx.zoom, ctx.onUpdate);

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -10,7 +10,7 @@ import { autoFormatPrice, setMonthNames } from "../core/format";
 import { type ChartLocale, mergeLocale } from "../core/i18n";
 import { DEFAULT_LAYOUT, DEFAULT_LAYOUT_NO_VOLUME, LayoutEngine } from "../core/layout";
 import type { PrimitivePlugin, SeriesRendererPlugin } from "../core/plugin-types";
-import { onTap } from "../core/pointer";
+import { onDoubleTap, onTap } from "../core/pointer";
 import { resolveRangeDuration } from "../core/range-utils";
 import { RendererRegistry } from "../core/renderer-registry";
 import { type PriceScale, TimeScale } from "../core/scale";
@@ -53,6 +53,23 @@ import { renderFrame } from "./render-pipeline";
 // ============================================
 // Default Options
 // ============================================
+
+/** Window during which a `dblclick` arriving after a drawing's completing
+ *  tap is treated as the same gesture and suppressed. Slightly longer than
+ *  the platform double-click threshold (~300 ms) so we don't miss the
+ *  trailing event. */
+const DRAWING_DOUBLECLICK_GUARD_MS = 400;
+
+/** Squared canvas-local distance under which a `dblclick` is considered the
+ *  same gesture as the preceding drawing tap (5px radius — matches the
+ *  pointer module's tap threshold). */
+const DRAWING_DOUBLECLICK_RADIUS_SQ = 25;
+
+function nowMs(): number {
+  return typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+}
 
 const DEFAULT_OPTIONS: Required<
   Pick<ChartOptions, "height" | "priceAxisWidth" | "timeAxisHeight" | "fontSize">
@@ -119,6 +136,21 @@ export class CanvasChart implements ChartInstance {
   private _chartType: import("../core/types").ChartType;
   private _drawingTool: DrawingTool | null = null;
   private _detachDrawTap: (() => void) | null = null;
+  private _detachDoubleTap: (() => void) | null = null;
+  /**
+   * Timestamp + canvas-local position of the most recent tap that *completed*
+   * a drawing (the only tap of a one-click tool, or the second tap of a
+   * two-click tool). Used to suppress the trailing native `dblclick` that
+   * the browser emits after that completing click — by then the drawing
+   * tool has already cleared its active state, so the plain `isActive()`
+   * guard in the doubleClick path isn't enough.
+   *
+   * The position match is essential: a time-only guard would drop *any*
+   * `doubleClick` that happens shortly after a drawing tap, even when the
+   * user intentionally double-clicks elsewhere on the chart.
+   */
+  private _lastDrawingCompleteAt = 0;
+  private _lastDrawingCompletePos: { x: number; y: number } | null = null;
 
   private _rendererRegistry = new RendererRegistry();
   private _drawHelper: DrawHelper | null = null;
@@ -405,6 +437,7 @@ export class CanvasChart implements ChartInstance {
         wheelInertia: options?.interaction?.wheelInertia ?? true,
         hotkeys: options?.hotkeys,
         onAction: (action) => this._handleHotkeyAction(action),
+        isDrawingActive: () => this._drawingTool?.isActive() ?? false,
       },
     );
 
@@ -470,6 +503,15 @@ export class CanvasChart implements ChartInstance {
       // placement will fire spuriously while the user is drawing.
       if (this._drawingTool?.isActive()) {
         this._drawingTool.handleTap(pos);
+        // If the tap *completed* the drawing (one-click tools complete on
+        // their only tap; two-click tools complete on the second tap) the
+        // tool transitions back to inactive. Stamp the position so the
+        // browser-paired `dblclick` arriving at the same spot can be
+        // suppressed without affecting double-clicks elsewhere.
+        if (!this._drawingTool.isActive()) {
+          this._lastDrawingCompleteAt = nowMs();
+          this._lastDrawingCompletePos = { x: pos.x, y: pos.y };
+        }
         return;
       }
       const idx = this._timeScale.xToIndex(pos.x);
@@ -480,6 +522,44 @@ export class CanvasChart implements ChartInstance {
         y: pos.y,
         index: inRange ? idx : null,
         time: inRange ? candles[idx].time : null,
+        shiftKey: pos.shiftKey,
+        altKey: pos.altKey,
+        metaKey: pos.metaKey,
+        ctrlKey: pos.ctrlKey,
+      });
+    });
+    this._detachDoubleTap = onDoubleTap(this._canvas, (pos) => {
+      // Drawing tool swallows double-taps for symmetry with `onTap` — a
+      // double-tap that lands inside an active drawing session shouldn't
+      // also drive Replay anchors or other host-side handlers.
+      if (this._drawingTool?.isActive()) return;
+      // Two-click drawings (trendline, ray, rectangle, channel, fib...) and
+      // one-click drawings dispatched via a fast double-click both clear
+      // `_activeTool` on the completion click before the browser fires the
+      // matching `dblclick`. Suppress only when the dblclick is the same
+      // gesture — i.e. close in time AND position to the drawing's
+      // completing tap. A pure time guard would drop unrelated double-
+      // clicks elsewhere on the chart.
+      if (this._lastDrawingCompletePos) {
+        const dt = nowMs() - this._lastDrawingCompleteAt;
+        if (dt < DRAWING_DOUBLECLICK_GUARD_MS) {
+          const dx = pos.x - this._lastDrawingCompletePos.x;
+          const dy = pos.y - this._lastDrawingCompletePos.y;
+          if (dx * dx + dy * dy <= DRAWING_DOUBLECLICK_RADIUS_SQ) return;
+        }
+      }
+      const idx = this._timeScale.xToIndex(pos.x);
+      const candles = this._data.candles;
+      const inRange = idx >= 0 && idx < candles.length;
+      this._emit("doubleClick", {
+        x: pos.x,
+        y: pos.y,
+        index: inRange ? idx : null,
+        time: inRange ? candles[idx].time : null,
+        shiftKey: pos.shiftKey,
+        altKey: pos.altKey,
+        metaKey: pos.metaKey,
+        ctrlKey: pos.ctrlKey,
       });
     });
 
@@ -1162,6 +1242,7 @@ export class CanvasChart implements ChartInstance {
     this._legendOverlay?.destroy();
     this._rendererRegistry.destroyAll();
     this._detachDrawTap?.();
+    this._detachDoubleTap?.();
     this._drawingTool?.reset();
     this._drawingTool = null;
     this._canvas.remove();

--- a/packages/chart/src/renderer/drawing-tool.ts
+++ b/packages/chart/src/renderer/drawing-tool.ts
@@ -34,8 +34,19 @@ export class DrawingTool {
   }
 
   setTool(tool: DrawingType | null): void {
-    this._activeTool = tool;
+    // Always reset the in-progress anchor so that re-selecting the same
+    // multi-click tool (e.g. via repeated toolbar click or re-pressing the
+    // hotkey) starts a fresh gesture instead of completing the abandoned
+    // half-drawn one. The `drawingToolChanged` emit is still de-duped so
+    // listeners don't churn on no-op calls.
+    const sameTool = this._activeTool === tool;
     this._inProgress = null;
+    if (sameTool) {
+      this._deps.requestRender();
+      return;
+    }
+    this._activeTool = tool;
+    this._deps.emit("drawingToolChanged", { tool });
     this._deps.requestRender();
   }
 
@@ -227,6 +238,10 @@ export class DrawingTool {
     this._deps.emit("drawingComplete", drawing);
     this._activeTool = null;
     this._inProgress = null;
+    // Mirror `setTool(null)` so listeners that key off `drawingToolChanged`
+    // (e.g. host toolbars syncing their highlighted-button state) see the
+    // tool clear immediately after a successful placement.
+    this._deps.emit("drawingToolChanged", { tool: null });
     this._deps.requestRender();
   }
 }


### PR DESCRIPTION
## Summary

Bundles the post-Alpaca polish surfaced during a focused UX walkthrough. Two-track delivery: **chart** keeps growing as a generic events/primitives surface; **strategy-studio** uses those primitives to build a richer epic-level UX.

### chart (generic primitives)

- Emit `doubleClick` event (mouse + touch with proper gesture gating, multi-touch / pan rejection, pending-tap cancel on invalid intervening gestures)
- Emit `drawingToolChanged` event whenever the active drawing tool changes (set / completion / Escape) so host toolbars can mirror state
- Attach modifier-key state (`shiftKey` / `altKey` / `metaKey` / `ctrlKey`) to the `click` and `doubleClick` payloads
- Suppress the chart's built-in touch double-tap `fitContent` and long-press crosshair lock while a drawing tool is armed (host opts in via the new `isDrawingActive` viewport callback)
- `DrawingTool.setTool()` always clears the in-progress anchor so re-arming the same multi-click tool restarts cleanly
- Trailing `dblclick` after a drawing's completing tap is suppressed by both time and pointer position so unrelated double-clicks elsewhere still fire
- De-dup the browser-synthesized mouse `dblclick` that follows a touch double-tap on iOS Safari / Android WebView (matches by both time window and position)

### strategy-studio (epic UX)

- **Replay anchoring** moved from chart double-click to an explicit Anchor mode button + Shift+click accelerator (with the toolbar hint and Esc-to-cancel)
- **New ChartToolbar**: chart-type segmented control (Candle / Line / Mountain / OHLC), drawing tools (HLine / VLine / Trend / Arrow / Rect / Channel / Fib / Fib+ / Text + Clear), Fit; chart type and drawing tool synced through separate effects so type changes never reset an in-progress drawing
- **PresetSelector** rewritten with full-text search across name / kind / oneLiner / whenToUse / signals, collapsible categories with chevron + count chips, and inline `oneLiner` descriptions on every row
- **Portfolio** symbols pull real Alpaca data when keys are configured (SPY / AAPL / NVDA), sliced by the chart's calendar time window rather than bar count, and recompute when the data-source Reload signal fires or the underlying bars change content
- **Sparkline hover** labels prefixed with `Equity` so the dollar number isn't mistaken for a stock price
- **Replay cursor** uses a fixed-width locale-independent ISO format
- **Scoring tabs** overflow contained inside `.risk-tabs` so the row scrolls in place instead of pushing the whole right pane
- **Optimization result table** wrapped in a horizontally scrollable container so wide multi-leg results don't break the panel layout
- **Strategy DNA → Genome** labels use a path-aware compact form (`in.short`, `out.long`, …) instead of the naive 5-char truncation that collapsed `entry.shortPeriod` and `entry.longPeriod` to the same `entry..`. Caption + low → high gradient legend added so the panel's diagnostic value (best params at the edge of the search range) reads at a glance.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — chart 831, studio 95, core 5043, mcp 74 all pass
- [x] `pnpm build` green for all packages and studio individually
- [x] Manual walkthrough via headless browser: chart-type cycle, drawing tools (one-click + two-click), Anchor mode + Shift+click, Esc cancel, indicator search (`macd` → 7 matches), category collapse, TF switch with portfolio recompute, Optimization grid search → DNA inspection