### PR TITLE
fix(core): Ichimoku incremental isWarmedUp + drop unused mid-price helper

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
@@ -2060,6 +2060,54 @@ describe("Ichimoku cloud components", () => {
     expect(r.value.chikou).toBe(null);
   });
 
+  it("isWarmedUp also waits for senkouA when kijunPeriod exceeds senkouBPeriod", () => {
+    // The API allows callers to flip the canonical period ordering.
+    // When `kijunPeriod > senkouBPeriod`, senkouA is the slower
+    // displaced channel — it needs `kijunPeriod + displacement` bars
+    // to settle. A naive `senkouBPeriod + displacement` threshold
+    // would fire early and leave `value.senkouA` null.
+    const ichi = createIchimoku({
+      tenkanPeriod: 3,
+      kijunPeriod: 20,
+      senkouBPeriod: 10,
+      displacement: 3,
+    });
+    // Past senkouB threshold (10 + 3 = 13), before senkouA threshold
+    // (20 + 3 = 23).
+    for (let i = 0; i < 22; i++) ichi.next(makeCandle(i));
+    expect(ichi.isWarmedUp).toBe(false);
+
+    // Feed up to count = 23.
+    ichi.next(makeCandle(22));
+    expect(ichi.isWarmedUp).toBe(true);
+    // The very next bar must have a non-null senkouA.
+    expect(ichi.next(makeCandle(23)).value.senkouA).not.toBeNull();
+  });
+
+  it("isWarmedUp waits for senkouB to settle, not just kijun + displacement", () => {
+    // The latest channel to settle is Senkou Span B: it needs
+    // `senkouBPeriod` bars to compute its base AND `displacement`
+    // bars to carry that base forward. Previously `isWarmedUp` only
+    // checked `kijunPeriod + displacement`, which fired early
+    // whenever `senkouBPeriod > kijunPeriod` (the canonical 9/26/52
+    // setup) — `value.senkouB` was still null at that point.
+    const ichi = createIchimoku({
+      tenkanPeriod: 3,
+      kijunPeriod: 5,
+      senkouBPeriod: 10,
+      displacement: 3,
+    });
+    // Past kijun+displacement (8) but before senkouBPeriod+displacement (13).
+    for (let i = 0; i < 10; i++) ichi.next(makeCandle(i));
+    expect(ichi.isWarmedUp).toBe(false);
+
+    // Feed up through count = senkouBPeriod + displacement = 13.
+    for (let i = 10; i < 13; i++) ichi.next(makeCandle(i));
+    expect(ichi.isWarmedUp).toBe(true);
+    // The very next bar must have a non-null senkouB.
+    expect(ichi.next(makeCandle(13)).value.senkouB).not.toBeNull();
+  });
+
   it("peek does not modify internal Ichimoku state", () => {
     const ichi = createIchimoku({ tenkanPeriod: 3, kijunPeriod: 5, displacement: 3 });
     for (let i = 0; i < 10; i++) ichi.next(makeCandle(i));

--- a/packages/core/src/indicators/incremental/trend/ichimoku.ts
+++ b/packages/core/src/indicators/incremental/trend/ichimoku.ts
@@ -61,18 +61,6 @@ function bufferMinMax(buf: CircularBuffer<number>): { min: number; max: number }
   return { min, max };
 }
 
-function _midPrice(
-  buf: CircularBuffer<number>,
-  period: number,
-  _highOrLow: "high" | "low",
-  otherBuf: CircularBuffer<number>,
-): number | null {
-  if (buf.length < period) return null;
-  const { max } = bufferMinMax(buf);
-  const { min } = bufferMinMax(otherBuf);
-  return (max + min) / 2;
-}
-
 /**
  * Create an incremental Ichimoku indicator
  *
@@ -217,8 +205,16 @@ export function createIchimoku(
     },
 
     get isWarmedUp() {
-      // Kijun (longest non-displaced period) and displacement for senkou
-      return count >= kijunPeriod + displacement;
+      // Two displaced channels gate readiness: `senkouA` depends on a
+      // valid kijun from `displacement` bars ago (so it needs
+      // `kijunPeriod + displacement`) and `senkouB` needs
+      // `senkouBPeriod + displacement`. The slower of the two wins.
+      // The previous threshold (`kijunPeriod + displacement`) was
+      // wrong for the canonical 9/26/52 setup (senkouB still null);
+      // the simpler swap to `senkouBPeriod + displacement` was wrong
+      // for caller-overridden setups where kijunPeriod > senkouBPeriod
+      // (senkouA would still be null). The Math.max here covers both.
+      return count >= Math.max(kijunPeriod, senkouBPeriod) + displacement;
     },
   };
 


### PR DESCRIPTION
## Summary

Two small fixes to the incremental Ichimoku indicator surfaced by a Phase 2 industry-standard verification pass.

## `isWarmedUp` threshold

**Before**: `count >= kijunPeriod + displacement` — fires early on the canonical 9 / 26 / 52 / 26 setup. SenkouB needs `senkouBPeriod + displacement = 78` bars before its first non-null value, but `kijunPeriod + displacement = 52` already flipped the flag at 52 bars. Downstream streaming code that gated on `isWarmedUp` consumed `value.senkouB === null` as if the indicator was ready.

**After**: `count >= Math.max(kijunPeriod, senkouBPeriod) + displacement`.

Two displaced channels gate readiness:
- **Senkou A** depends on a valid kijun from `displacement` bars ago → needs `kijunPeriod + displacement`
- **Senkou B** has its own period → needs `senkouBPeriod + displacement`

The `Math.max` covers both:

| Configuration | Slower channel | Threshold |
|---|---|---|
| Canonical 9 / 26 / 52 / 26 | senkouB | `52 + 26 = 78` |
| Inverted (e.g. `kijunPeriod: 20, senkouBPeriod: 10, displacement: 3`) | senkouA | `20 + 3 = 23` |

## Dead code removal

The unused `_midPrice` function was a stale helper that never made it into the final implementation (`_` prefix indicates unused; both bodies were superseded by `computeMidPrice` defined inside the factory). Removed.

## Scope

- Pure incremental fix. Batch `ichimoku()` is unchanged.
- Chart rendering (cloud fill + 5 lines) is unchanged. Verified end-to-end via agent-browser on indicator-showcase: tenkan / kijun / senkouA / senkouB / chikou render with the bullish-green / bearish-red cloud fill (industry-standard).
- No public API changes.

## Test plan

- [x] `pnpm test` (core) — 5058 / 5058 (was 5057; +2 net for `isWarmedUp` regression coverage)
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] `/codex:review` clean (2 iterations: P2 finding on inverted period ordering — addressed by `Math.max`)
- [x] **Visual verification via agent-browser** on indicator-showcase: Ichimoku Cloud renders the cloud + 5 lines on the main pane.

## Sources

- [Ichimoku Cloud | ChartSchool | StockCharts](https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-overlays/ichimoku-cloud)
- [Ichimoku Kinkō Hyō | Wikipedia](https://en.wikipedia.org/wiki/Ichimoku_Kink%C5%8D_Hy%C5%8D)