### PR TITLE
fix(chart): align Squeeze / Regime / S-R plugin visuals with industry conventions

### DIFF
--- a/packages/chart/src/__tests__/regime-heatmap.test.ts
+++ b/packages/chart/src/__tests__/regime-heatmap.test.ts
@@ -18,7 +18,17 @@ function mockCtx() {
     rect: vi.fn(),
     clip: vi.fn(),
     fillRect: vi.fn(),
+    fillText: vi.fn(),
+    fill: vi.fn(),
+    closePath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    measureText: vi.fn(() => ({ width: 80 }) as TextMetrics),
     fillStyle: "",
+    font: "",
+    textBaseline: "" as CanvasTextBaseline,
+    textAlign: "" as CanvasTextAlign,
   } as unknown as CanvasRenderingContext2D;
 }
 
@@ -124,6 +134,119 @@ describe("createRegimeHeatmap", () => {
     expect(ctx.fillRect).not.toHaveBeenCalled();
   });
 
+  it("renders a corner badge with the most recent regime label and confidence", () => {
+    const data = makeRegimeData([
+      { regime: 0, label: "trending-down", confidence: 0.6 },
+      { regime: 1, label: "ranging", confidence: 0.5 },
+      { regime: 2, label: "trending-up", confidence: 0.72 },
+    ]);
+    const plugin = createRegimeHeatmap(data);
+    const ctx = mockCtx();
+    const ts = mockTimeScale(0, 3);
+
+    plugin.render(
+      { ctx, pane: mockPaneRect, timeScale: ts } as PrimitiveRenderContext,
+      plugin.defaultState,
+    );
+
+    // Badge text: "<label> · <conf>%" — picks the most recent visible bar.
+    expect(ctx.fillText).toHaveBeenCalledWith(
+      "trending-up · 72%",
+      expect.any(Number),
+      expect.any(Number),
+    );
+  });
+
+  it("omits the badge when showBadge is false", () => {
+    const data = makeRegimeData([{ regime: 2, label: "trending-up", confidence: 0.9 }]);
+    const plugin = createRegimeHeatmap(data, { showBadge: false });
+    const ctx = mockCtx();
+    const ts = mockTimeScale(0, 1);
+
+    plugin.render(
+      { ctx, pane: mockPaneRect, timeScale: ts } as PrimitiveRenderContext,
+      plugin.defaultState,
+    );
+
+    expect(ctx.fillText).not.toHaveBeenCalled();
+  });
+
+  it("falls back to 'regime N' label when the data point has no label string", () => {
+    const data = makeRegimeData([{ regime: 2, confidence: 0.5 }]);
+    const plugin = createRegimeHeatmap(data);
+    const ctx = mockCtx();
+    const ts = mockTimeScale(0, 1);
+
+    plugin.render(
+      { ctx, pane: mockPaneRect, timeScale: ts } as PrimitiveRenderContext,
+      plugin.defaultState,
+    );
+
+    expect(ctx.fillText).toHaveBeenCalledWith(
+      "regime 2 · 50%",
+      expect.any(Number),
+      expect.any(Number),
+    );
+  });
+
+  it("clamps the badge lookup to the visible range and stays empty when no visible bar has data", () => {
+    // 5 bars total but only the first 2 carry regime data; the visible range
+    // is the last 3 (3..5) so the badge has nothing to show within view.
+    // It must NOT walk back into the off-screen bars at index 0/1 and
+    // surface a stale label.
+    const data: DataPoint<{ regime: number; label?: string; confidence?: number }>[] = [
+      { time: 1000, value: { regime: 2, label: "trending-up", confidence: 0.9 } },
+      { time: 1060, value: { regime: 2, label: "trending-up", confidence: 0.85 } },
+      { time: 1120, value: null as unknown as { regime: number } },
+      { time: 1180, value: null as unknown as { regime: number } },
+      { time: 1240, value: null as unknown as { regime: number } },
+    ];
+    const plugin = createRegimeHeatmap(data);
+    const ctx = mockCtx();
+    const ts = mockTimeScale(2, 5); // visibleStart=2, visibleEnd=5
+
+    plugin.render(
+      { ctx, pane: mockPaneRect, timeScale: ts } as PrimitiveRenderContext,
+      plugin.defaultState,
+    );
+
+    expect(ctx.fillText).not.toHaveBeenCalled();
+  });
+
+  it("renders the badge without a percentage when confidence is missing", () => {
+    const data = makeRegimeData([{ regime: 1, label: "ranging" }]);
+    const plugin = createRegimeHeatmap(data);
+    const ctx = mockCtx();
+    const ts = mockTimeScale(0, 1);
+
+    plugin.render(
+      { ctx, pane: mockPaneRect, timeScale: ts } as PrimitiveRenderContext,
+      plugin.defaultState,
+    );
+
+    expect(ctx.fillText).toHaveBeenCalledWith("ranging", expect.any(Number), expect.any(Number));
+  });
+
+  it("treats an empty-string label as missing and falls back to 'regime N'", () => {
+    // Some upstream normalizers emit `label: ""` to indicate "no label".
+    // The badge text must not collapse to a blank or `" · 50%"` pill.
+    const data = makeRegimeData([{ regime: 2, label: "", confidence: 0.5 }]);
+    const plugin = createRegimeHeatmap(data);
+    const ctx = mockCtx();
+    const ts = mockTimeScale(0, 1);
+
+    plugin.render(
+      { ctx, pane: mockPaneRect, timeScale: ts } as PrimitiveRenderContext,
+      plugin.defaultState,
+    );
+
+    expect(ctx.fillText).toHaveBeenCalledWith(
+      "regime 2 · 50%",
+      expect.any(Number),
+      expect.any(Number),
+    );
+  });
+
   it("modulates alpha by confidence", () => {
     const data = makeRegimeData([
       { regime: 2, label: "trending-up", confidence: 0.0 },
@@ -192,5 +315,27 @@ describe("connectRegimeHeatmap", () => {
     handle.update(newData);
 
     expect(chart.registerPrimitive).toHaveBeenCalledTimes(2);
+  });
+
+  it("update() preserves previously-applied options across data-only refreshes", () => {
+    // After a host toggles `showBadge: false` once, subsequent data refreshes
+    // must not silently revert to the original (showBadge: true) options.
+    const registrations: Array<{ defaultState: { options: { showBadge: boolean } } }> = [];
+    const chart = {
+      registerPrimitive: vi.fn((p) => {
+        registrations.push(p as (typeof registrations)[number]);
+      }),
+      removePrimitive: vi.fn(),
+    } as unknown as ChartInstance;
+
+    const handle = connectRegimeHeatmap(chart, [], { showBadge: true });
+    handle.update(makeRegimeData([{ regime: 2, label: "trending-up" }]), { showBadge: false });
+    // Data-only refresh — should keep showBadge: false.
+    handle.update(makeRegimeData([{ regime: 1, label: "ranging" }]));
+
+    expect(registrations).toHaveLength(3);
+    expect(registrations[0].defaultState.options.showBadge).toBe(true);
+    expect(registrations[1].defaultState.options.showBadge).toBe(false);
+    expect(registrations[2].defaultState.options.showBadge).toBe(false);
   });
 });

--- a/packages/chart/src/__tests__/squeeze-dots.test.ts
+++ b/packages/chart/src/__tests__/squeeze-dots.test.ts
@@ -60,7 +60,7 @@ describe("createSqueezeDots", () => {
     const plugin = createSqueezeDots([], candles);
     const ctx = mockCtx();
     plugin.render(makeCtx(ctx), plugin.defaultState);
-    expect(ctx.fillRect).not.toHaveBeenCalled();
+    expect(ctx.arc).not.toHaveBeenCalled();
   });
 
   it("draws a dot for each squeeze bar plus a release dot after the run", () => {
@@ -72,8 +72,11 @@ describe("createSqueezeDots", () => {
     const plugin = createSqueezeDots(signals, candles);
     const ctx = mockCtx();
     plugin.render(makeCtx(ctx), plugin.defaultState);
-    // 3 squeeze bars + 1 release bar at index 1008 = 4 fillRect calls
-    expect(ctx.fillRect).toHaveBeenCalledTimes(4);
+    // 3 squeeze dots + 1 release dot at index 1008 = 4 arc calls.
+    // Carter's TTM convention is small circular dots, not bars — make sure
+    // we never call fillRect for the dots themselves.
+    expect(ctx.arc).toHaveBeenCalledTimes(4);
+    expect(ctx.fillRect).not.toHaveBeenCalled();
   });
 
   it("does not emit a release dot when the squeeze runs to the last candle", () => {
@@ -82,8 +85,8 @@ describe("createSqueezeDots", () => {
     const plugin = createSqueezeDots(signals, candles);
     const ctx = mockCtx();
     plugin.render(makeCtx(ctx), plugin.defaultState);
-    // 1 squeeze bar, no release bar
-    expect(ctx.fillRect).toHaveBeenCalledTimes(1);
+    // 1 squeeze dot, no release dot.
+    expect(ctx.arc).toHaveBeenCalledTimes(1);
   });
 
   it("respects showRail option", () => {
@@ -92,5 +95,22 @@ describe("createSqueezeDots", () => {
     const ctx = mockCtx();
     plugin.render(makeCtx(ctx), plugin.defaultState);
     expect(ctx.setLineDash).not.toHaveBeenCalled();
+  });
+
+  it("keeps the dot's bottom edge `offsetFromBottom` away from the pane bottom", () => {
+    // Documented contract: `offsetFromBottom` is the distance from the pane
+    // bottom to the *bottom of the marker*, not its center. The dot must be
+    // lifted by `radius` so the full circle stays inside the gap.
+    const offsetFromBottom = 12;
+    const radius = 4;
+    const signals = [{ time: 1005, type: "squeeze" as const }];
+    const plugin = createSqueezeDots(signals, candles, { offsetFromBottom, radius });
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    const arcCalls = (ctx.arc as unknown as { mock: { calls: number[][] } }).mock.calls;
+    const dotCenterY = arcCalls[0][1];
+    const expectedCenterY = mockPane.y + mockPane.height - offsetFromBottom - radius;
+    expect(dotCenterY).toBe(expectedCenterY);
   });
 });

--- a/packages/chart/src/__tests__/sr-confluence.test.ts
+++ b/packages/chart/src/__tests__/sr-confluence.test.ts
@@ -79,6 +79,38 @@ describe("createSrConfluence", () => {
     plugin.render(makeCtx(ctx), plugin.defaultState);
     expect(ctx.fillRect).not.toHaveBeenCalled();
   });
+
+  it("appends touch count to the strength label when present", () => {
+    const zones = [
+      {
+        price: 100,
+        low: 98,
+        high: 102,
+        strength: 80,
+        touchCount: 5,
+      },
+    ];
+    const plugin = createSrConfluence(zones);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    // "S80 · ×5" — matches the BigBeluga / MTF Confluence convention of
+    // surfacing how many times the level has been retested.
+    expect(ctx.fillText).toHaveBeenCalledWith("S80 · ×5", expect.any(Number), expect.any(Number));
+  });
+
+  it("omits the touch count suffix when touchCount is 0 or absent", () => {
+    const zones = [
+      { price: 100, low: 98, high: 102, strength: 50 },
+      { price: 120, low: 118, high: 122, strength: 60, touchCount: 0 },
+    ];
+    const plugin = createSrConfluence(zones);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    expect(ctx.fillText).toHaveBeenCalledWith("S50", expect.any(Number), expect.any(Number));
+    expect(ctx.fillText).toHaveBeenCalledWith("S60", expect.any(Number), expect.any(Number));
+  });
 });
 
 describe("connectSrConfluence", () => {

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -166,7 +166,11 @@ export {
   type MarketProfileValue,
 } from "./plugins/market-profile";
 // Plugins — tree-shakeable visualization primitives
-export { connectRegimeHeatmap, createRegimeHeatmap } from "./plugins/regime-heatmap";
+export {
+  connectRegimeHeatmap,
+  createRegimeHeatmap,
+  type RegimeHeatmapOptions,
+} from "./plugins/regime-heatmap";
 export { connectSessionZones, createSessionZones } from "./plugins/session-zones";
 export type { SmcLevel, SmcMarker, SmcState, SmcZone } from "./plugins/smc-layer";
 export { connectSmcLayer, createSmcLayer } from "./plugins/smc-layer";

--- a/packages/chart/src/plugins/regime-heatmap.ts
+++ b/packages/chart/src/plugins/regime-heatmap.ts
@@ -34,8 +34,20 @@ type RegimeDataPoint = DataPoint<{
   confidence?: number;
 }>;
 
+export type RegimeHeatmapOptions = {
+  /**
+   * Whether to draw a corner badge showing the current regime + confidence.
+   * Mirrors the convention used by TradingView regime indicators
+   * (EXCAVO / LuxAlgo / RWCS_LTD): "trending-up · 72%" style pill in the
+   * top-left so the analyst can read the active regime without decoding
+   * background colors. Default `true`.
+   */
+  showBadge?: boolean;
+};
+
 type RegimeHeatmapState = {
   data: readonly RegimeDataPoint[];
+  options: Required<RegimeHeatmapOptions>;
 };
 
 // ---- Colors ----
@@ -60,7 +72,7 @@ function renderRegimeHeatmap(
   { ctx, pane, timeScale }: PrimitiveRenderContext,
   state: RegimeHeatmapState,
 ): void {
-  const { data } = state;
+  const { data, options } = state;
   if (data.length === 0) return;
 
   const start = timeScale.startIndex;
@@ -81,24 +93,110 @@ function renderRegimeHeatmap(
       ctx.fillRect(x - barWidth / 2, pane.y, barWidth, pane.height);
     }
   });
+
+  if (options.showBadge) {
+    renderRegimeBadge(ctx, pane, data, start, end);
+  }
+}
+
+/**
+ * Top-left corner pill: "trending-up · 72%" using the active regime's color.
+ * The regime is read from the most recent *visible* bar in `data` — we walk
+ * back from `end-1` only as far as `start`, so panning into a sparse region
+ * with no regime data can't surface a stale label from an off-screen bar.
+ * No visible regime → no badge at all.
+ */
+function renderRegimeBadge(
+  ctx: CanvasRenderingContext2D,
+  pane: { x: number; y: number; width: number; height: number },
+  data: readonly RegimeDataPoint[],
+  visibleStart: number,
+  visibleEnd: number,
+): void {
+  const lastVisibleIdx = Math.min(visibleEnd - 1, data.length - 1);
+  const firstVisibleIdx = Math.max(0, visibleStart);
+  let value: RegimeDataPoint["value"] | null = null;
+  for (let i = lastVisibleIdx; i >= firstVisibleIdx; i--) {
+    const v = data[i]?.value;
+    if (v) {
+      value = v;
+      break;
+    }
+  }
+  if (!value) return;
+
+  const rgb = regimeToRgb(value.regime, value.label);
+  // Treat empty string the same as missing — upstream normalizers sometimes
+  // emit `""` for "no label", and `??` would otherwise produce `" · 72%"`
+  // or a blank pill.
+  const text = value.label && value.label.length > 0 ? value.label : `regime ${value.regime}`;
+  const conf = value.confidence;
+  const display = conf != null ? `${text} · ${Math.round(conf * 100)}%` : text;
+
+  ctx.save();
+  ctx.font = "bold 11px -apple-system, BlinkMacSystemFont, sans-serif";
+  ctx.textBaseline = "top";
+  ctx.textAlign = "left";
+
+  const padX = 8;
+  const padY = 4;
+  const metrics = ctx.measureText(display);
+  const textW = metrics.width;
+  const textH = 11;
+  const pillX = pane.x + 8;
+  const pillY = pane.y + 8;
+  const pillW = textW + padX * 2;
+  const pillH = textH + padY * 2;
+
+  // Pill background — saturated regime tint with rounded corners.
+  const r = pillH / 2;
+  ctx.fillStyle = `rgba(${rgb},0.85)`;
+  ctx.beginPath();
+  ctx.moveTo(pillX + r, pillY);
+  ctx.lineTo(pillX + pillW - r, pillY);
+  ctx.quadraticCurveTo(pillX + pillW, pillY, pillX + pillW, pillY + r);
+  ctx.lineTo(pillX + pillW, pillY + pillH - r);
+  ctx.quadraticCurveTo(pillX + pillW, pillY + pillH, pillX + pillW - r, pillY + pillH);
+  ctx.lineTo(pillX + r, pillY + pillH);
+  ctx.quadraticCurveTo(pillX, pillY + pillH, pillX, pillY + pillH - r);
+  ctx.lineTo(pillX, pillY + r);
+  ctx.quadraticCurveTo(pillX, pillY, pillX + r, pillY);
+  ctx.closePath();
+  ctx.fill();
+
+  // White text — high contrast against the saturated pill regardless of
+  // the host theme (light vs dark).
+  ctx.fillStyle = "#fff";
+  ctx.fillText(display, pillX + padX, pillY + padY);
+  ctx.restore();
 }
 
 // ---- Factory ----
+
+const DEFAULT_OPTIONS: Required<RegimeHeatmapOptions> = {
+  showBadge: true,
+};
+
+function resolveOptions(options: RegimeHeatmapOptions = {}): Required<RegimeHeatmapOptions> {
+  return { ...DEFAULT_OPTIONS, ...options };
+}
 
 /**
  * Create a PrimitivePlugin that renders regime heatmap background.
  *
  * @param data - Series data from hmmRegimes() or any compatible shape
+ * @param options - Visual customization (badge on/off, etc.)
  * @returns PrimitivePlugin to register via chart.registerPrimitive()
  */
 export function createRegimeHeatmap(
   data: readonly RegimeDataPoint[],
+  options: RegimeHeatmapOptions = {},
 ): PrimitivePlugin<RegimeHeatmapState> {
   return definePrimitive<RegimeHeatmapState>({
     name: "regimeHeatmap",
     pane: "main",
     zOrder: "below",
-    defaultState: { data },
+    defaultState: { data, options: resolveOptions(options) },
     render: renderRegimeHeatmap,
   });
 }
@@ -107,7 +205,7 @@ export function createRegimeHeatmap(
 
 type RegimeHeatmapHandle = {
   /** Update with new regime data */
-  update(data: readonly RegimeDataPoint[]): void;
+  update(data: readonly RegimeDataPoint[], options?: RegimeHeatmapOptions): void;
   /** Remove the heatmap from the chart */
   remove(): void;
 };
@@ -117,19 +215,25 @@ type RegimeHeatmapHandle = {
  *
  * @param chart - ChartInstance to attach to
  * @param data - Series data from hmmRegimes()
+ * @param options - Visual customization (badge on/off, etc.)
  * @returns Handle for updating or removing the heatmap
  */
 export function connectRegimeHeatmap(
   chart: ChartInstance,
   data: readonly RegimeDataPoint[],
+  options: RegimeHeatmapOptions = {},
 ): RegimeHeatmapHandle {
-  const plugin = createRegimeHeatmap(data);
-  chart.registerPrimitive(plugin);
+  // Track the last-applied options so a host that toggles the badge once
+  // (`handle.update(data, { showBadge: false })`) and then keeps streaming
+  // data (`handle.update(nextData)`) doesn't see the toggle silently revert
+  // to the original options on the next refresh.
+  let appliedOptions = options;
+  chart.registerPrimitive(createRegimeHeatmap(data, appliedOptions));
 
   return {
-    update(newData: readonly RegimeDataPoint[]) {
-      // Re-register with new data (replaces existing primitive of same name)
-      chart.registerPrimitive(createRegimeHeatmap(newData));
+    update(newData: readonly RegimeDataPoint[], newOptions?: RegimeHeatmapOptions) {
+      if (newOptions !== undefined) appliedOptions = newOptions;
+      chart.registerPrimitive(createRegimeHeatmap(newData, appliedOptions));
     },
     remove() {
       chart.removePrimitive("regimeHeatmap");

--- a/packages/chart/src/plugins/squeeze-dots.ts
+++ b/packages/chart/src/plugins/squeeze-dots.ts
@@ -105,11 +105,13 @@ function renderSqueezeDots(
 
   const start = timeScale.startIndex;
   const end = timeScale.endIndex;
-  // The TTM ribbon sits as a thin colored bar row at the pane bottom. Bar
-  // width tracks bar spacing so it always reads as "this bar is in squeeze".
-  const ribbonHeight = options.radius * 2;
-  const ribbonY = pane.y + pane.height - options.offsetFromBottom - ribbonHeight / 2;
-  const barWidth = Math.max(2, timeScale.barSpacing * 0.9);
+  // Carter's TTM Squeeze convention: small *circular dots* riding a faint
+  // zero-line guide rail. The dots sit just above the pane's bottom edge so
+  // they never collide with candles. `offsetFromBottom` continues to mean
+  // "distance from the pane bottom to the bottom of the marker" (matching
+  // the previous bar-style implementation), so we lift the center by
+  // `radius` to keep the dot fully inside that gap.
+  const railY = pane.y + pane.height - options.offsetFromBottom - options.radius;
 
   withPaneClip(ctx, pane, () => {
     // Faint guide rail spanning the visible range
@@ -119,21 +121,23 @@ function renderSqueezeDots(
       ctx.strokeStyle = "rgba(120,123,134,0.25)";
       ctx.lineWidth = 1;
       ctx.beginPath();
-      ctx.moveTo(pane.x, ribbonY + ribbonHeight / 2);
-      ctx.lineTo(pane.x + pane.width, ribbonY + ribbonHeight / 2);
+      ctx.moveTo(pane.x, railY);
+      ctx.lineTo(pane.x + pane.width, railY);
       ctx.stroke();
       ctx.restore();
     }
 
-    const drawBar = (i: number, color: string) => {
+    const drawDot = (i: number, color: string) => {
       if (i < start || i >= end) return;
       const x = timeScale.indexToX(i);
       ctx.fillStyle = color;
-      ctx.fillRect(x - barWidth / 2, ribbonY, barWidth, ribbonHeight);
+      ctx.beginPath();
+      ctx.arc(x, railY, options.radius, 0, Math.PI * 2);
+      ctx.fill();
     };
 
-    for (const i of squeezeIndices) drawBar(i, `rgba(${options.squeezeColor},1)`);
-    for (const i of releaseIndices) drawBar(i, `rgba(${options.releaseColor},1)`);
+    for (const i of squeezeIndices) drawDot(i, `rgba(${options.squeezeColor},1)`);
+    for (const i of releaseIndices) drawDot(i, `rgba(${options.releaseColor},1)`);
   });
 }
 

--- a/packages/chart/src/plugins/sr-confluence.ts
+++ b/packages/chart/src/plugins/sr-confluence.ts
@@ -99,7 +99,15 @@ function renderSrConfluence(
       ctx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
       ctx.textAlign = "right";
       ctx.textBaseline = "middle";
-      ctx.fillText(`S${zone.strength.toFixed(0)}`, right - 4, centerY);
+      // Strength score + touch count (when available). Mirrors the
+      // convention used by TradingView S/R indicators (BigBeluga, MTF
+      // Confluence) where "how many tests has this level survived" is
+      // surfaced alongside the numeric strength.
+      const label =
+        zone.touchCount != null && zone.touchCount > 0
+          ? `S${zone.strength.toFixed(0)} · ×${zone.touchCount}`
+          : `S${zone.strength.toFixed(0)}`;
+      ctx.fillText(label, right - 4, centerY);
     }
   });
 }


### PR DESCRIPTION
## Summary

Three plugins had subtle display gaps versus the conventions established by the platforms most users compare against (TradingView, NinjaTrader, ToS, StockCharts on the TTM Squeeze side). All three are pure rendering changes — the data layer is unchanged.

### Squeeze Dots — name now matches the visual

The plugin used to render each squeeze / release bar with `fillRect`, producing short vertical rectangles despite the name. Carter's TTM Squeeze convention is small *circular dots* on a faint zero-line guide rail. Switched to `ctx.arc` so the dots are actually dots.

The `offsetFromBottom` contract is preserved: it still measures "distance from the pane bottom to the *bottom* of the marker", not to the dot center. The rail is now positioned at `pane.height - offsetFromBottom - radius` so existing callers tuning the offset to keep the marker clear of candles get the same clearance.

### Regime Heatmap — corner badge for the active regime

TradingView regime detectors (EXCAVO, LuxAlgo, RWCS_LTD, GYTS-CE) all pair the background tint with a persistent label / pill spelling out the active regime plus its confidence percentage. The plugin only had the tint.

Added a top-left rounded pill — `trending-up · 72%` — colored by the active regime so the analyst can read it without decoding the background. Behavior:

- Lookup is clamped to the visible range — panning into a sparse region with no regime data hides the badge instead of surfacing a stale label from an off-screen bar.
- Empty-string label inputs (some normalizers emit `""` for "missing") fall back to `regime N` instead of a blank pill.
- The connector tracks the last-applied options so `handle.update(data, { showBadge: false })` followed by `handle.update(nextData)` keeps the badge off — it does not silently revert to the original options.
- Opt-out: `showBadge: false`.

### S/R Confluence — touch count alongside strength

Industry S/R indicators (BigBeluga, MTF Confluence Key Levels, HappyTraderSPX) surface "how many tests has this level survived" alongside the numeric strength. The zone data shape already carried `touchCount`; the renderer just wasn't reading it. Label changed from `S{strength}` to `S{strength} · ×{touchCount}` when the field is present and non-zero. Otherwise unchanged.

## Sources verified

- [TTM Squeeze | ChartSchool | StockCharts.com](https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-indicators/ttm-squeeze)
- [TTM Squeeze Indicator | TrendSpider Learning Center](https://trendspider.com/learning-center/introduction-to-ttm-squeeze/)
- [Market Regime Classifier [EXCAVO]](https://www.tradingview.com/script/sQIv0hKZ-Market-Regime-Classifier-EXCAVO/)
- [Hidden Markov Model Market Regimes [LuxAlgo]](https://www.tradingview.com/script/USWQEica-Hidden-Markov-Model-Market-Regimes-LuxAlgo/)
- [MTF Confluence Key Levels | GrandAlgo](https://grandalgo.com/indicators/mtf-confluence-key-levels)
- [Adaptive Support and Resistance Zones [BigBeluga]](https://www.tradingview.com/script/E8byEL6g-Adaptive-Support-and-Resistance-Zones-BigBeluga/)

## Test plan

- [x] `pnpm test` (chart) — 820 / 820 (was 816; +6 net: 2 squeeze updated to circles, 1 squeeze regression test for `offsetFromBottom`, 4 regime tests for badge / visible range / empty label / applied options, 2 sr tests for touch count)
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] `pnpm size-check` green at unchanged limits
- [x] Public API: one new exported type `RegimeHeatmapOptions`. No removals.