### PR TITLE
feat(core)!: Elder Force Index returns canonical { short, long } pair

### DIFF
--- a/packages/chart/src/core/series-registry.ts
+++ b/packages/chart/src/core/series-registry.ts
@@ -185,6 +185,22 @@ const BUILTIN_RULES: IntrospectionRule[] = [
     },
   },
 
+  // Elder's Force Index — canonical short / long pair. The
+  // TrendCraft preset registry adds the same rule with channel
+  // colors / reference lines, but consumers that pass
+  // `elderForceIndex(...)` output straight into a chart without
+  // registering presets still need to render the two lines, so
+  // the default registry has to recognize the shape too.
+  {
+    name: "elderForceIndex",
+    test: (v) => hasKeys(v, ["short", "long"]),
+    seriesType: "line",
+    defaultPane: "sub",
+    decompose: (v) => {
+      return { short: v.short, long: v.long };
+    },
+  },
+
   // Simple number → line (catch-all for RSI, CCI, ATR, OBV, etc.)
   {
     name: "number",

--- a/packages/chart/src/presets.ts
+++ b/packages/chart/src/presets.ts
@@ -106,6 +106,15 @@ const TRENDCRAFT_RULES: IntrospectionRule[] = [
     decompose: (v) => ({ kst: v.kst, signal: v.signal }),
   },
 
+  // Elder's Force Index (canonical short / long pair)
+  {
+    name: "elderForceIndex",
+    test: (v) => hasKeys(v, ["short", "long"]),
+    seriesType: "line",
+    defaultPane: "sub",
+    decompose: (v) => ({ short: v.short, long: v.long }),
+  },
+
   // ATR Stops (long/short stop + TP levels)
   {
     name: "atrStops",
@@ -409,6 +418,18 @@ const TRENDCRAFT_PRESETS: [string, IndicatorPreset][] = [
     },
   ],
   [
+    "elderForceIndex",
+    {
+      pane: "sub",
+      label: "Force Index",
+      // Short = entry timing (lighter / faster), Long = trend bias (deeper /
+      // slower). Same orange palette as the other dual-line momentum
+      // oscillators so the canonical pairing reads consistently.
+      channelColors: { short: "#FF9800", long: "#673ab7" },
+      referenceLines: [0],
+    },
+  ],
+  [
     "klinger",
     {
       pane: "sub",
@@ -453,7 +474,9 @@ const TRENDCRAFT_PRESETS: [string, IndicatorPreset][] = [
   ["cmf", { color: "#00bcd4" }],
   ["mfi", { color: "#ff9800" }],
   ["adl", { color: "#8bc34a" }],
-  ["elderForceIndex", { color: "#673ab7" }],
+  // elderForceIndex is now a dual-channel value `{ short, long }` — see
+  // the channelColors entry above. The legacy single-color preset is no
+  // longer applicable.
   ["pvt", { color: "#009688" }],
   ["nvi", { color: "#3f51b5" }],
   ["cvd", { color: "#e91e63" }],

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+### Breaking — Elder's Force Index returns `{ short, long }`
+
+`elderForceIndex` and the incremental `createElderForceIndex` now
+emit Elder's canonical pair on every bar: a **2-period** EMA for
+entry timing and a **13-period** EMA for trend bias. The legacy
+single-period output (default `period: 13`) is gone.
+
+Migration:
+
+- Old: `elderForceIndex(c, { period: 13 })` → `Series<number | null>`
+- New: `elderForceIndex(c)` → `Series<{ short: number | null, long: number | null }>`
+
+Callers that only need the long line should read `.long`; callers
+that previously passed a custom `period` should pass it as
+`longPeriod` (and optionally a custom `shortPeriod` to match
+Elder's two-screen approach).
+
+The streaming preset wrappers (`indicatorPresets.elderForceIndex`,
+`livePresets.elderForceIndex`) now expose `shortPeriod` /
+`longPeriod` instead of `period`. The live snapshot key is now
+`efi_${shortPeriod}_${longPeriod}` so old `efi` snapshots from
+the single-period era are discarded cleanly on resume — no
+mixed-period state corruption.
+
+The chart introspection rule auto-detects the new shape and
+plots the `short` (orange) and `long` (purple) lines together
+in the sub-pane, so chart consumers don't need any host-side
+changes when the chart picks up the new core.
+
 ### Breaking — Ease of Movement default `volumeDivisor`
 
 `easeOfMovement` and the incremental `createEmv` now default

--- a/packages/core/cross-validation/__tests__/formula-verification.test.ts
+++ b/packages/core/cross-validation/__tests__/formula-verification.test.ts
@@ -421,28 +421,33 @@ describe("Ulcer Index", () => {
 });
 
 describe("Elder Force Index", () => {
-  it("matches EMA of (close-prevClose)*volume", () => {
-    const period = 13;
-    const result = elderForceIndex(candles, { period });
+  it.each([
+    { period: 2 as const, channel: "short" as const }, // Elder canonical short
+    { period: 13 as const, channel: "long" as const }, // Elder canonical long
+  ])("$period-period EMA of (close-prevClose)*volume matches the `$channel` channel", ({
+    period,
+    channel,
+  }) => {
+    // The indicator now returns both short and long EMAs in lockstep.
+    // Pin each channel independently against the canonical EMA formula.
+    const result = elderForceIndex(candles, { shortPeriod: 2, longPeriod: 13 });
 
-    // Raw force
     const rawForce: number[] = [0];
     for (let i = 1; i < candles.length; i++) {
       rawForce.push((candles[i].close - candles[i - 1].close) * candles[i].volume);
     }
 
-    // EMA smoothing
     const multiplier = 2 / (period + 1);
     let sum = 0;
     for (let i = 0; i < period; i++) {
       sum += rawForce[i];
     }
     let prev = sum / period;
-    expect(result[period - 1].value).toBeCloseTo(prev, 6);
+    expect(result[period - 1].value[channel]).toBeCloseTo(prev, 6);
 
     for (let i = period; i < candles.length; i++) {
       prev = rawForce[i] * multiplier + prev * (1 - multiplier);
-      expect(result[i].value).toBeCloseTo(prev, 6);
+      expect(result[i].value[channel]).toBeCloseTo(prev, 6);
     }
   });
 });

--- a/packages/core/examples/echarts-viewer/src/hooks/useIndicators.ts
+++ b/packages/core/examples/echarts-viewer/src/hooks/useIndicators.ts
@@ -613,8 +613,11 @@ export function useIndicators(
 
     // Elder Force Index
     if (enabledIndicators.includes("elderForce")) {
-      const series = elderForceIndex(candles, { period: p.elderForcePeriod });
-      data.elderForce = series.map((s) => s.value);
+      // The current single-line subchart maps to Elder's long-period FI
+      // (intermediate-trend bias) — extract `.long` from the canonical
+      // `{ short, long }` value shape.
+      const series = elderForceIndex(candles, { longPeriod: p.elderForcePeriod });
+      data.elderForce = series.map((s) => s.value.long);
     }
 
     return data;

--- a/packages/core/examples/trading-simulator/src/utils/indicators.ts
+++ b/packages/core/examples/trading-simulator/src/utils/indicators.ts
@@ -558,9 +558,13 @@ export function calculateIndicators(
   }
 
   if (enabledIndicators.includes("elderForce")) {
-    result.elderForceData = extractValues(
-      TrendCraft.elderForceIndex(candles, { period: p.elderForcePeriod }),
-    );
+    // The simulator's existing single-line view maps to Elder's
+    // long-period FI (intermediate-trend bias). Extract `.long` from
+    // the canonical `{ short, long }` shape.
+    const series = TrendCraft.elderForceIndex(candles, {
+      longPeriod: p.elderForcePeriod,
+    });
+    result.elderForceData = series.map((s) => s.value.long);
   }
 
   if (enabledIndicators.includes("volumeAnomaly")) {

--- a/packages/core/src/indicators/__tests__/elder-force-index.test.ts
+++ b/packages/core/src/indicators/__tests__/elder-force-index.test.ts
@@ -17,59 +17,81 @@ describe("elderForceIndex", () => {
     expect(elderForceIndex([])).toEqual([]);
   });
 
-  it("should return null for insufficient data", () => {
+  it("returns { short: null, long: null } until each EMA has warmed up", () => {
     const candles = makeCandles([
       { close: 100, volume: 1000 },
       { close: 101, volume: 1200 },
     ]);
-    const result = elderForceIndex(candles, { period: 13 });
-    // With period=13, first 12 values should be null
+    const result = elderForceIndex(candles); // canonical 2 / 13
+
     expect(result).toHaveLength(2);
-    result.forEach((r) => expect(r.value).toBeNull());
+    // Bar 0: neither EMA has seen `period` samples.
+    expect(result[0].value.short).toBeNull();
+    expect(result[0].value.long).toBeNull();
+    // Bar 1: shortPeriod=2 has just warmed up, but longPeriod=13 hasn't.
+    expect(result[1].value.short).not.toBeNull();
+    expect(result[1].value.long).toBeNull();
   });
 
-  it("should throw if period < 1", () => {
+  it("throws when shortPeriod or longPeriod is less than 1", () => {
     const candles = makeCandles([{ close: 100, volume: 1000 }]);
-    expect(() => elderForceIndex(candles, { period: 0 })).toThrow();
+    expect(() => elderForceIndex(candles, { shortPeriod: 0 })).toThrow();
+    expect(() => elderForceIndex(candles, { longPeriod: 0 })).toThrow();
   });
 
-  it("should produce non-null values with enough data", () => {
+  it("produces non-null short and long values once both EMAs warm up", () => {
     const data: { close: number; volume: number }[] = [];
     for (let i = 0; i < 30; i++) {
       data.push({ close: 100 + i * 0.5, volume: 1000 + i * 100 });
     }
     const candles = makeCandles(data);
-    const result = elderForceIndex(candles, { period: 13 });
+    const result = elderForceIndex(candles); // canonical 2 / 13
 
     expect(result).toHaveLength(30);
-    // Last value should be non-null
-    expect(result[result.length - 1].value).not.toBeNull();
+    const last = result[result.length - 1].value;
+    expect(last.short).not.toBeNull();
+    expect(last.long).not.toBeNull();
 
-    // In a rising market, force index should be positive
-    expect(result[result.length - 1].value!).toBeGreaterThan(0);
+    // Rising market with rising volume → both Force Index lines positive.
+    expect(last.short as number).toBeGreaterThan(0);
+    expect(last.long as number).toBeGreaterThan(0);
   });
 
-  it("should preserve timestamps", () => {
+  it("respects custom shortPeriod and longPeriod", () => {
+    const data: { close: number; volume: number }[] = [];
+    for (let i = 0; i < 30; i++) {
+      data.push({ close: 100 + i * 0.5, volume: 1000 });
+    }
+    const candles = makeCandles(data);
+    const result = elderForceIndex(candles, { shortPeriod: 5, longPeriod: 20 });
+
+    // shortPeriod=5 first non-null at bar 4; longPeriod=20 at bar 19.
+    expect(result[3].value.short).toBeNull();
+    expect(result[4].value.short).not.toBeNull();
+    expect(result[18].value.long).toBeNull();
+    expect(result[19].value.long).not.toBeNull();
+  });
+
+  it("preserves timestamps", () => {
     const data: { close: number; volume: number }[] = [];
     for (let i = 0; i < 20; i++) {
       data.push({ close: 100 + i, volume: 1000 });
     }
     const candles = makeCandles(data);
-    const result = elderForceIndex(candles, { period: 13 });
+    const result = elderForceIndex(candles);
 
     for (let i = 0; i < candles.length; i++) {
       expect(result[i].time).toBe(candles[i].time);
     }
   });
 
-  it("should handle zero volume", () => {
+  it("handles zero volume bars without crashing", () => {
     const data: { close: number; volume: number }[] = [];
     for (let i = 0; i < 20; i++) {
       data.push({ close: 100 + i, volume: i === 5 ? 0 : 1000 });
     }
     const candles = makeCandles(data);
-    const result = elderForceIndex(candles, { period: 13 });
-    // Should not crash
+    const result = elderForceIndex(candles);
     expect(result).toHaveLength(20);
   });
 });

--- a/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
@@ -559,41 +559,150 @@ describe("VolumeAnomaly detection accuracy", () => {
 // --- Elder Force Index ---
 
 describe("Elder Force Index", () => {
-  it("first candle returns null because there is no previous close for comparison", () => {
-    const efi = createElderForceIndex({ period: 3 });
+  // The new dual-period shape: short=2 entry timing, long=13 trend bias.
+  // Use shortPeriod / longPeriod options. `isWarmedUp` is gated by
+  // longPeriod so both EMAs are non-null when it returns true.
+  it("first candle returns { short: null, long: null } (no prevClose yet)", () => {
+    const efi = createElderForceIndex({ shortPeriod: 2, longPeriod: 3 });
     const r = efi.next(makeCandle(0));
-    expect(r.value).toBe(null);
+    expect(r.value.short).toBe(null);
+    expect(r.value.long).toBe(null);
   });
 
-  it("peek before warmup returns null", () => {
-    const efi = createElderForceIndex({ period: 3 });
+  it("peek before long-EMA warmup returns null long", () => {
+    const efi = createElderForceIndex({ shortPeriod: 2, longPeriod: 3 });
     efi.next(makeCandle(0));
     const r = efi.peek(makeCandle(1));
-    expect(r.value).toBe(null);
+    expect(r.value.long).toBe(null);
   });
 
-  it("peek at warmup boundary returns valid value matching next()", () => {
-    const efi = createElderForceIndex({ period: 3 });
+  it("peek at warmup boundary matches next()", () => {
+    const efi = createElderForceIndex({ shortPeriod: 2, longPeriod: 3 });
     for (let i = 0; i < 2; i++) efi.next(makeCandle(i));
     const candle = makeCandle(2);
-    const peekVal = efi.peek(candle).value;
-    expect(peekVal).not.toBe(null);
-    const nextVal = efi.next(candle).value;
-    expect(peekVal).toBeCloseTo(nextVal!, 10);
+    const peek = efi.peek(candle).value;
+    expect(peek.long).not.toBe(null);
+    const next = efi.next(candle).value;
+    expect(peek.short).toBeCloseTo(next.short!, 10);
+    expect(peek.long).toBeCloseTo(next.long!, 10);
   });
 
-  it("fromState restoration produces identical output", () => {
-    const efi1 = createElderForceIndex({ period: 3 });
+  it("fromState restoration produces identical output for both EMAs", () => {
+    const opts = { shortPeriod: 2, longPeriod: 3 };
+    const efi1 = createElderForceIndex(opts);
     for (let i = 0; i < 5; i++) efi1.next(makeCandle(i));
     const state = efi1.getState();
 
-    const efi2 = createElderForceIndex({ period: 3 }, { fromState: state });
-    expect(efi2.next(makeCandle(5)).value).toBeCloseTo(efi1.next(makeCandle(5)).value!, 10);
+    const efi2 = createElderForceIndex(opts, { fromState: state });
+    const v1 = efi1.next(makeCandle(5)).value;
+    const v2 = efi2.next(makeCandle(5)).value;
+    expect(v2.short).toBeCloseTo(v1.short!, 10);
+    expect(v2.long).toBeCloseTo(v1.long!, 10);
   });
 
   it("warmUp option works correctly", () => {
     const candles = generateCandles(5);
-    const efi = createElderForceIndex({ period: 3 }, { warmUp: candles });
+    const efi = createElderForceIndex({ shortPeriod: 2, longPeriod: 3 }, { warmUp: candles });
+    expect(efi.isWarmedUp).toBe(true);
+  });
+
+  it("fromState restores the persisted periods when options are not re-passed", () => {
+    // A state captured under custom periods must continue at those
+    // periods after resume — without this guard the EMAs would
+    // silently switch to canonical 2 / 13 mid-stream, producing a
+    // discontinuous output.
+    const opts = { shortPeriod: 5, longPeriod: 20 };
+    const efi1 = createElderForceIndex(opts);
+    for (let i = 0; i < 25; i++) efi1.next(makeCandle(i));
+    const state = efi1.getState();
+    expect(state.shortPeriod).toBe(5);
+    expect(state.longPeriod).toBe(20);
+
+    // Resume without re-passing options — periods must come from the
+    // snapshot, NOT silently revert to canonical 2 / 13.
+    const efi2 = createElderForceIndex({}, { fromState: state });
+    expect(efi2.getState().shortPeriod).toBe(5);
+    expect(efi2.getState().longPeriod).toBe(20);
+
+    // Subsequent values must match what efi1 would have produced.
+    for (let i = 25; i < 35; i++) {
+      const v1 = efi1.next(makeCandle(i)).value;
+      const v2 = efi2.next(makeCandle(i)).value;
+      expect(v2.short).toBeCloseTo(v1.short!, 10);
+      expect(v2.long).toBeCloseTo(v1.long!, 10);
+    }
+  });
+
+  it("explicit periods on resume override persisted state", () => {
+    const efi1 = createElderForceIndex({ shortPeriod: 5, longPeriod: 20 });
+    for (let i = 0; i < 25; i++) efi1.next(makeCandle(i));
+    // Caller explicitly re-parameterizes on resume — the snapshot's
+    // periods are ignored.
+    const efi2 = createElderForceIndex(
+      { shortPeriod: 3, longPeriod: 10 },
+      { fromState: efi1.getState() },
+    );
+    expect(efi2.getState().shortPeriod).toBe(3);
+    expect(efi2.getState().longPeriod).toBe(10);
+  });
+
+  it("re-parameterizing on resume resets EMA state and produces a fresh warm-up", () => {
+    // The previous EMA / sum / count were accumulated under the old
+    // multipliers; replaying them with new multipliers would produce a
+    // mathematically incorrect series. The new indicator must start
+    // its warm-up from scratch and only inherit `prevClose` from the
+    // snapshot (so the first raw-force computation after resume is
+    // still correct).
+    const efi1 = createElderForceIndex({ shortPeriod: 5, longPeriod: 20 });
+    for (let i = 0; i < 25; i++) efi1.next(makeCandle(i));
+    const snapshot = efi1.getState();
+
+    const efi2 = createElderForceIndex({ shortPeriod: 3, longPeriod: 10 }, { fromState: snapshot });
+
+    // EMAs / sums / count are reset for the new periods. prevClose
+    // carries over so the very next bar still has a valid raw force.
+    const reset = efi2.getState();
+    expect(reset.shortEma).toBeNull();
+    expect(reset.longEma).toBeNull();
+    expect(reset.shortSum).toBe(0);
+    expect(reset.longSum).toBe(0);
+    expect(reset.count).toBe(0);
+    expect(reset.prevClose).toBe(snapshot.prevClose);
+
+    // After feeding shortPeriod=3 bars, the short EMA must be the
+    // canonical SMA seed of the new bars' raw forces (NOT a value
+    // derived from the old 5-period multiplier on the snapshot's
+    // EMA). Compute it manually and compare.
+    const newBars: NormalizedCandle[] = [];
+    for (let i = 25; i < 28; i++) newBars.push(makeCandle(i));
+
+    let prevClose = snapshot.prevClose as number;
+    let sumRaw = 0;
+    for (const c of newBars) {
+      sumRaw += (c.close - prevClose) * c.volume;
+      prevClose = c.close;
+    }
+    const expectedShortSeed = sumRaw / 3;
+
+    let observedShort: number | null = null;
+    for (const c of newBars) observedShort = efi2.next(c).value.short;
+
+    expect(observedShort).not.toBeNull();
+    expect(observedShort as number).toBeCloseTo(expectedShortSeed, 8);
+  });
+
+  it("isWarmedUp accounts for the larger of shortPeriod / longPeriod", () => {
+    // The API allows shortPeriod > longPeriod (Elder's *canonical* pair
+    // is 2 / 13 but nothing forbids 7 / 3, e.g. for an inverted setup
+    // testing entry-vs-trend rolepairing). `isWarmedUp` must wait for
+    // the slower channel to seed — otherwise downstream code can read
+    // a `null` short value while the indicator claims it is ready.
+    const efi = createElderForceIndex({ shortPeriod: 7, longPeriod: 3 });
+    // Long channel warms up at count=3, but short channel needs count=7.
+    for (let i = 0; i < 3; i++) efi.next(makeCandle(i));
+    expect(efi.next(makeCandle(3)).value.long).not.toBe(null);
+    expect(efi.isWarmedUp).toBe(false);
+    for (let i = 4; i < 7; i++) efi.next(makeCandle(i));
     expect(efi.isWarmedUp).toBe(true);
   });
 });
@@ -2170,10 +2279,11 @@ describe("Single candle input returns null/initial values for indicators that ne
     expect(r.value.viPlus).toBe(null);
   });
 
-  it("Elder Force Index single candle: null (no prevClose)", () => {
-    const efi = createElderForceIndex({ period: 3 });
+  it("Elder Force Index single candle: { short: null, long: null } (no prevClose)", () => {
+    const efi = createElderForceIndex({ shortPeriod: 2, longPeriod: 3 });
     const r = efi.next(makeCandle(0));
-    expect(r.value).toBe(null);
+    expect(r.value.short).toBe(null);
+    expect(r.value.long).toBe(null);
   });
 
   it("ADL single candle: returns a number, isWarmedUp=true", () => {

--- a/packages/core/src/indicators/incremental/__tests__/consistency.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/consistency.test.ts
@@ -878,10 +878,33 @@ describe("TWAP consistency", () => {
 // ==========================================
 
 describe("Elder Force Index consistency", () => {
-  it.each([7, 13, 20])("period=%i matches batch", (period) => {
-    const batch = elderForceIndex(candles, { period });
-    const incremental = processAll(createElderForceIndex({ period }), candles);
-    assertConsistency(batch, incremental, 1e-8);
+  it.each([
+    { shortPeriod: 2, longPeriod: 13 }, // Elder canonical default
+    { shortPeriod: 5, longPeriod: 20 },
+    { shortPeriod: 1, longPeriod: 7 },
+  ])("shortPeriod=$shortPeriod longPeriod=$longPeriod matches batch", (opts) => {
+    const batch = elderForceIndex(candles, opts);
+    const incremental = processAll(createElderForceIndex(opts), candles);
+
+    expect(incremental.length).toBe(batch.length);
+    for (let i = 0; i < batch.length; i++) {
+      expect(incremental[i].time).toBe(batch[i].time);
+      const bv = batch[i].value;
+      const iv = incremental[i].value;
+
+      if (bv.short === null) {
+        expect(iv.short).toBeNull();
+      } else {
+        expect(iv.short).not.toBeNull();
+        expect(Math.abs((iv.short as number) - bv.short)).toBeLessThan(1e-8);
+      }
+      if (bv.long === null) {
+        expect(iv.long).toBeNull();
+      } else {
+        expect(iv.long).not.toBeNull();
+        expect(Math.abs((iv.long as number) - bv.long)).toBeLessThan(1e-8);
+      }
+    }
   });
 });
 

--- a/packages/core/src/indicators/incremental/volume/elder-force-index.ts
+++ b/packages/core/src/indicators/incremental/volume/elder-force-index.ts
@@ -1,55 +1,108 @@
 /**
  * Incremental Elder's Force Index
  *
- * Force Index = (Close - Previous Close) × Volume, smoothed with EMA.
+ * Tracks both short-period (entry timing) and long-period (trend bias)
+ * EMAs of raw FI(1) = `(close − prevClose) * volume` in lockstep, the
+ * canonical Elder pairing.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 
+export type ElderForceIndexValue = {
+  short: number | null;
+  long: number | null;
+};
+
 export type ElderForceIndexState = {
-  period: number;
+  shortPeriod: number;
+  longPeriod: number;
   prevClose: number | null;
-  emaMultiplier: number;
-  emaValue: number | null;
-  rawSum: number;
+  shortEma: number | null;
+  longEma: number | null;
+  /** Running sum used to seed each EMA's first non-null value (SMA of first `period` raw forces). */
+  shortSum: number;
+  longSum: number;
   count: number;
 };
 
 /**
  * Create an incremental Elder's Force Index indicator
  *
+ * Default periods are Elder's canonical pair: short=2 (entry timing),
+ * long=13 (trend bias).
+ *
  * @example
  * ```ts
- * const efi = createElderForceIndex({ period: 13 });
+ * const fi = createElderForceIndex();
  * for (const candle of stream) {
- *   const { value } = efi.next(candle);
- *   if (efi.isWarmedUp) console.log(value);
+ *   const { value } = fi.next(candle);
+ *   if (fi.isWarmedUp) console.log(value); // { short, long }
  * }
  * ```
  */
 export function createElderForceIndex(
-  options: { period?: number } = {},
+  options: { shortPeriod?: number; longPeriod?: number } = {},
   warmUpOptions?: WarmUpOptions<ElderForceIndexState>,
-): IncrementalIndicator<number | null, ElderForceIndexState> {
-  const period = options.period ?? 13;
-  const emaMultiplier = 2 / (period + 1);
+): IncrementalIndicator<ElderForceIndexValue, ElderForceIndexState> {
+  // Resume order: explicit option > persisted state > canonical default.
+  // Reading the snapshot first is critical — a state captured under
+  // custom periods (e.g. shortPeriod=5, longPeriod=20) would otherwise
+  // silently switch to 2 / 13 mid-stream after restore, producing a
+  // discontinuous EMA. Explicit options still win for callers that
+  // intentionally re-parameterize on resume.
+  const shortPeriod = options.shortPeriod ?? warmUpOptions?.fromState?.shortPeriod ?? 2;
+  const longPeriod = options.longPeriod ?? warmUpOptions?.fromState?.longPeriod ?? 13;
+
+  if (shortPeriod < 1) {
+    throw new Error("Elder Force Index shortPeriod must be at least 1");
+  }
+  if (longPeriod < 1) {
+    throw new Error("Elder Force Index longPeriod must be at least 1");
+  }
+
+  const shortMultiplier = 2 / (shortPeriod + 1);
+  const longMultiplier = 2 / (longPeriod + 1);
 
   let prevClose: number | null;
-  let emaValue: number | null;
-  let rawSum: number;
+  let shortEma: number | null;
+  let longEma: number | null;
+  let shortSum: number;
+  let longSum: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    prevClose = s.prevClose;
-    emaValue = s.emaValue;
-    rawSum = s.rawSum;
-    count = s.count;
+  const fs = warmUpOptions?.fromState ?? null;
+  const periodsMatchSnapshot =
+    fs !== null && fs.shortPeriod === shortPeriod && fs.longPeriod === longPeriod;
+
+  if (fs !== null && periodsMatchSnapshot) {
+    // Full restore — same periods, all EMA state is mathematically valid.
+    prevClose = fs.prevClose;
+    shortEma = fs.shortEma;
+    longEma = fs.longEma;
+    shortSum = fs.shortSum;
+    longSum = fs.longSum;
+    count = fs.count;
+  } else if (fs !== null) {
+    // The caller resumed with explicit periods that differ from the
+    // snapshot — intentional re-parameterization. The previous EMA /
+    // sum / count were accumulated under the old multipliers and can't
+    // be reused; replaying them with new multipliers would produce a
+    // mathematically incorrect series. Reset the EMA state and let the
+    // new periods warm up from scratch. We keep `prevClose` so the
+    // first raw-force computation after resume is still correct.
+    prevClose = fs.prevClose;
+    shortEma = null;
+    longEma = null;
+    shortSum = 0;
+    longSum = 0;
+    count = 0;
   } else {
     prevClose = null;
-    emaValue = null;
-    rawSum = 0;
+    shortEma = null;
+    longEma = null;
+    shortSum = 0;
+    longSum = 0;
     count = 0;
   }
 
@@ -58,50 +111,79 @@ export function createElderForceIndex(
     return (candle.close - prevClose) * candle.volume;
   }
 
-  const indicator: IncrementalIndicator<number | null, ElderForceIndexState> = {
+  /**
+   * Advance one EMA by one bar. Returns the new EMA value (or `null`
+   * if not yet warmed up). Mutates only via the returned value — the
+   * caller owns the assignment.
+   */
+  function stepEma(
+    raw: number,
+    period: number,
+    multiplier: number,
+    prev: number | null,
+    sum: number,
+  ): { ema: number | null; sum: number } {
+    if (count < period) {
+      return { ema: null, sum: sum + raw };
+    }
+    if (count === period) {
+      const next = (sum + raw) / period;
+      return { ema: next, sum: sum + raw };
+    }
+    return { ema: raw * multiplier + (prev ?? 0) * (1 - multiplier), sum };
+  }
+
+  const indicator: IncrementalIndicator<ElderForceIndexValue, ElderForceIndexState> = {
     next(candle: NormalizedCandle) {
-      const rawForce = computeRawForce(candle);
+      const raw = computeRawForce(candle);
       count++;
 
-      if (count < period) {
-        rawSum += rawForce;
-        prevClose = candle.close;
-        return { time: candle.time, value: null };
-      }
+      const s = stepEma(raw, shortPeriod, shortMultiplier, shortEma, shortSum);
+      const l = stepEma(raw, longPeriod, longMultiplier, longEma, longSum);
+      shortEma = s.ema;
+      longEma = l.ema;
+      shortSum = s.sum;
+      longSum = l.sum;
 
-      if (count === period) {
-        rawSum += rawForce;
-        emaValue = rawSum / period;
-        prevClose = candle.close;
-        return { time: candle.time, value: emaValue };
-      }
-
-      // EMA smoothing
-      emaValue = rawForce * emaMultiplier + (emaValue ?? 0) * (1 - emaMultiplier);
       prevClose = candle.close;
-      return { time: candle.time, value: emaValue };
+      return { time: candle.time, value: { short: shortEma, long: longEma } };
     },
 
     peek(candle: NormalizedCandle) {
-      const rawForce = computeRawForce(candle);
+      const raw = prevClose === null ? 0 : (candle.close - prevClose) * candle.volume;
       const peekCount = count + 1;
 
-      if (peekCount < period) {
-        return { time: candle.time, value: null };
-      }
-
-      if (peekCount === period) {
-        return { time: candle.time, value: (rawSum + rawForce) / period };
-      }
+      const peekStep = (
+        period: number,
+        multiplier: number,
+        prev: number | null,
+        sum: number,
+      ): number | null => {
+        if (peekCount < period) return null;
+        if (peekCount === period) return (sum + raw) / period;
+        return raw * multiplier + (prev ?? 0) * (1 - multiplier);
+      };
 
       return {
         time: candle.time,
-        value: rawForce * emaMultiplier + (emaValue ?? 0) * (1 - emaMultiplier),
+        value: {
+          short: peekStep(shortPeriod, shortMultiplier, shortEma, shortSum),
+          long: peekStep(longPeriod, longMultiplier, longEma, longSum),
+        },
       };
     },
 
     getState(): ElderForceIndexState {
-      return { period, prevClose, emaMultiplier, emaValue, rawSum, count };
+      return {
+        shortPeriod,
+        longPeriod,
+        prevClose,
+        shortEma,
+        longEma,
+        shortSum,
+        longSum,
+        count,
+      };
     },
 
     get count() {
@@ -109,7 +191,12 @@ export function createElderForceIndex(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      // Both channels must have warmed up before downstream code can
+      // treat the value as fully initialized. Without `Math.max` a
+      // caller passing `shortPeriod > longPeriod` (allowed by the API)
+      // would see `isWarmedUp === true` while `value.short` was still
+      // `null`.
+      return count >= Math.max(shortPeriod, longPeriod);
     },
   };
 

--- a/packages/core/src/indicators/volume/elder-force-index.ts
+++ b/packages/core/src/indicators/volume/elder-force-index.ts
@@ -2,7 +2,10 @@
  * Elder's Force Index
  *
  * Measures the force behind price movements by combining
- * price change and volume, smoothed with EMA.
+ * price change and volume, smoothed with two EMAs (short for entry
+ * timing, long for trend bias) — the canonical pairing recommended
+ * by Alexander Elder in *Trading for a Living* and *The New Sell &
+ * Sellshort*.
  */
 
 import { isNormalized, normalizeCandles } from "../../core/normalize";
@@ -14,33 +17,63 @@ import { ELDER_FORCE_INDEX_META } from "../indicator-meta";
  * Elder's Force Index options
  */
 export type ElderForceIndexOptions = {
-  /** EMA smoothing period (default: 13) */
-  period?: number;
+  /**
+   * Short EMA period for entry timing (default: 2). Elder uses the
+   * 2-period FI to find pullback entries — crossing below zero in an
+   * uptrend = buy, crossing above zero in a downtrend = short.
+   */
+  shortPeriod?: number;
+  /**
+   * Long EMA period for trend confirmation (default: 13). Elder uses
+   * the 13-period FI to read intermediate-trend bias — persistent
+   * positive readings = bullish, persistent negative = bearish.
+   */
+  longPeriod?: number;
+};
+
+/**
+ * Elder's Force Index value: both periods of the canonical pair.
+ */
+export type ElderForceIndexValue = {
+  /** Short-period EMA of `(Δclose * volume)`, or `null` until warm-up. */
+  short: number | null;
+  /** Long-period EMA of `(Δclose * volume)`, or `null` until warm-up. */
+  long: number | null;
 };
 
 /**
  * Calculate Elder's Force Index
  *
- * Force Index = (Close - Previous Close) × Volume
- * Then smoothed with an EMA of the specified period.
+ * Force Index(1) = (Close − Previous Close) × Volume.
+ * Each emitted bar carries the `short`-period and `long`-period EMA
+ * of FI(1). Default periods are Elder's canonical pair: short=2,
+ * long=13.
  *
  * @param candles - Array of candles (raw or normalized)
- * @param options - Options
- * @returns Series of smoothed Force Index values
+ * @param options - Short / long EMA periods
+ * @returns Series of `{ short, long }` Force Index values
  *
  * @example
  * ```ts
- * const efi = elderForceIndex(candles, { period: 13 });
+ * const fi = elderForceIndex(candles); // canonical 2 / 13
+ * const last = fi[fi.length - 1].value;
+ * if (last.long != null && last.long > 0 && last.short != null && last.short < 0) {
+ *   // Long FI bullish + short FI dipped below zero = pullback-buy setup
+ * }
  * ```
  */
 export function elderForceIndex(
   candles: Candle[] | NormalizedCandle[],
   options: ElderForceIndexOptions = {},
-): Series<number | null> {
-  const { period = 13 } = options;
+): Series<ElderForceIndexValue> {
+  const shortPeriod = options.shortPeriod ?? 2;
+  const longPeriod = options.longPeriod ?? 13;
 
-  if (period < 1) {
-    throw new Error("Elder Force Index period must be at least 1");
+  if (shortPeriod < 1) {
+    throw new Error("Elder Force Index shortPeriod must be at least 1");
+  }
+  if (longPeriod < 1) {
+    throw new Error("Elder Force Index longPeriod must be at least 1");
   }
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
@@ -49,32 +82,53 @@ export function elderForceIndex(
     return [];
   }
 
-  // Step 1: Calculate raw Force Index
+  // Step 1: Raw FI(1)
   const rawForce: number[] = new Array(normalized.length);
   rawForce[0] = 0;
   for (let i = 1; i < normalized.length; i++) {
     rawForce[i] = (normalized[i].close - normalized[i - 1].close) * normalized[i].volume;
   }
 
-  // Step 2: Smooth with EMA
-  const multiplier = 2 / (period + 1);
-  const result: Series<number | null> = [];
+  // Step 2: Two EMAs in parallel
+  const shortValues = emaOfRaw(rawForce, shortPeriod);
+  const longValues = emaOfRaw(rawForce, longPeriod);
 
-  let sum = 0;
+  const result: Series<ElderForceIndexValue> = new Array(normalized.length);
   for (let i = 0; i < normalized.length; i++) {
-    if (i < period - 1) {
-      sum += rawForce[i];
-      result.push({ time: normalized[i].time, value: null });
-    } else if (i === period - 1) {
-      sum += rawForce[i];
-      const seed = sum / period;
-      result.push({ time: normalized[i].time, value: seed });
-    } else {
-      const prev = result[i - 1].value as number;
-      const emaVal = rawForce[i] * multiplier + prev * (1 - multiplier);
-      result.push({ time: normalized[i].time, value: emaVal });
-    }
+    result[i] = {
+      time: normalized[i].time,
+      value: { short: shortValues[i], long: longValues[i] },
+    };
   }
 
-  return tagSeries(result, withLabelParams(ELDER_FORCE_INDEX_META, [period]));
+  return tagSeries(result, withLabelParams(ELDER_FORCE_INDEX_META, [shortPeriod, longPeriod]));
+}
+
+/**
+ * EMA over a numeric series, seeded with the SMA of the first `period`
+ * samples. Returns `null` for the first `period - 1` indices so callers
+ * know the EMA hasn't warmed up yet.
+ */
+function emaOfRaw(values: readonly number[], period: number): (number | null)[] {
+  const result: (number | null)[] = new Array(values.length).fill(null);
+  if (values.length === 0) return result;
+
+  const multiplier = 2 / (period + 1);
+  let sum = 0;
+
+  for (let i = 0; i < values.length; i++) {
+    if (i < period - 1) {
+      sum += values[i];
+      continue;
+    }
+    if (i === period - 1) {
+      sum += values[i];
+      result[i] = sum / period;
+      continue;
+    }
+    const prev = result[i - 1] as number;
+    result[i] = values[i] * multiplier + prev * (1 - multiplier);
+  }
+
+  return result;
 }

--- a/packages/core/src/manifest/entries/volume.ts
+++ b/packages/core/src/manifest/entries/volume.ts
@@ -225,16 +225,17 @@ export const VOLUME_MANIFESTS: IndicatorManifest[] = [
     pitfalls: [
       "Volume spike on a tiny price move yields a large Force value — can mislead",
       "Default 13 EMA smoothes substantial intra-period variation; raw 1-period FI is very noisy",
-      "Elder explicitly prescribes BOTH a short-period (2) FI for entries AND long-period (13) for trend; trendcraft's single-period default tilts to the long",
     ],
     synergy: [
-      "Pair with a separate short-period Force Index (period=2) for entries vs long-period (13) for trend (Elder's canonical setup)",
+      "Use long FI for trend bias (above zero = bullish), short FI for pullback entries (cross below zero in an uptrend = buy)",
     ],
     marketRegime: ["trending"],
     timeframe: ["swing"],
     paramHints: {
-      period:
-        "13 default EMA smoothing (Elder's long-period). Use period=2 for short-period entry signals",
+      shortPeriod:
+        "2 default (Elder canonical) — fine-tunes pullback entries within the long-period trend",
+      longPeriod:
+        "13 default (Elder canonical) — confirms intermediate-trend direction, look for divergences here first",
     },
   },
   {

--- a/packages/core/src/streaming/indicator-presets.ts
+++ b/packages/core/src/streaming/indicator-presets.ts
@@ -1243,12 +1243,36 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
   }),
   elderForceIndex: withCompute(
     "elderForceIndex",
-    (c, p) => elderForceIndex(c, { period: p.period ?? 13 }),
+    (c, p) =>
+      elderForceIndex(c, {
+        shortPeriod: p.shortPeriod ?? 2,
+        longPeriod: p.longPeriod ?? 13,
+      }),
     {
       category: "Volume",
       name: "Elder Force Index",
-      description: "Combines price change and volume to measure the power behind price movements.",
-      paramSchema: [period(13)],
+      description:
+        "Combines price change and volume to measure the power behind price movements. Default uses Elder's canonical pair: short=2 (entry timing), long=13 (trend bias).",
+      paramSchema: [
+        {
+          key: "shortPeriod",
+          label: "Short Period",
+          type: "number",
+          default: 2,
+          min: 1,
+          max: 50,
+          step: 1,
+        },
+        {
+          key: "longPeriod",
+          label: "Long Period",
+          type: "number",
+          default: 13,
+          min: 1,
+          max: 200,
+          step: 1,
+        },
+      ],
     },
   ),
   volumeAnomaly: withCompute(

--- a/packages/core/src/streaming/live-presets.ts
+++ b/packages/core/src/streaming/live-presets.ts
@@ -828,11 +828,18 @@ export const livePresets: Record<string, LivePreset> = {
   },
   elderForceIndex: {
     meta: ELDER_FORCE_INDEX_META,
-    defaultParams: { period: 13 },
-    snapshotName: "efi",
-    createFactory: factory<{ period?: number }>()(createElderForceIndex, (p) => ({
-      period: p.period ?? 13,
-    })),
+    defaultParams: { shortPeriod: 2, longPeriod: 13 },
+    // Snapshot key includes both periods — resuming under different
+    // periods would mix scales (each EMA's running state is tied to its
+    // own period). Different keys force a fresh warm-up.
+    snapshotName: (p) => `efi_${p.shortPeriod ?? 2}_${p.longPeriod ?? 13}`,
+    createFactory: factory<{ shortPeriod?: number; longPeriod?: number }>()(
+      createElderForceIndex,
+      (p) => ({
+        shortPeriod: p.shortPeriod ?? 2,
+        longPeriod: p.longPeriod ?? 13,
+      }),
+    ),
   },
   volumeAnomaly: {
     meta: VOLUME_ANOMALY_META,


### PR DESCRIPTION
> **Breaking change** — see CHANGELOG entry under `Breaking — Elder's Force Index returns { short, long }`.

## Summary

Aligns Elder's Force Index with Alexander Elder's canonical two-screen approach (*Trading for a Living*, *The New Sell & Sellshort*): a **2-period** EMA for entry timing AND a **13-period** EMA for trend bias, both emitted on every bar. The previous default (`period: 13`) only surfaced the long line.

## API change

| | Before | After |
|---|---|---|
| `elderForceIndex(c, opts)` return | `Series<number \| null>` | `Series<{ short: number \| null, long: number \| null }>` |
| `createElderForceIndex(opts)` value | `number \| null` | `{ short: number \| null, long: number \| null }` |
| Options | `{ period?: number }` | `{ shortPeriod?: number, longPeriod?: number }` |
| Defaults | `period: 13` | `shortPeriod: 2, longPeriod: 13` |

## Migration

```ts
// Elder canonical (default) — both lines available
const fi = elderForceIndex(candles);
const last = fi[fi.length - 1].value; // { short, long }

// Long-only (was the old trendcraft default)
const long = elderForceIndex(candles, { longPeriod: 13 }).map((p) => p.value.long);

// Short-only
const short = elderForceIndex(candles, { shortPeriod: 2 }).map((p) => p.value.short);
```

## Plumbing folded in

- **Streaming presets** (`indicatorPresets.elderForceIndex`, `livePresets.elderForceIndex`) expose `shortPeriod` / `longPeriod`. Live snapshot key is now `efi_${shortPeriod}_${longPeriod}` so old `efi` snapshots from the single-period era are discarded cleanly on resume.
- **Incremental** `createElderForceIndex(opts, { fromState })`:
  - Reads persisted periods from the snapshot when options are not re-passed (no silent revert to canonical 2/13 after a custom-period stream resumes).
  - Resets EMA / sum / count when explicit options conflict with the snapshot's periods (re-parameterization). `prevClose` is preserved so the first raw-force computation after re-parameterization is still correct.
  - `isWarmedUp` waits on `Math.max(shortPeriod, longPeriod)` so callers passing `shortPeriod > longPeriod` don't see `isWarmedUp === true` while one channel is still null.
- **Chart introspection**: both `presets.ts` (TrendCraft preset registry) and the default `series-registry.ts` rule list pick up `{ short, long }` and render two lines in the sub-pane — short orange (entry), long purple (trend). The legacy single-color preset was removed.
- `trendcraft/manifest` entry: `paramHints` and `synergy` updated to describe the short / long pair.
- Example call sites (echarts-viewer, trading-simulator) updated to pass `longPeriod` and read `.long` so their existing single-line subcharts continue to render.

## Test plan

- [x] `pnpm test` (core) — 5056 / 5056 (was 5053; +3 net)
- [x] `pnpm test` (chart) — 831 / 831
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] echarts-viewer `tsc --noEmit` clean
- [x] `/codex:review` clean (5 iterations: P1 in-repo callers / `defaultRegistry`, P2 `isWarmedUp`, P2 fromState period restore, P1 state reset on re-parameterization — all addressed)
- [x] **Visual end-to-end via agent-browser** on indicator-showcase: Force Index sub-pane renders short (orange) + long (purple) lines with the dashed zero reference line and "Force Index" label.
- [x] Coverage:
  - per-channel warmup (short=2 ready at bar 1, long=13 still null)
  - both lines positive in a rising market
  - cross-validation: each canonical period (2 and 13) matches `EMA-of-(Δclose × volume)` on its respective channel
  - 3 incremental consistency configurations match batch
  - branch coverage: first-candle null, peek-vs-next at warmup, fromState resume preserves periods, explicit re-parameterization resets EMA state and produces a fresh canonical SMA seed, `isWarmedUp` Math.max ordering

## Sources

- [Force Index | ChartSchool | StockCharts.com](https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-indicators/force-index)
- [Elder's Force Index (EFI) | TradingView Help](https://www.tradingview.com/support/solutions/43000502259-elder-s-force-index-efi/)