### PR TITLE
feat(core): KAMA resume contract + TA-Lib compatibility note

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
@@ -1231,6 +1231,76 @@ describe("KAMA adapts smoothing constant based on price efficiency", () => {
     const kama = createKama({ period: 3 }, { warmUp: candles });
     expect(kama.isWarmedUp).toBe(true);
   });
+
+  // Resume contract: KAMA is Mixed (price buffer + recursive prevKama).
+  // The recursive component permanently encodes past parameters so
+  // reconfiguring on resume is refused.
+  it("fromState restores period / source / fastSC / slowSC when options are omitted", () => {
+    const k1 = createKama({ period: 10, fastPeriod: 2, slowPeriod: 30, source: "high" });
+    for (let i = 0; i < 15; i++) k1.next(makeCandle(i));
+    const state = k1.getState();
+
+    const k2 = createKama({}, { fromState: state });
+    expect(k2.getState().period).toBe(10);
+    expect(k2.getState().source).toBe("high");
+    expect(k2.getState().fastSC).toBe(2 / 3);
+    expect(k2.getState().slowSC).toBe(2 / 31);
+  });
+
+  it("refuses resume with a different period", () => {
+    const k1 = createKama({ period: 10 });
+    for (let i = 0; i < 15; i++) k1.next(makeCandle(i));
+    const state = k1.getState();
+
+    expect(() => createKama({ period: 14 }, { fromState: state })).toThrow(/incompatible snapshot/);
+  });
+
+  it("refuses resume with a different fastPeriod", () => {
+    const k1 = createKama({ period: 10, fastPeriod: 2 });
+    for (let i = 0; i < 15; i++) k1.next(makeCandle(i));
+    const state = k1.getState();
+
+    expect(() => createKama({ period: 10, fastPeriod: 3 }, { fromState: state })).toThrow(
+      /incompatible snapshot/,
+    );
+  });
+
+  it("refuses resume with a different slowPeriod", () => {
+    const k1 = createKama({ period: 10, slowPeriod: 30 });
+    for (let i = 0; i < 15; i++) k1.next(makeCandle(i));
+    const state = k1.getState();
+
+    expect(() => createKama({ period: 10, slowPeriod: 40 }, { fromState: state })).toThrow(
+      /incompatible snapshot/,
+    );
+  });
+
+  it("refuses resume with a different source", () => {
+    const k1 = createKama({ period: 10, source: "close" });
+    for (let i = 0; i < 15; i++) k1.next(makeCandle(i));
+    const state = k1.getState();
+
+    expect(() => createKama({ period: 10, source: "high" }, { fromState: state })).toThrow(
+      /incompatible snapshot/,
+    );
+  });
+
+  it("peek matches next at every bar and does not mutate state", () => {
+    const kama = createKama({ period: 4 });
+    for (let i = 0; i < 15; i++) {
+      const candle = makeCandle(i + 100);
+      const stateBeforePeek = JSON.stringify(kama.getState());
+      const peeked = kama.peek(candle);
+      expect(JSON.stringify(kama.getState())).toBe(stateBeforePeek);
+      const advanced = kama.next(candle);
+      if (peeked.value === null) {
+        expect(advanced.value).toBe(null);
+      } else {
+        expect(advanced.value).not.toBe(null);
+        expect(peeked.value).toBeCloseTo(advanced.value!, 10);
+      }
+    }
+  });
 });
 
 // --- McGinley Dynamic ---

--- a/packages/core/src/indicators/incremental/moving-average/kama.ts
+++ b/packages/core/src/indicators/incremental/moving-average/kama.ts
@@ -2,6 +2,11 @@
  * Incremental KAMA (Kaufman Adaptive Moving Average)
  *
  * KAMA adapts smoothing speed based on Efficiency Ratio (ER).
+ *
+ * State category: **Mixed** (price buffer for ER + recursive
+ * `prevKama`). The recursive component permanently carries past
+ * parameters, so resume requires identical period, fastSC, slowSC,
+ * and source (or omit them and let the snapshot's params win).
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
@@ -35,21 +40,37 @@ export function createKama(
   options: { period?: number; fastPeriod?: number; slowPeriod?: number; source?: PriceSource } = {},
   warmUpOptions?: WarmUpOptions<KamaState>,
 ): IncrementalIndicator<number | null, KamaState> {
-  const period = options.period ?? 10;
-  const source: PriceSource = options.source ?? "close";
-  const fastSC = 2 / ((options.fastPeriod ?? 2) + 1);
-  const slowSC = 2 / ((options.slowPeriod ?? 30) + 1);
+  // Resume order: explicit option > snapshot value > canonical default.
+  // fastPeriod/slowPeriod aren't stored on state directly — fastSC and
+  // slowSC are. When the caller omits the period option, restore the
+  // SC from the snapshot; otherwise re-derive from the new period.
+  const fs = warmUpOptions?.fromState ?? null;
+  const period = options.period ?? fs?.period ?? 10;
+  const source: PriceSource = options.source ?? fs?.source ?? "close";
+  const fastSC =
+    options.fastPeriod !== undefined ? 2 / (options.fastPeriod + 1) : (fs?.fastSC ?? 2 / 3);
+  const slowSC =
+    options.slowPeriod !== undefined ? 2 / (options.slowPeriod + 1) : (fs?.slowSC ?? 2 / 31);
 
   // Need period+1 prices to compute direction and volatility
   let priceBuffer: CircularBuffer<number>;
   let prevKama: number | null;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    priceBuffer = CircularBuffer.fromSnapshot(s.priceBuffer);
-    prevKama = s.prevKama;
-    count = s.count;
+  if (fs) {
+    // KAMA is Mixed-recursive: `prevKama` carries past parameters
+    // forever, so reconfiguring mid-stream yields a hybrid series.
+    if (
+      fs.period !== period ||
+      fs.source !== source ||
+      fs.fastSC !== fastSC ||
+      fs.slowSC !== slowSC
+    ) {
+      throw new Error("KAMA: incompatible snapshot, re-warm required");
+    }
+    priceBuffer = CircularBuffer.fromSnapshot(fs.priceBuffer);
+    prevKama = fs.prevKama;
+    count = fs.count;
   } else {
     priceBuffer = new CircularBuffer<number>(period + 1);
     prevKama = null;

--- a/packages/core/src/indicators/moving-average/kama.ts
+++ b/packages/core/src/indicators/moving-average/kama.ts
@@ -29,12 +29,21 @@ export type KamaOptions = {
 /**
  * Calculate Kaufman Adaptive Moving Average
  *
- * Algorithm:
+ * Perry Kaufman's adaptive MA. The canonical configuration is
+ * KAMA(10, 2, 30) — 10-period efficiency ratio, fast EMA period 2,
+ * slow EMA period 30 (Kaufman 1995/2013):
+ *
  * 1. ER = |Price - Price[period]| / Sum(|Price[i] - Price[i-1]|, period)
- * 2. SC = (ER * (fastSC - slowSC) + slowSC)^2
- *    where fastSC = 2/(fastPeriod+1), slowSC = 2/(slowPeriod+1)
- * 3. KAMA seed = close[period-1] (TA-Lib compatible)
- * 4. KAMA = KAMA[prev] + SC * (Price - KAMA[prev])
+ * 2. fastSC = 2/(fastPeriod+1), slowSC = 2/(slowPeriod+1)
+ * 3. SC = (ER * (fastSC - slowSC) + slowSC)^2
+ * 4. KAMA seed = close[period-1] (TA-Lib compatible)
+ * 5. KAMA[i] = KAMA[i-1] + SC * (Price - KAMA[i-1])
+ *
+ * Note: TA-Lib hardcodes fast=2 / slow=30 internally and only exposes
+ * `timeperiod` (= our `period`). This implementation exposes
+ * `fastPeriod` / `slowPeriod` as options for flexibility while
+ * defaulting to TA-Lib's values. Output matches TA-Lib to 6 decimal
+ * places at default configuration.
  *
  * @param candles - Array of candles (raw or normalized)
  * @param options - KAMA options


### PR DESCRIPTION
## Summary

KAMA is **Mixed-recursive**: it keeps a raw price buffer for the efficiency-ratio calculation and a recursive `prevKama` that permanently carries past parameters. Reconfiguring `period`, `fastPeriod`, `slowPeriod`, or `source` mid-stream produces a hybrid series, so this PR pins resume to identical params.

**Phase 2C indicator 3/6.** Applies the Mixed-category policy that the upcoming State Contract Epic will adopt library-wide.

## Changes

- `createKama(options, { fromState })` now reads `period` / `source` / `fastSC` / `slowSC` from the snapshot when options are omitted, and throws on conflict (`"incompatible snapshot, re-warm required"`).
- JSDoc clarifies the TA-Lib relationship: TA-Lib hardcodes fast=2 / slow=30 and only exposes the ER period (`timeperiod`); this implementation exposes `fastPeriod` / `slowPeriod` as options for flexibility while defaulting to TA-Lib's values. Cross-validation already pins output to TA-Lib at 6 decimal places.
- Invariant tests added:
  - `fromState` restores period / source / fastSC / slowSC when options omitted
  - Resume with different period / fastPeriod / slowPeriod / source throws
  - `peek` matches `next` at every bar without mutating state

## What was NOT changed

- Formula (already canonical: ER → SC → KAMA recurrence)
- Seed: `close[period-1]` (TA-Lib compatible)
- Period defaults: KAMA(10, 2, 30) (Kaufman canonical)
- State schema (`fastSC` / `slowSC` retained; comparison happens on derived SC, not period)

## Test plan

- [x] `pnpm test` — all pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — green
- [x] `pnpm size-check` — within 38 kB cap
- [x] Visual: agent-browser confirms KAMA(10) shows canonical adaptive behavior (flat in ranging periods, responsive in trending)
- [x] Web search verified canonical formula against Kaufman 1995/2013 publications and TA-Lib reference