### PR TITLE
feat(core): partial defaults in resolveResume + requireParam helper

### DIFF
--- a/packages/core/docs/STATE_CONTRACT.md
+++ b/packages/core/docs/STATE_CONTRACT.md
@@ -331,7 +331,55 @@ commit at 0.4.0 release time.
 - **Schema introspection for tooling** (UI that knows what params
   each indicator's snapshot has).
 
-## 8. Decisions made (Phase 0 sign-off)
+## 8. Phase 2 per-indicator migration checklist
+
+Every indicator migration in Phase 2 must hit each of these so the
+contract is enforced uniformly. Drift here is what produces "type-safe
+looking" bugs where `params.period: number` is actually `undefined` at
+runtime.
+
+1. **Categorize.** Decide A/B/C/D/E (see §2.3).
+2. **Strip param fields from bare state.** `period`, `source`, etc.
+   live in `meta.params` now, not in the state object.
+3. **Bump `version` to `1`** in the constructor's `resolveResume` call.
+4. **Pick defaults honestly.** If a param has no canonical default
+   (SMA's `period`, etc.), omit it from `defaults` — do not invent a
+   placeholder. The helper accepts `Partial<TParams>`.
+5. **Validate required-but-defaultless params with `requireParam`.**
+   Immediately after `resolveResume`. Without this, the typed
+   `params.period: number` could be `undefined` at runtime.
+   ```ts
+   const { params, state } = resolveResume<SmaParams, SmaState>({
+     indicator: "sma",
+     defaults: { source: "close" },
+     ...
+   });
+   const period = requireParam(
+     "sma",
+     params,
+     "period",
+     (v): v is number => Number.isInteger(v) && v >= 1,
+     "must be a positive integer",
+   );
+   ```
+6. **Handle `reconfigured` for windowed/event indicators.** Rebuild
+   shape-dependent structures (buffers, etc.) at the new params; carry
+   raw data forward.
+7. **Return `IndicatorSnapshot<TState>` from `getState()`** via
+   `makeSnapshot(name, version, params, state)`.
+8. **Register with `describeContract`.** The seven invariants must
+   pass without overrides where possible; document any overrides
+   (e.g., `reconfigMargin` for non-period-warmup indicators).
+9. **Update internal users.** If indicator X embeds indicator Y's
+   state, X's state field changes from `YState` to
+   `IndicatorSnapshot<YState>`.
+10. **Pre-commit gate:** `pnpm test`, `pnpm lint`, `pnpm build`,
+    `pnpm size-check`, `pnpm exec tsc -p tsconfig.json --noEmit
+    --ignoreDeprecations "6.0"`. The last one is critical and not
+    covered by the others — see
+    `feedback_test_before_commit.md` (memory).
+
+## 9. Decisions made (Phase 0 sign-off)
 
 The following were agreed before Phase 0 finalization:
 

--- a/packages/core/src/indicators/incremental/__tests__/state-contract.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract.test.ts
@@ -5,7 +5,13 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { buildMeta, type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import {
+  buildMeta,
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
 
 type AlmaParams = {
   period: number;
@@ -35,7 +41,7 @@ function snapshot(
 describe("resolveResume", () => {
   describe("fresh start (no fromState)", () => {
     it("returns merged defaults + options with null state", () => {
-      const result = resolveResume({
+      const result = resolveResume<AlmaParams, AlmaState>({
         indicator: "alma",
         version: 1,
         category: "windowed",
@@ -50,7 +56,7 @@ describe("resolveResume", () => {
     });
 
     it("treats undefined fromState identically to null", () => {
-      const result = resolveResume({
+      const result = resolveResume<AlmaParams, AlmaState>({
         indicator: "alma",
         version: 1,
         category: "windowed",
@@ -68,7 +74,7 @@ describe("resolveResume", () => {
     it("throws when the snapshot was created for a different indicator", () => {
       const fromState = snapshot("frama", 1, ALMA_DEFAULTS, { buffer: [], count: 0 });
       expect(() =>
-        resolveResume({
+        resolveResume<AlmaParams, AlmaState>({
           indicator: "alma",
           version: 1,
           category: "windowed",
@@ -84,7 +90,7 @@ describe("resolveResume", () => {
     it("throws when the snapshot's version differs from the current version", () => {
       const fromState = snapshot("alma", 0, ALMA_DEFAULTS, { buffer: [], count: 0 });
       expect(() =>
-        resolveResume({
+        resolveResume<AlmaParams, AlmaState>({
           indicator: "alma",
           version: 1,
           category: "windowed",
@@ -100,7 +106,7 @@ describe("resolveResume", () => {
         state: { buffer: [], count: 0 },
       } as unknown as IndicatorSnapshot<AlmaState>;
       expect(() =>
-        resolveResume({
+        resolveResume<AlmaParams, AlmaState>({
           indicator: "alma",
           version: 1,
           category: "windowed",
@@ -122,7 +128,7 @@ describe("resolveResume", () => {
         state: { buffer: [], count: 0 },
       } as unknown as IndicatorSnapshot<AlmaState>;
       expect(() =>
-        resolveResume({
+        resolveResume<AlmaParams, AlmaState>({
           indicator: "alma",
           version: 1,
           category: "recursive",
@@ -139,7 +145,7 @@ describe("resolveResume", () => {
         state: { buffer: [], count: 0 },
       } as unknown as IndicatorSnapshot<AlmaState>;
       expect(() =>
-        resolveResume({
+        resolveResume<AlmaParams, AlmaState>({
           indicator: "alma",
           version: 1,
           category: "windowed",
@@ -159,7 +165,7 @@ describe("resolveResume", () => {
         state: { buffer: [], count: 0 },
       } as unknown as IndicatorSnapshot<AlmaState>;
       expect(() =>
-        resolveResume({
+        resolveResume<AlmaParams, AlmaState>({
           indicator: "alma",
           version: 1,
           category: "recursive",
@@ -175,7 +181,7 @@ describe("resolveResume", () => {
     it("returns state verbatim when options match snapshot params exactly", () => {
       const state: AlmaState = { buffer: [1, 2, 3], count: 3 };
       const fromState = snapshot("alma", 1, ALMA_DEFAULTS, state);
-      const result = resolveResume({
+      const result = resolveResume<AlmaParams, AlmaState>({
         indicator: "alma",
         version: 1,
         category: "windowed",
@@ -196,7 +202,7 @@ describe("resolveResume", () => {
         { ...ALMA_DEFAULTS, period: 14 },
         { buffer: [], count: 0 },
       );
-      const result = resolveResume({
+      const result = resolveResume<AlmaParams, AlmaState>({
         indicator: "alma",
         version: 1,
         category: "windowed",
@@ -214,7 +220,7 @@ describe("resolveResume", () => {
     it("throws for Windowed when source changes", () => {
       const fromState = snapshot("alma", 1, ALMA_DEFAULTS, { buffer: [], count: 0 });
       expect(() =>
-        resolveResume({
+        resolveResume<AlmaParams, AlmaState>({
           indicator: "alma",
           version: 1,
           category: "windowed",
@@ -226,6 +232,7 @@ describe("resolveResume", () => {
     });
 
     it("throws for Recursive when source changes", () => {
+      type EmaParams = { period: number; source: "close" | "high" };
       const fromState = snapshot(
         "ema",
         1,
@@ -233,7 +240,7 @@ describe("resolveResume", () => {
         { buffer: [], count: 0 },
       );
       expect(() =>
-        resolveResume({
+        resolveResume<EmaParams, AlmaState>({
           indicator: "ema",
           version: 1,
           category: "recursive",
@@ -249,7 +256,7 @@ describe("resolveResume", () => {
     it("returns reconfigured=true when a non-source param changes", () => {
       const state: AlmaState = { buffer: [1, 2, 3], count: 3 };
       const fromState = snapshot("alma", 1, ALMA_DEFAULTS, state);
-      const result = resolveResume({
+      const result = resolveResume<AlmaParams, AlmaState>({
         indicator: "alma",
         version: 1,
         category: "windowed",
@@ -289,7 +296,7 @@ describe("resolveResume", () => {
     it(`throws when any non-source param changes`, () => {
       const fromState = snapshot("frama", 1, ALMA_DEFAULTS, { buffer: [], count: 0 });
       expect(() =>
-        resolveResume({
+        resolveResume<AlmaParams, AlmaState>({
           indicator: "frama",
           version: 1,
           category,
@@ -304,7 +311,7 @@ describe("resolveResume", () => {
       const fromState = snapshot("frama", 1, ALMA_DEFAULTS, { buffer: [], count: 0 });
       let thrown: Error | null = null;
       try {
-        resolveResume({
+        resolveResume<AlmaParams, AlmaState>({
           indicator: "frama",
           version: 1,
           category,
@@ -329,7 +336,7 @@ describe("resolveResume", () => {
         { period: 14, offset: 0.5, sigma: 6, source: "close" },
         { buffer: [], count: 0 },
       );
-      const result = resolveResume({
+      const result = resolveResume<AlmaParams, AlmaState>({
         indicator: "alma",
         version: 1,
         category: "windowed",
@@ -353,7 +360,7 @@ describe("resolveResume", () => {
         { period: 14, offset: 0.85, sigma: 6, source: "close" },
         { buffer: [], count: 0 },
       );
-      const result = resolveResume({
+      const result = resolveResume<AlmaParams, AlmaState>({
         indicator: "alma",
         version: 1,
         category: "windowed",
@@ -365,6 +372,112 @@ describe("resolveResume", () => {
       expect(result.params.period).toBe(14);
       expect(result.reconfigured).toBe(false);
     });
+  });
+});
+
+describe("partial defaults (no canonical default for a param)", () => {
+  // SMA, EMA, and several other indicators don't have a meaningful
+  // canonical default for `period`. Callers must always provide it;
+  // omitting it on a fresh-start call should yield a params object
+  // where `period` is `undefined`, which the indicator constructor
+  // is expected to validate and reject.
+  type Params = { period: number; source: "close" | "high" };
+
+  it("accepts defaults that omit some keys", () => {
+    const result = resolveResume<Params, { count: number }>({
+      indicator: "sma",
+      version: 1,
+      category: "windowed",
+      options: { period: 20 },
+      fromState: null,
+      defaults: { source: "close" }, // no `period` default
+    });
+
+    expect(result.params.period).toBe(20);
+    expect(result.params.source).toBe("close");
+  });
+
+  it("returns undefined for a missing required param when caller omits it (constructor must validate)", () => {
+    const result = resolveResume<Params, { count: number }>({
+      indicator: "sma",
+      version: 1,
+      category: "windowed",
+      options: {},
+      fromState: null,
+      defaults: { source: "close" }, // no `period` default
+    });
+
+    // Helper does not throw — typing claims TParams but the caller
+    // is responsible for validating required fields.
+    expect(result.params.period).toBeUndefined();
+    expect(result.params.source).toBe("close");
+  });
+
+  it("recovers a defaultless param from the snapshot on resume", () => {
+    const fromState: IndicatorSnapshot<{ count: number }> = {
+      meta: { indicator: "sma", version: 1, params: { period: 20, source: "close" } },
+      state: { count: 5 },
+    };
+
+    const result = resolveResume<Params, { count: number }>({
+      indicator: "sma",
+      version: 1,
+      category: "windowed",
+      options: {}, // caller omits — snapshot supplies it
+      fromState,
+      defaults: { source: "close" },
+    });
+
+    expect(result.params.period).toBe(20);
+    expect(result.reconfigured).toBe(false);
+  });
+});
+
+describe("requireParam", () => {
+  type Params = { period: number; source: "close" };
+
+  it("returns the value when present", () => {
+    const params = { period: 14, source: "close" } as Params;
+    const v = requireParam("sma", params, "period");
+    expect(v).toBe(14);
+  });
+
+  it("throws when the value is undefined (defaultless param not supplied)", () => {
+    const params = { source: "close" } as unknown as Params;
+    expect(() => requireParam("sma", params, "period")).toThrow(
+      /sma: required option "period" was not provided/,
+    );
+  });
+
+  it("throws when the value is null", () => {
+    const params = { period: null, source: "close" } as unknown as Params;
+    expect(() => requireParam("sma", params, "period")).toThrow(
+      /sma: required option "period" was not provided/,
+    );
+  });
+
+  it("runs the optional validate callback and rejects invalid values", () => {
+    const params = { period: 0, source: "close" } as Params;
+    expect(() =>
+      requireParam(
+        "sma",
+        params,
+        "period",
+        (v): v is number => Number.isInteger(v) && v >= 1,
+        "must be a positive integer",
+      ),
+    ).toThrow(/sma: option "period" failed validation \(must be a positive integer\)/);
+  });
+
+  it("accepts values that pass the validate callback", () => {
+    const params = { period: 14, source: "close" } as Params;
+    const v = requireParam(
+      "sma",
+      params,
+      "period",
+      (val): val is number => Number.isInteger(val) && val >= 1,
+    );
+    expect(v).toBe(14);
   });
 });
 

--- a/packages/core/src/indicators/incremental/state-contract.ts
+++ b/packages/core/src/indicators/incremental/state-contract.ts
@@ -88,8 +88,16 @@ export type ResolveResumeOptions<TParams extends Record<string, unknown>, TState
   options: DeepPartial<TParams>;
   /** Optional saved snapshot. `null` / `undefined` → fresh start. */
   fromState: IndicatorSnapshot<TState> | null | undefined;
-  /** Canonical defaults for every param key. */
-  defaults: TParams;
+  /**
+   * Canonical defaults. Partial — keys can be omitted for params
+   * with no meaningful canonical default (e.g., SMA's `period`: every
+   * mainstream library makes the caller specify it). The merged
+   * `params` returned by `resolveResume` is still typed as `TParams`
+   * (the caller's declared intent); the constructor is expected to
+   * validate that any required-but-defaultless key was supplied via
+   * `options` or `fromState`, and throw otherwise.
+   */
+  defaults: Partial<TParams>;
 };
 
 /**
@@ -230,16 +238,76 @@ export function makeSnapshot<TState>(
   return { meta: buildMeta(indicator, version, params), state };
 }
 
+/**
+ * Standard runtime validation for a required indicator option.
+ *
+ * `resolveResume` types its returned `params` as the full `TParams`,
+ * but with `Partial<TParams>` defaults a key may still be `undefined`
+ * at runtime when the caller omits it AND no snapshot supplies it.
+ * Indicators like SMA / EMA / WMA whose `period` has no canonical
+ * default must call this immediately after `resolveResume` to fail
+ * early with a uniform error message.
+ *
+ * @example
+ * ```ts
+ * const { params } = resolveResume<SmaParams, SmaState>({
+ *   indicator: "sma",
+ *   defaults: { source: "close" }, // no `period` default
+ *   ...
+ * });
+ * const period = requireParam(
+ *   "sma",
+ *   params,
+ *   "period",
+ *   (v): v is number => Number.isInteger(v) && v >= 1,
+ *   "must be a positive integer",
+ * );
+ * ```
+ *
+ * @returns the validated value, narrowed to `NonNullable<TParams[K]>`.
+ */
+export function requireParam<TParams, K extends keyof TParams>(
+  indicator: string,
+  params: TParams,
+  key: K,
+  validate?: (value: NonNullable<TParams[K]>) => boolean,
+  expectation?: string,
+): NonNullable<TParams[K]> {
+  const value = params[key];
+  if (value === undefined || value === null) {
+    throw new Error(
+      `${indicator}: required option "${String(key)}" was not provided (no default and no snapshot value)`,
+    );
+  }
+  const narrowed = value as NonNullable<TParams[K]>;
+  if (validate && !validate(narrowed)) {
+    throw new Error(
+      `${indicator}: option "${String(key)}" failed validation${
+        expectation ? ` (${expectation})` : ""
+      }`,
+    );
+  }
+  return narrowed;
+}
+
 // ---- Internal helpers ----
 
 function mergeParams<TParams extends Record<string, unknown>>(
-  defaults: TParams,
+  defaults: Partial<TParams>,
   snapshotParams: Record<string, unknown> | undefined,
   options: Record<string, unknown>,
 ): TParams {
-  // Stage 1: defaults provide the universe of keys.
+  // Stage 1: seed from `defaults` (now partial; some keys may be
+  //          absent — those start as `undefined` and stay so unless
+  //          snapshot or options supply them).
   // Stage 2: snapshot deep-merges over defaults for any key it has.
   // Stage 3: explicit options deep-merge over that.
+  //
+  // After all three stages, a key may legitimately remain `undefined`
+  // when (a) it's not in defaults, (b) there's no snapshot, and
+  // (c) the caller omitted it. The constructor is responsible for
+  // validating any such required-but-defaultless key via
+  // `requireParam` and failing fast.
   //
   // Deep merge recurses into plain objects so sparse overrides work
   // for indicators with nested-object params:


### PR DESCRIPTION
## Summary

Pre-Phase 2 follow-up to the State Contract foundation (#?). External review surfaced two related concerns we should address before any real indicator is migrated:

1. **Some indicators have no canonical default for their primary param** (SMA / EMA / WMA / Highest / Lowest / Donchian / Returns). Every mainstream library forces the caller to specify e.g. `period`. The Phase 1 `resolveResume({ defaults: TParams })` shape would have forced us to invent a default and mask it with a sentinel + validate pattern in every defaultless indicator.

2. **Even after relaxing defaults, the typed `params: TParams` can be `undefined` at runtime** when no default and no snapshot supplies the key. Without a standard validator, each constructor's check would drift in error message and may be forgotten — a "type-safe-looking" bug class.

## Changes

### `resolveResume` accepts `Partial<TParams>` for `defaults`
Indicators without canonical defaults omit those keys; helper does not invent values. The merged `params` is still typed as `TParams` (caller's declared intent) but a key may legitimately be `undefined` at runtime when (a) absent from defaults, (b) no snapshot, (c) caller omitted it.

### New `requireParam` helper
```ts
const period = requireParam(
  "sma",
  params,
  "period",
  (v): v is number => Number.isInteger(v) && v >= 1,
  "must be a positive integer",
);
```
Throws with a uniform `"<indicator>: required option \"<key>\" was not provided ..."` message. Returns `NonNullable<TParams[K]>` so the caller can use the value immediately. Every constructor with a defaultless param must call this right after `resolveResume`.

### Test updates (17 callsites)
`state-contract.test.ts` now passes explicit `<TParams, TState>` generics on every `resolveResume(...)` call. `defaults: Partial<TParams>` weakens TS's inference anchor; without explicit generics, `TParams` collapses to `{}` and `params.<key>` type errors propagate. This also aligns with the pre-existing memory lesson (`feedback_test_before_commit.md`) that calls for explicit generics here.

### New tests
- 3 for "partial defaults" describe block (accepts partial; missing required yields undefined; snapshot recovers a defaultless param)
- 5 for `requireParam` (present / undefined / null / validate-fail / validate-pass)

### Documentation
`STATE_CONTRACT.md` adds **§8 Phase 2 per-indicator migration checklist** — 10 concrete steps every migration must follow:
1. Categorize (A/B/C/D/E)
2. Strip param fields from bare state
3. Bump `version` to 1
4. Honest defaults (no sentinels)
5. `requireParam` for defaultless params
6. Handle `reconfigured` for windowed/event
7. Return `IndicatorSnapshot<TState>` from `getState()`
8. Register with `describeContract`
9. Update internal users' state field types
10. Pre-commit gate including `tsc --noEmit`

### Comment fix
`mergeParams` JSDoc "defaults provide the universe of keys" was inaccurate after Partial<TParams> — replaced with an explicit description of when a key can remain `undefined`.

## What was NOT changed

- No indicator code (Phase 2 starts after this lands)
- No category semantics
- No wire format (`IndicatorSnapshot<TState>` unchanged)

## Test plan

- [x] `pnpm test` — full repo green
- [x] `pnpm lint` — clean
- [x] `pnpm build` — green
- [x] `pnpm size-check` — within cap
- [x] `pnpm exec tsc -p packages/core/tsconfig.json --noEmit --ignoreDeprecations "6.0"` — clean (this is the gate that caught the Phase 1 TS18048 surge)
- [x] State-contract + contract-helper test files: 60 tests pass

## Target branch

This PR targets `epic/state-contract` (not `main`). Will be rolled up into the 0.4.0 epic merge at release time.