### PR TITLE
feat(strategy-studio): price patterns plugin (PR15.5)

### DIFF
--- a/packages/chart/examples/strategy-studio/src/lib/plugins.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/plugins.ts
@@ -9,17 +9,24 @@
 import {
   type ChartInstance,
   connectAndrewsPitchfork,
+  connectPricePatterns,
   connectSmcLayer,
   connectVolumeProfile,
   connectWyckoffPhase,
+  filterPricePatterns,
 } from "@trendcraft/chart";
 import {
   breakOfStructure,
   changeOfCharacter,
+  doubleBottom,
+  doubleTop,
   fairValueGap,
   getAlternatingSwingPoints,
+  headAndShoulders,
+  inverseHeadAndShoulders,
   liquiditySweep,
   orderBlock,
+  type PatternSignal,
   volumeProfile,
   vsa,
   wyckoffPhases,
@@ -27,7 +34,7 @@ import {
 import type { CatalogEntry } from "../panels/ToggleCatalogPanel";
 import type { StudioCandle } from "./sample-data";
 
-export type PluginCategory = "smc" | "structure" | "volume";
+export type PluginCategory = "smc" | "structure" | "volume" | "patterns";
 
 export type PluginHandle = { remove(): void };
 
@@ -94,6 +101,28 @@ export const PLUGIN_CATALOG: readonly PluginDef[] = [
       if (candles.length < 20) return null;
       const profile = volumeProfile(candles, { levels: 30 });
       return connectVolumeProfile(chart, profile);
+    },
+  },
+  {
+    kind: "pricePatterns",
+    label: "Price Patterns",
+    category: "patterns",
+    description:
+      "Double tops / bottoms and (inverse) head-and-shoulders with measured-move targets and necklines.",
+    build: (chart, candles) => {
+      if (candles.length < 30) return null;
+      const signals: PatternSignal[] = [
+        ...doubleBottom(candles),
+        ...doubleTop(candles),
+        ...inverseHeadAndShoulders(candles),
+        ...headAndShoulders(candles),
+      ];
+      // Pre-filter so the toggle stays "available" only when something
+      // would actually render — otherwise the user sees an empty overlay
+      // and can't tell whether the slice has no patterns or the plugin
+      // failed silently.
+      if (filterPricePatterns(signals).length === 0) return null;
+      return connectPricePatterns(chart, signals);
     },
   },
 ];

--- a/packages/chart/examples/strategy-studio/src/panels/PluginsPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/PluginsPanel.tsx
@@ -6,9 +6,10 @@ const CATEGORY_LABELS: Record<PluginCategory, string> = {
   smc: "Smart Money",
   structure: "Structure",
   volume: "Volume",
+  patterns: "Patterns",
 };
 
-const CATEGORY_ORDER: readonly PluginCategory[] = ["smc", "structure", "volume"];
+const CATEGORY_ORDER: readonly PluginCategory[] = ["smc", "structure", "volume", "patterns"];
 
 type Props = {
   enabled: ReadonlySet<string>;


### PR DESCRIPTION
## Summary

Wire the chart-package's `connectPricePatterns` primitive (shipped in PR15) into Strategy Studio's PluginsPanel. Closes the **PR15.5** carve-out from the strategy-studio epic README — studio integration of the shared signal-pattern primitive.

The plugin runs the four classic reversal-pattern detectors from `trendcraft` core (double bottoms / tops + (inverse) head-and-shoulders), passes the merged signal list through `filterPricePatterns` so the toggle stays "unavailable" when the slice has nothing to render, and registers the resulting overlay with the chart.

## Lifecycle

Hooks into the existing PluginsPanel host loop in `App.tsx`:

- Toggling on → `def.build(chart, candles)` → `connectPricePatterns(chart, signals)`
- Toggling off / slice change → `handle.remove()`

Same lifecycle as SMC Layer / Wyckoff / Volume Profile. Now that PR14 is merged, batch-only indicator presets refresh during Replay; the pattern overlay rebuilds on slice changes the same way other plugins do, so scrubbing the playhead reveals patterns as they form.

## UI

A new **"Patterns"** plugin category appears in the toggle catalog. The category ordering (smc → structure → volume → patterns) mirrors the analytical workflow: market structure first, volume confirmation, then pattern recognition.

## Threshold

30-bar minimum (matching SMC Layer's threshold) keeps the toggle from offering itself on slices too short for the swing detectors to find anything meaningful.

## Scope

Studio-only wiring — no core / chart changes. The reusable primitive landed in PR15.

## Test plan

- [x] `pnpm test` (studio) — 95 / 95
- [x] `tsc --noEmit` clean
- [x] `pnpm lint` clean
- [x] `pnpm build` green for both chart and studio
- [x] Manual: toggling the new "Price Patterns" entry on a 200-bar slice renders zigzag + neckline + measured-move target + anchor labels, removes cleanly when toggled off, and rebuilds correctly when scrubbing the Replay playhead.