### PR TITLE
feat(core)!: migrate SMA to State Contract (Wave 1 SMA cluster)

### DIFF
--- a/packages/core/docs/STATE_CONTRACT.md
+++ b/packages/core/docs/STATE_CONTRACT.md
@@ -306,6 +306,28 @@ createFrama({ period: 14 }, { fromState: stateWith9 });
 
 For Category A (Windowed), period change is supported via carry-forward; source change still throws.
 
+### 5.3 Streaming session / pipeline persistence
+
+`createLiveCandle` / `createPipeline` / `createSession` store each
+indicator's `getState()` output as opaque `unknown` and pass it back
+to the indicator's factory on resume. Because the wire format of
+`getState()` changes to `IndicatorSnapshot<TState>`, **streaming
+session snapshots persisted under 0.3.x cannot be resumed in
+0.4.0**:
+
+- Operators upgrading a long-running streaming process must re-warm
+  from candle history rather than restore from the old session blob.
+- Session-level state (aggregator state, completed candles, etc.) is
+  unaffected — only the per-indicator snapshots inside the session
+  blob are incompatible.
+- The error surfaces with the standard `<indicator>: incompatible
+  snapshot, re-warm required` message thrown by `resolveResume`'s
+  meta-validation step.
+
+Strategy JSON (`serializeStrategy` / `parseStrategy`) describes
+indicator *configurations*, not runtime state — it is unaffected by
+this change.
+
 ## 6. Roadmap
 
 Five phases, ~4-5 weeks total. Each phase lands as a PR into

--- a/packages/core/src/indicators/incremental/__tests__/momentum-indicators.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/momentum-indicators.test.ts
@@ -95,8 +95,14 @@ function assertConsistency(
   }
 }
 
+// Test helper parameter `createFn` accepts a heterogeneous family of
+// indicator factories with disjoint option shapes. `unknown[]` is too
+// strict for inference (TS2345 against every concrete factory); the
+// runtime call already does `createFn(...args)`, so `any[]` here is
+// honest and unblocks `tsc --noEmit` as a pre-commit gate (see
+// `feedback_test_before_commit.md`).
 function peekTest(
-  createFn: (...args: unknown[]) => {
+  createFn: (...args: any[]) => {
     next: (c: NormalizedCandle) => unknown;
     peek: (c: NormalizedCandle) => unknown;
     getState: () => unknown;
@@ -104,7 +110,7 @@ function peekTest(
   args: unknown[],
   warmUpCount: number,
 ) {
-  const ind = (createFn as any)(...args);
+  const ind = createFn(...args);
   for (let i = 0; i < warmUpCount; i++) ind.next(candles[i]);
   const stateBefore = JSON.stringify(ind.getState());
   ind.peek(candles[warmUpCount]);
@@ -112,8 +118,9 @@ function peekTest(
   expect(stateAfter).toBe(stateBefore);
 }
 
+// Same rationale as peekTest above re: `any[]` for the factory.
 function stateRestoreTest(
-  createFn: (...args: unknown[]) => {
+  createFn: (...args: any[]) => {
     next: (c: NormalizedCandle) => { value: unknown };
     getState: () => unknown;
   },
@@ -121,10 +128,10 @@ function stateRestoreTest(
   splitAt: number,
   extractValue?: (v: unknown) => number | null,
 ) {
-  const ind1 = (createFn as any)(...args);
+  const ind1 = createFn(...args);
   for (let i = 0; i < splitAt; i++) ind1.next(candles[i]);
   const state = ind1.getState();
-  const ind2 = (createFn as any)(args[0], { fromState: state });
+  const ind2 = createFn(args[0], { fromState: state });
   const extract = extractValue ?? ((v: unknown) => v as number | null);
 
   for (let i = splitAt; i < splitAt + 50; i++) {

--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -1,0 +1,48 @@
+/**
+ * State Contract integration tests for migrated indicators.
+ *
+ * Every indicator migrated to the 0.4.0 State Contract registers
+ * here via `describeContract`. The DSL generates the seven invariants
+ * (round-trip, name guard, version guard, reconfig per category,
+ * peek consistency, warmup gate) automatically — pinning the contract
+ * uniformly across the library.
+ *
+ * Phase 2 migration adds entries to this file. The file should never
+ * shrink (only add new indicators) so this becomes a stable "what's
+ * migrated" registry.
+ */
+
+import type { NormalizedCandle } from "../../../types";
+import { createSma, type SmaState } from "../moving-average/sma";
+import { describeContract } from "./contract-helper";
+
+// ---- Shared candle generator ----
+
+function makeCandles(n: number): NormalizedCandle[] {
+  // Deterministic, mildly volatile series: trend + sine + noise.
+  return Array.from({ length: n }, (_, i) => {
+    const close = 100 + i * 0.05 + Math.sin(i * 0.3) * 5 + ((i * 7) % 11) * 0.1;
+    return {
+      time: 1700000000000 + i * 86400000,
+      open: close - 0.3,
+      high: close + 1.2,
+      low: close - 1.1,
+      close,
+      volume: 1000 + (i % 13) * 50,
+    };
+  });
+}
+
+// ---- SMA (Wave 1, Category Windowed, version 1) ----
+
+describeContract<number | null, SmaState>({
+  name: "sma",
+  create: (opts, warmUp) =>
+    createSma(opts as { period?: number; source?: "close" | "high" }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 20, source: "close" },
+  reconfigParams: [{ period: 8 }, { period: 30 }],
+  makeCandles,
+  streamLength: 100,
+});

--- a/packages/core/src/indicators/incremental/momentum/awesome-oscillator.ts
+++ b/packages/core/src/indicators/incremental/momentum/awesome-oscillator.ts
@@ -10,12 +10,13 @@
 import type { NormalizedCandle } from "../../../types";
 import type { SmaState } from "../moving-average/sma";
 import { createSma } from "../moving-average/sma";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import { makeCandle } from "../utils";
 
 export type AwesomeOscillatorState = {
-  fastSmaState: SmaState;
-  slowSmaState: SmaState;
+  fastSmaState: IndicatorSnapshot<SmaState>;
+  slowSmaState: IndicatorSnapshot<SmaState>;
   fastPeriod: number;
   slowPeriod: number;
   count: number;

--- a/packages/core/src/indicators/incremental/momentum/balance-of-power.ts
+++ b/packages/core/src/indicators/incremental/momentum/balance-of-power.ts
@@ -8,11 +8,12 @@
 import type { NormalizedCandle } from "../../../types";
 import type { SmaState } from "../moving-average/sma";
 import { createSma } from "../moving-average/sma";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import { makeCandle } from "../utils";
 
 export type BalanceOfPowerState = {
-  smaState: SmaState;
+  smaState: IndicatorSnapshot<SmaState>;
   smoothPeriod: number;
   count: number;
 };

--- a/packages/core/src/indicators/incremental/momentum/dpo.ts
+++ b/packages/core/src/indicators/incremental/momentum/dpo.ts
@@ -13,6 +13,7 @@
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import type { SmaState } from "../moving-average/sma";
 import { createSma } from "../moving-average/sma";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import { getSourcePrice } from "../utils";
 
@@ -25,7 +26,7 @@ export type DpoState = {
   period: number;
   source: PriceSource;
   shift: number;
-  smaState: SmaState;
+  smaState: IndicatorSnapshot<SmaState>;
   pending: PendingEntry[];
   /** Number of entries already resolved and removed from pending head */
   resolvedOffset: number;

--- a/packages/core/src/indicators/incremental/momentum/kst.ts
+++ b/packages/core/src/indicators/incremental/momentum/kst.ts
@@ -11,6 +11,7 @@
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import type { SmaState } from "../moving-average/sma";
 import { createSma } from "../moving-average/sma";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import { makeCandle } from "../utils";
 import type { RocState } from "./roc";
@@ -23,8 +24,13 @@ export type KstValue = {
 
 export type KstState = {
   rocStates: [RocState, RocState, RocState, RocState];
-  smaStates: [SmaState, SmaState, SmaState, SmaState];
-  signalSmaState: SmaState;
+  smaStates: [
+    IndicatorSnapshot<SmaState>,
+    IndicatorSnapshot<SmaState>,
+    IndicatorSnapshot<SmaState>,
+    IndicatorSnapshot<SmaState>,
+  ];
+  signalSmaState: IndicatorSnapshot<SmaState>;
   rocPeriods: [number, number, number, number];
   smaPeriods: [number, number, number, number];
   weights: [number, number, number, number];
@@ -169,7 +175,12 @@ export function createKst(
     getState(): KstState {
       return {
         rocStates: rocs.map((r) => r.getState()) as [RocState, RocState, RocState, RocState],
-        smaStates: smas.map((s) => s.getState()) as [SmaState, SmaState, SmaState, SmaState],
+        smaStates: smas.map((s) => s.getState()) as [
+          IndicatorSnapshot<SmaState>,
+          IndicatorSnapshot<SmaState>,
+          IndicatorSnapshot<SmaState>,
+          IndicatorSnapshot<SmaState>,
+        ],
         signalSmaState: signalSma.getState(),
         rocPeriods,
         smaPeriods,

--- a/packages/core/src/indicators/incremental/momentum/qstick.ts
+++ b/packages/core/src/indicators/incremental/momentum/qstick.ts
@@ -8,11 +8,12 @@
 import type { NormalizedCandle } from "../../../types";
 import type { SmaState } from "../moving-average/sma";
 import { createSma } from "../moving-average/sma";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import { makeCandle } from "../utils";
 
 export type QStickState = {
-  smaState: SmaState;
+  smaState: IndicatorSnapshot<SmaState>;
   period: number;
   count: number;
 };

--- a/packages/core/src/indicators/incremental/moving-average/sma.ts
+++ b/packages/core/src/indicators/incremental/moving-average/sma.ts
@@ -1,18 +1,43 @@
 /**
  * Incremental SMA (Simple Moving Average)
+ *
+ * State category: **Windowed** (raw price buffer, no recursion).
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<SmaState>` and `fromState` accepts the same.
+ *
+ * Defaults: `source` defaults to `"close"`. `period` has no canonical
+ * default (Pine Script / TA-Lib / Tulip all require it from the
+ * caller); it must be supplied on first construction. On resume, it
+ * may be omitted to inherit from the snapshot.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for SMA. Params (`period`, `source`) live in
+ * `meta.params` on the wire — they are not part of the bare state.
+ */
 export type SmaState = {
-  period: number;
-  source: PriceSource;
   buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   sum: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bump on any breaking state change. */
+export const SMA_VERSION = 1;
+
+type SmaParams = {
+  period: number;
+  source: PriceSource;
 };
 
 /**
@@ -20,51 +45,81 @@ export type SmaState = {
  *
  * @example
  * ```ts
+ * // Fresh start — period is required on first call.
  * const sma20 = createSma({ period: 20 });
  * for (const candle of stream) {
  *   const { value } = sma20.next(candle);
  *   if (sma20.isWarmedUp) console.log(value);
  * }
+ *
+ * // Resume from a saved snapshot — period may be omitted; the
+ * // snapshot supplies it.
+ * const resumed = createSma({}, { fromState: snapshot });
  * ```
  */
 export function createSma(
-  options: { period: number; source?: PriceSource },
-  warmUpOptions?: WarmUpOptions<SmaState>,
-): IncrementalIndicator<number | null, SmaState> {
-  const period = options.period;
-  const source: PriceSource = options.source ?? "close";
+  options: { period?: number; source?: PriceSource },
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<SmaState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<SmaState>> {
+  const { params, state, reconfigured } = resolveResume<SmaParams, SmaState>({
+    indicator: "sma",
+    version: SMA_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { source: "close" }, // `period` is intentionally absent — no canonical default.
+  });
+
+  const period = requireParam(
+    "sma",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
 
   let buffer: CircularBuffer<number>;
   let sum: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    sum = s.sum;
-    count = s.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // Period change. The snapshot's buffer is at the OLD capacity;
+      // we need a buffer at the NEW capacity holding the most recent
+      // min(snapshot.length, newPeriod) samples. Sum must be
+      // recomputed from those carried samples — the snapshot's `sum`
+      // was over the old window and would be wrong for the new one.
+      const oldBuffer = CircularBuffer.fromSnapshot(state.buffer);
+      buffer = new CircularBuffer<number>(period);
+      const available = oldBuffer.length;
+      const carryStart = Math.max(0, available - period);
+      sum = 0;
+      for (let i = carryStart; i < available; i++) {
+        const v = oldBuffer.get(i);
+        buffer.push(v);
+        sum += v;
+      }
+      // Preserve `count` as the public "candles processed so far"
+      // counter. Warm-up readiness is gated on `buffer.length`
+      // separately so a grown period correctly waits for new bars.
+      count = state.count;
+    } else {
+      // Same shape — restore buffer verbatim.
+      buffer = CircularBuffer.fromSnapshot(state.buffer);
+      sum = state.sum;
+      count = state.count;
+    }
   } else {
     buffer = new CircularBuffer<number>(period);
     sum = 0;
     count = 0;
   }
 
-  function compute(candle: NormalizedCandle): { time: number; value: number | null } {
-    const price = getSourcePrice(candle, source);
-    let newSum = sum;
-    const newCount = count + 1;
-
-    if (buffer.isFull) {
-      newSum = newSum - buffer.oldest() + price;
-    } else {
-      newSum = newSum + price;
-    }
-
-    const value = newCount >= period ? newSum / period : null;
-    return { time: candle.time, value };
-  }
-
-  const indicator: IncrementalIndicator<number | null, SmaState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<SmaState>> = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
 
@@ -77,22 +132,28 @@ export function createSma(
       buffer.push(price);
       count++;
 
-      const value = count >= period ? sum / period : null;
+      // Warm-up gated on the buffer being full, not on `count`. After
+      // a period-growing resume, `count` is the snapshot's large
+      // value but the rebuilt buffer needs more candles to fill.
+      const value = buffer.length >= period ? sum / period : null;
       return { time: candle.time, value };
     },
 
     peek(candle: NormalizedCandle) {
-      return compute(candle);
+      const price = getSourcePrice(candle, source);
+      const newSum = buffer.isFull ? sum - buffer.oldest() + price : sum + price;
+      const newLength = Math.min(buffer.length + 1, period);
+      const value = newLength >= period ? newSum / period : null;
+      return { time: candle.time, value };
     },
 
-    getState(): SmaState {
-      return {
-        period,
-        source,
-        buffer: buffer.snapshot(),
-        sum,
-        count,
-      };
+    getState(): IndicatorSnapshot<SmaState> {
+      return makeSnapshot(
+        "sma",
+        SMA_VERSION,
+        { period, source },
+        { buffer: buffer.snapshot(), sum, count },
+      );
     },
 
     get count() {
@@ -100,7 +161,7 @@ export function createSma(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      return buffer.length >= period;
     },
   };
 

--- a/packages/core/src/indicators/incremental/volatility/regime.ts
+++ b/packages/core/src/indicators/incremental/volatility/regime.ts
@@ -12,6 +12,7 @@ import type { NormalizedCandle } from "../../../types";
 import { createDmi, type DmiState } from "../../incremental/momentum/dmi";
 import { createSma, type SmaState } from "../../incremental/moving-average/sma";
 import { CircularBuffer } from "../circular-buffer";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import { type AtrState, createAtr } from "./atr";
 import { type BollingerBandsState, createBollingerBands } from "./bollinger-bands";
@@ -38,7 +39,7 @@ export type RegimeState = {
   atrState: AtrState;
   bbState: BollingerBandsState;
   dmiState: DmiState;
-  smaState: SmaState;
+  smaState: IndicatorSnapshot<SmaState>;
   atrBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   bwBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   count: number;
@@ -109,7 +110,7 @@ export function createRegime(
     BollingerBandsState
   >;
   let dmiInd: ReturnType<typeof createDmi>;
-  let smaInd: IncrementalIndicator<number | null, SmaState>;
+  let smaInd: IncrementalIndicator<number | null, IndicatorSnapshot<SmaState>>;
   let atrBuffer: CircularBuffer<number>;
   let bwBuffer: CircularBuffer<number>;
   let count: number;

--- a/packages/core/src/indicators/incremental/wyckoff/vsa.ts
+++ b/packages/core/src/indicators/incremental/wyckoff/vsa.ts
@@ -13,6 +13,7 @@ import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
 import type { SmaState } from "../moving-average/sma";
 import { createSma } from "../moving-average/sma";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import type { AtrState } from "../volatility/atr";
 import { createAtr } from "../volatility/atr";
@@ -54,7 +55,7 @@ type CandleEntry = {
 
 export type VsaState = {
   atrState: AtrState;
-  volumeSmaState: SmaState;
+  volumeSmaState: IndicatorSnapshot<SmaState>;
   candleBuffer: ReturnType<CircularBuffer<CandleEntry>["snapshot"]>;
   volumeMaPeriod: number;
   atrPeriod: number;


### PR DESCRIPTION
## Summary

First indicator migration on top of the State Contract foundation (`epic/state-contract`). SMA is **Category A (Windowed)** — the canonical pattern other windowed indicators will follow in Wave 1.

## Breaking changes

- `getState()` now returns `IndicatorSnapshot<SmaState>` (not bare `SmaState`). Pre-0.4.0 snapshots throw on resume with the standard `<indicator>: incompatible snapshot, re-warm required` message.
- `options.period` is now optional in TypeScript (was required). `period` has no canonical default — every mainstream library (Pine Script, TA-Lib, Tulip) makes the caller specify it. On fresh start, omitting `period` throws at runtime via `requireParam`. On resume, omitting `period` inherits from the snapshot. The TS-level weakening is the accepted trade-off (decided pre-implementation, see epic discussion) for the resume ergonomics and the uniform `resolveResume` → `requireParam` pattern every Phase 2 migration will follow.
- `SmaState` shape narrows: `period` and `source` move from bare state to `meta.params`. Bare state is now just `{ buffer, sum, count }`.
- Reconfig behavior on resume:
  - Same period & source: restore verbatim
  - Different period: rebuild buffer at new capacity, carry forward last `min(snapshot.length, new period)` samples, **recompute sum** from those carried samples (the snapshot's sum was over the old window). Warm-up gated on `buffer.length >= period`.
  - Different source: throw (Windowed source-change refuse rule).

## State Contract pattern applied

```ts
const { params, state, reconfigured } = resolveResume<SmaParams, SmaState>({
  indicator: "sma",
  version: SMA_VERSION,
  category: "windowed",
  options,
  fromState: warmUpOptions?.fromState ?? null,
  defaults: { source: "close" }, // `period` intentionally absent
});

const period = requireParam(
  "sma",
  params,
  "period",
  (v): v is number => Number.isInteger(v) && v >= 1,
  "must be a positive integer",
);
```

`describeContract` registration in new `state-contract-integration.test.ts` exercises all six invariants (round-trip, name guard, version guard, windowed reconfig, peek consistency, warmup gate) — passes.

## Internal SMA users — type field updates only

The seven indicators that embed SMA internally — **DPO, KST, BalanceOfPower, AwesomeOscillator, QStick, Regime, VSA** — have their `smaState` (or similar) field bumped from `SmaState` to `IndicatorSnapshot<SmaState>`. They treat the snapshot as **opaque pass-through** (no `.buffer` / `.sum` reach-in confirmed via pre-flight grep), so the rest of their code is unchanged.

**These indicators' own State Contract migration is intentionally NOT in this PR.** They remain on pre-0.4.0 contract semantics for their own state until their respective waves (most are Category D Cascaded — Wave 3). Their `createXxx(options, { fromState })` reconfig behavior is still the loose pre-0.4.0 behavior. Phase 2's per-indicator migration is what tightens it.

## Incidental cleanup

- **`momentum-indicators.test.ts` helper signatures**: `peekTest` / `stateRestoreTest` relaxed from `(...args: unknown[])` to `(...args: any[])`. Pre-existing TS infra debt producing TS2345 against every concrete factory. Necessary so `tsc --noEmit` can serve as a pre-commit gate per `feedback_test_before_commit.md` memory.
- **STATE_CONTRACT.md §5.3** added: streaming session snapshots persisted under 0.3.x cannot be resumed in 0.4.0 (only the per-indicator snapshots inside the session blob are incompatible; session-level state is unaffected; strategy JSON is unaffected).
- **`regime.ts` local `smaInd` type**: bumped to match the new SMA return type.

## Pre-flight investigation findings (informed scope)

| Concern | Result |
|---|---|
| 7 SMA users introspect state? | ✗ All opaque pass-through |
| `live-presets.ts` SMA factory | Factory wrap, no introspection |
| `bridge.ts` | No SMA state usage |
| `strategy/` | No `SmaState` references |
| `examples/*` | `createSma` only, no state-shape coupling |
| `streaming/{live-candle,session}.ts` | Stores `unknown` opaquely. Wire format changes but call path same. Documented in §5.3. |

## Test plan

- [x] `pnpm test` — 5165 tests green
- [x] `pnpm lint` — clean
- [x] `pnpm build` — green
- [x] `pnpm size-check` — within cap
- [x] `pnpm exec tsc -p packages/core/tsconfig.json --noEmit --ignoreDeprecations "6.0"` — incremental subgraph clean (10 pre-existing errors in `strategy-dna.test.ts` / `always-conditions.test.ts` are scope-out)
- [x] `describeContract` invariants: 6/6 pass for SMA

## Target branch

Targets `epic/state-contract`, not `main`. Will be rolled into the 0.4.0 epic merge at release time.