### PR TITLE
feat(strategy-studio): wire 9 additional chart plugins (PR15.6)

### DIFF
--- a/packages/chart/examples/strategy-studio/src/lib/plugins.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/plugins.ts
@@ -7,15 +7,25 @@
  */
 
 import {
+  addAutoChannelLine,
+  addAutoFibExtension,
+  addAutoFibRetracement,
+  addAutoTrendLine,
   type ChartInstance,
   connectAndrewsPitchfork,
+  connectMarketProfile,
   connectPricePatterns,
+  connectRegimeHeatmap,
+  connectSessionZones,
   connectSmcLayer,
+  connectSqueezeDots,
+  connectSrConfluence,
   connectVolumeProfile,
   connectWyckoffPhase,
   filterPricePatterns,
 } from "@trendcraft/chart";
 import {
+  bollingerSqueeze,
   breakOfStructure,
   changeOfCharacter,
   doubleBottom,
@@ -23,10 +33,14 @@ import {
   fairValueGap,
   getAlternatingSwingPoints,
   headAndShoulders,
+  hmmRegimes,
   inverseHeadAndShoulders,
+  killZones,
   liquiditySweep,
+  marketProfile,
   orderBlock,
   type PatternSignal,
+  srZones,
   volumeProfile,
   vsa,
   wyckoffPhases,
@@ -34,7 +48,15 @@ import {
 import type { CatalogEntry } from "../panels/ToggleCatalogPanel";
 import type { StudioCandle } from "./sample-data";
 
-export type PluginCategory = "smc" | "structure" | "volume" | "patterns";
+export type PluginCategory =
+  | "smc"
+  | "structure"
+  | "volume"
+  | "patterns"
+  | "regime"
+  | "session"
+  | "drawings"
+  | "signals";
 
 export type PluginHandle = { remove(): void };
 
@@ -123,6 +145,134 @@ export const PLUGIN_CATALOG: readonly PluginDef[] = [
       // failed silently.
       if (filterPricePatterns(signals).length === 0) return null;
       return connectPricePatterns(chart, signals);
+    },
+  },
+  {
+    kind: "srConfluence",
+    label: "S/R Confluence",
+    category: "structure",
+    description:
+      "Multi-source support / resistance zones (swing, pivot, VWAP, volume profile, round levels) clustered with strength scoring.",
+    build: (chart, candles) => {
+      if (candles.length < 30) return null;
+      const { zones } = srZones(candles);
+      if (zones.length === 0) return null;
+      return connectSrConfluence(chart, zones);
+    },
+  },
+  {
+    kind: "regimeHeatmap",
+    label: "Regime Heatmap",
+    category: "regime",
+    description:
+      "HMM-classified market regime as a background heatmap (trend up / trend down / range / volatile).",
+    build: (chart, candles) => {
+      // HMM Baum-Welch needs enough observations to fit a 4-state mixture
+      // — below ~60 bars the inferred regimes are noise.
+      if (candles.length < 60) return null;
+      return connectRegimeHeatmap(chart, hmmRegimes(candles));
+    },
+  },
+  {
+    kind: "sessionZones",
+    label: "Session Zones",
+    category: "session",
+    description:
+      "ICT kill-zone background bands (Tokyo / London / NY sessions). Needs intraday data to render.",
+    build: (chart, candles) => {
+      const zones = killZones(candles);
+      if (zones.length === 0) return null;
+      return connectSessionZones(chart, zones);
+    },
+  },
+  {
+    kind: "marketProfile",
+    label: "Market Profile",
+    category: "volume",
+    description:
+      "TPO-based time-at-price distribution: POC, VAH, VAL plus the full letter histogram on the right edge.",
+    build: (chart, candles) => {
+      if (candles.length < 20) return null;
+      return connectMarketProfile(chart, marketProfile(candles));
+    },
+  },
+  {
+    kind: "autoFibRetracement",
+    label: "Auto Fib Retracement",
+    category: "drawings",
+    description:
+      "Auto-anchored 23.6 / 38.2 / 50 / 61.8 / 78.6 retracement between the latest swing high and low.",
+    build: (chart, candles) => {
+      const anchors = getAlternatingSwingPoints(candles, 4, { leftBars: 10, rightBars: 10 });
+      if (anchors.length < 2) return null;
+      const id = addAutoFibRetracement(chart, anchors);
+      if (!id) return null;
+      return { remove: () => chart.removeDrawing(id) };
+    },
+  },
+  {
+    kind: "autoFibExtension",
+    label: "Auto Fib Extension",
+    category: "drawings",
+    description:
+      "Auto-anchored extension projecting from the last three alternating swings (127.2 / 161.8 / 200 / 261.8).",
+    build: (chart, candles) => {
+      const anchors = getAlternatingSwingPoints(candles, 6, { leftBars: 10, rightBars: 10 });
+      if (anchors.length < 3) return null;
+      const id = addAutoFibExtension(chart, anchors);
+      if (!id) return null;
+      return { remove: () => chart.removeDrawing(id) };
+    },
+  },
+  {
+    kind: "autoTrendLines",
+    label: "Auto Trend Lines",
+    category: "structure",
+    description:
+      "Resistance + support trend lines through the last two swing highs and lows, extended to the latest bar.",
+    build: (chart, candles) => {
+      const anchors = getAlternatingSwingPoints(candles, 6, { leftBars: 10, rightBars: 10 });
+      if (anchors.length < 2) return null;
+      const extendToTime = candles[candles.length - 1]?.time ?? 0;
+      const ids: string[] = [];
+      const r = addAutoTrendLine(chart, anchors, { line: "resistance", extendToTime });
+      if (r) ids.push(r);
+      const s = addAutoTrendLine(chart, anchors, { line: "support", extendToTime });
+      if (s) ids.push(s);
+      if (ids.length === 0) return null;
+      return {
+        remove: () => {
+          for (const id of ids) chart.removeDrawing(id);
+        },
+      };
+    },
+  },
+  {
+    kind: "autoChannel",
+    label: "Auto Channel",
+    category: "structure",
+    description:
+      "Parallel channel through the last two same-type swings with the opposing side as offset, extended to the latest bar.",
+    build: (chart, candles) => {
+      const anchors = getAlternatingSwingPoints(candles, 6, { leftBars: 10, rightBars: 10 });
+      if (anchors.length < 3) return null;
+      const extendToTime = candles[candles.length - 1]?.time ?? 0;
+      const id = addAutoChannelLine(chart, anchors, { extendToTime });
+      if (!id) return null;
+      return { remove: () => chart.removeDrawing(id) };
+    },
+  },
+  {
+    kind: "squeezeDots",
+    label: "Squeeze Dots",
+    category: "signals",
+    description:
+      "TTM-style squeeze indicator dots along the pane bottom — red while Bollinger ⊂ Keltner, green on release.",
+    build: (chart, candles) => {
+      if (candles.length < 30) return null;
+      const sigs = bollingerSqueeze(candles, { threshold: 10 });
+      if (sigs.length === 0) return null;
+      return connectSqueezeDots(chart, sigs, candles);
     },
   },
 ];

--- a/packages/chart/examples/strategy-studio/src/panels/PluginsPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/PluginsPanel.tsx
@@ -7,9 +7,22 @@ const CATEGORY_LABELS: Record<PluginCategory, string> = {
   structure: "Structure",
   volume: "Volume",
   patterns: "Patterns",
+  regime: "Regime",
+  session: "Session",
+  drawings: "Auto Drawings",
+  signals: "Signals",
 };
 
-const CATEGORY_ORDER: readonly PluginCategory[] = ["smc", "structure", "volume", "patterns"];
+const CATEGORY_ORDER: readonly PluginCategory[] = [
+  "smc",
+  "structure",
+  "volume",
+  "patterns",
+  "regime",
+  "session",
+  "drawings",
+  "signals",
+];
 
 type Props = {
   enabled: ReadonlySet<string>;


### PR DESCRIPTION
## Summary

Brings Strategy Studio's PluginsPanel up to parity with the `indicator-showcase` plugin set. After PR14 (chart live recompute) and PR15.5 (price patterns), the panel had 5 entries vs the showcase's 14. This adds the remaining 9.

## New entries

| Plugin | Category | Description |
|---|---|---|
| **S/R Confluence** | structure | Multi-source S/R zones (swing / pivot / VWAP / volume profile / round levels) clustered with strength scoring. |
| **Regime Heatmap** | regime | HMM-classified market regime as a background heatmap (trending up / range / trending down). |
| **Session Zones** | session | ICT kill-zone background bands (Tokyo / London / NY). Returns `null` on daily data so the toggle stays "unavailable" when there's nothing intraday to render. |
| **Market Profile** | volume | TPO time-at-price distribution: POC, VAH, VAL. |
| **Auto Fib Retracement** | drawings | Auto-anchored 23.6 / 38.2 / 50 / 61.8 / 78.6 levels between the latest swing high and low. |
| **Auto Fib Extension** | drawings | Projection from the last three alternating swings. |
| **Auto Trend Lines** | structure | Resistance + support lines through the last two swing highs / lows, extended to the latest bar. |
| **Auto Channel** | structure | Parallel channel through the last two same-type swings with the opposing side as offset. |
| **Squeeze Dots** | signals | TTM-style squeeze indicator dots along the pane bottom. |

## Category structure

Expanded from 4 to 8 categories. Ordering matches the analytical workflow (structure first, volume confirmation, then pattern / signal layers):

```
smc → structure → volume → patterns → regime → session → drawings → signals
```

## Scope

Studio is the only file changed. The underlying chart primitives all already shipped to `main` (PR179 / 180 / 181 cover the latest visual conventions). When `epic/strategy-studio` next merges `main`, this PR's plugins will pick up the chart-side improvements (Regime badge, Squeeze actual circles, S/R touch count, etc.) automatically — no changes needed here.

## Test plan

- [x] `pnpm test` (studio) — 95 / 95
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm lint` clean
- [x] `pnpm build` (studio) green
- [x] **Visual end-to-end via `agent-browser`**: all 14 plugin entries appear in the catalog with correct 8-category groupings; Regime Heatmap renders the colored vertical bands; Auto Trend Lines draws resistance + support through the recent swings; Squeeze Dots emits the bottom-rail dots; Session Zones correctly stays "unavailable" on the default 1D data set (no intraday session boundaries to mark).