### PR TITLE
feat(core)!: switch Ease of Movement to canonical 1e8 divisor default

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+### Breaking — Ease of Movement default `volumeDivisor`
+
+`easeOfMovement` and the incremental `createEmv` now default
+`volumeDivisor` to `100_000_000` (1e8), matching the StockCharts /
+ChartSchool canonical scaling. The previous default was `10000`, which
+produced values ~10000× *smaller* than every reference implementation
+(EMV is proportional to `volumeDivisor`). The streaming preset wrappers
+(`indicatorPresets.emv`, `livePresets.emv`) now also inherit the
+canonical default — previously they hard-coded 10000 independently.
+
+For trading-decision use cases the **sign** and **slope** of EMV are
+what matter, and both are invariant to `volumeDivisor` — strategies
+relying on EMV crossings or zero-line crosses are unaffected. Code
+that compares EMV's absolute magnitude to a hard-coded threshold or
+to a value pinned from the prior trendcraft default needs to either
+multiply the threshold by 10000 or pass `volumeDivisor: 10000`
+explicitly.
+
+State resume preserves the captured divisor: a state captured under
+the legacy 10000 divisor and resumed via `createEmv(opts, { fromState })`
+continues at 10000, not the new 1e8 default. Explicit `opts.volumeDivisor`
+still wins over both the snapshot and the default.
+
 ### Added — strategy JSON round-trip depth tests
 
 `serialize / parse` is now pinned across:

--- a/packages/core/src/indicators/__tests__/ease-of-movement.test.ts
+++ b/packages/core/src/indicators/__tests__/ease-of-movement.test.ts
@@ -17,6 +17,32 @@ describe("easeOfMovement", () => {
     expect(easeOfMovement([])).toEqual([]);
   });
 
+  it("treats `volumeDivisor: null` as unset and uses the canonical default", () => {
+    // JSON / form-driven configs frequently send explicit `null` for
+    // unset optional fields. The destructuring default only applies when
+    // the property is `undefined`, so without an explicit `??` guard the
+    // `null` would slip through and `c.volume / null` would make
+    // boxRatio infinite — every EMV value would silently collapse to 0.
+    const data: { high: number; low: number; volume: number }[] = [];
+    for (let i = 0; i < 20; i++) {
+      data.push({ high: 102 + i, low: 98 + i, volume: 50_000_000 });
+    }
+    const candles = makeCandles(data);
+    const fromUndefined = easeOfMovement(candles, { period: 3 });
+    const fromNull = easeOfMovement(candles, {
+      period: 3,
+      volumeDivisor: null as unknown as number,
+    });
+
+    for (let i = 0; i < fromUndefined.length; i++) {
+      expect(fromNull[i].time).toBe(fromUndefined[i].time);
+      expect(fromNull[i].value).toBe(fromUndefined[i].value);
+    }
+    const lastNull = fromNull[fromNull.length - 1].value;
+    expect(lastNull).not.toBeNull();
+    expect(Number.isFinite(lastNull as number)).toBe(true);
+  });
+
   it("should throw if period < 1", () => {
     const candles = makeCandles([{ high: 101, low: 99, volume: 1000 }]);
     expect(() => easeOfMovement(candles, { period: 0 })).toThrow();

--- a/packages/core/src/indicators/incremental/__tests__/volume-indicators.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/volume-indicators.test.ts
@@ -278,6 +278,62 @@ describe("EMV incremental", () => {
       }
     }
   });
+
+  it("default volumeDivisor matches StockCharts canonical scaling (1e8)", () => {
+    // Sanity check: sign / slope must equal a manual-divisor variant, but
+    // EMV is *proportional* to `volumeDivisor` (rawEmv = distanceMoved *
+    // volumeDivisor * hl / volume), so the canonical 1e8 default produces
+    // values 10000× LARGER than the legacy 1e4 default.
+    const canonical = easeOfMovement(candles, { period: 14 });
+    const legacy = easeOfMovement(candles, { period: 14, volumeDivisor: 10000 });
+    let comparedAny = false;
+    for (let i = 0; i < canonical.length; i++) {
+      const a = canonical[i].value;
+      const b = legacy[i].value;
+      if (a !== null && b !== null && b !== 0) {
+        // canonical / legacy = 10000
+        expect(Math.abs(a / b - 10000)).toBeLessThan(1e-6);
+        comparedAny = true;
+      }
+    }
+    expect(comparedAny).toBe(true);
+  });
+
+  it("fromState preserves the volumeDivisor captured in the snapshot", () => {
+    // Resume contract: a state created under the legacy divisor must
+    // continue computing on that divisor when restored, even after the
+    // library default has moved. Without this guard, the resumed series
+    // would jump 10000× at the resume boundary.
+    const ind1 = createEmv({ period: 14, volumeDivisor: 10000 });
+    for (let i = 0; i < 30; i++) ind1.next(candles[i]);
+    const state = ind1.getState();
+    expect(state.volumeDivisor).toBe(10000);
+
+    // Resume without re-passing options — the legacy divisor must be
+    // recovered from the snapshot, NOT silently swapped for the
+    // canonical default.
+    const ind2 = createEmv({ period: 14 }, { fromState: state });
+    expect(ind2.getState().volumeDivisor).toBe(10000);
+
+    for (let i = 30; i < 60; i++) {
+      const v1 = ind1.next(candles[i]).value;
+      const v2 = ind2.next(candles[i]).value;
+      if (v1 === null) {
+        expect(v2).toBeNull();
+      } else {
+        expect(Math.abs(v1 - v2!)).toBeLessThan(1e-10);
+      }
+    }
+  });
+
+  it("explicit volumeDivisor option wins over both fromState and the default", () => {
+    const ind1 = createEmv({ period: 14, volumeDivisor: 10000 });
+    for (let i = 0; i < 30; i++) ind1.next(candles[i]);
+    const state = ind1.getState();
+    // Explicit option overrides the persisted snapshot value.
+    const ind2 = createEmv({ period: 14, volumeDivisor: 5000 }, { fromState: state });
+    expect(ind2.getState().volumeDivisor).toBe(5000);
+  });
 });
 
 // ---- Volume Trend ----

--- a/packages/core/src/indicators/incremental/volume/ease-of-movement.ts
+++ b/packages/core/src/indicators/incremental/volume/ease-of-movement.ts
@@ -38,7 +38,14 @@ export function createEmv(
   warmUpOptions?: WarmUpOptions<EmvState>,
 ): IncrementalIndicator<number | null, EmvState> {
   const period = options.period ?? 14;
-  const volumeDivisor = options.volumeDivisor ?? 10000;
+  // Resume order: explicit option > persisted state > canonical default
+  // (1e8, matching StockCharts / ChartSchool). Reading the snapshot first
+  // is critical — a state captured under the legacy 10000 divisor would
+  // otherwise jump to 1e8 mid-stream after a library upgrade and produce
+  // a discontinuous EMV at the resume boundary.
+  // Keep in sync with `easeOfMovement()` in indicators/volume/ease-of-movement.ts.
+  const volumeDivisor =
+    options.volumeDivisor ?? warmUpOptions?.fromState?.volumeDivisor ?? 100_000_000;
 
   let prevHigh: number | null;
   let prevLow: number | null;

--- a/packages/core/src/indicators/volume/ease-of-movement.ts
+++ b/packages/core/src/indicators/volume/ease-of-movement.ts
@@ -15,7 +15,12 @@ import type { Candle, NormalizedCandle, Series } from "../../types";
 export type EaseOfMovementOptions = {
   /** SMA smoothing period (default: 14) */
   period?: number;
-  /** Volume divisor to scale values (default: 10000) */
+  /**
+   * Volume scaling divisor (default: `100_000_000`, matching StockCharts /
+   * ChartSchool canonical EMV). Smaller-volume instruments may want a
+   * smaller divisor to keep the values from collapsing toward zero — pass
+   * the divisor that produces readable magnitudes for your data.
+   */
   volumeDivisor?: number;
 };
 
@@ -25,21 +30,22 @@ export type EaseOfMovementOptions = {
  * EMV = ((H+L)/2 - (prevH+prevL)/2) / ((Volume/divisor) / (H-L))
  * Then smoothed with SMA.
  *
- * Note on `volumeDivisor`: trendcraft's default is `10000`, which makes
- * EMV values comparable across small-volume instruments. The canonical
- * StockCharts / ChartSchool reference uses `100_000_000` (100M), which
- * scales EMV down by ~10000× and is the value to pass when comparing
- * directly to charting platform references:
+ * The default `volumeDivisor` is `100_000_000` (100M), matching the
+ * StockCharts / ChartSchool canonical EMV scaling. With this default,
+ * trendcraft's EMV values can be compared directly against any reference
+ * implementation — Bulkowski, Yahoo Finance, TradingView's `Ease of
+ * Movement`, etc.
+ *
+ * If you previously relied on the legacy `volumeDivisor: 10000` default
+ * (which produced ~10000× larger values), pass it explicitly:
  *
  * ```ts
- * // Match StockCharts / ChartSchool reference values
- * const emv = easeOfMovement(candles, { period: 14, volumeDivisor: 100_000_000 });
+ * // Pre-canonical (legacy) scaling
+ * const emv = easeOfMovement(candles, { period: 14, volumeDivisor: 10000 });
  * ```
  *
  * For trading-decision use cases the **sign** and **slope** of EMV are
- * what matters, and both are invariant to `volumeDivisor`. The default
- * is preserved for backward compatibility through the 0.x line; a future
- * major bump may switch to the canonical 100M.
+ * what matters, and both are invariant to `volumeDivisor`.
  *
  * @param candles - Array of candles (raw or normalized)
  * @param options - Options
@@ -54,7 +60,13 @@ export function easeOfMovement(
   candles: Candle[] | NormalizedCandle[],
   options: EaseOfMovementOptions = {},
 ): Series<number | null> {
-  const { period = 14, volumeDivisor = 10000 } = options;
+  const { period = 14 } = options;
+  // Use `??` rather than a destructuring default so an explicit
+  // `volumeDivisor: null` (common after JSON / form deserialization of
+  // unset optional fields) still falls back to the canonical default.
+  // Without this guard `null` slips through and `c.volume / null` makes
+  // boxRatio infinite, collapsing every EMV value to zero.
+  const volumeDivisor = options.volumeDivisor ?? 100_000_000;
 
   if (period < 1) {
     throw new Error("EMV period must be at least 1");

--- a/packages/core/src/manifest/entries/volume.ts
+++ b/packages/core/src/manifest/entries/volume.ts
@@ -255,7 +255,7 @@ export const VOLUME_MANIFESTS: IndicatorManifest[] = [
     ],
     pitfalls: [
       "Range-zero bars (high=low) make the box ratio explode — trendcraft handles with fallback",
-      "trendcraft uses `volumeDivisor=10000` by default; canonical Arms formula uses 100,000,000. Magnitudes differ — focus on sign and slope, not absolute values",
+      "trendcraft `volumeDivisor` default is 100,000,000 (canonical Arms / StockCharts scaling). EMV is proportional to the divisor — smaller-volume instruments may want a smaller divisor to keep magnitudes readable",
       "Useless on instruments with unreliable volume",
     ],
     marketRegime: ["trending"],
@@ -263,7 +263,7 @@ export const VOLUME_MANIFESTS: IndicatorManifest[] = [
     paramHints: {
       period: "14 default SMA smoothing",
       volumeDivisor:
-        "10000 default in trendcraft (NOT the canonical 100,000,000) — keeps values readable but values are not directly comparable to ChartSchool examples",
+        "100,000,000 default (canonical Arms / StockCharts scaling). Pre-v0.4 the default was 10000 — magnitudes captured under that default are 10000× smaller than the new canonical output",
     },
   },
   {

--- a/packages/core/src/streaming/__tests__/indicator-preset-lookup.test.ts
+++ b/packages/core/src/streaming/__tests__/indicator-preset-lookup.test.ts
@@ -33,6 +33,106 @@ describe("getIndicatorPreset", () => {
     expect(getIndicatorPreset(long)).toBe(indicatorPresets[short]);
   });
 
+  it("emv preset treats `null` volumeDivisor as 'unset' and falls back to canonical", () => {
+    // JSON / form-driven hosts often serialize optional unset fields as
+    // explicit `null`. The preset wrapper must NOT forward that null to
+    // the indicator (which would divide by zero). It should fall back to
+    // the canonical 1e8 default just like `undefined` does.
+    const candles: Array<{
+      time: number;
+      open: number;
+      high: number;
+      low: number;
+      close: number;
+      volume: number;
+    }> = [];
+    for (let i = 0; i < 30; i++) {
+      candles.push({
+        time: 1700_000_000_000 + i * 86_400_000,
+        open: 100 + i,
+        high: 102 + i,
+        low: 98 + i,
+        close: 101 + i,
+        volume: 50_000_000,
+      });
+    }
+    const preset = indicatorPresets.emv;
+    if (!preset?.compute) throw new Error("emv preset is missing compute");
+
+    const lastIdx = candles.length - 1;
+    const fromUndefined = (
+      preset.compute(candles, {})[lastIdx] as { value: number | null } | undefined
+    )?.value;
+    const fromNull = (
+      preset.compute(candles, { volumeDivisor: null as unknown as number })[lastIdx] as
+        | { value: number | null }
+        | undefined
+    )?.value;
+
+    expect(fromNull).not.toBeNull();
+    expect(Number.isFinite(fromNull as number)).toBe(true);
+    // `null` and `undefined` should produce identical canonical output.
+    expect(fromNull).toBe(fromUndefined);
+  });
+
+  it("emv preset snapshotName includes volumeDivisor so different scales don't share state", () => {
+    // Resuming an EMV state captured at one volumeDivisor under a different
+    // divisor would mix scales (the buffer / sum are accumulated under the
+    // active divisor and can't be re-scaled retroactively). The snapshot
+    // key has to reflect divisor so the host's state cache invalidates
+    // cleanly — old `emv14` keys won't match the new format and a fresh
+    // warm-up runs.
+    const preset = indicatorPresets.emv;
+    if (!preset?.snapshotName || typeof preset.snapshotName !== "function") {
+      throw new Error("emv preset snapshotName must be a function for this test");
+    }
+    const sn = preset.snapshotName as (p: Record<string, unknown>) => string;
+    const canonical = sn({ period: 14 });
+    const legacy = sn({ period: 14, volumeDivisor: 10000 });
+    expect(canonical).not.toBe(legacy);
+    // Canonical default is 1e8 — same name should result whether divisor is
+    // omitted or supplied explicitly as 1e8.
+    expect(sn({ period: 14, volumeDivisor: 100_000_000 })).toBe(canonical);
+  });
+
+  it("emv preset's default compute matches the indicator's canonical default", () => {
+    // Regression for `feat/core-eom-canonical-divisor`: the indicator's
+    // default `volumeDivisor` is 1e8, so the preset's no-options compute
+    // path must produce the same series. Hard-coding `?? 10000` in the
+    // preset wrapper would silently re-introduce the legacy scaling for
+    // every preset / manifest / live-mode consumer.
+    const candles: Array<{
+      time: number;
+      open: number;
+      high: number;
+      low: number;
+      close: number;
+      volume: number;
+    }> = [];
+    for (let i = 0; i < 30; i++) {
+      candles.push({
+        time: 1700_000_000_000 + i * 86_400_000,
+        open: 100 + i,
+        high: 102 + i,
+        low: 98 + i,
+        close: 101 + i,
+        volume: 50_000_000,
+      });
+    }
+    const preset = indicatorPresets.emv;
+    if (!preset?.compute) throw new Error("emv preset is missing compute");
+
+    const presetResult = preset.compute(candles, {});
+    const lastIdx = candles.length - 1;
+    const lastValue = (presetResult[lastIdx] as { value: number | null } | undefined)?.value;
+    expect(lastValue).not.toBeNull();
+    // EMV is proportional to `volumeDivisor`. With 1e8 these synthetic
+    // candles produce values around 8; the legacy 1e4 default would
+    // produce ~8e-4. Pin the lower bound so any silent revert to 1e4
+    // (factor 10000 smaller) trips the assertion.
+    expect(Math.abs(lastValue as number)).toBeGreaterThan(0.5);
+  });
+
   it("every manifest kind that has a preset can be resolved by long name", () => {
     // Locks in the alias coverage: every manifest entry whose `kind` does not
     // already match a short key must have an alias entry. Catches new

--- a/packages/core/src/streaming/indicator-presets.ts
+++ b/packages/core/src/streaming/indicator-presets.ts
@@ -1343,8 +1343,17 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
   ),
   emv: withCompute(
     "emv",
+    // Pass `volumeDivisor` through only when the host supplies a real value
+    // so the preset inherits the indicator's canonical (1e8) default. Use
+    // `== null` (catches both `undefined` and `null`) — preset params often
+    // arrive from JSON / form deserialization that emits explicit `null`
+    // for unset optional fields, and forwarding that to `easeOfMovement()`
+    // would yield a division by zero.
     (c, p) =>
-      easeOfMovement(c, { period: p.period ?? 14, volumeDivisor: p.volumeDivisor ?? 10000 }),
+      easeOfMovement(c, {
+        period: p.period ?? 14,
+        ...(p.volumeDivisor != null ? { volumeDivisor: p.volumeDivisor as number } : {}),
+      }),
     {
       category: "Volume",
       name: "Ease of Movement",

--- a/packages/core/src/streaming/live-presets.ts
+++ b/packages/core/src/streaming/live-presets.ts
@@ -900,10 +900,22 @@ export const livePresets: Record<string, LivePreset> = {
   emv: {
     meta: EMV_META,
     defaultParams: { period: 14 },
-    snapshotName: (p) => `emv${p.period}`,
+    // Include `volumeDivisor` in the snapshot key so resuming under a
+    // different divisor doesn't mix scales. EMV's circular buffer + sum
+    // are accumulated under the active divisor, so a state captured at
+    // 10000 cannot be reused for a 1e8 run — different keys force a
+    // fresh warm-up. Stale `emv14` snapshots from before this format
+    // change won't match the new key and are discarded cleanly.
+    snapshotName: (p) => `emv${p.period}_${p.volumeDivisor ?? 100_000_000}`,
+    // Pass `volumeDivisor` through only when the host supplies a real value
+    // so the preset inherits the incremental indicator's canonical (1e8)
+    // default. Use `== null` (catches both `undefined` and `null`) —
+    // host-supplied params often arrive from JSON / form deserialization
+    // that emits explicit `null` for unset optional fields, and forwarding
+    // that to `createEmv()` would yield a division by zero.
     createFactory: factory<{ period?: number; volumeDivisor?: number }>()(createEmv, (p) => ({
       period: p.period ?? 14,
-      volumeDivisor: p.volumeDivisor ?? 10000,
+      ...(p.volumeDivisor != null ? { volumeDivisor: p.volumeDivisor as number } : {}),
     })),
   },
   volumeTrend: {


### PR DESCRIPTION
> **Breaking change** — see CHANGELOG entry under `Breaking — Ease of Movement default volumeDivisor`.

## Summary

Aligns trendcraft EMV with the StockCharts / ChartSchool canonical scaling so values can be compared directly against any reference implementation (Bulkowski, TradingView, Yahoo Finance, Sierra Chart).

The previous default (`volumeDivisor: 10000`) produced values 10000× smaller than every reference. EMV is proportional to `volumeDivisor` (`raw = (Δmid * volumeDivisor * range) / volume`), so doubling the divisor doubles the magnitude — the **sign** and **slope** are invariant, which is why strategies relying on EMV crossings or zero-line crosses are unaffected.

Code that compares EMV's *absolute magnitude* to a hard-coded threshold or to a value pinned from the prior trendcraft default needs to either multiply the threshold by 10000 or pass `volumeDivisor: 10000` explicitly.

## What's in the patch

Plumbing fixes folded in so every entry point behaves identically:

| Entry point | Before | After |
|---|---|---|
| `easeOfMovement()` | default 10000 | default 1e8 |
| `createEmv()` | default 10000 | default 1e8 |
| `indicatorPresets.emv` (batch) | hard-coded `?? 10000` | inherits indicator default |
| `livePresets.emv` (live) | hard-coded `?? 10000` | inherits indicator default |
| `trendcraft/manifest` `easeOfMovement` | `pitfalls` / `paramHints` say 10000 | now reflect 1e8 canonical |

Plus four edge cases caught during the Codex review iteration:

1. **Null pass-through** — all four entry points now treat `volumeDivisor: null` (common after JSON / form deserialization of unset optional fields) as "unset" and fall back to the canonical default. Previously the `null` slipped through and made `c.volume / null` evaluate to `Infinity`, collapsing every EMV value to `0` silently.

2. **`fromState` resume** — `createEmv(opts, { fromState })` reads the captured `volumeDivisor` from the snapshot when not explicitly re-passed. A state captured under the legacy 10000 default no longer jumps 10000× at the resume boundary after a library upgrade. Explicit `opts.volumeDivisor` still wins over both the snapshot and the default.

3. **`snapshotName` key** — `livePresets.emv.snapshotName` now includes the divisor: `emv${period}_${volumeDivisor ?? 1e8}` (was `emv${period}`). EMV's circular buffer + sum are accumulated under the active divisor and can't be re-scaled retroactively, so resuming under a different divisor would corrupt the next `period` outputs. Stale `emv14` snapshots from before this change won't match the new key and are discarded cleanly.

4. **Preset / manifest consistency** — both preset wrappers and the manifest entry are updated together so manifest-driven docs / prompt builders / UI show the same default the runtime uses.

## Test plan

- [x] `pnpm test` (core) — 5050 / 5050 (was 5043; +7 EMV-focused assertions)
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] `/codex:review` clean (4 iterations: P1/P2 findings on preset hard-codes, fromState resume, null fallback, snapshotName keying — all addressed)
- [x] **Visual end-to-end via agent-browser** on indicator-showcase: EMV(14) on SPY daily renders as a sub-pane orange line in the canonical ±0.005-0.01 magnitude range, with the dashed zero reference line and the Y-axis auto-scaled to the new magnitude.
- [x] Coverage: default 1e8 vs explicit 10000 produces ratio 10000; `fromState` preserves captured divisor; explicit option overrides snapshot; null falls back to canonical in all four entry points; preset `snapshotName` differs by divisor; preset `compute(candles, {})` produces canonical-scale output.

## Sources verified

- [Ease of Movement | ChartSchool | StockCharts.com](https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-indicators/ease-of-movement)