### PR TITLE
feat(core)!: Connors RSI resume contract + state schema source field

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import type { NormalizedCandle } from "../../../types";
+import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
 import { createAdxr } from "../momentum/adxr";
 import { createAroon } from "../momentum/aroon";
@@ -1643,6 +1643,95 @@ describe("Connors RSI streak tracking and composite value", () => {
     crsi.next({ ...makeCandle(0), close: 0 });
     const r = crsi.next(makeCandle(1));
     expect(r.value.rocPercentile).toBe(null);
+  });
+
+  // Resume contract: CRSI is Mixed/Cascaded — two recursive Wilder
+  // RSIs embed past periods, so reconfigure-on-resume is refused.
+  it("fromState restores rsiPeriod / streakPeriod / rocPeriod / source when options are omitted", () => {
+    const c1 = createConnorsRsi({ rsiPeriod: 3, streakPeriod: 2, rocPeriod: 5, source: "high" });
+    for (let i = 0; i < 15; i++) c1.next(makeCandle(i));
+    const state = c1.getState();
+
+    const c2 = createConnorsRsi({}, { fromState: state });
+    expect(c2.getState().rsiPeriod).toBe(3);
+    expect(c2.getState().streakPeriod).toBe(2);
+    expect(c2.getState().rocPeriod).toBe(5);
+    expect(c2.getState().source).toBe("high");
+  });
+
+  it("refuses resume with a different rsiPeriod", () => {
+    const c1 = createConnorsRsi({ rsiPeriod: 3, streakPeriod: 2, rocPeriod: 5 });
+    for (let i = 0; i < 15; i++) c1.next(makeCandle(i));
+    const state = c1.getState();
+
+    expect(() =>
+      createConnorsRsi({ rsiPeriod: 5, streakPeriod: 2, rocPeriod: 5 }, { fromState: state }),
+    ).toThrow(/incompatible snapshot/);
+  });
+
+  it("refuses resume with a different streakPeriod", () => {
+    const c1 = createConnorsRsi({ rsiPeriod: 3, streakPeriod: 2, rocPeriod: 5 });
+    for (let i = 0; i < 15; i++) c1.next(makeCandle(i));
+    const state = c1.getState();
+
+    expect(() =>
+      createConnorsRsi({ rsiPeriod: 3, streakPeriod: 3, rocPeriod: 5 }, { fromState: state }),
+    ).toThrow(/incompatible snapshot/);
+  });
+
+  it("refuses resume with a different rocPeriod", () => {
+    const c1 = createConnorsRsi({ rsiPeriod: 3, streakPeriod: 2, rocPeriod: 5 });
+    for (let i = 0; i < 15; i++) c1.next(makeCandle(i));
+    const state = c1.getState();
+
+    expect(() =>
+      createConnorsRsi({ rsiPeriod: 3, streakPeriod: 2, rocPeriod: 10 }, { fromState: state }),
+    ).toThrow(/incompatible snapshot/);
+  });
+
+  it("refuses resume with a different source", () => {
+    const c1 = createConnorsRsi({ rsiPeriod: 3, streakPeriod: 2, rocPeriod: 5, source: "close" });
+    for (let i = 0; i < 15; i++) c1.next(makeCandle(i));
+    const state = c1.getState();
+
+    expect(() =>
+      createConnorsRsi(
+        { rsiPeriod: 3, streakPeriod: 2, rocPeriod: 5, source: "high" },
+        { fromState: state },
+      ),
+    ).toThrow(/incompatible snapshot/);
+  });
+
+  it("peek matches next at every bar and does not mutate state", () => {
+    const crsi = createConnorsRsi({ rsiPeriod: 3, streakPeriod: 2, rocPeriod: 5 });
+    for (let i = 0; i < 20; i++) {
+      const candle = makeCandle(i);
+      const stateBeforePeek = JSON.stringify(crsi.getState());
+      const peeked = crsi.peek(candle);
+      expect(JSON.stringify(crsi.getState())).toBe(stateBeforePeek);
+      const advanced = crsi.next(candle);
+      // Both should agree on which sub-values are null vs numeric
+      expect(peeked.value.crsi === null).toBe(advanced.value.crsi === null);
+      if (peeked.value.crsi !== null && advanced.value.crsi !== null) {
+        expect(peeked.value.crsi).toBeCloseTo(advanced.value.crsi, 10);
+      }
+    }
+  });
+
+  // Pre-this-PR snapshots have no `source` field. They are not
+  // resumable — re-warm is required. (The natural source-equality
+  // check throws since `undefined !== <any-string>`.)
+  it("rejects pre-source snapshots regardless of options.source", () => {
+    const fresh = createConnorsRsi({ rsiPeriod: 3, streakPeriod: 2, rocPeriod: 5 });
+    for (let i = 0; i < 10; i++) fresh.next(makeCandle(i));
+    const legacy = { ...fresh.getState(), source: undefined as unknown as PriceSource };
+    expect(() => createConnorsRsi({}, { fromState: legacy })).toThrow(/incompatible snapshot/);
+    expect(() =>
+      createConnorsRsi(
+        { rsiPeriod: 3, streakPeriod: 2, rocPeriod: 5, source: "close" },
+        { fromState: legacy },
+      ),
+    ).toThrow(/incompatible snapshot/);
   });
 });
 

--- a/packages/core/src/indicators/incremental/momentum/connors-rsi.ts
+++ b/packages/core/src/indicators/incremental/momentum/connors-rsi.ts
@@ -2,6 +2,12 @@
  * Incremental Connors RSI (CRSI)
  *
  * CRSI = (RSI(close, rsiPeriod) + RSI(streak, streakPeriod) + PercentRank(ROC(1), rocPeriod)) / 3
+ *
+ * State category: **Mixed/Cascaded** (two internal RSI states using
+ * Wilder smoothing + a windowed ROC buffer + streak tracker). The
+ * recursive RSI components permanently encode past parameters, so
+ * resume requires identical `rsiPeriod`, `streakPeriod`, `rocPeriod`,
+ * and `source` (or omit them and let the snapshot's params win).
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
@@ -22,6 +28,7 @@ export type ConnorsRsiState = {
   rsiPeriod: number;
   streakPeriod: number;
   rocPeriod: number;
+  source: PriceSource;
   priceRsiState: RsiState;
   streakRsiState: RsiState;
   rocBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
@@ -51,10 +58,12 @@ export function createConnorsRsi(
   } = {},
   warmUpOptions?: WarmUpOptions<ConnorsRsiState>,
 ): IncrementalIndicator<ConnorsRsiValue, ConnorsRsiState> {
-  const rsiPeriod = options.rsiPeriod ?? 3;
-  const streakPeriod = options.streakPeriod ?? 2;
-  const rocPeriod = options.rocPeriod ?? 100;
-  const source: PriceSource = options.source ?? "close";
+  // Resume order: explicit option > snapshot value > canonical default.
+  const fs = warmUpOptions?.fromState ?? null;
+  const rsiPeriod = options.rsiPeriod ?? fs?.rsiPeriod ?? 3;
+  const streakPeriod = options.streakPeriod ?? fs?.streakPeriod ?? 2;
+  const rocPeriod = options.rocPeriod ?? fs?.rocPeriod ?? 100;
+  const source: PriceSource = options.source ?? fs?.source ?? "close";
 
   let priceRsi: ReturnType<typeof createRsi>;
   let streakRsi: ReturnType<typeof createRsi>;
@@ -63,14 +72,26 @@ export function createConnorsRsi(
   let streak: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    priceRsi = createRsi({ period: rsiPeriod, source }, { fromState: s.priceRsiState });
-    streakRsi = createRsi({ period: streakPeriod }, { fromState: s.streakRsiState });
-    rocBuffer = CircularBuffer.fromSnapshot(s.rocBuffer);
-    prevClose = s.prevClose;
-    streak = s.streak;
-    count = s.count;
+  if (fs) {
+    // CRSI is Mixed/Cascaded: two internal Wilder-RSI states
+    // permanently encode past parameters. Refuse all parameter changes
+    // on resume. Pre-this-PR snapshots (no `source` field, undefined !==
+    // any string) are naturally rejected by the equality check and
+    // surface the same re-warm message.
+    if (
+      fs.rsiPeriod !== rsiPeriod ||
+      fs.streakPeriod !== streakPeriod ||
+      fs.rocPeriod !== rocPeriod ||
+      fs.source !== source
+    ) {
+      throw new Error("Connors RSI: incompatible snapshot, re-warm required");
+    }
+    priceRsi = createRsi({ period: rsiPeriod, source }, { fromState: fs.priceRsiState });
+    streakRsi = createRsi({ period: streakPeriod }, { fromState: fs.streakRsiState });
+    rocBuffer = CircularBuffer.fromSnapshot(fs.rocBuffer);
+    prevClose = fs.prevClose;
+    streak = fs.streak;
+    count = fs.count;
   } else {
     priceRsi = createRsi({ period: rsiPeriod, source });
     streakRsi = createRsi({ period: streakPeriod });
@@ -181,6 +202,7 @@ export function createConnorsRsi(
         rsiPeriod,
         streakPeriod,
         rocPeriod,
+        source,
         priceRsiState: priceRsi.getState(),
         streakRsiState: streakRsi.getState(),
         rocBuffer: rocBuffer.snapshot(),

--- a/packages/core/src/indicators/momentum/connors-rsi.ts
+++ b/packages/core/src/indicators/momentum/connors-rsi.ts
@@ -46,12 +46,28 @@ export type ConnorsRsiValue = {
 /**
  * Calculate Connors RSI
  *
- * Components:
- * 1. RSI(close, rsiPeriod) — standard RSI of closing prices
- * 2. RSI(streak, streakPeriod) — RSI of consecutive up/down day streak
- * 3. PercentRank(ROC(1), rocPeriod) — percent rank of 1-day ROC over lookback
+ * Larry Connors' composite oscillator (2013 ebook "An Introduction to
+ * ConnorsRSI"). Combines three components:
  *
- * CRSI = (Component1 + Component2 + Component3) / 3
+ * 1. RSI(close, rsiPeriod=3) — Wilder-smoothed RSI of the price series
+ * 2. RSI(streak, streakPeriod=2) — RSI of the consecutive up/down
+ *    streak: +N for N consecutive up closes, -N for N consecutive
+ *    down closes, 0 for unchanged
+ * 3. PercentRank(ROC(1), rocPeriod=100) — ranks the current 1-bar ROC
+ *    against the prior `rocPeriod` ROCs as a percentage
+ *
+ *   CRSI = (Component1 + Component2 + Component3) / 3
+ *
+ * The result oscillates between 0 and 100. Connors' convention treats
+ * readings above 90 as overbought and below 10 as oversold.
+ *
+ * Note on percent-rank semantics: this implementation counts ROCs
+ * `<=` the current value (population-rank convention) and emits
+ * best-effort values during warmup using whatever samples are
+ * available. Pine Script's `ta.percentrank` uses strict `<` and waits
+ * for a full lookback. Both forms are seen in published references;
+ * pre-1.0 the library has not standardized one — tracked in the
+ * State Contract Epic notes.
  *
  * @param candles - Array of candles (raw or normalized)
  * @param options - Connors RSI options


### PR DESCRIPTION
## Summary

Connors RSI is **Mixed/Cascaded** — two internal Wilder-RSI states permanently encode past `rsiPeriod` / `streakPeriod`, and the `source` parameter feeds the price RSI's recursion. Reconfiguring any parameter mid-stream produces a hybrid series, so this PR pins resume to identical params.

**Phase 2C indicator 4/6.** Applies the Mixed/Cascaded-category policy that the upcoming State Contract Epic will adopt library-wide.

## Breaking change

`ConnorsRsiState` now includes a `source` field. Snapshots taken before this PR have no `source` and cannot be resumed: the old `priceRsiState` could have been computed with any source, and that information is not recoverable from the snapshot. Callers must re-warm from candle history.

Connors RSI is a niche short-term oscillator with limited persisted-state usage, so the pre-1.0 schema break is acceptable per the project's release practice for canonical alignment.

## Changes

- `createConnorsRsi(options, { fromState })` reads `rsiPeriod` / `streakPeriod` / `rocPeriod` / `source` from the snapshot when options are omitted, and throws on mismatch (`"incompatible snapshot, re-warm required"`). Legacy snapshots (`source === undefined`) trigger the same throw via the natural source-equality check.
- JSDoc references Larry Connors' 2013 ebook "An Introduction to ConnorsRSI" and documents the three components precisely.
- JSDoc notes the percent-rank semantics variant (population `<=` vs Pine Script's strict `<`, partial-warmup vs full-lookback) is a library-wide policy question deferred to the State Contract Epic.
- Invariant tests added:
  - `fromState` restores rsiPeriod / streakPeriod / rocPeriod / source when options are omitted
  - Resume with different rsiPeriod / streakPeriod / rocPeriod / source throws
  - Pre-source snapshots throw regardless of options.source
  - `peek` matches `next` at every bar without mutating state

## What was NOT changed

- Formula (`(RSI(close, 3) + RSI(streak, 2) + PercentRank(ROC(1), 100)) / 3`)
- Percent-rank semantics (held — deferred to State Contract Epic as library-wide policy)
- Default periods: (3, 2, 100) (Connors canonical)

## Test plan

- [x] `pnpm test` — all pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — green
- [x] `pnpm size-check` — within 38 kB cap
- [x] Visual: agent-browser confirms CRSI renders as sub-pane 0-100 oscillator
- [x] Web search verified canonical formula against Larry Connors 2013 publication, StockCharts ChartSchool, and Backtrader reference implementation