### PR TITLE
feat(chart): trade analysis P&L label + magnitude-aware MFE/MAE labels

### DIFF
--- a/packages/chart/src/__tests__/trade-analysis.test.ts
+++ b/packages/chart/src/__tests__/trade-analysis.test.ts
@@ -18,9 +18,14 @@ const mockCtx = () =>
     lineTo: vi.fn(),
     arc: vi.fn(),
     setLineDash: vi.fn(),
+    fillText: vi.fn(),
+    measureText: vi.fn((text: string) => ({ width: text.length * 5.5 })),
     fillStyle: "",
     strokeStyle: "",
     lineWidth: 1,
+    font: "",
+    textAlign: "" as CanvasTextAlign,
+    textBaseline: "" as CanvasTextBaseline,
   }) as unknown as CanvasRenderingContext2D;
 
 const candles = Array.from({ length: 50 }, (_, i) => ({
@@ -94,6 +99,149 @@ describe("createTradeAnalysis", () => {
     plugin.render(makeCtx(ctx), plugin.defaultState);
     expect(ctx.stroke).not.toHaveBeenCalled();
   });
+
+  it("renders a P&L label near the exit dot by default (formatted with sign)", () => {
+    const trades = [
+      {
+        entryTime: 1000,
+        entryPrice: 100,
+        exitTime: 1000 + 5 * 60,
+        exitPrice: 108,
+        returnPercent: 8.25,
+        direction: "long" as const,
+      },
+      {
+        entryTime: 1000 + 6 * 60,
+        entryPrice: 110,
+        exitTime: 1000 + 12 * 60,
+        exitPrice: 105,
+        returnPercent: -4.55,
+        direction: "long" as const,
+      },
+    ];
+    const plugin = createTradeAnalysis(trades, candles);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    expect(ctx.fillText).toHaveBeenCalledWith("+8.25%", expect.any(Number), expect.any(Number));
+    expect(ctx.fillText).toHaveBeenCalledWith("-4.55%", expect.any(Number), expect.any(Number));
+  });
+
+  it("omits the P&L label when showPnlLabel is false", () => {
+    const trades = [
+      {
+        entryTime: 1000,
+        entryPrice: 100,
+        exitTime: 1000 + 5 * 60,
+        exitPrice: 108,
+        returnPercent: 8,
+      },
+    ];
+    const plugin = createTradeAnalysis(trades, candles, { showPnlLabel: false });
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    const calls = (ctx.fillText as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.some((c) => typeof c[0] === "string" && c[0].endsWith("%"))).toBe(false);
+  });
+
+  it("does not render MFE/MAE end-of-line price labels by default", () => {
+    const trades = [
+      {
+        entryTime: 1000,
+        entryPrice: 100,
+        exitTime: 1000 + 5 * 60,
+        exitPrice: 105,
+        returnPercent: 5,
+      },
+    ];
+    const plugin = createTradeAnalysis(trades, candles);
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    // Default `showMfeMaeLabels: false` — only the P&L label fires; no
+    // standalone numeric price labels for the dashed lines.
+    const calls = (ctx.fillText as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const numericLabels = calls.filter((c) => /^\d/.test(String(c[0])));
+    expect(numericLabels).toHaveLength(0);
+  });
+
+  it("renders MFE/MAE price labels when showMfeMaeLabels is true", () => {
+    const trades = [
+      {
+        entryTime: 1000,
+        entryPrice: 100,
+        exitTime: 1000 + 5 * 60,
+        exitPrice: 105,
+        returnPercent: 5,
+      },
+    ];
+    const plugin = createTradeAnalysis(trades, candles, { showMfeMaeLabels: true });
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    // MFE + MAE labels should each fire once. Their content is the
+    // computed price level (numeric, formatted by the default formatter).
+    const calls = (ctx.fillText as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const numericLabels = calls.filter((c) => /^\d/.test(String(c[0])));
+    expect(numericLabels.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("default price formatter adapts decimals to magnitude (FX / low-priced crypto safe)", () => {
+    // Single trade on a low-priced crypto-style instrument: candles in
+    // the 0.0001 range. Without magnitude-aware formatting the labels
+    // collapse to "0.00" and become unreadable.
+    const microCandles = Array.from({ length: 10 }, (_, i) => ({
+      time: 1000 + i * 60,
+      high: 0.000123 + i * 0.000001,
+      low: 0.000115 + i * 0.000001,
+    }));
+    const trades = [
+      {
+        entryTime: microCandles[0].time,
+        entryPrice: 0.000118,
+        exitTime: microCandles[5].time,
+        exitPrice: 0.000122,
+        returnPercent: 3.39,
+      },
+    ];
+    const plugin = createTradeAnalysis(trades, microCandles, { showMfeMaeLabels: true });
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    const calls = (ctx.fillText as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const priceLabels = calls
+      .map((c) => String(c[0]))
+      .filter((s) => /^\d/.test(s) && !s.endsWith("%"));
+
+    // No "0.00" labels — the formatter must keep enough decimals to
+    // distinguish MFE and MAE values in this magnitude.
+    expect(priceLabels.every((s) => s !== "0.00" && s !== "0")).toBe(true);
+    // The two distinct levels should produce distinct text.
+    expect(new Set(priceLabels).size).toBeGreaterThanOrEqual(2);
+  });
+
+  it("respects a custom priceFormatter", () => {
+    const trades = [
+      {
+        entryTime: 1000,
+        entryPrice: 100,
+        exitTime: 1000 + 5 * 60,
+        exitPrice: 105,
+        returnPercent: 5,
+      },
+    ];
+    const plugin = createTradeAnalysis(trades, candles, {
+      showMfeMaeLabels: true,
+      priceFormatter: (p) => `$${p.toFixed(0)}`,
+    });
+    const ctx = mockCtx();
+    plugin.render(makeCtx(ctx), plugin.defaultState);
+
+    const calls = (ctx.fillText as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const dollarLabels = calls.filter((c) => /^\$\d/.test(String(c[0])));
+    expect(dollarLabels.length).toBeGreaterThanOrEqual(2);
+  });
 });
 
 describe("connectTradeAnalysis", () => {
@@ -114,5 +262,63 @@ describe("connectTradeAnalysis", () => {
     } as unknown as ChartInstance;
     connectTradeAnalysis(chart, [], []).remove();
     expect(chart.removePrimitive).toHaveBeenCalledWith("tradeAnalysis");
+  });
+
+  it("update() preserves last-applied options across data-only refreshes", () => {
+    // Toggle showPnlLabel off once, then refresh trade data without
+    // re-passing options. The toggle must stay off — same contract as
+    // connectRegimeHeatmap / connectVolumeProfile.
+    const registrations: Array<{ defaultState: { options: { showPnlLabel: boolean } } }> = [];
+    const chart = {
+      registerPrimitive: vi.fn((p) => {
+        registrations.push(p as (typeof registrations)[number]);
+      }),
+      removePrimitive: vi.fn(),
+    } as unknown as ChartInstance;
+
+    const handle = connectTradeAnalysis(chart, [], [], { showPnlLabel: true });
+    handle.update([], [], { showPnlLabel: false });
+    handle.update([], []); // data-only refresh
+
+    expect(registrations).toHaveLength(3);
+    expect(registrations[0].defaultState.options.showPnlLabel).toBe(true);
+    expect(registrations[1].defaultState.options.showPnlLabel).toBe(false);
+    expect(registrations[2].defaultState.options.showPnlLabel).toBe(false);
+  });
+
+  it("update() merges partial option objects instead of replacing them", () => {
+    // Initial connect sets multiple fields. A subsequent partial update
+    // toggling only one of them must preserve the others — otherwise a
+    // host that flips showPnlLabel via update() would silently lose any
+    // showMfeMaeLabels / priceFormatter previously installed.
+    const registrations: Array<{
+      defaultState: {
+        options: {
+          showPnlLabel: boolean;
+          showMfeMaeLabels: boolean;
+          priceFormatter: (p: number) => string;
+        };
+      };
+    }> = [];
+    const chart = {
+      registerPrimitive: vi.fn((p) => {
+        registrations.push(p as (typeof registrations)[number]);
+      }),
+      removePrimitive: vi.fn(),
+    } as unknown as ChartInstance;
+
+    const customFormatter = (p: number) => `¥${p.toFixed(0)}`;
+    const handle = connectTradeAnalysis(chart, [], [], {
+      showMfeMaeLabels: true,
+      priceFormatter: customFormatter,
+    });
+    handle.update([], [], { showPnlLabel: false });
+
+    expect(registrations).toHaveLength(2);
+    // After the partial toggle, both the original showMfeMaeLabels AND
+    // the custom formatter must still be in effect.
+    expect(registrations[1].defaultState.options.showMfeMaeLabels).toBe(true);
+    expect(registrations[1].defaultState.options.priceFormatter).toBe(customFormatter);
+    expect(registrations[1].defaultState.options.showPnlLabel).toBe(false);
   });
 });

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -180,7 +180,11 @@ export {
   type SqueezeDotsOptions,
 } from "./plugins/squeeze-dots";
 export { connectSrConfluence, createSrConfluence } from "./plugins/sr-confluence";
-export { connectTradeAnalysis, createTradeAnalysis } from "./plugins/trade-analysis";
+export {
+  connectTradeAnalysis,
+  createTradeAnalysis,
+  type TradeAnalysisOptions,
+} from "./plugins/trade-analysis";
 export {
   connectVolumeProfile,
   createVolumeProfile,

--- a/packages/chart/src/plugins/trade-analysis.ts
+++ b/packages/chart/src/plugins/trade-analysis.ts
@@ -42,10 +42,44 @@ type CandleRef = {
   low: number;
 };
 
+export type TradeAnalysisOptions = {
+  /**
+   * Whether to draw the P&L percentage as a small label near the exit
+   * dot. Default `true`. Backtest analysts read this number first when
+   * scanning a result; without it the win / loss color of the exit dot
+   * is the only signal.
+   */
+  showPnlLabel?: boolean;
+  /**
+   * Whether to label the right end of each MFE / MAE dashed line with
+   * the absolute price level. Default `false` — useful when reviewing
+   * single trades, but on a full backtest the labels stack and clutter.
+   */
+  showMfeMaeLabels?: boolean;
+  /**
+   * Custom price formatter for MFE / MAE labels. The default adapts the
+   * decimal count to the price magnitude (≥1000 → 2 dp, ≥1 → 4 dp, <1 →
+   * up to 8 dp), which works for equities, FX and crypto. Override this
+   * if your instrument has a fixed tick size or a non-decimal display.
+   */
+  priceFormatter?: (price: number) => string;
+};
+
 type TradeAnalysisState = {
   trades: readonly TradeData[];
   candles: readonly CandleRef[];
+  options: Required<TradeAnalysisOptions>;
 };
+
+const DEFAULT_OPTIONS: Required<TradeAnalysisOptions> = {
+  showPnlLabel: true,
+  showMfeMaeLabels: false,
+  priceFormatter: defaultFormatPrice,
+};
+
+function resolveOptions(options: TradeAnalysisOptions = {}): Required<TradeAnalysisOptions> {
+  return { ...DEFAULT_OPTIONS, ...options };
+}
 
 // ---- Colors ----
 
@@ -98,7 +132,7 @@ function renderTradeAnalysis(
   { ctx, pane, timeScale, priceScale }: PrimitiveRenderContext,
   state: TradeAnalysisState,
 ): void {
-  const { trades, candles } = state;
+  const { trades, candles, options } = state;
   if (trades.length === 0 || candles.length === 0) return;
 
   withPaneClip(ctx, pane, () => {
@@ -147,6 +181,17 @@ function renderTradeAnalysis(
       ctx.stroke();
       ctx.restore();
 
+      // Optional MFE / MAE end-of-line price labels.
+      if (options.showMfeMaeLabels) {
+        ctx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
+        ctx.textAlign = "left";
+        ctx.textBaseline = "middle";
+        ctx.fillStyle = `rgba(${MFE_COLOR},0.85)`;
+        ctx.fillText(options.priceFormatter(mfePrice), exitX + 4, mfeY);
+        ctx.fillStyle = `rgba(${MAE_COLOR},0.85)`;
+        ctx.fillText(options.priceFormatter(maePrice), exitX + 4, maeY);
+      }
+
       // Shaded area between MFE and MAE
       const topY = Math.min(mfeY, maeY);
       const bottomY = Math.max(mfeY, maeY);
@@ -173,8 +218,48 @@ function renderTradeAnalysis(
       ctx.beginPath();
       ctx.arc(exitX, exitY, 3, 0, Math.PI * 2);
       ctx.fill();
+
+      // P&L label — placed above the exit dot for wins, below for losses
+      // so it never visually crosses the trade line on its way out.
+      if (options.showPnlLabel) {
+        const pct = trade.returnPercent;
+        const sign = pct >= 0 ? "+" : "";
+        const label = `${sign}${pct.toFixed(2)}%`;
+        ctx.font = "bold 10px -apple-system, BlinkMacSystemFont, sans-serif";
+        ctx.textAlign = "left";
+        if (isWin) {
+          ctx.textBaseline = "bottom";
+          ctx.fillStyle = `rgba(${TRADE_WIN_COLOR},0.95)`;
+          ctx.fillText(label, exitX + 5, exitY - 4);
+        } else {
+          ctx.textBaseline = "top";
+          ctx.fillStyle = `rgba(${TRADE_LOSS_COLOR},0.95)`;
+          ctx.fillText(label, exitX + 5, exitY + 4);
+        }
+      }
     }
   });
+}
+
+/**
+ * Adapt decimal count to the price's magnitude so the label is readable
+ * across equities (e.g. `4500.12`), FX (e.g. `1.23456`) and low-priced
+ * crypto (e.g. `0.00012345`) without callers having to specify precision.
+ *
+ * Hosts that need a fixed tick size or a non-decimal display can override
+ * this via `TradeAnalysisOptions.priceFormatter`.
+ */
+function defaultFormatPrice(value: number): string {
+  if (!Number.isFinite(value)) return "";
+  const abs = Math.abs(value);
+  let decimals: number;
+  if (abs >= 1000) decimals = 2;
+  else if (abs >= 1) decimals = 4;
+  else if (abs >= 0.01) decimals = 6;
+  else decimals = 8;
+  // Trim trailing zeros so "100.0000" reads as "100" but "1.2345" stays
+  // intact. The trailing-dot guard handles values like "100." → "100".
+  return value.toFixed(decimals).replace(/\.?0+$/, "");
 }
 
 // ---- Factory ----
@@ -182,12 +267,13 @@ function renderTradeAnalysis(
 export function createTradeAnalysis(
   trades: readonly TradeData[],
   candles: readonly CandleRef[],
+  options: TradeAnalysisOptions = {},
 ): PrimitivePlugin<TradeAnalysisState> {
   return definePrimitive<TradeAnalysisState>({
     name: "tradeAnalysis",
     pane: "main",
     zOrder: "above",
-    defaultState: { trades, candles },
+    defaultState: { trades, candles, options: resolveOptions(options) },
     render: renderTradeAnalysis,
   });
 }
@@ -195,7 +281,11 @@ export function createTradeAnalysis(
 // ---- Convenience connector ----
 
 type TradeAnalysisHandle = {
-  update(trades: readonly TradeData[], candles: readonly CandleRef[]): void;
+  update(
+    trades: readonly TradeData[],
+    candles: readonly CandleRef[],
+    options?: TradeAnalysisOptions,
+  ): void;
   remove(): void;
 };
 
@@ -203,12 +293,22 @@ export function connectTradeAnalysis(
   chart: ChartInstance,
   trades: readonly TradeData[],
   candles: readonly CandleRef[],
+  options: TradeAnalysisOptions = {},
 ): TradeAnalysisHandle {
-  chart.registerPrimitive(createTradeAnalysis(trades, candles));
+  // Track the last-applied options. Merge (not replace) so a partial
+  // update — e.g. `update(data, candles, { showPnlLabel: false })` —
+  // preserves previously-applied fields like `showMfeMaeLabels` or a
+  // custom `priceFormatter` instead of silently reverting them to
+  // defaults on the next render.
+  let appliedOptions: TradeAnalysisOptions = { ...options };
+  chart.registerPrimitive(createTradeAnalysis(trades, candles, appliedOptions));
 
   return {
-    update(newTrades, newCandles) {
-      chart.registerPrimitive(createTradeAnalysis(newTrades, newCandles));
+    update(newTrades, newCandles, newOptions) {
+      if (newOptions !== undefined) {
+        appliedOptions = { ...appliedOptions, ...newOptions };
+      }
+      chart.registerPrimitive(createTradeAnalysis(newTrades, newCandles, appliedOptions));
     },
     remove() {
       chart.removePrimitive("tradeAnalysis");


### PR DESCRIPTION
## Summary

The Trade Analysis primitive previously rendered the entry / exit dots, MFE / MAE dashed lines, and the entry-to-exit trade line — but no text. The single most actionable read in a backtest review ("did this trade make money, how much?") was encoded only as the exit dot's win / loss color. Industry backtest tools (TradesViz, Pineify, TradingView Strategy Tester) all surface the per-trade return as a visible label.

## Changes

### P&L percentage label (default ON)

Bold percentage rendered next to each exit dot:

- Wins sit above the dot: `+8.25%` (green)
- Losses sit below the dot: `-4.55%` (red)

Flip off via `TradeAnalysisOptions.showPnlLabel: false`.

### Optional MFE / MAE end-of-line price labels (default OFF)

Off by default — on a many-trade backtest the labels stack and clutter; on by default would regress single-trade reviews. Enable via `showMfeMaeLabels: true`.

### Magnitude-aware price formatter

| Magnitude | Decimals | Example |
|---|---|---|
| ≥ 1000 | 2 | `4500.12` |
| ≥ 1 | 4 | `1.2345` |
| ≥ 0.01 | 6 | `0.123456` |
| < 0.01 | 8 | `0.00012345` |

Keeps FX and low-priced crypto labels distinct instead of collapsing both numbers to `0.00` (the failure mode of a fixed `toFixed(2)`). Hosts that need a fixed tick size or non-decimal display can override via `priceFormatter: (price: number) => string`.

### Option merge on update()

The connector tracks last-applied options and **merges** new partial options into the existing set, so a host that initializes with `{ showMfeMaeLabels: true, priceFormatter: custom }` and later toggles a single field via `update(data, candles, { showPnlLabel: false })` doesn't silently lose the previously installed labels / formatter.

## Public API

- New optional 4th argument on `connectTradeAnalysis` / `createTradeAnalysis`.
- New exported type `TradeAnalysisOptions`.

Existing callers compile unchanged.

## Test plan

- [x] `pnpm test` (chart) — 831 / 831 (was 823; +8 net)
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] `pnpm size-check` green at unchanged limits
- [x] `/codex:review` clean (after addressing 2 P2 findings: hardcoded 2 dp formatting, partial-update option merge)
- [x] Coverage:
  - `+X.XX%` / `-X.XX%` formatting with sign
  - `showPnlLabel: false` opt-out
  - default omits MFE/MAE price labels
  - `showMfeMaeLabels: true` emits both
  - magnitude-aware formatter keeps `0.000118 / 0.000122`-style prices distinct
  - custom `priceFormatter` is honored
  - partial `update()` preserves previously-applied option fields
  - existing data-only refresh test continues to pass

## Sources verified

- [TradingView Strategy Tester documentation (Pineify)](https://pineify.app/backtest-report)
- [MFE & MAE Tool indicator (TradingView)](https://www.tradingview.com/script/hsnNd02H-MFE-MAE-Tool/)
- [TradesViz stock journal](https://www.tradesviz.com/stocks/)