### PR TITLE
feat(core): McGinley Dynamic resume contract + canonical JSDoc

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
@@ -1216,6 +1216,62 @@ describe("McGinley Dynamic responds to price changes", () => {
     const md = createMcGinleyDynamic({ period: 3 }, { warmUp: candles });
     expect(md.isWarmedUp).toBe(true);
   });
+
+  // Resume contract: McGinley is recursive (single-pole) — `prevMd`
+  // permanently encodes past parameters, so reconfiguring on resume is
+  // mathematically undefined.
+  it("fromState restores period / k / source when options are not re-passed", () => {
+    const md1 = createMcGinleyDynamic({ period: 7, k: 0.4, source: "high" });
+    for (let i = 0; i < 10; i++) md1.next(makeCandle(i));
+    const state = md1.getState();
+
+    const md2 = createMcGinleyDynamic({}, { fromState: state });
+    expect(md2.getState().period).toBe(7);
+    expect(md2.getState().k).toBe(0.4);
+    expect(md2.getState().source).toBe("high");
+  });
+
+  it("refuses resume with a different period", () => {
+    const md1 = createMcGinleyDynamic({ period: 7 });
+    for (let i = 0; i < 10; i++) md1.next(makeCandle(i));
+    const state = md1.getState();
+
+    expect(() => createMcGinleyDynamic({ period: 14 }, { fromState: state })).toThrow(
+      /incompatible snapshot/,
+    );
+  });
+
+  it("refuses resume with a different k", () => {
+    const md1 = createMcGinleyDynamic({ period: 7, k: 0.6 });
+    for (let i = 0; i < 10; i++) md1.next(makeCandle(i));
+    const state = md1.getState();
+
+    expect(() => createMcGinleyDynamic({ period: 7, k: 1 }, { fromState: state })).toThrow(
+      /incompatible snapshot/,
+    );
+  });
+
+  it("refuses resume with a different source", () => {
+    const md1 = createMcGinleyDynamic({ period: 7, source: "close" });
+    for (let i = 0; i < 10; i++) md1.next(makeCandle(i));
+    const state = md1.getState();
+
+    expect(() =>
+      createMcGinleyDynamic({ period: 7, source: "high" }, { fromState: state }),
+    ).toThrow(/incompatible snapshot/);
+  });
+
+  it("peek matches next at every bar and does not mutate state", () => {
+    const md = createMcGinleyDynamic({ period: 4 });
+    for (let i = 0; i < 12; i++) {
+      const candle = makeCandle(i + 100);
+      const stateBeforePeek = JSON.stringify(md.getState());
+      const peeked = md.peek(candle);
+      expect(JSON.stringify(md.getState())).toBe(stateBeforePeek);
+      const advanced = md.next(candle);
+      expect(peeked.value).toEqual(advanced.value);
+    }
+  });
 });
 
 // --- CMF ---

--- a/packages/core/src/indicators/incremental/moving-average/mcginley-dynamic.ts
+++ b/packages/core/src/indicators/incremental/moving-average/mcginley-dynamic.ts
@@ -2,6 +2,12 @@
  * Incremental McGinley Dynamic
  *
  * MD[i] = MD[i-1] + (Price - MD[i-1]) / (k × period × (Price / MD[i-1])^4)
+ *
+ * State category: **Recursive** (single-pole). `prevMd` carries
+ * permanent dependence on past parameters, so resume-time reconfig
+ * (different period, k, or source) is mathematically undefined and
+ * refused. Pass identical options on resume, or omit them and let the
+ * snapshot's params win.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
@@ -33,19 +39,27 @@ export function createMcGinleyDynamic(
   options: { period?: number; k?: number; source?: PriceSource } = {},
   warmUpOptions?: WarmUpOptions<McGinleyDynamicState>,
 ): IncrementalIndicator<number | null, McGinleyDynamicState> {
-  const period = options.period ?? 14;
-  const k = options.k ?? 0.6;
-  const source: PriceSource = options.source ?? "close";
+  // Resume order: explicit option > snapshot value > canonical default.
+  const fs = warmUpOptions?.fromState ?? null;
+  const period = options.period ?? fs?.period ?? 14;
+  const k = options.k ?? fs?.k ?? 0.6;
+  const source: PriceSource = options.source ?? fs?.source ?? "close";
 
   let prevMd: number | null;
   let sum: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    prevMd = s.prevMd;
-    sum = s.sum;
-    count = s.count;
+  if (fs) {
+    // McGinley is recursive: `prevMd` carries past parameters forever,
+    // so reconfiguring on resume produces a hybrid series that doesn't
+    // match either fresh-with-old-options or fresh-with-new-options
+    // computed over the same candle history. Refuse explicitly.
+    if (fs.period !== period || fs.k !== k || fs.source !== source) {
+      throw new Error("McGinley Dynamic: incompatible snapshot, re-warm required");
+    }
+    prevMd = fs.prevMd;
+    sum = fs.sum;
+    count = fs.count;
   } else {
     prevMd = null;
     sum = 0;

--- a/packages/core/src/indicators/moving-average/mcginley-dynamic.ts
+++ b/packages/core/src/indicators/moving-average/mcginley-dynamic.ts
@@ -25,9 +25,21 @@ export type McGinleyDynamicOptions = {
 /**
  * Calculate McGinley Dynamic
  *
- * MD[i] = MD[i-1] + (Close - MD[i-1]) / (k × period × (Close / MD[i-1])^4)
+ * John R. McGinley, Jr.'s adaptive moving average. The original 1990
+ * formulation (Market Technicians Association Journal, 1997) uses just
+ * the period N:
  *
- * The initial seed is the SMA of the first `period` values.
+ *   MD[i] = MD[i-1] + (Price - MD[i-1]) / (N * (Price / MD[i-1])^4)
+ *
+ * The widely-used "improved" form adds a smoothing constant `k` to slow
+ * the response (k ≈ 0.6 is the de-facto convention on TradingView):
+ *
+ *   MD[i] = MD[i-1] + (Price - MD[i-1]) / (k * N * (Price / MD[i-1])^4)
+ *
+ * This implementation uses the improved k-form. Pass `k: 1` for the
+ * original 1990 form. Initial seed is the SMA of the first `period`
+ * values; some references seed with the first close instead — the
+ * difference fades after a few bars.
  *
  * @param candles - Array of candles (raw or normalized)
  * @param options - Options


### PR DESCRIPTION
## Summary

McGinley Dynamic is a single-pole recursive moving average — `prevMd` permanently encodes past parameters, so reconfiguring on resume is mathematically undefined. This PR pins that contract and clarifies the canonical formula in JSDoc.

This is the first **Phase 2C** indicator — applying the pre-emptive design rules drafted from prior canonical-alignment review iterations to keep review scope tight.

## Changes

- `createMcGinleyDynamic(options, { fromState })` now reads `period`, `k`, `source` from the snapshot when options are omitted, and throws on conflict (`"incompatible snapshot, re-warm required"`). Aligns with the Recursive-category policy that the upcoming State Contract Epic will adopt library-wide.
- JSDoc documents both formulations:
  - McGinley's original 1990 form: `MD = MD[1] + (Price - MD[1]) / (N * (Price/MD[1])^4)`
  - Improved form with `k = 0.6` default (this implementation): `MD = MD[1] + (Price - MD[1]) / (k * N * (Price/MD[1])^4)`
  - Pass `k: 1` for the original 1990 form.
- Invariant tests added:
  - `fromState` restores period / k / source when options are not re-passed
  - Resume with different period / k / source throws
  - `peek` matches `next` at every bar without mutating state

## What was NOT changed

- Formula (already canonical for the improved variant)
- Seed (SMA of first `period` values — documented variant; alternative is first-close seed used by some Pine implementations)
- Period minimum (no numerical stability issue at `period >= 1`)

## Notes on held P2

An audit suggested allowing `k` changes mid-warmup (while `prevMd === null`) since `k` hasn't influenced state yet. Held in favor of consistent strict-refuse semantics across all Recursive indicators — the lenient-mode question is a library-wide policy decision belonging to the State Contract Epic, not a per-indicator exception.

## Test plan

- [x] `pnpm test` — all pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — green
- [x] `pnpm size-check` — within 38 kB cap
- [x] Visual: agent-browser confirms McGinley(14) renders as smooth low-lag line tracking price
- [x] Web search verified canonical formula against McGinley's 1990 / 1997 publications and TradingView community implementations