### PR TITLE
feat(core)!: Roofing Filter + FRAMA align with canonical Ehlers formulas

### DIFF
--- a/packages/chart/examples/indicator-showcase/src/main.ts
+++ b/packages/chart/examples/indicator-showcase/src/main.ts
@@ -283,3 +283,46 @@ chartEl.addEventListener("click", () => {
     sidebarEl.classList.remove("open");
   }
 });
+
+// ============================================
+// Test hooks (window.__showcase) — for AI-agent / e2e access
+// ============================================
+//
+// Exposes the chart, the live IndicatorConnection, and a few helpers so an
+// external driver (agent-browser, Playwright, etc.) can add/remove indicators
+// without depending on the sidebar DOM. `conn` is a getter because the
+// connection is rebuilt on every mode/timeframe switch.
+
+declare global {
+  interface Window {
+    __showcase?: {
+      chart: typeof chart;
+      readonly conn: IndicatorConnection | null;
+      add(id: string, params?: Record<string, unknown>): void;
+      remove(id: string): void;
+      list(): string[];
+    };
+  }
+}
+
+window.__showcase = {
+  chart,
+  get conn() {
+    return conn;
+  },
+  add(id, params = {}) {
+    if (!conn) throw new Error("connection not ready");
+    // Mirror the sidebar's "primary instance" behavior: snapshotName is
+    // pinned to the preset id, so calling add() while one is already
+    // active replaces it (same as toggling params from the sidebar UI).
+    // Without this, connectIndicators rejects the duplicate snapshotName.
+    conn.remove(id);
+    conn.add(id, { ...resolveParams(id, params), snapshotName: id });
+  },
+  remove(id) {
+    conn?.remove(id);
+  },
+  list() {
+    return conn ? conn.list().map((c) => c.snapshotName) : [];
+  },
+};

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -119,7 +119,7 @@
     {
       "name": "Main (createChart + all exports)",
       "path": "dist/index.js",
-      "limit": "37 kB"
+      "limit": "38 kB"
     },
     {
       "name": "Headless API",

--- a/packages/core/src/indicators/__tests__/roofing-filter.test.ts
+++ b/packages/core/src/indicators/__tests__/roofing-filter.test.ts
@@ -17,10 +17,13 @@ describe("roofingFilter", () => {
     expect(roofingFilter([])).toEqual([]);
   });
 
-  it("should throw if highPassPeriod is less than 1", () => {
+  it("should throw if highPassPeriod is less than 2", () => {
     const candles = makeCandles([100]);
+    expect(() => roofingFilter(candles, { highPassPeriod: 1 })).toThrow(
+      "Roofing filter highPassPeriod must be at least 2",
+    );
     expect(() => roofingFilter(candles, { highPassPeriod: 0 })).toThrow(
-      "Roofing filter highPassPeriod must be at least 1",
+      "Roofing filter highPassPeriod must be at least 2",
     );
   });
 

--- a/packages/core/src/indicators/filter/roofing-filter.ts
+++ b/packages/core/src/indicators/filter/roofing-filter.ts
@@ -46,8 +46,15 @@ export function roofingFilter(
 ): Series<number | null> {
   const { highPassPeriod = 48, lowPassPeriod = 10, source = "close" } = options;
 
-  if (highPassPeriod < 1) {
-    throw new Error("Roofing filter highPassPeriod must be at least 1");
+  // The canonical HP coefficients (`alpha1 = (cos+sin-1)/cos`) place both
+  // recurrence poles inside the unit circle for `highPassPeriod >= 2`.
+  // At `period = 1` the angle `theta = sqrt(2)*pi` lands deep in the
+  // third quadrant, alpha1 jumps to ~8.3, and the resulting coefficients
+  // (|c2| ≈ 14.5, |c3| ≈ 53) drive the recurrence to infinity on bounded
+  // inputs. period=1 is also the Nyquist degenerate case and has no
+  // practical use for cycle filtering anyway.
+  if (highPassPeriod < 2) {
+    throw new Error("Roofing filter highPassPeriod must be at least 2");
   }
   if (lowPassPeriod < 1) {
     throw new Error("Roofing filter lowPassPeriod must be at least 1");
@@ -61,12 +68,19 @@ export function roofingFilter(
     return result;
   }
 
-  // High-pass filter coefficients (2-pole Butterworth)
-  const a1HP = Math.exp((-Math.SQRT2 * Math.PI) / highPassPeriod);
-  const b1HP = 2 * a1HP * Math.cos((Math.SQRT2 * Math.PI) / highPassPeriod);
-  const c2HP = b1HP;
-  const c3HP = -(a1HP * a1HP);
-  const c1HP = (1 + c2HP - c3HP) / 4; // Coefficient for 2-pole high-pass
+  // 2-pole high-pass filter coefficients (Ehlers canonical form, from
+  // "Cybernetic Analysis for Stocks and Futures" ch. 13 / "Predictive
+  // Indicators"):
+  //   theta  = sqrt(2) * pi / highPassPeriod
+  //   alpha1 = (cos(theta) + sin(theta) - 1) / cos(theta)
+  //   HP = (1 - alpha1/2)^2 * (P - 2*P[-1] + P[-2])
+  //      + 2*(1 - alpha1)   * HP[-1]
+  //      -    (1 - alpha1)^2 * HP[-2]
+  const thetaHP = (Math.SQRT2 * Math.PI) / highPassPeriod;
+  const alpha1 = (Math.cos(thetaHP) + Math.sin(thetaHP) - 1) / Math.cos(thetaHP);
+  const c1HP = (1 - alpha1 / 2) * (1 - alpha1 / 2);
+  const c2HP = 2 * (1 - alpha1);
+  const c3HP = -((1 - alpha1) * (1 - alpha1));
 
   // Super Smoother (low-pass) coefficients
   const a1SS = Math.exp((-Math.SQRT2 * Math.PI) / lowPassPeriod);

--- a/packages/core/src/indicators/incremental/filter/roofing-filter.ts
+++ b/packages/core/src/indicators/incremental/filter/roofing-filter.ts
@@ -31,12 +31,13 @@ export type RoofingFilterState = {
 };
 
 function highPassCoeffs(period: number) {
-  const a1 = Math.exp((-Math.SQRT2 * Math.PI) / period);
-  const b1 = 2 * a1 * Math.cos((Math.SQRT2 * Math.PI) / period);
-  const c2 = b1;
-  const c3 = -(a1 * a1);
-  // 2-pole Butterworth high-pass
-  const c1 = (1 + c2 - c3) / 4;
+  // 2-pole high-pass, Ehlers canonical form (Cybernetic Analysis ch. 13).
+  // Mirrors the batch coefficients exactly so resume + streaming agree.
+  const theta = (Math.SQRT2 * Math.PI) / period;
+  const alpha1 = (Math.cos(theta) + Math.sin(theta) - 1) / Math.cos(theta);
+  const c1 = (1 - alpha1 / 2) * (1 - alpha1 / 2);
+  const c2 = 2 * (1 - alpha1);
+  const c3 = -((1 - alpha1) * (1 - alpha1));
   return { c1, c2, c3 };
 }
 
@@ -71,7 +72,9 @@ export function createRoofingFilter(
   const lowPassPeriod = warmUpOptions?.fromState?.lowPassPeriod ?? options.lowPassPeriod ?? 10;
   const source: PriceSource = warmUpOptions?.fromState?.source ?? options.source ?? "close";
 
-  if (highPassPeriod < 1) throw new Error("Roofing filter highPassPeriod must be at least 1");
+  // See batch `roofingFilter()` for why the canonical formula requires
+  // highPassPeriod >= 2 (only period=1 leaves the unit circle).
+  if (highPassPeriod < 2) throw new Error("Roofing filter highPassPeriod must be at least 2");
   if (lowPassPeriod < 1) throw new Error("Roofing filter lowPassPeriod must be at least 1");
 
   const hp = highPassCoeffs(highPassPeriod);

--- a/packages/core/src/indicators/incremental/moving-average/frama.ts
+++ b/packages/core/src/indicators/incremental/moving-average/frama.ts
@@ -68,26 +68,17 @@ export function createFrama(
   let count: number;
 
   if (fs) {
-    if (fs.effectivePeriod !== effectivePeriod) {
-      throw new Error(
-        `FRAMA cannot be resumed with a different period (snapshot effectivePeriod=${fs.effectivePeriod}, requested=${effectivePeriod}). Re-warm a fresh instance instead.`,
-      );
-    }
-    if (fs.source !== source) {
-      throw new Error(
-        `FRAMA cannot be resumed with a different source (snapshot=${fs.source}, requested=${source}). Re-warm a fresh instance instead.`,
-      );
-    }
-
-    if (!fs.highBuffer || !fs.lowBuffer) {
-      // Pre-canonical FRAMA stored a single close-only `buffer`. We
-      // refuse silent migration: seeding both buffers from closes loses
-      // the wick range information, and any preservation of the old
-      // `prevFrama` would bake the non-canonical close-based smoothing
-      // into every subsequent value. Force a clean re-warm.
-      throw new Error(
-        "FRAMA state schema changed: snapshots taken before high/low range support cannot be resumed. Re-warm a fresh instance from candle history.",
-      );
+    // Resume contract: same period and source as the snapshot, or omit
+    // both. FRAMA's recursive `prevFrama` makes mid-stream reconfig
+    // mathematically undefined, and pre-canonical snapshots (close-only
+    // buffer, no wick range) cannot be migrated cleanly — re-warm.
+    if (
+      fs.effectivePeriod !== effectivePeriod ||
+      fs.source !== source ||
+      !fs.highBuffer ||
+      !fs.lowBuffer
+    ) {
+      throw new Error("FRAMA: incompatible snapshot, re-warm required");
     }
     highBuffer = CircularBuffer.fromSnapshot(fs.highBuffer);
     lowBuffer = CircularBuffer.fromSnapshot(fs.lowBuffer);

--- a/packages/core/src/indicators/incremental/moving-average/frama.ts
+++ b/packages/core/src/indicators/incremental/moving-average/frama.ts
@@ -1,11 +1,16 @@
 /**
  * Incremental FRAMA (Fractal Adaptive Moving Average)
  *
- * Dynamically adjusts smoothing alpha based on fractal dimension:
- * 1. Split period into two halves, compute high-low ranges
- * 2. Fractal dimension D = (log(n1 + n2) - log(n3)) / log(2)
- * 3. alpha = exp(-4.6 * (D - 1)), clamped to [0.01, 1]
- * 4. FRAMA = alpha * price + (1 - alpha) * prevFRAMA
+ * Canonical Ehlers (2005): the fractal-dimension lookback uses each
+ * candle's high and low (not the smoothing source), so the period
+ * range reflects true intrabar excursion. The `source` option still
+ * drives the FRAMA update.
+ *
+ * 1. Split period into two halves, compute (HighestHigh - LowestLow)/N
+ *    for each half and the full period.
+ * 2. Fractal dimension D = (log(n1 + n2) - log(n3)) / log(2).
+ * 3. alpha = exp(-4.6 * (D - 1)), clamped to [0.01, 1].
+ * 4. FRAMA = alpha * source + (1 - alpha) * prevFRAMA.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
@@ -19,7 +24,8 @@ export type FramaState = {
   halfPeriod: number;
   source: PriceSource;
   prevFrama: number | null;
-  buffer: { data: number[]; head: number; length: number; capacity: number };
+  highBuffer: { data: number[]; head: number; length: number; capacity: number };
+  lowBuffer: { data: number[]; head: number; length: number; capacity: number };
   count: number;
 };
 
@@ -39,28 +45,62 @@ export function createFrama(
   options: { period?: number; source?: PriceSource } = {},
   warmUpOptions?: WarmUpOptions<FramaState>,
 ): IncrementalIndicator<number | null, FramaState> {
-  const period = options.period ?? 16;
-  const source: PriceSource = options.source ?? "close";
+  // Resume contract: a snapshot can only be resumed with the SAME
+  // period and source it was created under. FRAMA is fundamentally
+  // recursive (`prevFrama` carries the smoothed history forward forever),
+  // so changing either of those mid-stream produces a series that
+  // doesn't match what `createFrama(newOptions)` would compute over the
+  // same candle history. We refuse the reconfiguration explicitly rather
+  // than silently producing a hybrid output.
+  //
+  // If options are omitted on resume, snapshot values are restored.
+  // If options are provided, they must match the snapshot or be the
+  // first time the indicator is created (no fromState).
+  const fs = warmUpOptions?.fromState ?? null;
+  const period = options.period ?? fs?.period ?? 16;
+  const source: PriceSource = options.source ?? fs?.source ?? "close";
   const effectivePeriod = period % 2 === 0 ? period : period + 1;
   const halfPeriod = effectivePeriod / 2;
 
-  let buffer: CircularBuffer<number>;
+  let highBuffer: CircularBuffer<number>;
+  let lowBuffer: CircularBuffer<number>;
   let prevFrama: number | null;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    prevFrama = s.prevFrama;
-    count = s.count;
+  if (fs) {
+    if (fs.effectivePeriod !== effectivePeriod) {
+      throw new Error(
+        `FRAMA cannot be resumed with a different period (snapshot effectivePeriod=${fs.effectivePeriod}, requested=${effectivePeriod}). Re-warm a fresh instance instead.`,
+      );
+    }
+    if (fs.source !== source) {
+      throw new Error(
+        `FRAMA cannot be resumed with a different source (snapshot=${fs.source}, requested=${source}). Re-warm a fresh instance instead.`,
+      );
+    }
+
+    if (!fs.highBuffer || !fs.lowBuffer) {
+      // Pre-canonical FRAMA stored a single close-only `buffer`. We
+      // refuse silent migration: seeding both buffers from closes loses
+      // the wick range information, and any preservation of the old
+      // `prevFrama` would bake the non-canonical close-based smoothing
+      // into every subsequent value. Force a clean re-warm.
+      throw new Error(
+        "FRAMA state schema changed: snapshots taken before high/low range support cannot be resumed. Re-warm a fresh instance from candle history.",
+      );
+    }
+    highBuffer = CircularBuffer.fromSnapshot(fs.highBuffer);
+    lowBuffer = CircularBuffer.fromSnapshot(fs.lowBuffer);
+    prevFrama = fs.prevFrama;
+    count = fs.count;
   } else {
-    buffer = new CircularBuffer<number>(effectivePeriod);
+    highBuffer = new CircularBuffer<number>(effectivePeriod);
+    lowBuffer = new CircularBuffer<number>(effectivePeriod);
     prevFrama = null;
     count = 0;
   }
 
-  function computeFromBuffer(price: number): number {
-    // Calculate high/low ranges for first half, second half, and full period
+  function rangesAndAlpha(): number {
     let h1High = Number.NEGATIVE_INFINITY;
     let h1Low = Number.POSITIVE_INFINITY;
     let h2High = Number.NEGATIVE_INFINITY;
@@ -69,70 +109,75 @@ export function createFrama(
     let fLow = Number.POSITIVE_INFINITY;
 
     for (let j = 0; j < effectivePeriod; j++) {
-      const p = buffer.get(j);
+      const high = highBuffer.get(j);
+      const low = lowBuffer.get(j);
 
       if (j < halfPeriod) {
-        h1High = Math.max(h1High, p);
-        h1Low = Math.min(h1Low, p);
+        if (high > h1High) h1High = high;
+        if (low < h1Low) h1Low = low;
       } else {
-        h2High = Math.max(h2High, p);
-        h2Low = Math.min(h2Low, p);
+        if (high > h2High) h2High = high;
+        if (low < h2Low) h2Low = low;
       }
 
-      fHigh = Math.max(fHigh, p);
-      fLow = Math.min(fLow, p);
+      if (high > fHigh) fHigh = high;
+      if (low < fLow) fLow = low;
     }
 
     const n1 = (h1High - h1Low) / halfPeriod;
     const n2 = (h2High - h2Low) / halfPeriod;
     const n3 = (fHigh - fLow) / effectivePeriod;
 
-    let alpha: number;
     if (n1 > 0 && n2 > 0 && n3 > 0) {
       const d = (Math.log(n1 + n2) - Math.log(n3)) / Math.log(2);
-      alpha = Math.exp(-4.6 * (d - 1));
-      alpha = Math.max(0.01, Math.min(1, alpha));
-    } else {
-      alpha = 0.01;
+      const a = Math.exp(-4.6 * (d - 1));
+      return Math.max(0.01, Math.min(1, a));
     }
-
-    return alpha * price + (1 - alpha) * (prevFrama ?? price);
+    return 0.01;
   }
 
   const indicator: IncrementalIndicator<number | null, FramaState> = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
       count++;
-      buffer.push(price);
+      highBuffer.push(candle.high);
+      lowBuffer.push(candle.low);
 
-      if (count < effectivePeriod) {
+      // Warm-up gated on the buffer being full, not on `count`. After a
+      // period-growing resume the snapshot's `count` is large but the
+      // rebuilt buffer needs new candles to fill.
+      if (highBuffer.length < effectivePeriod) {
         return { time: candle.time, value: null };
       }
 
       if (prevFrama === null) {
-        // Seed with current price
         prevFrama = price;
         return { time: candle.time, value: prevFrama };
       }
 
-      prevFrama = computeFromBuffer(price);
+      const alpha = rangesAndAlpha();
+      prevFrama = alpha * price + (1 - alpha) * prevFrama;
       return { time: candle.time, value: prevFrama };
     },
 
     peek(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
 
-      if (count + 1 < effectivePeriod) {
+      // Gate on the *existing* buffer being full (not the simulated +1
+      // length). Otherwise the loop below would call
+      // `highBuffer.get(j+1)` for j up to effectivePeriod-2 — which
+      // requires length >= effectivePeriod. After a period-growing
+      // resume the buffer is partially refilled and we must report null
+      // until next() finishes warming.
+      if (highBuffer.length < effectivePeriod) {
         return { time: candle.time, value: null };
       }
 
       if (prevFrama === null) {
-        // Would be the seed bar
         return { time: candle.time, value: price };
       }
 
-      // Simulate buffer with new price
-      // Build temporary array representing buffer state after push
+      // Simulate buffer with new candle's high/low.
       let h1High = Number.NEGATIVE_INFINITY;
       let h1Low = Number.POSITIVE_INFINITY;
       let h2High = Number.NEGATIVE_INFINITY;
@@ -140,20 +185,20 @@ export function createFrama(
       let fHigh = Number.NEGATIVE_INFINITY;
       let fLow = Number.POSITIVE_INFINITY;
 
-      // After push, buffer would be: [buffer.get(1), ..., buffer.get(ep-1), price]
       for (let j = 0; j < effectivePeriod; j++) {
-        const p = j < effectivePeriod - 1 ? buffer.get(j + 1) : price;
+        const high = j < effectivePeriod - 1 ? highBuffer.get(j + 1) : candle.high;
+        const low = j < effectivePeriod - 1 ? lowBuffer.get(j + 1) : candle.low;
 
         if (j < halfPeriod) {
-          h1High = Math.max(h1High, p);
-          h1Low = Math.min(h1Low, p);
+          if (high > h1High) h1High = high;
+          if (low < h1Low) h1Low = low;
         } else {
-          h2High = Math.max(h2High, p);
-          h2Low = Math.min(h2Low, p);
+          if (high > h2High) h2High = high;
+          if (low < h2Low) h2Low = low;
         }
 
-        fHigh = Math.max(fHigh, p);
-        fLow = Math.min(fLow, p);
+        if (high > fHigh) fHigh = high;
+        if (low < fLow) fLow = low;
       }
 
       const n1 = (h1High - h1Low) / halfPeriod;
@@ -163,8 +208,7 @@ export function createFrama(
       let alpha: number;
       if (n1 > 0 && n2 > 0 && n3 > 0) {
         const d = (Math.log(n1 + n2) - Math.log(n3)) / Math.log(2);
-        alpha = Math.exp(-4.6 * (d - 1));
-        alpha = Math.max(0.01, Math.min(1, alpha));
+        alpha = Math.max(0.01, Math.min(1, Math.exp(-4.6 * (d - 1))));
       } else {
         alpha = 0.01;
       }
@@ -179,7 +223,8 @@ export function createFrama(
         halfPeriod,
         source,
         prevFrama,
-        buffer: buffer.snapshot(),
+        highBuffer: highBuffer.snapshot(),
+        lowBuffer: lowBuffer.snapshot(),
         count,
       };
     },

--- a/packages/core/src/indicators/moving-average/frama.ts
+++ b/packages/core/src/indicators/moving-average/frama.ts
@@ -23,12 +23,19 @@ export type FramaOptions = {
 /**
  * Calculate Fractal Adaptive Moving Average
  *
- * FRAMA dynamically adjusts its alpha based on the fractal dimension:
- * 1. Split the period into two halves
- * 2. Calculate the range (max-min) for each half and the full period
- * 3. Compute fractal dimension D
- * 4. alpha = exp(-4.6 * (D - 1))
- * 5. FRAMA = alpha * price + (1 - alpha) * prev_FRAMA
+ * Canonical Ehlers FRAMA (2005 paper): the fractal-dimension calculation
+ * uses **candle highs and lows** (not the smoothing `source`) so the
+ * period-range slope reflects true price excursion, matching Pine Script
+ * `ta.frama()` and Ehlers' original `Highest(High, N/2) - Lowest(Low, N/2)`
+ * formulation.
+ *
+ * 1. Split the period into two halves of length N/2.
+ * 2. n1, n2, n3 = (HighestHigh - LowestLow) / length for each half + full.
+ * 3. D = (log(n1 + n2) - log(n3)) / log(2).
+ * 4. alpha = exp(-4.6 * (D - 1)), clamped to [0.01, 1].
+ * 5. FRAMA = alpha * source + (1 - alpha) * prevFRAMA.
+ *
+ * The `source` option only controls the price term in step 5.
  *
  * @param candles - Array of candles (raw or normalized)
  * @param options - FRAMA options
@@ -77,7 +84,10 @@ export function frama(
       continue;
     }
 
-    // Calculate high/low ranges for first half, second half, and full period
+    // Range calc uses the candle's high/low (Ehlers canonical) so the
+    // fractal-dimension input reflects true intrabar excursion rather
+    // than just the smoothing source. The source price still drives the
+    // FRAMA update step below.
     let h1High = Number.NEGATIVE_INFINITY;
     let h1Low = Number.POSITIVE_INFINITY;
     let h2High = Number.NEGATIVE_INFINITY;
@@ -86,18 +96,20 @@ export function frama(
     let fLow = Number.POSITIVE_INFINITY;
 
     for (let j = 0; j < effectivePeriod; j++) {
-      const p = getPrice(normalized[i - effectivePeriod + 1 + j], source);
+      const c = normalized[i - effectivePeriod + 1 + j];
+      const high = c.high;
+      const low = c.low;
 
       if (j < halfPeriod) {
-        h1High = Math.max(h1High, p);
-        h1Low = Math.min(h1Low, p);
+        if (high > h1High) h1High = high;
+        if (low < h1Low) h1Low = low;
       } else {
-        h2High = Math.max(h2High, p);
-        h2Low = Math.min(h2Low, p);
+        if (high > h2High) h2High = high;
+        if (low < h2Low) h2Low = low;
       }
 
-      fHigh = Math.max(fHigh, p);
-      fLow = Math.min(fLow, p);
+      if (high > fHigh) fHigh = high;
+      if (low < fLow) fLow = low;
     }
 
     const n1 = (h1High - h1Low) / halfPeriod;


### PR DESCRIPTION
## Summary

Two indicators were using formula variants that diverged from John Ehlers' published reference. The output difference is small at default parameters (<1% on Roofing at period=48; on FRAMA depending on candle wick width), but the names promise canonical filters and the JSDoc links to Ehlers' work — this aligns implementation to spec before 1.0.

This is a **breaking change**:

- Roofing Filter `highPassPeriod` minimum bumps from 1 to 2 (canonical formula diverges at 1).
- FRAMA fractal-dimension input changes from source price to candle high/low; output values shift on instruments where wicks differ from closes.
- Incremental FRAMA state schema changes (single `buffer` → `highBuffer` + `lowBuffer`). Pre-existing snapshots cannot be resumed; callers must re-warm from candle history.
- Incremental FRAMA `createFrama(options, { fromState })` now refuses resume with mismatched `period` or `source` (mathematically undefined for any recursive smoother).

Pre-1.0 breaking change is acceptable per the project's release practice for canonical alignment.

## Roofing Filter — canonical 2-pole high-pass

Switched from a Butterworth-shape coefficient form to Ehlers' canonical critically-damped recurrence (Cybernetic Analysis ch. 13 / Predictive Indicators paper):

```
theta  = sqrt(2) * pi / highPassPeriod
alpha1 = (cos(theta) + sin(theta) - 1) / cos(theta)
c1 = (1 - alpha1/2)^2
c2 = 2 * (1 - alpha1)
c3 = -(1 - alpha1)^2
HP[n] = c1*(P[n] - 2*P[n-1] + P[n-2]) + c2*HP[n-1] + c3*HP[n-2]
```

At `highPassPeriod = 48` (default) the new and old coefficients agree to < 1%, so user-visible behavior is essentially unchanged at canonical operating points. At shorter periods, the new form aligns with the published reference.

`highPassPeriod >= 2` because the canonical recurrence has both poles inside the unit circle for `period >= 2`, but diverges at `period = 1` (Nyquist degenerate).

## FRAMA — canonical Ehlers 2005

Fractal-dimension range calculation now uses each candle's `high` / `low`, matching `Highest(High, N/2) - Lowest(Low, N/2)` from the paper:

```ts
// Before: range over getPrice(candle, source)
// After:
for (const c of window) {
  if (c.high > maxHigh) maxHigh = c.high;
  if (c.low < minLow)   minLow = c.low;
}
```

The `source` option still drives the recursive smoothing step `prevFrama = alpha * source + (1 - alpha) * prevFrama` — `source` no longer affects the period-range slope inputs.

### State schema change

Incremental FRAMA `State` now has separate `highBuffer` / `lowBuffer` instead of a single source-price `buffer`. There is no clean migration: the close-only legacy buffer can't be reinterpreted as wick range, and any preservation of `prevFrama` would permanently bake the old non-canonical smoothing into the recurrence. Pre-existing snapshots are rejected with a clear re-warm message.

### Resume contract

`createFrama(options, { fromState })` now refuses to resume with a different `period` or `source`. FRAMA is a recursive smoother — changing those mid-stream is mathematically undefined. Callers must either pass identical params or omit them (in which case snapshot values are restored).

## Showcase test hook

`window.__showcase` exposed on the indicator-showcase example for AI-agent / e2e drivers (no DOM dependency). `add()` does remove-then-add so callers can reconfigure the active preset without manual cleanup, mirroring the sidebar's primary-instance behavior.

## Follow-up: State Contract Epic

This PR's redesign of FRAMA's resume policy (same-config-only, throw on schema mismatch) is the same conclusion the upcoming **library-wide State Contract Epic** will adopt for all recursive / mixed / cascaded indicators before 1.0. Tracked in internal notes; not included here to keep scope focused.

## Test plan

- [x] `pnpm test` — 5063 core + 832 chart pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — all packages succeed
- [x] Visual verification via agent-browser:
  - Roofing Filter: oscillates around zero in sub-pane (canonical bandpass behavior)
  - FRAMA: tracks steep moves quickly, smooths through consolidation (adaptive alpha)
- [x] Web search verified canonical formulas against Ehlers' references and TradingView community implementations