### PR TITLE
feat(core): Klinger Volume Oscillator resume contract + canonical JSDoc

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/new-indicators.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/new-indicators.test.ts
@@ -308,6 +308,59 @@ describe("Klinger incremental", () => {
       }
     }
   });
+
+  // Resume contract: Cascaded (3 internal recursive EMAs).
+  it("fromState restores shortPeriod / longPeriod / signalPeriod when options are omitted", () => {
+    const ind1 = createKlinger({ shortPeriod: 20, longPeriod: 40, signalPeriod: 9 });
+    for (let i = 0; i < 50; i++) ind1.next(candles[i]);
+    const state = ind1.getState();
+
+    const ind2 = createKlinger({}, { fromState: state });
+    expect(ind2.getState().shortPeriod).toBe(20);
+    expect(ind2.getState().longPeriod).toBe(40);
+    expect(ind2.getState().signalPeriod).toBe(9);
+  });
+
+  it("refuses resume with a different shortPeriod", () => {
+    const ind1 = createKlinger({ shortPeriod: 34, longPeriod: 55, signalPeriod: 13 });
+    for (let i = 0; i < 50; i++) ind1.next(candles[i]);
+    const state = ind1.getState();
+    expect(() =>
+      createKlinger({ shortPeriod: 20, longPeriod: 55, signalPeriod: 13 }, { fromState: state }),
+    ).toThrow(/incompatible snapshot/);
+  });
+
+  it("refuses resume with a different longPeriod", () => {
+    const ind1 = createKlinger({ shortPeriod: 34, longPeriod: 55, signalPeriod: 13 });
+    for (let i = 0; i < 50; i++) ind1.next(candles[i]);
+    const state = ind1.getState();
+    expect(() =>
+      createKlinger({ shortPeriod: 34, longPeriod: 80, signalPeriod: 13 }, { fromState: state }),
+    ).toThrow(/incompatible snapshot/);
+  });
+
+  it("refuses resume with a different signalPeriod", () => {
+    const ind1 = createKlinger({ shortPeriod: 34, longPeriod: 55, signalPeriod: 13 });
+    for (let i = 0; i < 50; i++) ind1.next(candles[i]);
+    const state = ind1.getState();
+    expect(() =>
+      createKlinger({ shortPeriod: 34, longPeriod: 55, signalPeriod: 9 }, { fromState: state }),
+    ).toThrow(/incompatible snapshot/);
+  });
+
+  it("peek matches next at every bar and does not mutate state", () => {
+    const ind = createKlinger();
+    for (let i = 0; i < 100; i++) {
+      const stateBeforePeek = JSON.stringify(ind.getState());
+      const peeked = ind.peek(candles[i]);
+      expect(JSON.stringify(ind.getState())).toBe(stateBeforePeek);
+      const advanced = ind.next(candles[i]);
+      expect(peeked.value.kvo === null).toBe(advanced.value.kvo === null);
+      if (peeked.value.kvo !== null && advanced.value.kvo !== null) {
+        expect(peeked.value.kvo).toBeCloseTo(advanced.value.kvo, 10);
+      }
+    }
+  });
 });
 
 // ---- DEMA ----

--- a/packages/core/src/indicators/incremental/volume/klinger.ts
+++ b/packages/core/src/indicators/incremental/volume/klinger.ts
@@ -2,6 +2,11 @@
  * Incremental Klinger Volume Oscillator (KVO)
  *
  * Computes Volume Force → short/long EMA → KVO = short - long → signal = EMA(KVO).
+ *
+ * State category: **Cascaded** (three internal EMAs, each
+ * single-pole recursive). The EMAs permanently encode past periods,
+ * so resume requires identical `shortPeriod`, `longPeriod`, and
+ * `signalPeriod` (or omit them and let the snapshot's params win).
  */
 
 import type { NormalizedCandle } from "../../../types";
@@ -100,9 +105,11 @@ export function createKlinger(
   options: { shortPeriod?: number; longPeriod?: number; signalPeriod?: number } = {},
   warmUpOptions?: WarmUpOptions<KlingerState>,
 ): IncrementalIndicator<KlingerValue, KlingerState> {
-  const shortPeriod = options.shortPeriod ?? 34;
-  const longPeriod = options.longPeriod ?? 55;
-  const signalPeriod = options.signalPeriod ?? 13;
+  // Resume order: explicit option > snapshot value > canonical default.
+  const fs = warmUpOptions?.fromState ?? null;
+  const shortPeriod = options.shortPeriod ?? fs?.shortPeriod ?? 34;
+  const longPeriod = options.longPeriod ?? fs?.longPeriod ?? 55;
+  const signalPeriod = options.signalPeriod ?? fs?.signalPeriod ?? 13;
 
   let prevHlc: number | null;
   let prevTrend: number;
@@ -112,15 +119,23 @@ export function createKlinger(
   let signalEma: ReturnType<typeof createInternalEma>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    prevHlc = s.prevHlc;
-    prevTrend = s.prevTrend;
-    cm = s.cm;
-    shortEma = createInternalEma(shortPeriod, s.shortEma);
-    longEma = createInternalEma(longPeriod, s.longEma);
-    signalEma = createInternalEma(signalPeriod, s.signalEma);
-    count = s.count;
+  if (fs) {
+    // Cascaded: three internal recursive EMAs permanently encode past
+    // periods, so reconfiguring mid-stream produces a hybrid series.
+    if (
+      fs.shortPeriod !== shortPeriod ||
+      fs.longPeriod !== longPeriod ||
+      fs.signalPeriod !== signalPeriod
+    ) {
+      throw new Error("Klinger: incompatible snapshot, re-warm required");
+    }
+    prevHlc = fs.prevHlc;
+    prevTrend = fs.prevTrend;
+    cm = fs.cm;
+    shortEma = createInternalEma(shortPeriod, fs.shortEma);
+    longEma = createInternalEma(longPeriod, fs.longEma);
+    signalEma = createInternalEma(signalPeriod, fs.signalEma);
+    count = fs.count;
   } else {
     prevHlc = null;
     prevTrend = 1;

--- a/packages/core/src/indicators/volume/klinger.ts
+++ b/packages/core/src/indicators/volume/klinger.ts
@@ -37,12 +37,27 @@ export type KlingerOptions = {
 /**
  * Calculate Klinger Volume Oscillator
  *
- * 1. Trend (T) = +1 if (H+L+C) > prev(H+L+C), else -1
- * 2. dm = H - L
- * 3. cm = accumulates dm when trend continues, resets when trend reverses
- * 4. Volume Force (VF) = Volume × |2×(dm/cm) - 1| × T × 100
- * 5. KVO = EMA(VF, short) - EMA(VF, long)
- * 6. Signal = EMA(KVO, signal)
+ * Stephen J. Klinger's volume oscillator (1997 Stocks & Commodities
+ * article). The default (34, 55, 13) parameters are Klinger's own.
+ *
+ * 1. Key Price = High + Low + Close
+ * 2. Trend (T) = +1 if Key Price > prev Key Price, else -1
+ * 3. DM = High - Low (daily range)
+ * 4. CM (cumulative measurement):
+ *    - same trend: CM = prev CM + DM
+ *    - trend reversal: CM = DM (this implementation; the original
+ *      paper specifies CM = prev DM + DM. Both forms are seen in
+ *      published implementations and produce nearly identical
+ *      oscillator shapes at default periods. Held to avoid a breaking
+ *      VF-magnitude shift; pin the variant in JSDoc as a documented
+ *      choice.)
+ * 5. Volume Force (VF) = Volume × |2 × (DM / CM) − 1| × T × 100
+ * 6. KVO = EMA(VF, shortPeriod) − EMA(VF, longPeriod)
+ * 7. Signal = EMA(KVO, signalPeriod)
+ *
+ * The Key Price is intentionally the **sum** H+L+C (not HLC/3) — only
+ * its sign of change matters for trend determination, so the divisor
+ * is a no-op.
  *
  * @param candles - Array of candles (raw or normalized)
  * @param options - Options


### PR DESCRIPTION
## Summary

Klinger Volume Oscillator is **Cascaded** — three internal recursive EMAs (short, long, signal) permanently encode past `shortPeriod` / `longPeriod` / `signalPeriod`. Reconfiguring any of those mid-stream produces a hybrid series, so this PR pins resume to identical params.

**Phase 2C indicator 5/6.** Applies the Cascaded-category policy that the upcoming State Contract Epic will adopt library-wide.

## Changes

- `createKlinger(options, { fromState })` reads `shortPeriod` / `longPeriod` / `signalPeriod` from the snapshot when options are omitted, and throws on mismatch (`"incompatible snapshot, re-warm required"`).
- JSDoc references Stephen Klinger's 1997 Stocks & Commodities article and clarifies:
  - Key Price = `H + L + C` (sum, not `/3` — only its sign of change is used, so a divisor would be a no-op)
  - Default `(34, 55, 13)` is Klinger's own parameter choice
  - CM reset on reversal: this implementation uses `cm = dm`; the original paper specifies `cm = prev_dm + dm`. Both forms are seen in published implementations and produce nearly identical oscillator shapes at default periods. Variant held to avoid a breaking VF-magnitude shift.
- Invariant tests added:
  - `fromState` restores shortPeriod / longPeriod / signalPeriod when options are omitted
  - Resume with different short / long / signal periods throws
  - `peek` matches `next` at every bar without mutating state

## What was NOT changed

- VF / CM / Trend formulas (already canonical for the documented variant)
- Default periods `(34, 55, 13)` (Klinger canonical)
- State schema (existing shape preserved)

## Test plan

- [x] `pnpm test` — all pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — green
- [x] `pnpm size-check` — within 38 kB cap
- [x] Visual: agent-browser confirms Klinger sub-pane shows canonical KVO + signal + histogram
- [x] Web search verified formula against Stephen Klinger's 1997 publication and multiple secondary references (StockManiacs, MotiveWave, LightingChart, daytrading.com)