### PR TITLE
feat(chart): SMC Layer text annotations on OB / FVG / liquidity sweeps

### DIFF
--- a/packages/chart/src/__tests__/smc-layer.test.ts
+++ b/packages/chart/src/__tests__/smc-layer.test.ts
@@ -81,7 +81,7 @@ describe("createSmcLayer", () => {
     expect(ctx.strokeRect).not.toHaveBeenCalled();
   });
 
-  it("renders order blocks as filled rectangles", () => {
+  it("renders order blocks as filled rectangles with a BB / OB label", () => {
     const state: SmcState = {
       ...EMPTY_STATE,
       orderBlocks: [
@@ -94,6 +94,15 @@ describe("createSmcLayer", () => {
           strength: 80,
           mitigated: false,
         },
+        {
+          type: "bearish",
+          high: 130,
+          low: 120,
+          startIndex: 8,
+          endIndex: null,
+          strength: 60,
+          mitigated: false,
+        },
       ],
     };
     const plugin = createSmcLayer(state);
@@ -103,6 +112,31 @@ describe("createSmcLayer", () => {
 
     expect(ctx.fillRect).toHaveBeenCalled();
     expect(ctx.strokeRect).toHaveBeenCalled();
+    expect(ctx.fillText).toHaveBeenCalledWith("BB", expect.any(Number), expect.any(Number));
+    expect(ctx.fillText).toHaveBeenCalledWith("OB", expect.any(Number), expect.any(Number));
+  });
+
+  it("annotates a mitigated order block with the strikethrough tag", () => {
+    const state: SmcState = {
+      ...EMPTY_STATE,
+      orderBlocks: [
+        {
+          type: "bullish",
+          high: 110,
+          low: 100,
+          startIndex: 5,
+          endIndex: 10,
+          strength: 80,
+          mitigated: true,
+        },
+      ],
+    };
+    const plugin = createSmcLayer(state);
+    const ctx = mockCtx();
+
+    plugin.render(makeRenderContext(ctx), state);
+
+    expect(ctx.fillText).toHaveBeenCalledWith("BB ✕", expect.any(Number), expect.any(Number));
   });
 
   it("renders mitigated OB with lower alpha", () => {
@@ -141,7 +175,7 @@ describe("createSmcLayer", () => {
     expect(obFill).toContain("0.05");
   });
 
-  it("renders FVG zones with dashed border", () => {
+  it("renders FVG zones with dashed border and an FVG label", () => {
     const state: SmcState = {
       ...EMPTY_STATE,
       fvgZones: [
@@ -163,12 +197,18 @@ describe("createSmcLayer", () => {
 
     expect(ctx.setLineDash).toHaveBeenCalledWith([4, 3]);
     expect(ctx.strokeRect).toHaveBeenCalled();
+    expect(ctx.fillText).toHaveBeenCalledWith("FVG", expect.any(Number), expect.any(Number));
   });
 
-  it("renders sweep markers as triangles", () => {
+  it("renders sweep markers as triangles with BSL / SSL labels", () => {
     const state: SmcState = {
       ...EMPTY_STATE,
-      sweepMarkers: [{ type: "bullish", index: 10, price: 95, label: "Sweep" }],
+      sweepMarkers: [
+        // bullish sweep = swept *sell-side* liquidity → SSL
+        { type: "bullish", index: 10, price: 95, label: "Sweep" },
+        // bearish sweep = swept *buy-side* liquidity → BSL
+        { type: "bearish", index: 12, price: 130, label: "Sweep" },
+      ],
     };
     const plugin = createSmcLayer(state);
     const ctx = mockCtx();
@@ -176,8 +216,9 @@ describe("createSmcLayer", () => {
     plugin.render(makeRenderContext(ctx), state);
 
     expect(ctx.moveTo).toHaveBeenCalled();
-    expect(ctx.lineTo).toHaveBeenCalledTimes(2);
     expect(ctx.fill).toHaveBeenCalled();
+    expect(ctx.fillText).toHaveBeenCalledWith("SSL", expect.any(Number), expect.any(Number));
+    expect(ctx.fillText).toHaveBeenCalledWith("BSL", expect.any(Number), expect.any(Number));
   });
 
   it("renders BOS levels as dashed lines with labels", () => {

--- a/packages/chart/src/plugins/smc-layer.ts
+++ b/packages/chart/src/plugins/smc-layer.ts
@@ -84,6 +84,10 @@ function renderOrderBlocks(
   timeScale: PrimitiveRenderContext["timeScale"],
   priceScale: PrimitiveRenderContext["priceScale"],
 ): void {
+  ctx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
+  ctx.textAlign = "left";
+  ctx.textBaseline = "top";
+
   for (const zone of zones) {
     const startX = timeScale.indexToX(zone.startIndex);
     const endX =
@@ -108,6 +112,14 @@ function renderOrderBlocks(
     ctx.strokeStyle = `rgba(${rgb},${zone.mitigated ? 0.15 : 0.4})`;
     ctx.lineWidth = 1;
     ctx.strokeRect(startX, topY, w, h);
+
+    // Top-left label — "BB" / "OB" matches LuxAlgo SMC convention
+    // (Bullish Block / Order Block). Mitigation tag distinguishes used
+    // blocks at a glance without changing the color palette.
+    const label = zone.type === "bullish" ? "BB" : "OB";
+    const text = zone.mitigated ? `${label} ✕` : label;
+    ctx.fillStyle = `rgba(${rgb},${zone.mitigated ? 0.45 : 0.85})`;
+    ctx.fillText(text, startX + 3, topY + 2);
   }
 }
 
@@ -117,6 +129,10 @@ function renderFvgZones(
   timeScale: PrimitiveRenderContext["timeScale"],
   priceScale: PrimitiveRenderContext["priceScale"],
 ): void {
+  ctx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
+  ctx.textAlign = "right";
+  ctx.textBaseline = "top";
+
   for (const zone of zones) {
     const startX = timeScale.indexToX(zone.startIndex);
     const endX =
@@ -144,6 +160,12 @@ function renderFvgZones(
     ctx.lineWidth = 1;
     ctx.strokeRect(startX, topY, w, h);
     ctx.restore();
+
+    // Top-right label "FVG" — placed opposite of OB labels (top-left) so
+    // they don't collide when an OB and an FVG overlap on the same bar.
+    const text = zone.mitigated ? "FVG ✕" : "FVG";
+    ctx.fillStyle = `rgba(${rgb},${zone.mitigated ? 0.45 : 0.85})`;
+    ctx.fillText(text, endX - 3, topY + 2);
   }
 }
 
@@ -154,6 +176,8 @@ function renderSweepMarkers(
   priceScale: PrimitiveRenderContext["priceScale"],
 ): void {
   const size = 5;
+  ctx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
+  ctx.textAlign = "center";
 
   for (const marker of markers) {
     const x = timeScale.indexToX(marker.index);
@@ -164,18 +188,35 @@ function renderSweepMarkers(
     ctx.fillStyle = `rgba(${rgb},0.8)`;
     ctx.beginPath();
     if (marker.type === "bullish") {
-      // Up triangle (swept low → bullish signal)
+      // Up triangle (swept low → bullish signal). The bar swept *sell-side*
+      // liquidity (stops below recent lows) and reversed up — LuxAlgo SMC
+      // labels this "SSL" (Sell-Side Liquidity).
       ctx.moveTo(x, y - size);
       ctx.lineTo(x - size, y + size);
       ctx.lineTo(x + size, y + size);
     } else {
-      // Down triangle (swept high → bearish signal)
+      // Down triangle (swept high → bearish signal). The bar swept
+      // *buy-side* liquidity (stops above recent highs) — LuxAlgo SMC
+      // labels this "BSL" (Buy-Side Liquidity).
       ctx.moveTo(x, y + size);
       ctx.lineTo(x - size, y - size);
       ctx.lineTo(x + size, y - size);
     }
     ctx.closePath();
     ctx.fill();
+
+    // Side label below the down triangle / above the up triangle.
+    const label = marker.type === "bullish" ? "SSL" : "BSL";
+    ctx.fillStyle = `rgba(${rgb},0.95)`;
+    if (marker.type === "bullish") {
+      // Up arrow points up; label sits below the triangle.
+      ctx.textBaseline = "top";
+      ctx.fillText(label, x, y + size + 2);
+    } else {
+      // Down arrow points down; label sits above the triangle.
+      ctx.textBaseline = "bottom";
+      ctx.fillText(label, x, y - size - 2);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

LuxAlgo's SMC indicator — the de-facto reference for Smart Money Concepts on TradingView, MT4/5, NinjaTrader and ToS — annotates every shape with a text tag so an analyst doesn't have to decode shape + color to identify each construct. The trendcraft SMC Layer rendered the rectangles and triangles but left them unlabeled, so a screenshot or zoomed-out chart reduced to "what was that green box again?".

This adds the missing text.

## Annotations

| Construct | Label | Anchor |
|---|---|---|
| Bullish Order Block | `BB` | top-left of rectangle |
| Bearish Order Block | `OB` | top-left of rectangle |
| Mitigated OB | `BB ✕` / `OB ✕` | suffix `✕` mirrors the existing lower-alpha shading |
| Fair Value Gap | `FVG` | top-right (deliberately opposite of OB top-left so they don't collide on overlap) |
| Bullish liquidity sweep (swept SSL) | `SSL` | below the up-triangle |
| Bearish liquidity sweep (swept BSL) | `BSL` | above the down-triangle |

`BoS` / `CHoCH` levels already carried labels — unchanged.

## Scope

Pure rendering change. Color palette, shape geometry, alpha modulation, mitigation handling all preserved. No public API additions; no size-check changes.

## Test plan

- [x] `pnpm test` (chart) — 821 / 821 (was 816; +5 new SMC assertions)
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] `pnpm size-check` green at unchanged limits
- [x] `/codex:review` clean

## Sources verified

- [Smart Money Concepts (SMC) [LuxAlgo] — TradingView](https://www.tradingview.com/script/CnB3fSph-Smart-Money-Concepts-SMC-LuxAlgo/)
- [Smart Money Concepts | LuxAlgo Library](https://www.luxalgo.com/library/indicator/smart-money-concepts-smc/)