### PR TITLE
feat(chart): labels and 0.25/0.75 half-lines on Andrews Pitchfork

### DIFF
--- a/packages/chart/src/__tests__/andrews-pitchfork.test.ts
+++ b/packages/chart/src/__tests__/andrews-pitchfork.test.ts
@@ -21,10 +21,14 @@ const mockCtx = () =>
     closePath: vi.fn(),
     fill: vi.fn(),
     arc: vi.fn(),
+    fillText: vi.fn(),
     setLineDash: vi.fn(),
     fillStyle: "",
     strokeStyle: "",
     lineWidth: 1,
+    font: "",
+    textAlign: "" as CanvasTextAlign,
+    textBaseline: "" as CanvasTextBaseline,
   }) as unknown as CanvasRenderingContext2D;
 
 const mockTs = () =>
@@ -54,7 +58,7 @@ describe("createAndrewsPitchfork", () => {
     expect(plugin.zOrder).toBe("below");
   });
 
-  it("renders three parallel lines, the handle connector, and anchor dots", () => {
+  it("renders three parallel lines, the handle connector, anchor dots, and labels", () => {
     const plugin = createAndrewsPitchfork(anchors);
     const ctx = mockCtx();
     plugin.render(makeCtx(ctx), plugin.defaultState);
@@ -65,6 +69,36 @@ describe("createAndrewsPitchfork", () => {
     expect(ctx.stroke).toHaveBeenCalledTimes(3);
     // Three anchor arcs
     expect(ctx.arc).toHaveBeenCalledTimes(3);
+    // Labels for upper / median / lower lines (default `showLabels: true`)
+    expect(ctx.fillText).toHaveBeenCalledWith("UML", expect.any(Number), expect.any(Number));
+    expect(ctx.fillText).toHaveBeenCalledWith("ML", expect.any(Number), expect.any(Number));
+    expect(ctx.fillText).toHaveBeenCalledWith("LML", expect.any(Number), expect.any(Number));
+  });
+
+  it("omits labels when showLabels is false", () => {
+    const plugin = createAndrewsPitchfork(anchors, { showLabels: false });
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+    expect(ctx.fillText).not.toHaveBeenCalled();
+  });
+
+  it("draws 0.25 / 0.75 half-lines when showHalfLines is true", () => {
+    const plugin = createAndrewsPitchfork(anchors, { showHalfLines: true });
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    // Default 3 strokes + 1 extra stroke for the two half-lines (single
+    // batched path) = 4.
+    expect(ctx.stroke).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not draw half-lines by default", () => {
+    const plugin = createAndrewsPitchfork(anchors);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    // 3 strokes: handle connector + median + (upper+lower batched).
+    expect(ctx.stroke).toHaveBeenCalledTimes(3);
   });
 
   it("bails out on a degenerate configuration where p0 aligns vertically with midpoint", () => {
@@ -86,9 +120,13 @@ describe("createAndrewsPitchfork", () => {
     const plugin = createAndrewsPitchfork(anchors, {
       color: "rgba(255,0,0,1)",
       fillColor: "rgba(255,0,0,0.2)",
+      labelColor: "rgba(0,255,0,1)",
+      halfLineColor: "rgba(0,0,255,0.5)",
     });
     expect(plugin.defaultState.color).toBe("rgba(255,0,0,1)");
     expect(plugin.defaultState.fillColor).toBe("rgba(255,0,0,0.2)");
+    expect(plugin.defaultState.labelColor).toBe("rgba(0,255,0,1)");
+    expect(plugin.defaultState.halfLineColor).toBe("rgba(0,0,255,0.5)");
   });
 });
 

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -151,6 +151,7 @@ export {
   type SwingAnchor,
 } from "./integration/drawing-helpers";
 export {
+  type AndrewsPitchforkOptions,
   type AndrewsPitchforkState,
   connectAndrewsPitchfork,
   createAndrewsPitchfork,

--- a/packages/chart/src/plugins/andrews-pitchfork.ts
+++ b/packages/chart/src/plugins/andrews-pitchfork.ts
@@ -55,6 +55,24 @@ export type AndrewsPitchforkState = {
   color?: string;
   /** Fill color for the area between upper and lower handles. */
   fillColor?: string;
+  /**
+   * Whether to draw "ML" / "UML" / "LML" labels at the right edge of each
+   * line. Default `true`. Helpful for distinguishing the three parallel
+   * lines, especially on screenshots and shallow slopes where the colors
+   * alone aren't enough.
+   */
+  showLabels?: boolean;
+  /**
+   * Whether to draw the 0.25 / 0.75 half-lines (parallel intermediate lines
+   * sitting halfway between the median and each handle). Default `false`
+   * — opt-in because on tight ranges they can clutter the view. Heavy
+   * pitchfork users use these as finer support / resistance levels.
+   */
+  showHalfLines?: boolean;
+  /** Override the label text color. Defaults to `color`. */
+  labelColor?: string;
+  /** Override the half-line stroke color. Defaults to `color`. */
+  halfLineColor?: string;
 };
 
 // ---- Render ----
@@ -140,6 +158,41 @@ function renderAndrewsPitchfork(
     ctx.lineTo(lowerEndX, lowerEndY);
     ctx.stroke();
 
+    // Optional 0.25 / 0.75 half-lines. Geometric trick: a parallel line
+    // through the midpoint of (P0, upperAnchor) is exactly halfway between
+    // the median and the upper handle (and similarly for the lower side).
+    if (state.showHalfLines) {
+      const halfUpperX = (x0 + upperAnchorX) / 2;
+      const halfUpperY = (y0 + upperAnchorY) / 2;
+      const halfLowerX = (x0 + lowerAnchorX) / 2;
+      const halfLowerY = (y0 + lowerAnchorY) / 2;
+      const slope = dyMed / dxMed;
+      const halfUpperEndY = halfUpperY + slope * (rightEdgeX - halfUpperX);
+      const halfLowerEndY = halfLowerY + slope * (rightEdgeX - halfLowerX);
+
+      ctx.strokeStyle = state.halfLineColor ?? stroke;
+      ctx.lineWidth = 1;
+      ctx.setLineDash([2, 4]);
+      ctx.beginPath();
+      ctx.moveTo(halfUpperX, halfUpperY);
+      ctx.lineTo(rightEdgeX, halfUpperEndY);
+      ctx.moveTo(halfLowerX, halfLowerY);
+      ctx.lineTo(rightEdgeX, halfLowerEndY);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
+    // Right-edge labels for the three parallel lines.
+    if (state.showLabels !== false) {
+      ctx.fillStyle = state.labelColor ?? stroke;
+      ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.textAlign = "right";
+      ctx.textBaseline = "middle";
+      ctx.fillText("UML", rightEdgeX - 4, upperEndY);
+      ctx.fillText("ML", rightEdgeX - 4, medianEndY);
+      ctx.fillText("LML", rightEdgeX - 4, lowerEndY);
+    }
+
     // Small anchor dots
     ctx.fillStyle = stroke;
     for (const [ax, ay] of [
@@ -156,15 +209,18 @@ function renderAndrewsPitchfork(
 
 // ---- Factory ----
 
+/** Visual options accepted by `createAndrewsPitchfork` / `connectAndrewsPitchfork`. */
+export type AndrewsPitchforkOptions = Omit<AndrewsPitchforkState, "anchors">;
+
 export function createAndrewsPitchfork(
   anchors: PitchforkAnchors,
-  options: { color?: string; fillColor?: string } = {},
+  options: AndrewsPitchforkOptions = {},
 ): PrimitivePlugin<AndrewsPitchforkState> {
   return definePrimitive<AndrewsPitchforkState>({
     name: "andrewsPitchfork",
     pane: "main",
     zOrder: "below",
-    defaultState: { anchors, color: options.color, fillColor: options.fillColor },
+    defaultState: { anchors, ...options },
     render: renderAndrewsPitchfork,
   });
 }
@@ -172,14 +228,14 @@ export function createAndrewsPitchfork(
 // ---- Convenience connector ----
 
 type AndrewsPitchforkHandle = {
-  update(anchors: PitchforkAnchors, options?: { color?: string; fillColor?: string }): void;
+  update(anchors: PitchforkAnchors, options?: AndrewsPitchforkOptions): void;
   remove(): void;
 };
 
 export function connectAndrewsPitchfork(
   chart: ChartInstance,
   anchors: PitchforkAnchors,
-  options: { color?: string; fillColor?: string } = {},
+  options: AndrewsPitchforkOptions = {},
 ): AndrewsPitchforkHandle {
   chart.registerPrimitive(createAndrewsPitchfork(anchors, options));
 


### PR DESCRIPTION
## Summary

Adds two industry-standard visual elements that the Andrews Pitchfork primitive was previously missing:

- **Right-edge line labels** — `ML` (median), `UML` / `LML` (upper / lower handles). Without them, a screenshot or a shallow-slope pitchfork left the viewer guessing which line was which.
- **0.25 / 0.75 half-lines** (opt-in) — parallel intermediate lines halfway between the median and each handle. Heavy pitchfork users read these as finer support / resistance levels.

The existing renderer already drew the three parallel lines, the value-area shading, the P1↔P2 connector and the three anchor dots. This change extends what's drawn at the right edge and (optionally) inside the handles.

## API additions

Four new optional fields on `AndrewsPitchforkState`:

- `showLabels?: boolean` — default `true`. Right-aligned at pane edge with `textBaseline: "middle"`.
- `showHalfLines?: boolean` — default `false`. Opt-in to keep the default view visually quiet on tight ranges.
- `labelColor?: string` — independent label color override; falls back to `color`.
- `halfLineColor?: string` — independent half-line stroke override; falls back to `color`.

Plus an exported `AndrewsPitchforkOptions` type (`Omit<AndrewsPitchforkState, "anchors">`) so hosts can spread / type their option bag without restating each field. The previous inline `{ color?, fillColor? }` shape was a strict subset of the new type, so existing callers continue to compile.

## Geometric shortcut

For two parallel lines `L_m` (median, through `P0`) and `L_u` (upper, through `upperAnchor`), the line through `(P0 + upperAnchor) / 2` with the same slope is exactly midway between them. No explicit perpendicular-offset math needed. The half-line implementation uses this directly.

## Test plan

- [x] `pnpm test` (chart) — 810 / 810 (+3 pitchfork tests)
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] `pnpm size-check` green at unchanged limits
- [x] Coverage:
  - default render produces three line labels (`UML` / `ML` / `LML`)
  - `showLabels: false` suppresses all `fillText` calls
  - `showHalfLines: true` adds a 4th `stroke` call (the two half-lines batched into a single path)
  - half-lines do not render by default
  - `labelColor` / `halfLineColor` flow into `defaultState`