### PR TITLE
fix(core): ALMA fromState restores params; warm-up now buffer-based

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ packages/core/src/manifest/sources/
 
 .claude/projects/
 .claude/commands/release.md
+# Runtime lockfile created by Claude Code's scheduled-task runner.
+.claude/scheduled_tasks.lock
 .plans/
 packages/core/examples/data/
 packages/core/examples/alpaca-demo/

--- a/packages/core/src/indicators/incremental/__tests__/new-indicators.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/new-indicators.test.ts
@@ -469,6 +469,125 @@ describe("ALMA incremental", () => {
       }
     }
   });
+
+  it("fromState restores period / offset / sigma / source when options are not re-passed", () => {
+    // The buffer capacity and the Gaussian weights are functions of all
+    // four shape params. Without explicit restoration, a snapshot from
+    // `{ period: 20, offset: 0.7, sigma: 8 }` would resume under the
+    // canonical 9 / 0.85 / 6 defaults — different weights applied to a
+    // 20-slot buffer = mathematically broken output.
+    const ind1 = createAlma({ period: 20, offset: 0.7, sigma: 8 });
+    for (let i = 0; i < 40; i++) ind1.next(candles[i]);
+    const state = ind1.getState();
+    expect(state.period).toBe(20);
+    expect(state.offset).toBe(0.7);
+    expect(state.sigma).toBe(8);
+
+    // Resume without re-passing options — periods / shape must come
+    // from the snapshot, NOT silently revert to canonical defaults.
+    const ind2 = createAlma({}, { fromState: state });
+    expect(ind2.getState().period).toBe(20);
+    expect(ind2.getState().offset).toBe(0.7);
+    expect(ind2.getState().sigma).toBe(8);
+
+    // Subsequent values must match what ind1 would have produced.
+    for (let i = 40; i < 60; i++) {
+      const v1 = ind1.next(candles[i]).value;
+      const v2 = ind2.next(candles[i]).value;
+      expect(v2).toBeCloseTo(v1!, 10);
+    }
+  });
+
+  it("re-parameterizing on resume carries forward the latest snapshot prices", () => {
+    // The snapshot stores raw source prices (not derived EMA / weighted
+    // values), so a Gaussian-shape change does not invalidate them.
+    // Resuming a 20-bar snapshot under `period: 9` must therefore emit
+    // a non-null value immediately from the latest 9 prices already on
+    // hand — and that value must equal what a fresh 9-bar ALMA would
+    // produce when fed the same 9 prices in order.
+    const ind1 = createAlma({ period: 20, offset: 0.7, sigma: 8 });
+    for (let i = 0; i < 40; i++) ind1.next(candles[i]);
+    const state = ind1.getState();
+
+    const ind2 = createAlma({ period: 9, offset: 0.85, sigma: 6 }, { fromState: state });
+    expect(ind2.getState().period).toBe(9);
+    // `count` preserves the public "candles processed so far" contract
+    // across reconfiguration — 40 bars went through ind1.
+    expect(ind2.getState().count).toBe(40);
+    // Warm-up is gated on the buffer (filled with the latest 9 prices
+    // from the snapshot), not on count. So the indicator emits a
+    // value immediately on the next bar.
+    expect(ind2.isWarmedUp).toBe(true);
+
+    // Compare the resumed indicator's next bar against what a brand-new
+    // 9-bar ALMA, primed with the same raw price tail, would output.
+    const baseline = createAlma({ period: 9, offset: 0.85, sigma: 6 });
+    for (let i = 31; i < 40; i++) baseline.next(candles[i]);
+    const v1 = ind2.next(candles[40]).value;
+    const v2 = baseline.next(candles[40]).value;
+    expect(v1).not.toBeNull();
+    expect(v1).toBeCloseTo(v2!, 10);
+  });
+
+  it("changing source on resume discards the old buffer and warms up fresh", () => {
+    // The buffer holds source-derived numbers (close prices in this
+    // case). Mixing them with `high` prices in the next `period`
+    // outputs would be mathematically incorrect, so the source switch
+    // forces a fresh warm-up regardless of whether shape params match.
+    const ind1 = createAlma({ period: 9, source: "close" });
+    for (let i = 0; i < 30; i++) ind1.next(candles[i]);
+    const state = ind1.getState();
+    expect(state.source).toBe("close");
+
+    const ind2 = createAlma({ source: "high" }, { fromState: state });
+    expect(ind2.getState().source).toBe("high");
+    // `count` preserves the public processed-candles contract even
+    // though the buffer is reset — readers using count for backfill
+    // / progress tracking shouldn't see the counter snap to 0.
+    expect(ind2.getState().count).toBe(30);
+    // Buffer is empty — warm-up is buffer-based.
+    expect(ind2.isWarmedUp).toBe(false);
+
+    // Need a full period of new-source bars before the first output.
+    for (let i = 30; i < 38; i++) {
+      expect(ind2.next(candles[i]).value).toBeNull();
+    }
+    expect(ind2.next(candles[38]).value).not.toBeNull();
+  });
+
+  it("growing the period on resume waits for the buffer to fill before emitting", () => {
+    // When the new period exceeds the snapshot's old period, we don't
+    // have enough buffered prices to compute the wider Gaussian
+    // window. `count` is reset to the carried-over buffer length so
+    // `isWarmedUp` correctly stays false until more bars arrive.
+    const ind1 = createAlma({ period: 9 });
+    for (let i = 0; i < 30; i++) ind1.next(candles[i]);
+    const state = ind1.getState();
+
+    const ind2 = createAlma({ period: 20 }, { fromState: state });
+    // `count` preserves the public processed-candles contract (30
+    // bars went through ind1) regardless of the buffer carry-over.
+    expect(ind2.getState().count).toBe(30);
+    // Warm-up is gated on the buffer (only 9 of 20 entries carried
+    // forward), so the new indicator stays not-yet-warmed-up until
+    // 11 more bars fill the window.
+    expect(ind2.isWarmedUp).toBe(false);
+
+    // Need 11 more bars to fill the new 20-bar window.
+    for (let i = 30; i < 40; i++) {
+      expect(ind2.next(candles[i]).value).toBeNull();
+    }
+    expect(ind2.next(candles[40]).value).not.toBeNull();
+  });
+
+  it("explicit options on resume override persisted state", () => {
+    const ind1 = createAlma({ period: 20, offset: 0.7, sigma: 8 });
+    for (let i = 0; i < 40; i++) ind1.next(candles[i]);
+    const ind2 = createAlma({ period: 5, offset: 0.5, sigma: 4 }, { fromState: ind1.getState() });
+    expect(ind2.getState().period).toBe(5);
+    expect(ind2.getState().offset).toBe(0.5);
+    expect(ind2.getState().sigma).toBe(4);
+  });
 });
 
 // ---- FRAMA ----

--- a/packages/core/src/indicators/incremental/moving-average/alma.ts
+++ b/packages/core/src/indicators/incremental/moving-average/alma.ts
@@ -35,19 +35,28 @@ export function createAlma(
   options: { period?: number; offset?: number; sigma?: number; source?: PriceSource } = {},
   warmUpOptions?: WarmUpOptions<AlmaState>,
 ): IncrementalIndicator<number | null, AlmaState> {
-  const period = options.period ?? 9;
-  const offset = options.offset ?? 0.85;
-  const sigma = options.sigma ?? 6;
-  const source: PriceSource = options.source ?? "close";
+  // Resume order: explicit option > persisted state > canonical default.
+  // Reading the snapshot first is critical — every parameter shapes the
+  // pre-computed Gaussian weights and the sliding-window buffer size, so
+  // silently swapping to defaults on resume produces a discontinuous
+  // ALMA after restore.
+  const fs = warmUpOptions?.fromState ?? null;
+  const period = options.period ?? fs?.period ?? 9;
+  const offset = options.offset ?? fs?.offset ?? 0.85;
+  const sigma = options.sigma ?? fs?.sigma ?? 6;
+  const source: PriceSource = options.source ?? fs?.source ?? "close";
 
-  // Pre-compute normalized Gaussian weights
+  // Pre-compute normalized Gaussian weights (Pine Script convention:
+  // `m = offset * (period - 1)`, matching TradingView's `ta.alma()`).
+  // Some references use `m = offset * period` instead — the magnitude
+  // shift is small; we standardize on the Pine Script form.
   const m = offset * (period - 1);
-  const s = period / sigma;
+  const sd = period / sigma;
   const weights: number[] = new Array(period);
   let weightSum = 0;
 
   for (let i = 0; i < period; i++) {
-    const w = Math.exp(-((i - m) * (i - m)) / (2 * s * s));
+    const w = Math.exp(-((i - m) * (i - m)) / (2 * sd * sd));
     weights[i] = w;
     weightSum += w;
   }
@@ -55,16 +64,52 @@ export function createAlma(
     weights[i] /= weightSum;
   }
 
+  // The snapshot stores raw source prices, not derived state. That
+  // means a *shape*-only parameter change on resume (period / offset /
+  // sigma) only invalidates the weights — the buffered prices remain
+  // valid input. Carry the latest min(snapshot.length, new period)
+  // prices into a buffer of the new capacity so re-parameterization
+  // can emit a value immediately when enough history is on hand.
+  //
+  // A `source` change is different: the old buffer holds numbers
+  // derived from the old source (e.g. `close`) and would mix
+  // mathematically with new source values (e.g. `high`) for the next
+  // `period` outputs. When source differs, the buffered prices have to
+  // be discarded — the new indicator starts a fresh warm-up.
+  const shapeMatchesSnapshot =
+    fs !== null && fs.period === period && fs.offset === offset && fs.sigma === sigma;
+  const sourceMatchesSnapshot = fs !== null && fs.source === source;
+  const snapshotMatches = shapeMatchesSnapshot && sourceMatchesSnapshot;
+
   let buffer: CircularBuffer<number>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    count = s.count;
-  } else {
+  if (fs !== null && snapshotMatches) {
+    buffer = CircularBuffer.fromSnapshot(fs.buffer);
+    count = fs.count;
+  } else if (fs !== null && sourceMatchesSnapshot) {
+    // Shape change only — buffered source prices stay valid.
     buffer = new CircularBuffer<number>(period);
-    count = 0;
+    const oldBuffer = CircularBuffer.fromSnapshot(fs.buffer);
+    const available = oldBuffer.length;
+    const carryStart = Math.max(0, available - period);
+    for (let i = carryStart; i < available; i++) {
+      buffer.push(oldBuffer.get(i));
+    }
+    // Preserve the public count contract — `count` is "candles
+    // processed so far" across the indicator's whole lifetime.
+    // Warm-up readiness uses `buffer.length >= period` instead, so a
+    // grown period correctly stays not-warmed-up even though count
+    // is large.
+    count = fs.count;
+  } else {
+    // Fresh start (fs === null) — count begins at 0 by definition.
+    // For a source change we *also* discard buffered prices because
+    // their meaning shifts (close vs high vs hl2 etc.), but we keep
+    // `fs.count` so the public processed-candles counter stays
+    // monotonic across the reconfiguration.
+    buffer = new CircularBuffer<number>(period);
+    count = fs?.count ?? 0;
   }
 
   function computeAlma(): number {
@@ -81,7 +126,12 @@ export function createAlma(
       count++;
       buffer.push(price);
 
-      if (count < period) {
+      // Warm-up is gated on the *buffer* having `period` samples, not
+      // on the public `count`. A shape-only resume can carry forward
+      // historical prices (so buffer is full and we emit immediately
+      // even though count is the old run's total), and a grown-period
+      // resume needs more bars even when count is already large.
+      if (buffer.length < period) {
         return { time: candle.time, value: null };
       }
 
@@ -91,7 +141,10 @@ export function createAlma(
     peek(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
 
-      if (count + 1 < period) {
+      // Buffer-based warm-up gate (see next()'s comment). A simulated
+      // push grows length by 1 until the buffer is full, then it caps.
+      const peekLength = Math.min(buffer.length + 1, period);
+      if (peekLength < period) {
         return { time: candle.time, value: null };
       }
 
@@ -134,7 +187,7 @@ export function createAlma(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      return buffer.length >= period;
     },
   };
 

--- a/packages/core/src/indicators/moving-average/alma.ts
+++ b/packages/core/src/indicators/moving-average/alma.ts
@@ -30,6 +30,13 @@ export type AlmaOptions = {
  * ALMA applies a Gaussian distribution curve as weight to the price series.
  * The offset parameter shifts the Gaussian curve, and sigma controls its width.
  *
+ * Weights are computed as `w[i] = exp(-((i - m)^2) / (2 * s^2))` with
+ * `m = offset * (period - 1)` (Pine Script / TradingView `ta.alma()`
+ * convention) and `s = period / sigma`. Some references use
+ * `m = offset * period` instead — the magnitude shift is small; this
+ * implementation standardizes on the Pine Script form so values match
+ * any TradingView reference chart at the same parameters.
+ *
  * @param candles - Array of candles (raw or normalized)
  * @param options - ALMA options
  * @returns Series of ALMA values (null for insufficient data)


### PR DESCRIPTION
## Summary

Resuming an incremental ALMA with `fromState` previously dropped the persisted `period` / `offset` / `sigma` / `source` whenever the caller did not also re-pass `options`, silently reverting to canonical defaults and producing a discontinuous series after restore. Independent review also surfaced a regression where reconfiguring (shape or source change) reset the public `count`, violating the `IncrementalIndicator.count` contract of "candles processed so far."

## What changed

- **Snapshot-first resume** — read `period` / `offset` / `sigma` / `source` from `fromState` when `options` omit them; explicit options still win.
- **Shape-only resume carries forward prices** — the snapshot stores raw source prices (not derived state), so a `period` / `offset` / `sigma` change only invalidates the Gaussian weights. Carry the latest `min(snapshot.length, new period)` prices into a buffer of the new capacity so re-parameterization can emit immediately when enough history is on hand.
- **Source change discards the buffer** — old buffer holds numbers derived from the old source (e.g. close); mixing them with new source values (e.g. high) for the next `period` outputs would corrupt the result. Source switch starts a fresh warm-up.
- **`count` is preserved across reconfiguration** — `count` stays the public "candles processed so far" counter. Warm-up readiness is now gated on `buffer.length >= period` instead, so a grown period still correctly waits for new bars even when `count` is large.
- **Pine Script convention documented on batch ALMA** — `m = offset * (period - 1)` (matches TradingView `ta.alma()`); some references use `m = offset * period` instead, so the convention is now explicit.
- **Gitignore lockfile** — `.claude/scheduled_tasks.lock` (Claude Code's scheduled-task runner runtime state) added to `.gitignore`.

## Tests

5 new regression tests in `new-indicators.test.ts`:

1. `fromState` restores period / offset / sigma / source when options are not re-passed
2. Re-parameterizing on resume carries forward the latest snapshot prices
3. Growing the period on resume waits for the buffer to fill before emitting
4. Changing source on resume discards the old buffer and warms up fresh
5. Explicit options on resume override persisted state

All 5063 core tests pass; lint clean; build green.

## Test plan

- [x] `pnpm test` — 328 files / 5063 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — all packages succeed