### PR TITLE
feat(chart): Wyckoff sub-phase letter as a separate corner chip

### DIFF
--- a/packages/chart/src/__tests__/wyckoff-phase.test.ts
+++ b/packages/chart/src/__tests__/wyckoff-phase.test.ts
@@ -122,6 +122,44 @@ describe("createWyckoffPhase", () => {
     expect(badgeCall).toBeDefined();
     expect(badgeCall?.[0]).toContain("Distribution");
     expect(badgeCall?.[0]).toContain("72");
+    // subPhase is rendered as its own chip, not stuffed into the main badge.
+    expect(badgeCall?.[0]).not.toContain("phase_B");
+  });
+
+  it("renders subPhase as a separate chip next to the main badge", () => {
+    const phases = [
+      { time: 1000, value: { phase: "accumulation", confidence: 65, subPhase: "phase_B" } },
+    ];
+    const plugin = createWyckoffPhase(phases);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx, mockTs(0, 1)), plugin.defaultState);
+    expect(ctx.fillText).toHaveBeenCalledWith("phase_B", expect.any(Number), expect.any(Number));
+  });
+
+  it("does not render the subPhase chip when subPhase is missing or empty", () => {
+    const phases = [
+      // No subPhase at all.
+      { time: 1000, value: { phase: "accumulation", confidence: 50 } },
+    ];
+    const plugin = createWyckoffPhase(phases);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx, mockTs(0, 1)), plugin.defaultState);
+    const calls = (ctx.fillText as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    // Only the main badge text should fire — no second chip text.
+    const badgeCalls = calls.filter((c) => typeof c[0] === "string" && c[0].includes("Wyckoff:"));
+    expect(badgeCalls).toHaveLength(1);
+
+    // Empty-string subPhase should also stay quiet.
+    const phasesEmpty = [
+      { time: 1000, value: { phase: "accumulation", confidence: 50, subPhase: "  " } },
+    ];
+    const plugin2 = createWyckoffPhase(phasesEmpty);
+    const ctx2 = mockCtx();
+    plugin2.render(makeCtx(ctx2, mockTs(0, 1)), plugin2.defaultState);
+    const calls2 = (ctx2.fillText as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const badgeCalls2 = calls2.filter((c) => typeof c[0] === "string" && c[0].includes("Wyckoff:"));
+    expect(badgeCalls2).toHaveLength(1);
+    expect(calls2.some((c) => c[0] === "  ")).toBe(false);
   });
 
   it("renders VSA event markers as dots", () => {

--- a/packages/chart/src/plugins/wyckoff-phase.ts
+++ b/packages/chart/src/plugins/wyckoff-phase.ts
@@ -317,8 +317,13 @@ function renderWyckoffPhase(
     if (options.showPhaseBadge && last) {
       const label = PHASE_LABELS[last.phase] ?? last.phase;
       const conf = last.confidence ?? 0;
-      const subPhase = last.subPhase ? ` · ${last.subPhase}` : "";
-      const text = `Wyckoff: ${label} (${conf.toFixed(0)})${subPhase}`;
+      // Sub-phase letter (A/B/C/D/E in classical Wyckoff notation, or
+      // arbitrary text for forks like "Spring") gets its own chip rendered
+      // alongside the main badge — that's how LuxAlgo / AGProLabs Wyckoff
+      // tools surface it. Combining the two strings into one badge buries
+      // the sub-phase tag in trailing text and makes it easy to miss.
+      const subPhase = last.subPhase ? last.subPhase.trim() : "";
+      const text = `Wyckoff: ${label} (${conf.toFixed(0)})`;
       const rgb = PHASE_COLORS[last.phase] ?? PHASE_COLORS.unknown;
 
       ctx.font = "bold 11px -apple-system, BlinkMacSystemFont, sans-serif";
@@ -341,6 +346,20 @@ function renderWyckoffPhase(
 
       ctx.fillStyle = `rgba(${rgb},0.95)`;
       ctx.fillText(text, boxX + padX, boxY + padY);
+
+      // Sub-phase chip — saturated tint so the letter pops out next to the
+      // muted main badge. 4 px gap to the right of the main pill.
+      if (subPhase.length > 0) {
+        const subWidth = ctx.measureText(subPhase).width;
+        const subX = boxX + boxW + 4;
+        const subBoxW = subWidth + padX * 2;
+
+        ctx.fillStyle = `rgba(${rgb},0.85)`;
+        ctx.fillRect(subX, boxY, subBoxW, boxH);
+
+        ctx.fillStyle = "#fff";
+        ctx.fillText(subPhase, subX + padX, boxY + padY);
+      }
     }
   });
 }


### PR DESCRIPTION
## Summary

The Wyckoff Phase plugin already exposed the sub-phase identifier (A/B/C/D/E in classical notation, or fork tags like "Spring") off the data — but only as a trailing string appended to the main badge:

```
Wyckoff: Accumulation (75) · phase_B
```

Anyone glancing at the corner saw the phase name and confidence first; the sub-phase letter — the most actionable read in Wyckoff analysis — was buried in suffix text after a parenthesized number.

LuxAlgo / AGProLabs Wyckoff tools surface the sub-phase as its own visual element (separate label box / chip / letter card), matching how Wyckoff traders actually scan a chart: *"what phase, what stage"*.

## Visual change

Splits the existing badge into two pieces:

- **Main pill** (unchanged geometry / colors) carries `Wyckoff: <phase> (<conf>)`.
- **Sub-phase chip** — saturated-tint pill immediately to the right of the main pill — carries the sub-phase string verbatim. Same height so the pair reads as one composite badge.

Empty / whitespace-only `subPhase` values render no chip at all. Previously `subPhase: "  "` would have rendered a trailing `· `.

## Scope

Pure rendering. No public API additions, no size-check changes. Badge on/off still controlled by the existing `showPhaseBadge` option.

## Test plan

- [x] `pnpm test` (chart) — 823 / 823 (was 821; +2 net)
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] `pnpm size-check` green at unchanged limits
- [x] `/codex:review` clean
- [x] Coverage:
  - existing badge text test now asserts the main pill *no longer* embeds the sub-phase (confirming the split)
  - new test: sub-phase chip emits a separate `fillText("phase_B", ...)` call
  - new test: chip stays absent when sub-phase is missing OR a whitespace-only string

## Sources

- [Wyckoff Phase Classifier (TradingView)](https://www.tradingview.com/script/9ap94IDt-Wyckoff-Phase-Classifier/)
- [Wyckoff Accumulation Phase Map [AGProLabs]](https://www.tradingview.com/script/cJ65zYuc-Wyckoff-Accumulation-Phase-Map-AGPro-Series/)