### PR TITLE
feat(core): Schaff Trend Cycle factor option + resume contract

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/momentum-indicators.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/momentum-indicators.test.ts
@@ -349,8 +349,99 @@ describe("STC incremental", () => {
     );
     assertConsistency(batch, incremental, 1e-8);
   });
+
+  it("batch and incremental agree on non-default factor", () => {
+    // Pins the fix for the previously-hardcoded batch factor: passing
+    // factor=0.7 must yield the same series in both APIs.
+    const opts = { fastPeriod: 23, slowPeriod: 50, cyclePeriod: 10, factor: 0.7 };
+    const batch = schaffTrendCycle(candles, opts);
+    const incremental = processAll(createStc(opts), candles);
+    assertConsistency(batch, incremental, 1e-8);
+  });
+
   it("peek does not mutate state", () =>
     peekTest(createStc, [{ fastPeriod: 23, slowPeriod: 50, cyclePeriod: 10 }], 80));
   it("getState/fromState restores correctly", () =>
     stateRestoreTest(createStc, [{ fastPeriod: 23, slowPeriod: 50, cyclePeriod: 10 }], 90));
+
+  // Resume contract: Cascaded category — two recursive EMAs and two
+  // recursive stoch smoothings permanently encode past parameters.
+  it("fromState restores all params when options are omitted", () => {
+    const s1 = createStc({
+      fastPeriod: 12,
+      slowPeriod: 26,
+      cyclePeriod: 7,
+      factor: 0.4,
+      source: "high",
+    });
+    for (let i = 0; i < 80; i++) s1.next(candles[i]);
+    const state = s1.getState();
+
+    const s2 = createStc({}, { fromState: state });
+    expect(s2.getState().fastPeriod).toBe(12);
+    expect(s2.getState().slowPeriod).toBe(26);
+    expect(s2.getState().cyclePeriod).toBe(7);
+    expect(s2.getState().factor).toBe(0.4);
+    expect(s2.getState().source).toBe("high");
+  });
+
+  it("refuses resume with a different fastPeriod", () => {
+    const s1 = createStc({ fastPeriod: 23, slowPeriod: 50, cyclePeriod: 10 });
+    for (let i = 0; i < 80; i++) s1.next(candles[i]);
+    expect(() =>
+      createStc({ fastPeriod: 12, slowPeriod: 50, cyclePeriod: 10 }, { fromState: s1.getState() }),
+    ).toThrow(/incompatible snapshot/);
+  });
+
+  it("refuses resume with a different slowPeriod", () => {
+    const s1 = createStc({ fastPeriod: 23, slowPeriod: 50, cyclePeriod: 10 });
+    for (let i = 0; i < 80; i++) s1.next(candles[i]);
+    expect(() =>
+      createStc({ fastPeriod: 23, slowPeriod: 100, cyclePeriod: 10 }, { fromState: s1.getState() }),
+    ).toThrow(/incompatible snapshot/);
+  });
+
+  it("refuses resume with a different cyclePeriod", () => {
+    const s1 = createStc({ fastPeriod: 23, slowPeriod: 50, cyclePeriod: 10 });
+    for (let i = 0; i < 80; i++) s1.next(candles[i]);
+    expect(() =>
+      createStc({ fastPeriod: 23, slowPeriod: 50, cyclePeriod: 20 }, { fromState: s1.getState() }),
+    ).toThrow(/incompatible snapshot/);
+  });
+
+  it("refuses resume with a different factor", () => {
+    const s1 = createStc({ fastPeriod: 23, slowPeriod: 50, cyclePeriod: 10, factor: 0.5 });
+    for (let i = 0; i < 80; i++) s1.next(candles[i]);
+    expect(() =>
+      createStc(
+        { fastPeriod: 23, slowPeriod: 50, cyclePeriod: 10, factor: 0.7 },
+        { fromState: s1.getState() },
+      ),
+    ).toThrow(/incompatible snapshot/);
+  });
+
+  it("refuses resume with a different source", () => {
+    const s1 = createStc({ fastPeriod: 23, slowPeriod: 50, cyclePeriod: 10, source: "close" });
+    for (let i = 0; i < 80; i++) s1.next(candles[i]);
+    expect(() =>
+      createStc(
+        { fastPeriod: 23, slowPeriod: 50, cyclePeriod: 10, source: "high" },
+        { fromState: s1.getState() },
+      ),
+    ).toThrow(/incompatible snapshot/);
+  });
+
+  // Validation must match the batch indicator's so the same options
+  // object behaves identically across both APIs.
+  it("rejects invalid factor (<=0 or >1) just like the batch indicator", () => {
+    expect(() => createStc({ factor: 0 })).toThrow(/factor must be in/);
+    expect(() => createStc({ factor: -0.1 })).toThrow(/factor must be in/);
+    expect(() => createStc({ factor: 1.5 })).toThrow(/factor must be in/);
+  });
+
+  it("rejects invalid periods (<1) just like the batch indicator", () => {
+    expect(() => createStc({ fastPeriod: 0 })).toThrow(/periods must be at least 1/);
+    expect(() => createStc({ slowPeriod: 0 })).toThrow(/periods must be at least 1/);
+    expect(() => createStc({ cyclePeriod: 0 })).toThrow(/periods must be at least 1/);
+  });
 });

--- a/packages/core/src/indicators/incremental/momentum/schaff-trend-cycle.ts
+++ b/packages/core/src/indicators/incremental/momentum/schaff-trend-cycle.ts
@@ -1,10 +1,17 @@
 /**
  * Incremental Schaff Trend Cycle (STC)
  *
- * Combines MACD with double Stochastic smoothing:
+ * Doug Schaff's 1999 momentum oscillator. Combines MACD with double
+ * Stochastic smoothing:
  * 1. MACD = EMA(fast) - EMA(slow)
  * 2. Stochastic of MACD over cyclePeriod → smooth with factor → PF
  * 3. Stochastic of PF over cyclePeriod → smooth with factor → STC
+ *
+ * State category: **Cascaded** (two recursive EMAs + two recursive
+ * stochastic smoothings + two windowed buffers). The recursive
+ * components permanently encode past parameters, so resume requires
+ * identical `fastPeriod`, `slowPeriod`, `cyclePeriod`, `factor`, and
+ * `source` (or omit them and let the snapshot's params win).
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
@@ -55,11 +62,23 @@ export function createStc(
   } = {},
   warmUpOptions?: WarmUpOptions<StcState>,
 ): IncrementalIndicator<number | null, StcState> {
-  const fastPeriod = options.fastPeriod ?? 23;
-  const slowPeriod = options.slowPeriod ?? 50;
-  const cyclePeriod = options.cyclePeriod ?? 10;
-  const factor = options.factor ?? 0.5;
-  const source: PriceSource = options.source ?? "close";
+  // Resume order: explicit option > snapshot value > canonical default.
+  const fs = warmUpOptions?.fromState ?? null;
+  const fastPeriod = options.fastPeriod ?? fs?.fastPeriod ?? 23;
+  const slowPeriod = options.slowPeriod ?? fs?.slowPeriod ?? 50;
+  const cyclePeriod = options.cyclePeriod ?? fs?.cyclePeriod ?? 10;
+  const factor = options.factor ?? fs?.factor ?? 0.5;
+  const source: PriceSource = options.source ?? fs?.source ?? "close";
+
+  // Validate parameters identically to the batch indicator so the same
+  // options object behaves the same in both APIs.
+  if (fastPeriod < 1 || slowPeriod < 1 || cyclePeriod < 1) {
+    throw new Error("Schaff Trend Cycle periods must be at least 1");
+  }
+  if (factor <= 0 || factor > 1) {
+    throw new Error("Schaff Trend Cycle factor must be in (0, 1]");
+  }
+
   const fastMult = 2 / (fastPeriod + 1);
   const slowMult = 2 / (slowPeriod + 1);
 
@@ -75,19 +94,30 @@ export function createStc(
   let firstStcDone: boolean;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    fastEma = s.fastEma;
-    slowEma = s.slowEma;
-    fastSum = s.fastSum;
-    slowSum = s.slowSum;
-    macdBuffer = CircularBuffer.fromSnapshot(s.macdBuffer);
-    prevPf = s.prevPf;
-    pfBuffer = CircularBuffer.fromSnapshot(s.pfBuffer);
-    prevStc = s.prevStc;
-    firstPfDone = s.firstPfDone;
-    firstStcDone = s.firstStcDone;
-    count = s.count;
+  if (fs) {
+    // Cascaded: two recursive EMAs + two recursive stochastic
+    // smoothings permanently encode past parameters, so reconfiguring
+    // on resume produces a hybrid series.
+    if (
+      fs.fastPeriod !== fastPeriod ||
+      fs.slowPeriod !== slowPeriod ||
+      fs.cyclePeriod !== cyclePeriod ||
+      fs.factor !== factor ||
+      fs.source !== source
+    ) {
+      throw new Error("Schaff Trend Cycle: incompatible snapshot, re-warm required");
+    }
+    fastEma = fs.fastEma;
+    slowEma = fs.slowEma;
+    fastSum = fs.fastSum;
+    slowSum = fs.slowSum;
+    macdBuffer = CircularBuffer.fromSnapshot(fs.macdBuffer);
+    prevPf = fs.prevPf;
+    pfBuffer = CircularBuffer.fromSnapshot(fs.pfBuffer);
+    prevStc = fs.prevStc;
+    firstPfDone = fs.firstPfDone;
+    firstStcDone = fs.firstStcDone;
+    count = fs.count;
   } else {
     fastEma = null;
     slowEma = null;

--- a/packages/core/src/indicators/trend/schaff-trend-cycle.ts
+++ b/packages/core/src/indicators/trend/schaff-trend-cycle.ts
@@ -19,6 +19,12 @@ export type SchaffTrendCycleOptions = {
   slowPeriod?: number;
   /** Stochastic cycle period (default: 10) */
   cyclePeriod?: number;
+  /**
+   * Smoothing factor for both stochastic passes (default: 0.5).
+   * Doug Schaff's published value; range [0, 1]. Lower values produce
+   * smoother but more lagged output.
+   */
+  factor?: number;
   /** Price source (default: 'close') */
   source?: PriceSource;
 };
@@ -26,15 +32,27 @@ export type SchaffTrendCycleOptions = {
 /**
  * Calculate Schaff Trend Cycle
  *
- * 1. Calculate MACD line (fast EMA - slow EMA)
- * 2. Apply Stochastic on MACD (first stochastic pass)
- * 3. Apply Stochastic again on the result (second stochastic pass)
- * 4. Result is bounded between 0-100
+ * Doug Schaff's 1999 momentum oscillator. Combines MACD with a
+ * double-smoothed stochastic to identify cyclic trend changes with
+ * less lag than MACD alone. Default `(23, 50, 10)` is Schaff's own
+ * parameter set; smoothing `factor = 0.5` is the canonical value.
  *
- * Interpretation:
- * - Above 75: Overbought / uptrend
- * - Below 25: Oversold / downtrend
- * - Crossings of 25 and 75 signal trend changes
+ * Algorithm:
+ * 1. MACD = `EMA(price, fastPeriod) - EMA(price, slowPeriod)`
+ * 2. First stochastic over `cyclePeriod`:
+ *    - `%K1 = 100 × (MACD - min) / (max - min)`
+ *    - `PF = prevPF + factor × (%K1 - prevPF)` (EMA-style smoothing)
+ * 3. Second stochastic over `cyclePeriod` (on PF):
+ *    - `%K2 = 100 × (PF - min) / (max - min)`
+ *    - `STC = prevSTC + factor × (%K2 - prevSTC)`
+ *
+ * Output bounded to 0-100. Conventional thresholds: > 75 overbought,
+ * < 25 oversold; crossings of 25 / 75 signal trend changes.
+ *
+ * Degenerate-range fallback: when min == max in a stochastic window,
+ * the smoothed value carries forward (no division-by-zero). This
+ * matches the de-facto implementations across Pine Script community
+ * scripts and stockindicators.dev.
  *
  * @param candles - Array of candles (raw or normalized)
  * @param options - STC options
@@ -50,10 +68,19 @@ export function schaffTrendCycle(
   candles: Candle[] | NormalizedCandle[],
   options: SchaffTrendCycleOptions = {},
 ): Series<number | null> {
-  const { fastPeriod = 23, slowPeriod = 50, cyclePeriod = 10, source = "close" } = options;
+  const {
+    fastPeriod = 23,
+    slowPeriod = 50,
+    cyclePeriod = 10,
+    factor = 0.5,
+    source = "close",
+  } = options;
 
   if (fastPeriod < 1 || slowPeriod < 1 || cyclePeriod < 1) {
     throw new Error("Schaff Trend Cycle periods must be at least 1");
+  }
+  if (factor <= 0 || factor > 1) {
+    throw new Error("Schaff Trend Cycle factor must be in (0, 1]");
   }
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
@@ -96,7 +123,7 @@ export function schaffTrendCycle(
 
   // Apply exponentially smoothed stochastic to a nullable series
   function stochSmooth(input: (number | null)[]): (number | null)[] {
-    const smoothFactor = 0.5;
+    const smoothFactor = factor;
     const output: (number | null)[] = new Array(input.length).fill(null);
     let prevSmoothed = 0;
 
@@ -144,6 +171,7 @@ export function schaffTrendCycle(
       fastPeriod,
       slowPeriod,
       cyclePeriod,
+      factor,
     ]),
   );
 }


### PR DESCRIPTION
## Summary

STC's batch implementation hardcoded the stochastic smoothing factor at 0.5 while the incremental implementation already accepted it as an option. **Same options object produced different output across the two APIs.** This PR aligns them and tightens resume semantics for the cascaded indicator stack.

**Phase 2C indicator 6/6 — closes Phase 2C canonical alignment.**

## Changes

- Batch `schaffTrendCycle()` adds `factor?: number` option (default `0.5`, Doug Schaff's canonical value). Existing callers see no change because the previous hardcoded value matches the new default.
- Validation added in both APIs: periods >= 1, factor in `(0, 1]`.
- `createStc(options, { fromState })` reads `fastPeriod` / `slowPeriod` / `cyclePeriod` / `factor` / `source` from the snapshot when options are omitted, and throws on mismatch (`"incompatible snapshot, re-warm required"`). STC is **Cascaded** — two recursive EMAs plus two recursive stochastic smoothings all encode past parameters.
- JSDoc references Doug Schaff (1999), documents the algorithm precisely, and notes the degenerate-range fallback (carry forward prev smoothed when min == max).
- Batch series label now includes `factor` so charts / caches keyed on `__meta.label` distinguish variants with the same periods but different factors.
- Invariant tests added:
  - Batch and incremental agree on non-default factor (regression pin for the previously-hardcoded factor)
  - `fromState` restores all 5 params when options are omitted
  - Resume with different fastPeriod / slowPeriod / cyclePeriod / factor / source throws (5 individual tests)
  - Invalid factor / period inputs throw identically in both APIs

## What was NOT changed

- Algorithm (already canonical: MACD → stochastic → smooth → stochastic → smooth)
- Default periods `(23, 50, 10)` and factor `0.5` (Doug Schaff canonical)
- State schema (existing shape already had all 5 params for comparison)
- Degenerate-range fallback (carry forward prev smoothed — matches Pine community / stockindicators.dev convention)

## Test plan

- [x] `pnpm test` — all pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — green
- [x] `pnpm size-check` — within 38 kB cap
- [x] Visual: agent-browser confirms STC(23, 50, 10) renders as canonical sub-pane 0-100 oscillator with 25 / 75 reference lines
- [x] Web search verified canonical algorithm against Doug Schaff's 1999 publication, stockindicators.dev, LiteFinance, and TradingPedia references