### PR TITLE
feat(chart): live recompute for batch-only indicator presets (PR14)

### DIFF
--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -275,13 +275,10 @@ export function App() {
       // `live.completedCandles` for warm-up. Passing the full `candles` here
       // would duplicate the seed AND warm indicators with future bars the
       // replay hasn't reached — exactly the look-ahead leak Replay exists
-      // to prevent.
-      // KNOWN LIMITATION (PR14 follow-up): batch-only presets (no
-      // `createFactory`, e.g. adaptiveRsi, heikinAshi) freeze at the seed
-      // boundary in Replay mode. `connectIndicators` warms them up once
-      // and never re-computes on candleComplete. Fixing this needs a
-      // chart-side change so the host doesn't have to know which presets
-      // are batch-only — see PR14 in the Studio epic.
+      // to prevent. Batch-only presets (no `createFactory`, e.g. adaptiveRsi,
+      // heikinAshi) are kept fresh by connectIndicators itself: it re-runs
+      // `compute` against the growing history on every candleComplete unless
+      // a preset opts out via `liveRecompute: false`.
       conn = connectIndicators(chart, {
         presets: indicatorPresets,
         candles: [],

--- a/packages/chart/src/__tests__/connect-indicators.test.ts
+++ b/packages/chart/src/__tests__/connect-indicators.test.ts
@@ -335,6 +335,249 @@ describe("connectIndicators", () => {
       expect(handles[0].updates).toHaveLength(0);
     });
 
+    it("recomputes batch-only presets on candleComplete (PR14)", () => {
+      const { chart, handles } = createMockChart();
+      const completed: CandleData[] = [candle(1, 100), candle(2, 102)];
+      const { source, emitComplete } = createMockLiveSource(completed);
+      const preset = makeComputePreset("custom");
+      const conn = connectIndicators(chart, {
+        presets: { custom: preset },
+        candles: [],
+        live: source,
+      });
+      conn.add("custom");
+
+      // Initial backfill goes through `addIndicator(initialData, ...)` and
+      // doesn't show up in setDataCalls — that's a `setData()` counter.
+      expect(handles[0].data).toHaveLength(2);
+      expect(handles[0].setDataCalls).toHaveLength(0);
+
+      // A new completed candle arrives. The simulator pushes to the same
+      // completedCandles array (`createLiveCandle` does the equivalent), then
+      // fires the event — recompute should see the longer history.
+      const c3 = candle(3, 105);
+      completed.push(c3);
+      emitComplete(c3, {});
+
+      expect(handles[0].setDataCalls).toHaveLength(1);
+      expect(handles[0].setDataCalls[0]).toHaveLength(3);
+      // No streaming `update()` for batch-only presets — recompute uses setData.
+      expect(handles[0].updates).toHaveLength(0);
+    });
+
+    it("does NOT recompute factory-driven presets on candleComplete", () => {
+      const { chart, handles } = createMockChart();
+      const completed: CandleData[] = [candle(1, 100)];
+      const { source, emitComplete } = createMockLiveSource(completed);
+      const conn = connectIndicators(chart, {
+        presets: { rsi: makeFactoryPreset("rsi") },
+        candles: [],
+        live: source,
+      });
+      conn.add("rsi");
+
+      const initialSetData = handles[0].setDataCalls.length;
+
+      const c2 = candle(2, 105);
+      completed.push(c2);
+      emitComplete(c2, { rsi: 65 });
+
+      // Streaming path stays — update fires, setData does not.
+      expect(handles[0].updates).toHaveLength(1);
+      expect(handles[0].setDataCalls).toHaveLength(initialSetData);
+    });
+
+    it("recomputes batch-only presets with options.candles as warm-up history", () => {
+      // Common setup: host passes warm-up history via `options.candles` and
+      // an empty live source that fills via addCandle(). Auto-recompute must
+      // include the warm-up — otherwise long-lookback batch indicators see
+      // only the post-warmup tail and produce wrong values.
+      const warmUp = [candle(1, 100), candle(2, 102), candle(3, 101)];
+      const completed: CandleData[] = [];
+      const { chart, handles } = createMockChart();
+      const { source, emitComplete } = createMockLiveSource(completed);
+      const preset = makeComputePreset("custom");
+      const conn = connectIndicators(chart, {
+        presets: { custom: preset },
+        candles: warmUp,
+        live: source,
+      });
+      conn.add("custom");
+
+      const c4 = candle(4, 105);
+      completed.push(c4);
+      emitComplete(c4, {});
+
+      expect(handles[0].setDataCalls).toHaveLength(1);
+      expect(handles[0].setDataCalls[0]).toHaveLength(warmUp.length + completed.length);
+    });
+
+    it("does not double-count after a manual recompute() in live mode", () => {
+      // Manual `recompute(custom)` replaces the connection's canonical
+      // history. A subsequent `candleComplete` *appends* the new bar onto
+      // that custom window — it does not re-concat the live source's
+      // completedCandles, so no bar is counted twice.
+      const { chart, handles } = createMockChart();
+      const completed: CandleData[] = [candle(1, 100), candle(2, 102)];
+      const { source, emitComplete } = createMockLiveSource(completed);
+      const preset = makeComputePreset("custom");
+      const conn = connectIndicators(chart, {
+        presets: { custom: preset },
+        candles: [],
+        live: source,
+      });
+      conn.add("custom");
+
+      // Host triggers a manual refresh — passes the full live history.
+      conn.recompute(completed);
+      const afterManual = handles[0].setDataCalls.length;
+
+      // New bar arrives.
+      const c3 = candle(3, 105);
+      completed.push(c3);
+      emitComplete(c3, {});
+
+      // Auto-recompute fires once with the correct length (= completed.length),
+      // not 2x.
+      expect(handles[0].setDataCalls).toHaveLength(afterManual + 1);
+      expect(handles[0].setDataCalls.at(-1)).toHaveLength(completed.length);
+    });
+
+    it("merges options.candles + completedCandles by time at construction (Pattern C)", () => {
+      // Defensive against a host that seeds the same bars into both
+      // options.candles and the live source: dedup by `time` so the chart
+      // doesn't see each bar twice in the backfill.
+      const seed = [candle(1, 100), candle(2, 102)];
+      const completed: CandleData[] = [...seed];
+      const { chart, handles } = createMockChart();
+      const { source } = createMockLiveSource(completed);
+      const preset = makeComputePreset("custom");
+      const conn = connectIndicators(chart, {
+        presets: { custom: preset },
+        candles: seed,
+        live: source,
+      });
+      conn.add("custom");
+
+      // Backfill arrives via addIndicator(initialData, ...). Length should be
+      // seed.length, NOT seed.length + completed.length.
+      expect(handles[0].data).toHaveLength(seed.length);
+    });
+
+    it("replaces the last bar on candleComplete with same time (re-emit / correction)", () => {
+      // LiveCandle can re-emit a bar (e.g. tick aggregator finalizing a
+      // partial). The connection should replace the last entry, not push a
+      // duplicate.
+      const initial = candle(1, 100);
+      const completed: CandleData[] = [initial];
+      const { chart, handles } = createMockChart();
+      const { source, emitComplete } = createMockLiveSource(completed);
+      const conn = connectIndicators(chart, {
+        presets: { custom: makeComputePreset("custom") },
+        candles: [],
+        live: source,
+      });
+      conn.add("custom");
+
+      const corrected = { ...initial, close: 999 };
+      // Live source mutates the completedCandles tail (typical re-emit).
+      completed[completed.length - 1] = corrected;
+      emitComplete(corrected, {});
+
+      expect(handles[0].setDataCalls).toHaveLength(1);
+      // History length stayed at 1 — no duplicate. The last bar carries the
+      // corrected close.
+      expect(handles[0].setDataCalls[0]).toHaveLength(1);
+      const lastPoint = handles[0].setDataCalls[0][0] as { time: number; value: number };
+      expect(lastPoint.time).toBe(initial.time);
+      expect(lastPoint.value).toBe(999);
+    });
+
+    it("manual recompute() in live mode is a permanent override, not a one-shot", () => {
+      // After conn.recompute(custom), the new history *is* the canonical
+      // view. Subsequent candleComplete events extend that custom window
+      // (not the original options.candles + completedCandles seed).
+      const { chart, handles } = createMockChart();
+      const completed: CandleData[] = [];
+      const { source, emitComplete } = createMockLiveSource(completed);
+      const conn = connectIndicators(chart, {
+        presets: { custom: makeComputePreset("custom") },
+        candles: [],
+        live: source,
+      });
+      conn.add("custom");
+
+      // Host injects a custom window unrelated to the live source's history.
+      const customWindow = [candle(10, 100), candle(11, 102), candle(12, 101)];
+      conn.recompute(customWindow);
+      expect(handles[0].setDataCalls.at(-1)).toHaveLength(customWindow.length);
+
+      // New bar arrives via the live source.
+      const c13 = candle(13, 105);
+      completed.push(c13);
+      emitComplete(c13, {});
+
+      // Auto-recompute extends the custom window — does NOT revert to the
+      // (empty) seed view, and does NOT discard host's custom bars.
+      expect(handles[0].setDataCalls.at(-1)).toHaveLength(customWindow.length + 1);
+    });
+
+    it("respects liveRecompute=false opt-out for expensive batch presets", () => {
+      const { chart, handles } = createMockChart();
+      const completed: CandleData[] = [candle(1, 100)];
+      const { source, emitComplete } = createMockLiveSource(completed);
+      const preset: IndicatorPresetEntry = {
+        ...makeComputePreset("hmm"),
+        liveRecompute: false,
+      };
+      const conn = connectIndicators(chart, {
+        presets: { hmm: preset },
+        candles: [],
+        live: source,
+      });
+      conn.add("hmm");
+      const initialSetData = handles[0].setDataCalls.length;
+
+      const c2 = candle(2, 102);
+      completed.push(c2);
+      emitComplete(c2, {});
+
+      // Opted-out preset stays frozen at seed values.
+      expect(handles[0].setDataCalls).toHaveLength(initialSetData);
+    });
+
+    it("liveRecompute=false makes manual recompute() the permanent override", () => {
+      // The flip-side contract of liveRecompute: when a preset opts out of
+      // auto-recompute, conn.recompute(custom) is the *only* way data
+      // changes — and subsequent candleComplete events do not overwrite it.
+      const { chart, handles } = createMockChart();
+      const completed: CandleData[] = [candle(1, 100), candle(2, 102)];
+      const { source, emitComplete } = createMockLiveSource(completed);
+      const preset: IndicatorPresetEntry = {
+        ...makeComputePreset("hmm"),
+        liveRecompute: false,
+      };
+      const conn = connectIndicators(chart, {
+        presets: { hmm: preset },
+        candles: [],
+        live: source,
+      });
+      conn.add("hmm");
+
+      // Host pushes a custom candle window through recompute().
+      const customWindow = [candle(1, 100), candle(2, 102), candle(3, 104)];
+      conn.recompute(customWindow);
+      const afterManual = handles[0].setDataCalls.length;
+      expect(handles[0].setDataCalls.at(-1)).toHaveLength(3);
+
+      // Live source advances. Auto-recompute is OFF, so the host's custom
+      // window stays put — no setData fires.
+      const c4 = candle(4, 106);
+      completed.push(c4);
+      emitComplete(c4, {});
+      expect(handles[0].setDataCalls).toHaveLength(afterManual);
+    });
+
     it("should clean up on remove in live mode", () => {
       const { chart, handles } = createMockChart();
       const { source, registeredIndicators } = createMockLiveSource([candle(1, 100)]);

--- a/packages/chart/src/integration/connect-indicators.ts
+++ b/packages/chart/src/integration/connect-indicators.ts
@@ -57,6 +57,27 @@ export type IndicatorPresetEntry = {
   compute?: (candles: SourceCandle[], params: Record<string, unknown>) => DataPoint<unknown>[];
   /** Incremental factory for live streaming */
   createFactory?: (params: Record<string, unknown>) => LiveIndicatorFactoryFn;
+  /**
+   * Behavior in live mode for presets that have `compute` but no `createFactory`
+   * ("batch-only").
+   *
+   * - **`true` (default)**: connection auto-recomputes on every `candleComplete`
+   *   against its connection-owned canonical history (built once from
+   *   `options.candles + liveSource.completedCandles` and extended on each
+   *   subsequent `candleComplete`). Manual `conn.recompute(custom)` calls
+   *   replace that history permanently — new bars append onto the host's
+   *   custom window rather than reverting to the seed view.
+   *
+   * - **`false`**: connection skips auto-recompute. The preset stays at its
+   *   seed-time value (or whatever `recompute()` last produced) until the
+   *   host calls `conn.recompute(...)` again. Use this for batch presets
+   *   whose recompute is too heavy to run per bar (e.g. HMM regimes on long
+   *   histories).
+   *
+   * Has no effect on presets with a `createFactory` — those always stream
+   * incrementally regardless of this flag.
+   */
+  liveRecompute?: boolean;
 };
 
 /** Duck-typed LiveCandle-compatible data source */
@@ -167,7 +188,14 @@ export type IndicatorConnection = {
   /** Look up a single handle by snapshot name */
   get(snapshotName: string): IndicatorHandle | undefined;
 
-  /** Recompute all static indicators with new candle data */
+  /**
+   * Recompute all indicators with new candle data.
+   *
+   * Replaces the connection-owned canonical history with `candles`, then
+   * fires `setData(compute(candles))` on every active indicator. In live
+   * mode, subsequent `candleComplete` events append onto this new history
+   * — the override is permanent, not a one-shot.
+   */
   recompute(candles: readonly SourceCandle[]): void;
   /** Disconnect: remove all indicators and unsubscribe events */
   disconnect(): void;
@@ -234,7 +262,26 @@ export function connectIndicators(
   const mode = liveSource ? ("live" as const) : ("static" as const);
   /** Keyed by snapshotName (single source of truth, matches LiveCandle's indicator map) */
   const active = new Map<string, ActiveEntry>();
-  let _candles: readonly SourceCandle[] = initialCandles;
+  /**
+   * Connection-owned canonical view of the candle history. All paths read
+   * from here:
+   * - `add()` backfill
+   * - `recomputeBatchOnlyIndicators()` on candleComplete
+   * - `recompute(custom)` (replace)
+   *
+   * In live mode, seeded once at construction by `mergeByTime(options.candles,
+   * liveSource.completedCandles)` (deduplicated by `time`, with completedCandles
+   * winning on conflict). Each subsequent `candleComplete` event appends the
+   * incoming candle (or replaces the last entry on `time` collision) — we do
+   * NOT re-read `liveSource.completedCandles`, so source-side trimming
+   * (`maxHistory`) cannot retroactively shrink our long-lookback view.
+   *
+   * In static mode, just a copy of `options.candles`. `recompute(custom)`
+   * replaces the entire array.
+   */
+  const _runningHistory: SourceCandle[] = liveSource
+    ? mergeByTime(initialCandles, liveSource.completedCandles)
+    : [...initialCandles];
 
   // Unsub handles for live events
   let unsubTick: (() => void) | null = null;
@@ -272,6 +319,29 @@ export function connectIndicators(
     }
   }
 
+  /**
+   * Recompute batch-only indicators (no `createFactory`) on candleComplete.
+   * Without this pass, presets that only ship `compute` would freeze at the
+   * seed boundary in live mode — `updateLiveIndicators` skips them by design
+   * because they don't expose a per-bar streaming value.
+   *
+   * Reads the connection-owned `_runningHistory`, which already includes
+   * the bar that just fired this event (the candleComplete handler appends
+   * before invoking us). Hosts that opt out via `liveRecompute: false`
+   * stay frozen at their last `setData` value.
+   */
+  function recomputeBatchOnlyIndicators(): void {
+    if (!liveSource) return;
+    for (const entry of active.values()) {
+      if (!entry.staticOnly) continue;
+      const preset = presets[entry.presetId];
+      if (!preset?.compute) continue;
+      if (preset.liveRecompute === false) continue;
+      const newData = computeData(preset, entry.params, _runningHistory);
+      entry.series.setData(newData);
+    }
+  }
+
   // Initialize live subscriptions
   if (liveSource) {
     if (options.initHistory !== false) {
@@ -291,10 +361,21 @@ export function connectIndicators(
     });
 
     unsubComplete = liveSource.on("candleComplete", ({ candle, snapshot }) => {
+      // Update the connection-owned canonical history first so both the
+      // streaming path (factory-driven) and batch recompute see the new bar.
+      // Append, or replace the last entry on `time` collision (handles
+      // re-emit / correction without duplicating).
+      appendOrReplaceByTime(_runningHistory, candle);
+
       try {
         updateLiveIndicators(snapshot, candle);
       } catch (e) {
         console.error("[@trendcraft/chart] connect-indicators candleComplete error:", e);
+      }
+      try {
+        recomputeBatchOnlyIndicators();
+      } catch (e) {
+        console.error("[@trendcraft/chart] connect-indicators batch recompute error:", e);
       }
     });
   }
@@ -385,9 +466,12 @@ export function connectIndicators(
       if (factory) liveSource.addIndicator(snapshotName, factory);
     }
 
-    // Compute initial data (backfill)
-    const allCandles = liveSource ? [..._candles, ...liveSource.completedCandles] : [..._candles];
-    const historyData = allCandles.length > 0 ? computeData(preset, params, allCandles) : [];
+    // Compute initial data (backfill) from the connection-owned canonical
+    // view. In live mode this was already deduplicated against the live
+    // source's seed at construction; in static mode it's `options.candles`
+    // (or whatever the host last passed to `recompute()`).
+    const historyData =
+      _runningHistory.length > 0 ? computeData(preset, params, _runningHistory) : [];
 
     // Build series config
     const series = buildSeriesConfig(preset.meta, snapshotName, params, seriesOverrides, presetId);
@@ -480,13 +564,15 @@ export function connectIndicators(
 
   function recompute(candles: readonly SourceCandle[]): void {
     assertConnected();
-    _candles = candles;
+    // Replace the canonical view permanently. Subsequent candleComplete
+    // events append onto this; subsequent add() calls backfill from this.
+    _runningHistory.splice(0, _runningHistory.length, ...candles);
 
     for (const entry of active.values()) {
       const preset = presets[entry.presetId];
       if (!preset) continue;
 
-      const newData = computeData(preset, entry.params, candles);
+      const newData = computeData(preset, entry.params, _runningHistory);
       entry.series.setData(newData);
     }
   }
@@ -524,4 +610,38 @@ export function connectIndicators(
       return mode;
     },
   };
+}
+
+// ============================================
+// Internal helpers
+// ============================================
+
+/**
+ * Merge two candle arrays by `time`, deduplicating collisions. Bars from `b`
+ * take precedence on conflict — used at construction time so the live source's
+ * view of a shared bar wins over the host's seed copy. Returns a new array
+ * sorted by `time` ascending.
+ */
+function mergeByTime(a: readonly SourceCandle[], b: readonly SourceCandle[]): SourceCandle[] {
+  if (a.length === 0) return [...b];
+  if (b.length === 0) return [...a];
+  const seen = new Map<number, SourceCandle>();
+  for (const c of a) seen.set(c.time, c);
+  for (const c of b) seen.set(c.time, c);
+  return [...seen.values()].sort((x, y) => x.time - y.time);
+}
+
+/**
+ * Append a candle to a chronologically-ordered array, or replace the last
+ * entry if it shares the same `time` (handles re-emit / late-correction
+ * without duplicating the bar). LiveCandle's contract guarantees monotonic
+ * candleComplete times, so we only need to compare against the tail.
+ */
+function appendOrReplaceByTime(arr: SourceCandle[], candle: SourceCandle): void {
+  const last = arr[arr.length - 1];
+  if (last && last.time === candle.time) {
+    arr[arr.length - 1] = candle;
+  } else {
+    arr.push(candle);
+  }
 }


### PR DESCRIPTION
## Summary

Closes the **PR14** carve-out from the strategy-studio epic README. Batch-only indicator presets — those with `compute` but no `createFactory` (adaptiveRsi, heikinAshi, anything that needs a full pass over history) — used to freeze at the seed boundary in live / Replay mode because `connectIndicators`'s live event loop only forwards snapshot values through the factory streaming path. With this change, those presets refresh on every `candleComplete`.

Strategy Studio's Replay mode now keeps batch presets live as the user scrubs, instead of showing stale seed-time values.

## Design: connection-owned canonical history

The previous implementation juggled three candle sources at every read site:

- `options.candles` (immutable, what the host passed in)
- `_candles` (mutated by `recompute()`)
- `liveSource.completedCandles` (mutated by the live source on every event, possibly trimmed by `maxHistory`)

`add()`'s backfill concatenated `_candles + completedCandles`. A naive auto-recompute that mirrored that pattern produced a different behavior in three different host setups (warm-up via `options.candles`, warm-up via `addCandle()`, mirror pattern), with no single concat strategy correct in all of them. Three rounds of code review surfaced opposite-direction failures with each successive patch — a sign the model was the problem, not the patch.

The new model: `connectIndicators` owns a single mutable `_runningHistory: SourceCandle[]`.

- **Construction** (live mode): `mergeByTime(options.candles, liveSource.completedCandles)`. Deduplicated by `time` so hosts that mirror the same bars into both arrays don't get a doubled backfill (a pre-existing bug in `add()` falls out).
- **`candleComplete`**: append the incoming candle to `_runningHistory`, or replace the last entry on `time` collision (LiveCandle re-emit / late-correction tolerance).
- **`add()` backfill** / **auto-recompute** / **`recompute()`**: all read `_runningHistory` directly. No more case-split concat branching.
- **`recompute(custom)`**: replaces `_runningHistory` permanently. New bars append onto the host's custom window, so manual refresh in live mode is a real override, not a one-shot that the next bar undoes.

## Per-preset opt-out

`IndicatorPresetEntry.liveRecompute?: boolean` (default `true`). Set `false` for batch presets too heavy to recompute per bar (e.g. HMM regimes on long histories). The host then drives refreshes via `conn.recompute(...)`, and those refreshes stay live — they're not overwritten on the next `candleComplete`.

`liveRecompute` has no effect on presets with a `createFactory` — those always stream incrementally.

## Setup patterns now correctly handled

| Setup | Before | After |
|---|---|---|
| `options.candles=[]` + live source seeded via `addCandle()` (Studio) | OK | OK |
| `options.candles=warmUp` + live source starts empty | OK | OK |
| `options.candles=full` + `liveSource.completedCandles=full` (mirror) | **2× backfill** | dedup OK |
| `liveSource` trims `completedCandles` via `maxHistory` | shrinks long-lookback view | unaffected (own array) |
| Re-emit / correction with same `time` on candleComplete | duplicates | replaces |
| Manual `recompute(custom)` then candleComplete | **lost** on next bar | extends custom window |

## Pre-existing limitation (not in scope)

Warm-up history hidden inside `createLiveCandle({ history })` is invisible to the chart — the `LiveSource` interface doesn't expose `_history`. Hosts that want chart-side visibility should pass the warm-up via `options.candles` or feed it into the live source through `addCandle()`. This is documented in the JSDoc but not addressed here; fixing it would require a `LiveSource` interface change.

## Test plan

- [x] `pnpm test` (chart) — 855 / 855
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] `pnpm size-check` green at unchanged limits
- [x] strategy-studio `tsc --noEmit` clean
- [x] 8 new PR14 tests cover: auto-recompute on candleComplete, factory presets stay on streaming path, warm-up via `options.candles`, Pattern C dedup at construction, `time`-collision replace, manual recompute as permanent override, `liveRecompute: false` opt-out, opt-out + manual recompute as the only writer.

## Follow-ups

- Studio integration of `connectPricePatterns` (PR15.5 carve-out, optional now that the live recompute foundation is in place).
- Per-preset `liveRecompute: false` annotations on expensive batch presets in `trendcraft/streaming/indicator-presets.ts` (deferred — none of the currently registered presets are heavy enough to require it).