### PR TITLE
test(chart): pin Supertrend channel-name contract with the dispatcher

### DIFF
--- a/packages/chart/src/__tests__/series-registry.test.ts
+++ b/packages/chart/src/__tests__/series-registry.test.ts
@@ -74,6 +74,27 @@ describe("SeriesRegistry", () => {
     expect(rule!.defaultPane).toBe("main");
   });
 
+  it("Supertrend decompose preserves the channel names the dispatcher expects", () => {
+    // The chart's specialized supertrend dispatch
+    // (renderer/series-dispatcher.ts) reads `upperBand`, `lowerBand`,
+    // and `trend` to render the canonical switching line + cloud fill.
+    // Renaming any of these silently disables the renderer.
+    const rule = registry.detect([
+      { time: 1, value: { supertrend: 95, upperBand: 105, lowerBand: 95, direction: 1 } },
+    ]);
+    if (!rule) throw new Error("Supertrend rule not detected");
+
+    const decomposed = rule.decompose({
+      supertrend: 95,
+      upperBand: 105,
+      lowerBand: 95,
+      direction: 1,
+    });
+    expect(decomposed.upperBand).toBe(105);
+    expect(decomposed.lowerBand).toBe(95);
+    expect(decomposed.trend).toBe(1);
+  });
+
   it("detects Parabolic SAR shape", () => {
     const data: DataPoint<{ sar: number; direction: number }>[] = [
       { time: 1, value: { sar: 100, direction: 1 } },

--- a/packages/chart/src/core/series-registry.ts
+++ b/packages/chart/src/core/series-registry.ts
@@ -108,7 +108,15 @@ const BUILTIN_RULES: IntrospectionRule[] = [
     },
   },
 
-  // Supertrend
+  // Supertrend — the chart's specialized supertrend dispatch
+  // (renderer/series-dispatcher.ts) reads `upperBand`, `lowerBand`,
+  // and `trend` to draw the canonical industry-standard
+  // visualization: a single line that *switches* between the lower
+  // band (when bullish, direction=1) and the upper band (when
+  // bearish, direction=-1), with a translucent fill between price
+  // and the line. Channel names here MUST stay in sync with that
+  // dispatch path — renaming them silently disables the renderer
+  // and the indicator stops drawing.
   {
     name: "supertrend",
     test: (v) => hasKeys(v, ["upperBand", "lowerBand", "direction"]) && hasKeys(v, ["supertrend"]),


### PR DESCRIPTION
## Summary

The chart's rendering decision for Supertrend is split across two files:

- `core/series-registry.ts` decomposes the indicator value into named channels
- `renderer/series-dispatcher.ts` has a **hard-coded `rule.name === "supertrend"` branch** that reads `upperBand`, `lowerBand`, and `trend` to draw the canonical switching line + translucent fill

Renaming any of those channels in the registry silently disables the dispatcher's specialized branch — the legend still appears but **nothing draws on the chart**. The series-registry rule and the dispatcher are coupled by string-keyed channel names with no compile-time guard.

## What this PR adds

- **Regression test** pinning the channel names the registry produces. Any future change that tries to rename, split, or remove the `upperBand` / `lowerBand` / `trend` channels (e.g. an attempt at "splitting into directional channels", which sounds like an industry-standard improvement until you realize it disables the renderer) now trips the test before it ships.
- **Comment** above the rule recording the dispatcher contract, so the next reader doesn't have to re-derive it by tracing through the renderer source.

## Why this is just docs + test, not a behavior change

The Supertrend rendering is **already canonical** — the dispatcher draws the color-switching line + translucent fill that matches TradingView / ToS / NinjaTrader. Verified end-to-end via agent-browser on indicator-showcase. No production code path changes here.

## Test plan

- [x] `pnpm test` (chart) — 832 / 832 (was 831; +1 regression-pin test)
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] `/codex:review` clean
- [x] **Visual via agent-browser**: Supertrend renders the canonical switching line + cloud fill on indicator-showcase (`/tmp/st-verify/07-final.png`).

## Sources verified

- [Supertrend Indicator (LuxAlgo)](https://www.luxalgo.com/blog/how-to-use-the-supertrend-indicator-effectively/)
- [Supertrend Indicator Settings + Formula (TrendSpider)](https://trendspider.com/learning-center/supertrend-indicator-a-comprehensive-guide/)