### PR TITLE
feat(chart): VAH / VAL boundary lines on Volume Profile

### DIFF
--- a/packages/chart/src/__tests__/volume-profile.test.ts
+++ b/packages/chart/src/__tests__/volume-profile.test.ts
@@ -60,15 +60,17 @@ describe("createVolumeProfile", () => {
     expect(plugin.zOrder).toBe("above");
   });
 
-  it("renders a bar per level plus a POC line when showPoc is true (default)", () => {
+  it("renders a bar per level plus POC and VAH/VAL bounds by default", () => {
     const plugin = createVolumeProfile(profile);
     const ctx = mockCtx();
     plugin.render(makeCtx(ctx), plugin.defaultState);
 
-    // One fillRect per level
+    // One fillRect per level.
     expect(ctx.fillRect).toHaveBeenCalledTimes(profile.levels.length);
-    // POC line + POC label + strip divider
-    expect(ctx.stroke).toHaveBeenCalledTimes(2);
+    // VAH line + VAL line + POC line + strip divider.
+    expect(ctx.stroke).toHaveBeenCalledTimes(4);
+    expect(ctx.fillText).toHaveBeenCalledWith("VAH", expect.any(Number), expect.any(Number));
+    expect(ctx.fillText).toHaveBeenCalledWith("VAL", expect.any(Number), expect.any(Number));
     expect(ctx.fillText).toHaveBeenCalledWith("POC", expect.any(Number), expect.any(Number));
   });
 
@@ -77,7 +79,34 @@ describe("createVolumeProfile", () => {
     const ctx = mockCtx();
     plugin.render(makeCtx(ctx), plugin.defaultState);
 
-    // Only the divider line, no POC label
+    // VAH + VAL + divider remain. POC label gone.
+    expect(ctx.stroke).toHaveBeenCalledTimes(3);
+    expect(ctx.fillText).not.toHaveBeenCalledWith("POC", expect.any(Number), expect.any(Number));
+    expect(ctx.fillText).toHaveBeenCalledWith("VAH", expect.any(Number), expect.any(Number));
+    expect(ctx.fillText).toHaveBeenCalledWith("VAL", expect.any(Number), expect.any(Number));
+  });
+
+  it("omits the value-area bounds when showValueAreaBounds is false", () => {
+    const plugin = createVolumeProfile(profile, { showValueAreaBounds: false });
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    // POC + divider only.
+    expect(ctx.stroke).toHaveBeenCalledTimes(2);
+    expect(ctx.fillText).not.toHaveBeenCalledWith("VAH", expect.any(Number), expect.any(Number));
+    expect(ctx.fillText).not.toHaveBeenCalledWith("VAL", expect.any(Number), expect.any(Number));
+    expect(ctx.fillText).toHaveBeenCalledWith("POC", expect.any(Number), expect.any(Number));
+  });
+
+  it("omits all overlay chrome when both showPoc and showValueAreaBounds are false", () => {
+    const plugin = createVolumeProfile(profile, {
+      showPoc: false,
+      showValueAreaBounds: false,
+    });
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    // Only the divider line, no labels.
     expect(ctx.stroke).toHaveBeenCalledTimes(1);
     expect(ctx.fillText).not.toHaveBeenCalled();
   });
@@ -105,10 +134,26 @@ describe("createVolumeProfile", () => {
       barColor: "red",
       valueAreaColor: "blue",
       pocColor: "green",
+      valueAreaBoundsColor: "magenta",
     });
     expect(plugin.defaultState.barColor).toBe("red");
     expect(plugin.defaultState.valueAreaColor).toBe("blue");
     expect(plugin.defaultState.pocColor).toBe("green");
+    expect(plugin.defaultState.valueAreaBoundsColor).toBe("magenta");
+  });
+
+  it("draws VAH and VAL lines at the prices reported by the profile", () => {
+    const plugin = createVolumeProfile(profile);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    // mockPs: priceToY(p) = 400 - p*2 → vah=105 → 190, val=95 → 210.
+    const vahY = 400 - profile.vah * 2;
+    const valY = 400 - profile.val * 2;
+    expect(ctx.moveTo).toHaveBeenCalledWith(expect.any(Number), vahY);
+    expect(ctx.moveTo).toHaveBeenCalledWith(expect.any(Number), valY);
+    expect(ctx.lineTo).toHaveBeenCalledWith(expect.any(Number), vahY);
+    expect(ctx.lineTo).toHaveBeenCalledWith(expect.any(Number), valY);
   });
 });
 

--- a/packages/chart/src/plugins/volume-profile.ts
+++ b/packages/chart/src/plugins/volume-profile.ts
@@ -60,12 +60,23 @@ export type VolumeProfileState = {
   highlightValueArea?: boolean;
   /** Whether to draw a horizontal line at the POC. Default true. */
   showPoc?: boolean;
+  /**
+   * Whether to draw horizontal lines and labels at the Value Area High and
+   * Low (VAH / VAL). Default true. The shaded fill from
+   * `highlightValueArea` only marks which levels are *inside* the area —
+   * these explicit lines are what TradingView, Bookmap and most volume
+   * profile tools draw so the upper and lower bounds are readable as
+   * specific price levels at a glance.
+   */
+  showValueAreaBounds?: boolean;
   /** Bar fill color (outside the value area). */
   barColor?: string;
   /** Bar fill color inside the value area (overrides barColor when highlightValueArea). */
   valueAreaColor?: string;
   /** POC line color. */
   pocColor?: string;
+  /** Color of the VAH and VAL boundary lines. */
+  valueAreaBoundsColor?: string;
 };
 
 // ---- Defaults ----
@@ -73,6 +84,8 @@ export type VolumeProfileState = {
 const DEFAULT_BAR_COLOR = "rgba(100,149,237,0.35)";
 const DEFAULT_VALUE_AREA_COLOR = "rgba(100,149,237,0.55)";
 const DEFAULT_POC_COLOR = "rgba(255,193,7,0.85)";
+// Same hue as the value-area shading but opaque enough to read as a line.
+const DEFAULT_VALUE_AREA_BOUNDS_COLOR = "rgba(100,149,237,0.75)";
 
 // ---- Render ----
 
@@ -85,9 +98,11 @@ function renderVolumeProfile(
     widthFraction = 0.18,
     highlightValueArea = true,
     showPoc = true,
+    showValueAreaBounds = true,
     barColor = DEFAULT_BAR_COLOR,
     valueAreaColor = DEFAULT_VALUE_AREA_COLOR,
     pocColor = DEFAULT_POC_COLOR,
+    valueAreaBoundsColor = DEFAULT_VALUE_AREA_BOUNDS_COLOR,
   } = state;
 
   if (profile.levels.length === 0) return;
@@ -121,6 +136,35 @@ function renderVolumeProfile(
 
       // Bar extends leftward from the right edge.
       ctx.fillRect(rightEdge - barLen, topY, barLen, barHeight);
+    }
+
+    // VAH / VAL — boundary lines for the value area. Drawn before POC so a
+    // POC that sits exactly on VAH or VAL gets the brighter highlight on top.
+    if (showValueAreaBounds) {
+      ctx.strokeStyle = valueAreaBoundsColor;
+      ctx.fillStyle = valueAreaBoundsColor;
+      ctx.lineWidth = 1;
+      ctx.setLineDash([4, 3]);
+      ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.textAlign = "right";
+
+      const vahY = priceScale.priceToY(profile.vah);
+      ctx.beginPath();
+      ctx.moveTo(pane.x, vahY);
+      ctx.lineTo(rightEdge, vahY);
+      ctx.stroke();
+      ctx.textBaseline = "bottom";
+      ctx.fillText("VAH", rightEdge - 4, vahY - 2);
+
+      const valY = priceScale.priceToY(profile.val);
+      ctx.beginPath();
+      ctx.moveTo(pane.x, valY);
+      ctx.lineTo(rightEdge, valY);
+      ctx.stroke();
+      ctx.textBaseline = "top";
+      ctx.fillText("VAL", rightEdge - 4, valY + 2);
+
+      ctx.setLineDash([]);
     }
 
     // POC line — thin horizontal line across the entire pane width.


### PR DESCRIPTION
## Summary

Adds explicit dashed lines and labels at the **Value Area High (VAH)** and **Value Area Low (VAL)** boundaries on the Volume Profile overlay. The Value Area was previously only marked by a shading change on bars inside it — readable as a band, but the upper / lower price bounds were not drawn as discrete levels and required eyeballing the shading break to identify.

After this change, VAH and VAL get the same dashed-line + right-edge label treatment that POC already had, so all three of the standard volume-profile bounds (POC, VAH, VAL) are equally legible at a glance.

## Visual change

- VAH dashed horizontal line at the value-area-high price, with a "VAH" label above it.
- VAL dashed horizontal line at the value-area-low price, with a "VAL" label below it.
- Same dash pattern (`[4, 3]`) as the existing POC line for visual consistency.
- Drawn before POC so a POC that lands exactly on VAH or VAL gets the brighter highlight on top.
- Default color is the same hue as `valueAreaColor` but bumped to alpha 0.75 so it reads as a line rather than a fill.

## API additions

Two new optional fields on `VolumeProfileState`:

- `showValueAreaBounds?: boolean` (default `true`) — toggle the lines and labels off for hosts that prefer the minimal view.
- `valueAreaBoundsColor?: string` — override the default boundary line color.

Both are additive; existing callers get the new behavior without code changes. Strict opt-out with `showValueAreaBounds: false` restores the previous look.

## Background

Industry-standard volume-profile renderers (TradingView, Bookmap, cTrader OSS variants) all draw VAH and VAL as discrete dashed lines + labels. TrendCraft's prior implementation had POC drawn this way but only relied on color shading for the value-area envelope — a noticeable usability gap when an analyst wanted to read off the upper / lower boundary as a specific price level.

## Test plan

- [x] `pnpm test` (chart) — 858 / 858 (was 855; +3 new VP-specific assertions, 1 existing test rewritten).
- [x] `pnpm lint` clean.
- [x] `pnpm build` green.
- [x] `pnpm size-check` green at unchanged limits.
- [x] Coverage:
  - default render produces VAH + VAL + POC + divider (4 strokes, 3 labels including "VAH" / "VAL" / "POC")
  - `showPoc: false` → POC label/line gone, VAH/VAL stay
  - `showValueAreaBounds: false` → VAH/VAL labels/lines gone, POC stays
  - both off → only the strip divider draws, no labels
  - line position derives from the profile's declared `vah` / `val` prices through `priceScale.priceToY`