### PR TITLE
feat(chart): connectPricePatterns plugin (PR15)

### DIFF
--- a/packages/chart/examples/indicator-showcase/src/signals-panel.ts
+++ b/packages/chart/examples/indicator-showcase/src/signals-panel.ts
@@ -13,7 +13,7 @@
  */
 
 import type { ChartInstance, PrimitiveRenderContext } from "@trendcraft/chart";
-import { connectSqueezeDots, definePrimitive } from "@trendcraft/chart";
+import { connectPricePatterns, connectSqueezeDots, definePrimitive } from "@trendcraft/chart";
 import type { NormalizedCandle, PatternSignal } from "trendcraft";
 import {
   bollingerSqueeze,
@@ -287,188 +287,9 @@ function connectRsiDivergence(candles: NormalizedCandle[]): PluginHandle | null 
 
 // ---- Signal: Price Patterns (Double Top/Bottom + H&S) ----------------------
 //
-// The "山" idiom: connect each pattern's keyPoints with a continuous zigzag
-// line, draw the neckline as a dashed reference, shade the pattern body, and
-// label the salient anchors (e.g. "Bottom 1" / "Bottom 2" / "Target").
-
-type PatternRender = {
-  signal: PatternSignal;
-  bullish: boolean;
-};
-
-const ANCHOR_LABEL_MAP: Record<string, string> = {
-  "First Trough": "Bottom 1",
-  "Second Trough": "Bottom 2",
-  "First Peak": "Top 1",
-  "Second Peak": "Top 2",
-  "Left Shoulder": "L. Shoulder",
-  Head: "Head",
-  "Right Shoulder": "R. Shoulder",
-};
-
-function makePricePatternsPlugin(candles: NormalizedCandle[]) {
-  const all: PatternSignal[] = [
-    ...doubleBottom(candles),
-    ...doubleTop(candles),
-    ...inverseHeadAndShoulders(candles),
-    ...headAndShoulders(candles),
-  ];
-  if (all.length === 0) return null;
-
-  // Dedup overlapping detections by keeping the highest-confidence pattern in
-  // each [startTime, endTime] envelope. Filter low-confidence noise and cap
-  // the total so dense regions don't pile up overlays.
-  const MIN_CONFIDENCE = 60;
-  const MAX_PATTERNS = 8;
-  const sorted = all
-    .filter((s) => s.confidence >= MIN_CONFIDENCE)
-    .sort((a, b) => b.confidence - a.confidence);
-  const accepted: PatternSignal[] = [];
-  for (const sig of sorted) {
-    if (accepted.length >= MAX_PATTERNS) break;
-    const overlaps = accepted.some(
-      (acc) =>
-        sig.pattern.startTime <= acc.pattern.endTime &&
-        sig.pattern.endTime >= acc.pattern.startTime,
-    );
-    if (!overlaps) accepted.push(sig);
-  }
-  if (accepted.length === 0) return null;
-  const renders: PatternRender[] = accepted.map((signal) => ({
-    signal,
-    bullish: signal.type === "double_bottom" || signal.type === "inverse_head_shoulders",
-  }));
-
-  return definePrimitive<{ renders: PatternRender[] }>({
-    name: "showcase-price-patterns",
-    pane: "main",
-    zOrder: "above",
-    defaultState: { renders },
-    render({ ctx, pane, timeScale, priceScale }, state) {
-      ctx.save();
-      clipToPane(ctx, pane);
-      const start = timeScale.startIndex;
-      const end = timeScale.endIndex;
-
-      for (const { signal, bullish } of state.renders) {
-        const kps = signal.pattern.keyPoints;
-        if (kps.length === 0) continue;
-        if (kps[kps.length - 1].index < start || kps[0].index >= end) continue;
-
-        const color = bullish ? BULL : BEAR;
-        const rgb = bullish ? BULL_RGB : BEAR_RGB;
-
-        // Filter keyPoints that are actual price extremes (skip neckline
-        // intersection points which sit on the neckline, not on the swing).
-        const extremes = kps.filter(
-          (k) => k.label !== "Neckline Start" && k.label !== "Neckline End",
-        );
-
-        // Body shading (light fill under the zigzag, between min and max y)
-        const xs = extremes.map((k) => timeScale.indexToX(k.index));
-        const ys = extremes.map((k) => priceScale.priceToY(k.price));
-        const necklineY = signal.pattern.neckline
-          ? priceScale.priceToY(signal.pattern.neckline.currentPrice)
-          : null;
-
-        if (necklineY !== null && xs.length >= 2) {
-          ctx.fillStyle = `rgba(${rgb},0.08)`;
-          ctx.beginPath();
-          ctx.moveTo(xs[0], necklineY);
-          for (let i = 0; i < xs.length; i++) ctx.lineTo(xs[i], ys[i]);
-          ctx.lineTo(xs[xs.length - 1], necklineY);
-          ctx.closePath();
-          ctx.fill();
-        }
-
-        // Zigzag connector through the price extremes
-        ctx.strokeStyle = color;
-        ctx.lineWidth = 1.8;
-        ctx.beginPath();
-        for (let i = 0; i < xs.length; i++) {
-          if (i === 0) ctx.moveTo(xs[i], ys[i]);
-          else ctx.lineTo(xs[i], ys[i]);
-        }
-        ctx.stroke();
-
-        // Neckline (dashed, horizontal-ish)
-        if (signal.pattern.neckline && xs.length >= 2) {
-          const nl = signal.pattern.neckline;
-          const x1 = xs[0];
-          const x2 = xs[xs.length - 1];
-          // Approximate slope using start/end of neckline if available
-          const yNeckLeft = priceScale.priceToY(nl.startPrice);
-          const yNeckRight = priceScale.priceToY(nl.endPrice);
-          ctx.save();
-          ctx.setLineDash([5, 4]);
-          ctx.strokeStyle = `rgba(${rgb},0.85)`;
-          ctx.lineWidth = 1.5;
-          ctx.beginPath();
-          ctx.moveTo(x1, yNeckLeft);
-          ctx.lineTo(x2, yNeckRight);
-          ctx.stroke();
-          ctx.restore();
-        }
-
-        // Anchor labels at each notable extreme. Resolve horizontal collisions
-        // by stacking labels vertically when their x-positions are too close.
-        const labels: { x: number; y: number; text: string }[] = [];
-        for (const k of extremes) {
-          const mapped = ANCHOR_LABEL_MAP[k.label];
-          if (!mapped) continue;
-          labels.push({
-            x: timeScale.indexToX(k.index),
-            y: priceScale.priceToY(k.price),
-            text: mapped,
-          });
-        }
-        const placement = bullish ? "below" : "above";
-        const stackDir = bullish ? 1 : -1;
-        const STACK_GAP = 22;
-        const MIN_X_SEP = 60;
-        for (let i = 0; i < labels.length; i++) {
-          let stackLevel = 0;
-          for (let j = 0; j < i; j++) {
-            if (Math.abs(labels[i].x - labels[j].x) < MIN_X_SEP) stackLevel++;
-          }
-          drawAnchoredLabel(
-            ctx,
-            labels[i].x,
-            labels[i].y + stackLevel * STACK_GAP * stackDir,
-            labels[i].text,
-            `rgba(${rgb},0.92)`,
-            placement,
-          );
-        }
-
-        // Measured-move target — dashed projector + Target pill
-        if (signal.pattern.target != null && xs.length >= 1) {
-          const lastX = xs[xs.length - 1];
-          const targetY = priceScale.priceToY(signal.pattern.target);
-          const lastY = ys[ys.length - 1];
-          ctx.save();
-          ctx.setLineDash([3, 3]);
-          ctx.strokeStyle = `rgba(${rgb},0.9)`;
-          ctx.lineWidth = 1;
-          ctx.beginPath();
-          ctx.moveTo(lastX, lastY);
-          ctx.lineTo(lastX, targetY);
-          ctx.stroke();
-          ctx.restore();
-          drawAnchoredLabel(
-            ctx,
-            lastX,
-            targetY,
-            "Target",
-            `rgba(${rgb},0.92)`,
-            bullish ? "above" : "below",
-          );
-        }
-      }
-      ctx.restore();
-    },
-  });
-}
+// Rendered through `connectPricePatterns` from `@trendcraft/chart` — the
+// zigzag + neckline + measured-move idiom is now a generic chart primitive
+// reusable across hosts.
 
 // ---- Specs ------------------------------------------------------------------
 
@@ -506,10 +327,14 @@ const SPECS: SignalSpec[] = [
     description:
       "Double Top/Bottom + Head & Shoulders rendered as zigzag + neckline + measured-move target",
     connect: (candles) => {
-      const plugin = makePricePatternsPlugin(candles);
-      if (!plugin) return null;
-      chartRef.registerPrimitive(plugin);
-      return { remove: () => chartRef.removePrimitive(plugin.name) };
+      const signals: PatternSignal[] = [
+        ...doubleBottom(candles),
+        ...doubleTop(candles),
+        ...inverseHeadAndShoulders(candles),
+        ...headAndShoulders(candles),
+      ];
+      if (signals.length === 0) return null;
+      return connectPricePatterns(chartRef, signals);
     },
   },
 ];

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -119,7 +119,7 @@
     {
       "name": "Main (createChart + all exports)",
       "path": "dist/index.js",
-      "limit": "38 kB"
+      "limit": "40 kB"
     },
     {
       "name": "Headless API",
@@ -149,12 +149,12 @@
     {
       "name": "React wrapper",
       "path": "dist/react/TrendChart.js",
-      "limit": "32 kB"
+      "limit": "33 kB"
     },
     {
       "name": "Vue wrapper",
       "path": "dist/vue/TrendChart.js",
-      "limit": "32 kB"
+      "limit": "33 kB"
     }
   ],
   "devDependencies": {

--- a/packages/chart/src/__tests__/price-patterns.test.ts
+++ b/packages/chart/src/__tests__/price-patterns.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PrimitiveRenderContext } from "../core/plugin-types";
+import type { PriceScale, TimeScale } from "../core/scale";
+import type { PaneRect, ThemeColors } from "../core/types";
+import { createPricePatterns, type PricePatternSignal } from "../plugins/price-patterns";
+
+function mockCtx() {
+  return {
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    rect: vi.fn(),
+    clip: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    fillRect: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    closePath: vi.fn(),
+    setLineDash: vi.fn(),
+    fillText: vi.fn(),
+    measureText: vi.fn(() => ({ width: 30 }) as TextMetrics),
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 1,
+    font: "",
+    textBaseline: "",
+    textAlign: "",
+  } as unknown as CanvasRenderingContext2D;
+}
+
+const mockTimeScale = {
+  startIndex: 0,
+  endIndex: 50,
+  barSpacing: 8,
+  indexToX: (i: number) => i * 8 + 4,
+} as TimeScale;
+
+const mockPriceScale = { priceToY: (p: number) => 400 - p * 2 } as PriceScale;
+
+const mockPane = { id: "main", x: 0, y: 0, width: 800, height: 400 } as PaneRect;
+const mockTheme = { text: "#fff", textSecondary: "#888" } as ThemeColors;
+
+function makeCtx(ctx: CanvasRenderingContext2D): PrimitiveRenderContext {
+  return {
+    ctx,
+    pane: mockPane,
+    timeScale: mockTimeScale,
+    priceScale: mockPriceScale,
+    theme: mockTheme,
+  } as PrimitiveRenderContext;
+}
+
+function makeSignal(overrides: Partial<PricePatternSignal> = {}): PricePatternSignal {
+  return {
+    type: "double_bottom",
+    confidence: 80,
+    pattern: {
+      startTime: 1000,
+      endTime: 2000,
+      keyPoints: [
+        { index: 5, price: 100, label: "First Trough" },
+        { index: 15, price: 110, label: "Pull-back Peak" },
+        { index: 25, price: 100, label: "Second Trough" },
+      ],
+      neckline: { startPrice: 110, endPrice: 110, currentPrice: 110 },
+      target: 120,
+    },
+    ...overrides,
+  };
+}
+
+describe("createPricePatterns", () => {
+  it("returns a primitive plugin with stable identity", () => {
+    const plugin = createPricePatterns([]);
+    expect(plugin.name).toBe("trendcraft-price-patterns");
+    expect(plugin.pane).toBe("main");
+    expect(plugin.zOrder).toBe("above");
+  });
+
+  it("renders nothing when no signals are present", () => {
+    const plugin = createPricePatterns([]);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+    // Pane clip still fires (it always runs), but no fill / stroke happens.
+    expect(ctx.fill).not.toHaveBeenCalled();
+    expect(ctx.stroke).not.toHaveBeenCalled();
+  });
+
+  it("draws zigzag + neckline + body shading + target for an in-range pattern", () => {
+    const plugin = createPricePatterns([makeSignal()]);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+    expect(ctx.stroke).toHaveBeenCalled(); // zigzag + neckline + target line
+    expect(ctx.fill).toHaveBeenCalled(); // body shading + label pills
+    expect(ctx.setLineDash).toHaveBeenCalledWith([5, 4]);
+    expect(ctx.setLineDash).toHaveBeenCalledWith([3, 3]);
+  });
+
+  it("filters patterns below the minConfidence threshold", () => {
+    const low = makeSignal({ confidence: 20 });
+    const plugin = createPricePatterns([low], { minConfidence: 60 });
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+    expect(ctx.stroke).not.toHaveBeenCalled();
+  });
+
+  it("dedups overlapping patterns by keeping the higher-confidence one", () => {
+    const a = makeSignal({ confidence: 70 });
+    const b = makeSignal({ confidence: 90 });
+    const plugin = createPricePatterns([a, b]);
+    expect(plugin.defaultState.renders).toHaveLength(1);
+    expect(plugin.defaultState.renders[0].signal.confidence).toBe(90);
+  });
+
+  it("colors bearish pattern types with the bear palette", () => {
+    const top = makeSignal({ type: "double_top" });
+    const plugin = createPricePatterns([top]);
+    expect(plugin.defaultState.renders[0].bullish).toBe(false);
+  });
+
+  it("respects bullishTypes override", () => {
+    const top = makeSignal({ type: "custom_bull" });
+    const plugin = createPricePatterns([top], { bullishTypes: ["custom_bull"] });
+    expect(plugin.defaultState.renders[0].bullish).toBe(true);
+  });
+
+  it("skips a pattern entirely when its key points fall outside the visible range", () => {
+    const offscreen = makeSignal({
+      pattern: {
+        startTime: 1000,
+        endTime: 2000,
+        keyPoints: [
+          { index: 100, price: 100, label: "First Trough" },
+          { index: 110, price: 110, label: "Second Trough" },
+        ],
+      },
+    });
+    const plugin = createPricePatterns([offscreen]);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+    expect(ctx.stroke).not.toHaveBeenCalled();
+  });
+
+  it("suppresses an anchor label when overridden to null", () => {
+    const plugin = createPricePatterns([makeSignal()], {
+      anchorLabels: { "First Trough": null },
+    });
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+    // fillText runs once per visible label; without the suppressed "First Trough"
+    // we have "Bottom 2" + "Target".
+    const calls = (ctx.fillText as unknown as { mock: { calls: unknown[] } }).mock.calls;
+    expect(calls.length).toBe(2);
+  });
+});

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -165,6 +165,12 @@ export {
   type MarketProfileValue,
 } from "./plugins/market-profile";
 // Plugins — tree-shakeable visualization primitives
+export {
+  connectPricePatterns,
+  createPricePatterns,
+  type PricePatternSignal,
+  type PricePatternsOptions,
+} from "./plugins/price-patterns";
 export { connectRegimeHeatmap, createRegimeHeatmap } from "./plugins/regime-heatmap";
 export { connectSessionZones, createSessionZones } from "./plugins/session-zones";
 export type { SmcLevel, SmcMarker, SmcState, SmcZone } from "./plugins/smc-layer";

--- a/packages/chart/src/plugins/price-patterns.ts
+++ b/packages/chart/src/plugins/price-patterns.ts
@@ -1,0 +1,384 @@
+/**
+ * Price Patterns Plugin — Visualizes chart-pattern signals (Double Top /
+ * Bottom, Head and Shoulders + inverse, etc.) using the standard zigzag +
+ * neckline + measured-move idiom: a zigzag line through the swing extremes,
+ * a dashed neckline, light body shading, anchored labels at each extreme,
+ * and a dashed projector to the measured-move target.
+ *
+ * Hosts compute pattern signals via `trendcraft`'s detectors (`doubleTop`,
+ * `doubleBottom`, `headAndShoulders`, `inverseHeadAndShoulders`, etc.) and
+ * pass them to this plugin verbatim.
+ *
+ * @example
+ * ```typescript
+ * import { createChart, connectPricePatterns } from '@trendcraft/chart';
+ * import { doubleBottom, doubleTop } from 'trendcraft';
+ *
+ * const chart = createChart(el);
+ * chart.setCandles(candles);
+ * const signals = [...doubleBottom(candles), ...doubleTop(candles)];
+ * const handle = connectPricePatterns(chart, signals);
+ * // Later: handle.remove();
+ * ```
+ */
+
+import { withPaneClip } from "../core/draw-helper";
+import { definePrimitive } from "../core/plugin-types";
+import type { ChartInstance } from "../core/types";
+
+// ---- Types (duck-typed; no core dependency) ----
+
+type PatternKeyPoint = {
+  index: number;
+  price: number;
+  label: string;
+};
+
+type PatternNeckline = {
+  startPrice: number;
+  endPrice: number;
+  currentPrice: number;
+};
+
+/**
+ * The subset of `trendcraft`'s `PatternSignal` this plugin needs. Compatible
+ * with the full `PatternSignal` shape so callers can pass detector results
+ * verbatim.
+ */
+export type PricePatternSignal = {
+  /** Detector key — `"double_top"`, `"double_bottom"`,
+   *  `"head_shoulders"`, `"inverse_head_shoulders"`, etc. The plugin only
+   *  uses this to decide bull vs bear coloring. */
+  type: string;
+  pattern: {
+    startTime: number;
+    endTime: number;
+    keyPoints: PatternKeyPoint[];
+    neckline?: PatternNeckline;
+    target?: number;
+  };
+  /** 0–100 confidence. Used for filtering and dedup ordering. */
+  confidence: number;
+};
+
+export type PricePatternsOptions = {
+  /** Hex color for bullish patterns (default: `"#26a69a"`) */
+  bullColor?: string;
+  /** Hex color for bearish patterns (default: `"#ef5350"`) */
+  bearColor?: string;
+  /**
+   * Comma-separated `r,g,b` triplet for bullish fills/translucent strokes.
+   * Defaults to the rgb decomposition of `bullColor` when only the hex
+   * form is supplied for the standard teal `#26a69a`.
+   */
+  bullColorRgb?: string;
+  bearColorRgb?: string;
+  /** Body fill alpha for the area between the zigzag and the neckline. */
+  bodyAlpha?: number;
+  /** Dash pattern for the neckline. Default `[5, 4]`. */
+  necklineDash?: [number, number];
+  /** Dash pattern for the measured-move projector. Default `[3, 3]`. */
+  targetDash?: [number, number];
+  /** Minimum confidence (0–100) for a pattern to be drawn. Default `60`. */
+  minConfidence?: number;
+  /** Cap on simultaneously visible patterns after dedup. Default `8`. */
+  maxPatterns?: number;
+  /**
+   * Override the displayed text for an extreme by its `keyPoint.label`.
+   * Defaults map common detector labels to compact UI strings
+   * (e.g. `"First Trough"` → `"Bottom 1"`). Pass `null` for a label to
+   * suppress its anchor pill entirely.
+   */
+  anchorLabels?: Record<string, string | null>;
+  /** Pattern types treated as bullish for coloring. Default: `["double_bottom",
+   *  "inverse_head_shoulders"]`. */
+  bullishTypes?: string[];
+};
+
+// ---- Defaults ----
+
+const DEFAULT_BULL = "#26a69a";
+const DEFAULT_BEAR = "#ef5350";
+const DEFAULT_BULL_RGB = "38,166,154";
+const DEFAULT_BEAR_RGB = "239,83,80";
+const DEFAULT_BULLISH_TYPES = ["double_bottom", "inverse_head_shoulders"];
+
+const DEFAULT_ANCHOR_LABELS: Record<string, string | null> = {
+  "First Trough": "Bottom 1",
+  "Second Trough": "Bottom 2",
+  "First Peak": "Top 1",
+  "Second Peak": "Top 2",
+  "Left Shoulder": "L. Shoulder",
+  Head: "Head",
+  "Right Shoulder": "R. Shoulder",
+};
+
+const NECKLINE_KEYPOINTS = new Set(["Neckline Start", "Neckline End"]);
+
+// ---- Helpers ----
+
+/**
+ * Dedup overlapping detections by keeping the highest-confidence pattern in
+ * each `[startTime, endTime]` envelope, then cap the survivor count.
+ */
+function dedupPatterns(
+  signals: PricePatternSignal[],
+  minConfidence: number,
+  maxPatterns: number,
+): PricePatternSignal[] {
+  const sorted = signals
+    .filter((s) => s.confidence >= minConfidence)
+    .sort((a, b) => b.confidence - a.confidence);
+  const accepted: PricePatternSignal[] = [];
+  for (const sig of sorted) {
+    if (accepted.length >= maxPatterns) break;
+    const overlaps = accepted.some(
+      (acc) =>
+        sig.pattern.startTime <= acc.pattern.endTime &&
+        sig.pattern.endTime >= acc.pattern.startTime,
+    );
+    if (!overlaps) accepted.push(sig);
+  }
+  return accepted;
+}
+
+/**
+ * Pill-shaped label with a small triangular tail pointing back toward
+ * `(anchorX, anchorY)`. The pill is offset on the opposite side of the
+ * indicated `placement`; the tail visually connects label → anchor.
+ */
+function drawAnchoredLabel(
+  ctx: CanvasRenderingContext2D,
+  anchorX: number,
+  anchorY: number,
+  text: string,
+  bg: string,
+  placement: "above" | "below",
+): void {
+  ctx.font = "11px system-ui, sans-serif";
+  const padX = 6;
+  const w = ctx.measureText(text).width + padX * 2;
+  const h = 18;
+  const gap = 12;
+  const labelY = placement === "above" ? anchorY - gap - h : anchorY + gap;
+  const labelX = anchorX - w / 2;
+  const r = 3;
+
+  ctx.fillStyle = bg;
+  ctx.beginPath();
+  ctx.moveTo(labelX + r, labelY);
+  ctx.lineTo(labelX + w - r, labelY);
+  ctx.quadraticCurveTo(labelX + w, labelY, labelX + w, labelY + r);
+  ctx.lineTo(labelX + w, labelY + h - r);
+  ctx.quadraticCurveTo(labelX + w, labelY + h, labelX + w - r, labelY + h);
+  ctx.lineTo(labelX + r, labelY + h);
+  ctx.quadraticCurveTo(labelX, labelY + h, labelX, labelY + h - r);
+  ctx.lineTo(labelX, labelY + r);
+  ctx.quadraticCurveTo(labelX, labelY, labelX + r, labelY);
+  ctx.closePath();
+  ctx.fill();
+
+  // Tail
+  ctx.beginPath();
+  if (placement === "above") {
+    ctx.moveTo(anchorX - 4, labelY + h);
+    ctx.lineTo(anchorX + 4, labelY + h);
+    ctx.lineTo(anchorX, labelY + h + 4);
+  } else {
+    ctx.moveTo(anchorX - 4, labelY);
+    ctx.lineTo(anchorX + 4, labelY);
+    ctx.lineTo(anchorX, labelY - 4);
+  }
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = "#fff";
+  ctx.textBaseline = "middle";
+  ctx.textAlign = "center";
+  ctx.fillText(text, anchorX, labelY + h / 2);
+  ctx.textAlign = "start";
+}
+
+/**
+ * Build the price-pattern primitive without registering it. Most hosts want
+ * `connectPricePatterns` instead — `createPricePatterns` is exposed for
+ * tests and advanced setups that prefer to call `chart.registerPrimitive`
+ * themselves.
+ */
+export function createPricePatterns(
+  signals: PricePatternSignal[],
+  options: PricePatternsOptions = {},
+) {
+  const bull = options.bullColor ?? DEFAULT_BULL;
+  const bear = options.bearColor ?? DEFAULT_BEAR;
+  const bullRgb =
+    options.bullColorRgb ?? (bull === DEFAULT_BULL ? DEFAULT_BULL_RGB : hexToRgb(bull));
+  const bearRgb =
+    options.bearColorRgb ?? (bear === DEFAULT_BEAR ? DEFAULT_BEAR_RGB : hexToRgb(bear));
+  const bodyAlpha = options.bodyAlpha ?? 0.08;
+  const necklineDash = options.necklineDash ?? [5, 4];
+  const targetDash = options.targetDash ?? [3, 3];
+  const minConfidence = options.minConfidence ?? 60;
+  const maxPatterns = options.maxPatterns ?? 8;
+  const anchorLabels = { ...DEFAULT_ANCHOR_LABELS, ...(options.anchorLabels ?? {}) };
+  const bullishTypes = new Set(options.bullishTypes ?? DEFAULT_BULLISH_TYPES);
+
+  const accepted = dedupPatterns(signals, minConfidence, maxPatterns);
+  const renders = accepted.map((signal) => ({
+    signal,
+    bullish: bullishTypes.has(signal.type),
+  }));
+
+  return definePrimitive<{ renders: typeof renders }>({
+    name: "trendcraft-price-patterns",
+    pane: "main",
+    zOrder: "above",
+    defaultState: { renders },
+    render({ ctx, pane, timeScale, priceScale }, state) {
+      withPaneClip(ctx, pane, () => {
+        const start = timeScale.startIndex;
+        const end = timeScale.endIndex;
+
+        for (const { signal, bullish } of state.renders) {
+          const kps = signal.pattern.keyPoints;
+          if (kps.length === 0) continue;
+          if (kps[kps.length - 1].index < start || kps[0].index >= end) continue;
+
+          const color = bullish ? bull : bear;
+          const rgb = bullish ? bullRgb : bearRgb;
+
+          // Filter keyPoints that are actual price extremes (skip neckline
+          // intersection points which sit on the neckline, not on the swing).
+          const extremes = kps.filter((k) => !NECKLINE_KEYPOINTS.has(k.label));
+          if (extremes.length === 0) continue;
+
+          const xs = extremes.map((k) => timeScale.indexToX(k.index));
+          const ys = extremes.map((k) => priceScale.priceToY(k.price));
+          const necklineY = signal.pattern.neckline
+            ? priceScale.priceToY(signal.pattern.neckline.currentPrice)
+            : null;
+
+          // Body shading between the zigzag and the neckline reference.
+          if (necklineY !== null && xs.length >= 2) {
+            ctx.fillStyle = `rgba(${rgb},${bodyAlpha})`;
+            ctx.beginPath();
+            ctx.moveTo(xs[0], necklineY);
+            for (let i = 0; i < xs.length; i++) ctx.lineTo(xs[i], ys[i]);
+            ctx.lineTo(xs[xs.length - 1], necklineY);
+            ctx.closePath();
+            ctx.fill();
+          }
+
+          // Zigzag connector through the price extremes.
+          ctx.strokeStyle = color;
+          ctx.lineWidth = 1.8;
+          ctx.beginPath();
+          for (let i = 0; i < xs.length; i++) {
+            if (i === 0) ctx.moveTo(xs[i], ys[i]);
+            else ctx.lineTo(xs[i], ys[i]);
+          }
+          ctx.stroke();
+
+          // Neckline (dashed).
+          if (signal.pattern.neckline && xs.length >= 2) {
+            const nl = signal.pattern.neckline;
+            ctx.save();
+            ctx.setLineDash(necklineDash);
+            ctx.strokeStyle = `rgba(${rgb},0.85)`;
+            ctx.lineWidth = 1.5;
+            ctx.beginPath();
+            ctx.moveTo(xs[0], priceScale.priceToY(nl.startPrice));
+            ctx.lineTo(xs[xs.length - 1], priceScale.priceToY(nl.endPrice));
+            ctx.stroke();
+            ctx.restore();
+          }
+
+          // Anchor labels — stack vertically when x-positions collide.
+          const labels: { x: number; y: number; text: string }[] = [];
+          for (const k of extremes) {
+            const mapped = anchorLabels[k.label];
+            if (mapped == null) continue;
+            labels.push({
+              x: timeScale.indexToX(k.index),
+              y: priceScale.priceToY(k.price),
+              text: mapped,
+            });
+          }
+          const placement = bullish ? "below" : "above";
+          const stackDir = bullish ? 1 : -1;
+          const STACK_GAP = 22;
+          const MIN_X_SEP = 60;
+          for (let i = 0; i < labels.length; i++) {
+            let stackLevel = 0;
+            for (let j = 0; j < i; j++) {
+              if (Math.abs(labels[i].x - labels[j].x) < MIN_X_SEP) stackLevel++;
+            }
+            drawAnchoredLabel(
+              ctx,
+              labels[i].x,
+              labels[i].y + stackLevel * STACK_GAP * stackDir,
+              labels[i].text,
+              `rgba(${rgb},0.92)`,
+              placement,
+            );
+          }
+
+          // Measured-move target — dashed projector + Target pill.
+          if (signal.pattern.target != null && xs.length >= 1) {
+            const lastX = xs[xs.length - 1];
+            const targetY = priceScale.priceToY(signal.pattern.target);
+            const lastY = ys[ys.length - 1];
+            ctx.save();
+            ctx.setLineDash(targetDash);
+            ctx.strokeStyle = `rgba(${rgb},0.9)`;
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.moveTo(lastX, lastY);
+            ctx.lineTo(lastX, targetY);
+            ctx.stroke();
+            ctx.restore();
+            drawAnchoredLabel(
+              ctx,
+              lastX,
+              targetY,
+              "Target",
+              `rgba(${rgb},0.92)`,
+              bullish ? "above" : "below",
+            );
+          }
+        }
+      });
+    },
+  });
+}
+
+/**
+ * Wire a price-pattern overlay primitive onto an existing chart instance.
+ *
+ * Returns a handle whose `remove()` detaches the primitive. Calling
+ * `connectPricePatterns` again (with a new signal set) is the supported way
+ * to update the visualization — remove the previous handle first.
+ */
+export function connectPricePatterns(
+  chart: ChartInstance,
+  signals: PricePatternSignal[],
+  options: PricePatternsOptions = {},
+): { remove: () => void } {
+  const plugin = createPricePatterns(signals, options);
+  chart.registerPrimitive(plugin);
+  return {
+    remove: () => chart.removePrimitive(plugin.name),
+  };
+}
+
+/**
+ * Naive `#rrggbb` → `r,g,b` for the rgba() string helper. Falls back to a
+ * neutral grey if the input is malformed; never throws so an unrelated
+ * feature can't break chart rendering.
+ */
+function hexToRgb(hex: string): string {
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex);
+  if (!m) return "128,128,128";
+  const v = Number.parseInt(m[1], 16);
+  return `${(v >> 16) & 0xff},${(v >> 8) & 0xff},${v & 0xff}`;
+}


### PR DESCRIPTION
## Summary

Closes the **PR15** carve-out from the studio epic README: extract the chart-pattern overlay (zigzag + neckline + body shading + measured-move target) from `indicator-showcase`'s inline implementation into a generic chart-package primitive so other hosts (Strategy Studio, future examples) can render the same idiom without copying ~170 lines of canvas code.

### Public API

```ts
import { connectPricePatterns } from '@trendcraft/chart';
import { doubleBottom, doubleTop, headAndShoulders, inverseHeadAndShoulders } from 'trendcraft';

const signals = [
  ...doubleBottom(candles),
  ...doubleTop(candles),
  ...inverseHeadAndShoulders(candles),
  ...headAndShoulders(candles),
];
const handle = connectPricePatterns(chart, signals);
// Later: handle.remove();
```

`createPricePatterns(signals, options?)` is exposed as a sibling for tests / advanced setups that prefer to register the primitive themselves.

`PricePatternsOptions` covers:
- bull / bear hex colors and matching `r,g,b` triplets for alpha blending
- body-fill alpha, neckline / target dash patterns
- min-confidence floor, max-patterns cap (overlap dedup keeps the higher-confidence detection)
- anchor-label rename map (pass `null` for any label to suppress its pill)
- which detector `type` strings count as bullish (default: `double_bottom` + `inverse_head_shoulders`)

The plugin is duck-typed against `trendcraft`'s `PatternSignal` so chart keeps zero hard core dependency.

### Showcase migration

`indicator-showcase/signals-panel.ts` drops the ~170-line inline `makePricePatternsPlugin` and the `Signal: Price Patterns` arm collapses to a 7-line `connect: ...` that calls `connectPricePatterns`. Visual output unchanged — same colors, same labels, same dedup behaviour.

### Size limits

The new primitive is tree-shakeable, but the all-exports bundle measurement grows by ~1.1 kB:

- Main: 38 kB → **40 kB** (observed 39.11 kB)
- React / Vue wrappers: 32 kB → **33 kB** (Vue observed 32.17 kB; React stays under at 31.82 kB)

### Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — chart 840 / 832 (+9 new in `price-patterns.test.ts`), studio 95, core 5043, mcp 74
- [x] `pnpm build` green for all packages
- [x] `pnpm size-check` green at the new limits