### PR TITLE
feat(core): HMA resume contract + canonical JSDoc

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
@@ -436,6 +436,54 @@ describe("HMA (Hull Moving Average)", () => {
     const hma = createHma({ period: 4 }, { warmUp: candles });
     expect(hma.isWarmedUp).toBe(true);
   });
+
+  // Resume contract: HMA is cascaded — `finalWma` carries intermediate
+  // values that depend on `period`, so reconfig is refused.
+  it("fromState restores period / source when options are not re-passed", () => {
+    const hma1 = createHma({ period: 16, source: "high" });
+    for (let i = 0; i < 30; i++) hma1.next(makeCandle(i));
+    const state = hma1.getState();
+
+    const hma2 = createHma({}, { fromState: state });
+    expect(hma2.getState().period).toBe(16);
+    expect(hma2.getState().source).toBe("high");
+  });
+
+  it("refuses resume with a different period", () => {
+    const hma1 = createHma({ period: 16 });
+    for (let i = 0; i < 30; i++) hma1.next(makeCandle(i));
+    const state = hma1.getState();
+
+    expect(() => createHma({ period: 25 }, { fromState: state })).toThrow(/incompatible snapshot/);
+  });
+
+  it("refuses resume with a different source", () => {
+    const hma1 = createHma({ period: 16, source: "close" });
+    for (let i = 0; i < 30; i++) hma1.next(makeCandle(i));
+    const state = hma1.getState();
+
+    expect(() => createHma({ period: 16, source: "high" }, { fromState: state })).toThrow(
+      /incompatible snapshot/,
+    );
+  });
+
+  it("peek matches next at every bar and does not mutate state", () => {
+    const hma = createHma({ period: 4 });
+    // Drive past warmup to exercise both pre-warmup and steady-state branches.
+    for (let i = 0; i < 15; i++) {
+      const candle = makeCandle(i);
+      const stateBeforePeek = JSON.stringify(hma.getState());
+      const peeked = hma.peek(candle);
+      expect(JSON.stringify(hma.getState())).toBe(stateBeforePeek);
+      const advanced = hma.next(candle);
+      if (peeked.value === null) {
+        expect(advanced.value).toBe(null);
+      } else {
+        expect(advanced.value).not.toBe(null);
+        expect(peeked.value).toBeCloseTo(advanced.value!, 10);
+      }
+    }
+  });
 });
 
 // --- VWMA ---

--- a/packages/core/src/indicators/incremental/moving-average/hma.ts
+++ b/packages/core/src/indicators/incremental/moving-average/hma.ts
@@ -2,6 +2,13 @@
  * Incremental HMA (Hull Moving Average)
  *
  * HMA(n) = WMA(2 * WMA(n/2) - WMA(n), sqrt(n))
+ *
+ * State category: **Cascaded** (3 stacked WMAs). The inner half/full
+ * WMAs hold raw price buffers, but the outer `finalWma` holds
+ * intermediate `2*WMA(n/2) - WMA(n)` values whose meaning depends on
+ * `period`. Reconfiguring `period` mid-stream invalidates that
+ * intermediate buffer, so resume requires identical `period` and
+ * `source` (or omit them and let the snapshot's params win).
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
@@ -35,8 +42,10 @@ export function createHma(
   options: { period?: number; source?: PriceSource } = {},
   warmUpOptions?: WarmUpOptions<HmaState>,
 ): IncrementalIndicator<number | null, HmaState> {
-  const period = options.period ?? 9;
-  const source: PriceSource = options.source ?? "close";
+  // Resume order: explicit option > snapshot value > canonical default.
+  const fs = warmUpOptions?.fromState ?? null;
+  const period = options.period ?? fs?.period ?? 9;
+  const source: PriceSource = options.source ?? fs?.source ?? "close";
   const halfPeriod = Math.floor(period / 2);
   const sqrtPeriod = Math.floor(Math.sqrt(period));
 
@@ -45,12 +54,18 @@ export function createHma(
   let finalWma: ReturnType<typeof createWma>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    halfWma = createWma({ period: halfPeriod, source }, { fromState: s.halfWmaState });
-    fullWma = createWma({ period, source }, { fromState: s.fullWmaState });
-    finalWma = createWma({ period: sqrtPeriod }, { fromState: s.finalWmaState });
-    count = s.count;
+  if (fs) {
+    // HMA is a cascade: the outer `finalWma` carries intermediate
+    // `2*WMA(n/2) - WMA(n)` values whose semantics depend on `period`.
+    // Reconfiguring `period` invalidates those intermediates, so
+    // resume requires identical params.
+    if (fs.period !== period || fs.source !== source) {
+      throw new Error("HMA: incompatible snapshot, re-warm required");
+    }
+    halfWma = createWma({ period: halfPeriod, source }, { fromState: fs.halfWmaState });
+    fullWma = createWma({ period, source }, { fromState: fs.fullWmaState });
+    finalWma = createWma({ period: sqrtPeriod }, { fromState: fs.finalWmaState });
+    count = fs.count;
   } else {
     halfWma = createWma({ period: halfPeriod, source });
     fullWma = createWma({ period, source });

--- a/packages/core/src/indicators/moving-average/hma.ts
+++ b/packages/core/src/indicators/moving-average/hma.ts
@@ -24,13 +24,19 @@ export type HmaOptions = {
 /**
  * Calculate Hull Moving Average
  *
- * HMA = WMA(2 * WMA(n/2) - WMA(n), sqrt(n))
+ * Alan Hull's 2005 cascaded-WMA design that reduces lag while
+ * preserving smoothness. Canonical formula:
+ *
+ *   HMA(n) = WMA(2 * WMA(n/2) - WMA(n), sqrt(n))
  *
  * Steps:
  * 1. Calculate WMA with period n/2
  * 2. Calculate WMA with period n
  * 3. Compute 2 * WMA(n/2) - WMA(n) for each point
  * 4. Apply WMA with period sqrt(n) to the result
+ *
+ * `halfPeriod = floor(n/2)` and `sqrtPeriod = floor(sqrt(n))` match
+ * Pine Script's `ta.hma()` integer-truncation convention.
  *
  * @param candles - Array of candles (raw or normalized)
  * @param options - HMA options (period, source)


### PR DESCRIPTION
## Summary

HMA is a cascade of three WMAs (`WMA(2*WMA(n/2) - WMA(n), sqrt(n))`). While each inner WMA is windowed, the outer `finalWma` holds intermediate `2*WMA(n/2) - WMA(n)` values whose meaning depends on `period`. Reconfiguring `period` mid-stream invalidates that intermediate buffer, so this PR pins resume semantics.

**Phase 2C indicator 2/6.** Applies the Cascaded-category policy that the upcoming State Contract Epic will adopt library-wide.

## Changes

- `createHma(options, { fromState })` now reads `period` and `source` from the snapshot when options are omitted, and throws on conflict (`"incompatible snapshot, re-warm required"`).
- JSDoc references Alan Hull (2005) and documents the `floor(period/2)` / `floor(sqrt(period))` integer-truncation convention that matches Pine Script `ta.hma()`.
- Invariant tests added:
  - `fromState` restores period / source when options are not re-passed
  - Resume with different period / source throws
  - `peek` matches `next` at every bar without mutating state

## What was NOT changed

- Formula (already canonical: `WMA(2*WMA(n/2) - WMA(n), sqrt(n))`)
- Period minimum 2 (mathematically motivated; `halfPeriod=1, sqrtPeriod=1` still numerically stable)
- State schema (existing shape preserved)

## Test plan

- [x] `pnpm test` — all pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — green
- [x] `pnpm size-check` — within 38 kB cap
- [x] Visual: agent-browser confirms HMA(16) renders as smooth low-lag line tracking trend reversals quickly
- [x] Web search verified canonical formula against Alan Hull's 2005 publication and TradingView Pine Script `ta.hma()`