### PR TITLE
feat(core)!: migrate ALMA to State Contract (Wave 1 ALMA cluster)

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/new-indicators.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/new-indicators.test.ts
@@ -532,16 +532,16 @@ describe("ALMA incremental", () => {
     const ind1 = createAlma({ period: 20, offset: 0.7, sigma: 8 });
     for (let i = 0; i < 40; i++) ind1.next(candles[i]);
     const state = ind1.getState();
-    expect(state.period).toBe(20);
-    expect(state.offset).toBe(0.7);
-    expect(state.sigma).toBe(8);
+    expect(state.meta.params.period).toBe(20);
+    expect(state.meta.params.offset).toBe(0.7);
+    expect(state.meta.params.sigma).toBe(8);
 
-    // Resume without re-passing options — periods / shape must come
-    // from the snapshot, NOT silently revert to canonical defaults.
+    // Resume without re-passing options — params must come from the
+    // snapshot, NOT silently revert to canonical defaults.
     const ind2 = createAlma({}, { fromState: state });
-    expect(ind2.getState().period).toBe(20);
-    expect(ind2.getState().offset).toBe(0.7);
-    expect(ind2.getState().sigma).toBe(8);
+    expect(ind2.getState().meta.params.period).toBe(20);
+    expect(ind2.getState().meta.params.offset).toBe(0.7);
+    expect(ind2.getState().meta.params.sigma).toBe(8);
 
     // Subsequent values must match what ind1 would have produced.
     for (let i = 40; i < 60; i++) {
@@ -563,10 +563,10 @@ describe("ALMA incremental", () => {
     const state = ind1.getState();
 
     const ind2 = createAlma({ period: 9, offset: 0.85, sigma: 6 }, { fromState: state });
-    expect(ind2.getState().period).toBe(9);
+    expect(ind2.getState().meta.params.period).toBe(9);
     // `count` preserves the public "candles processed so far" contract
     // across reconfiguration — 40 bars went through ind1.
-    expect(ind2.getState().count).toBe(40);
+    expect(ind2.getState().state.count).toBe(40);
     // Warm-up is gated on the buffer (filled with the latest 9 prices
     // from the snapshot), not on count. So the indicator emits a
     // value immediately on the next bar.
@@ -582,30 +582,22 @@ describe("ALMA incremental", () => {
     expect(v1).toBeCloseTo(v2!, 10);
   });
 
-  it("changing source on resume discards the old buffer and warms up fresh", () => {
-    // The buffer holds source-derived numbers (close prices in this
-    // case). Mixing them with `high` prices in the next `period`
-    // outputs would be mathematically incorrect, so the source switch
-    // forces a fresh warm-up regardless of whether shape params match.
+  it("changing source on resume throws (Windowed source-change refuse rule)", () => {
+    // The buffer holds source-derived numbers (close prices here).
+    // Mixing them with `high` prices in the next `period` outputs
+    // would be mathematically incorrect. Under the 0.4.0 State
+    // Contract, a `source` change on resume is library-wide refused
+    // (rather than silently discarding and re-warming), forcing the
+    // caller to make a deliberate choice between re-warming a fresh
+    // instance or keeping the original source.
     const ind1 = createAlma({ period: 9, source: "close" });
     for (let i = 0; i < 30; i++) ind1.next(candles[i]);
     const state = ind1.getState();
-    expect(state.source).toBe("close");
+    expect(state.meta.params.source).toBe("close");
 
-    const ind2 = createAlma({ source: "high" }, { fromState: state });
-    expect(ind2.getState().source).toBe("high");
-    // `count` preserves the public processed-candles contract even
-    // though the buffer is reset — readers using count for backfill
-    // / progress tracking shouldn't see the counter snap to 0.
-    expect(ind2.getState().count).toBe(30);
-    // Buffer is empty — warm-up is buffer-based.
-    expect(ind2.isWarmedUp).toBe(false);
-
-    // Need a full period of new-source bars before the first output.
-    for (let i = 30; i < 38; i++) {
-      expect(ind2.next(candles[i]).value).toBeNull();
-    }
-    expect(ind2.next(candles[38]).value).not.toBeNull();
+    expect(() => createAlma({ source: "high" }, { fromState: state })).toThrow(
+      /source mismatch|incompatible snapshot/,
+    );
   });
 
   it("growing the period on resume waits for the buffer to fill before emitting", () => {
@@ -620,7 +612,7 @@ describe("ALMA incremental", () => {
     const ind2 = createAlma({ period: 20 }, { fromState: state });
     // `count` preserves the public processed-candles contract (30
     // bars went through ind1) regardless of the buffer carry-over.
-    expect(ind2.getState().count).toBe(30);
+    expect(ind2.getState().state.count).toBe(30);
     // Warm-up is gated on the buffer (only 9 of 20 entries carried
     // forward), so the new indicator stays not-yet-warmed-up until
     // 11 more bars fill the window.
@@ -637,9 +629,9 @@ describe("ALMA incremental", () => {
     const ind1 = createAlma({ period: 20, offset: 0.7, sigma: 8 });
     for (let i = 0; i < 40; i++) ind1.next(candles[i]);
     const ind2 = createAlma({ period: 5, offset: 0.5, sigma: 4 }, { fromState: ind1.getState() });
-    expect(ind2.getState().period).toBe(5);
-    expect(ind2.getState().offset).toBe(0.5);
-    expect(ind2.getState().sigma).toBe(4);
+    expect(ind2.getState().meta.params.period).toBe(5);
+    expect(ind2.getState().meta.params.offset).toBe(0.5);
+    expect(ind2.getState().meta.params.sigma).toBe(4);
   });
 });
 

--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -13,6 +13,7 @@
  */
 
 import type { NormalizedCandle } from "../../../types";
+import { type AlmaState, createAlma } from "../moving-average/alma";
 import { createSma, type SmaState } from "../moving-average/sma";
 import { describeContract } from "./contract-helper";
 
@@ -43,6 +44,31 @@ describeContract<number | null, SmaState>({
   version: 1,
   defaultParams: { period: 20, source: "close" },
   reconfigParams: [{ period: 8 }, { period: 30 }],
+  makeCandles,
+  streamLength: 100,
+});
+
+// ---- ALMA (Wave 1 ALMA cluster, Category Windowed, version 1) ----
+
+describeContract<number | null, AlmaState>({
+  name: "alma",
+  create: (opts, warmUp) =>
+    createAlma(
+      opts as {
+        period?: number;
+        offset?: number;
+        sigma?: number;
+        source?: "close" | "high";
+      },
+      warmUp,
+    ),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 9, offset: 0.85, sigma: 6, source: "close" },
+  // Mix period changes with offset/sigma changes so the windowed
+  // reconfig invariant exercises shape changes that aren't just
+  // period grows/shrinks.
+  reconfigParams: [{ period: 14 }, { period: 5 }, { offset: 0.5 }, { sigma: 3 }],
   makeCandles,
   streamLength: 100,
 });

--- a/packages/core/src/indicators/incremental/moving-average/alma.ts
+++ b/packages/core/src/indicators/incremental/moving-average/alma.ts
@@ -2,59 +2,127 @@
  * Incremental ALMA (Arnaud Legoux Moving Average)
  *
  * Uses a Gaussian distribution to weight prices in a sliding window.
+ *
+ * State category: **Windowed** (raw price buffer, no recursion).
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<AlmaState>` and `fromState` accepts the same.
+ *
+ * Defaults: full canonical defaults are available
+ * (`period: 9, offset: 0.85, sigma: 6, source: "close"`), so callers
+ * can omit any param. On resume, omitted params inherit from the
+ * snapshot; explicit options override.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for ALMA. Params (`period`, `offset`, `sigma`,
+ * `source`) live in `meta.params` on the wire — they are not part of
+ * the bare state. `weights` is recomputed at construction from
+ * params, so it's intentionally not persisted (cleaner state,
+ * deterministic regeneration).
+ */
 export type AlmaState = {
+  buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
+  count: number;
+};
+
+/** Per-indicator schema version. Bump on any breaking state change. */
+export const ALMA_VERSION = 1;
+
+type AlmaParams = {
   period: number;
   offset: number;
   sigma: number;
   source: PriceSource;
-  weights: number[];
-  buffer: { data: number[]; head: number; length: number; capacity: number };
-  count: number;
+};
+
+const ALMA_DEFAULTS: AlmaParams = {
+  period: 9,
+  offset: 0.85,
+  sigma: 6,
+  source: "close",
 };
 
 /**
- * Create an incremental ALMA indicator
+ * Create an incremental ALMA indicator.
  *
  * @example
  * ```ts
- * const alma = createAlma({ period: 9, offset: 0.85, sigma: 6 });
+ * const ind = createAlma({ period: 9, offset: 0.85, sigma: 6 });
  * for (const candle of stream) {
- *   const { value } = alma.next(candle);
- *   if (alma.isWarmedUp) console.log(value);
+ *   const { value } = ind.next(candle);
+ *   if (ind.isWarmedUp) console.log(value);
  * }
+ *
+ * // Resume from a snapshot. Params inherit from the snapshot when
+ * // options are omitted; explicit options trigger reconfig.
+ * const resumed = createAlma({}, { fromState: snapshot });
  * ```
  */
 export function createAlma(
-  options: { period?: number; offset?: number; sigma?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<AlmaState>,
-): IncrementalIndicator<number | null, AlmaState> {
-  // Resume order: explicit option > persisted state > canonical default.
-  // Reading the snapshot first is critical — every parameter shapes the
-  // pre-computed Gaussian weights and the sliding-window buffer size, so
-  // silently swapping to defaults on resume produces a discontinuous
-  // ALMA after restore.
-  const fs = warmUpOptions?.fromState ?? null;
-  const period = options.period ?? fs?.period ?? 9;
-  const offset = options.offset ?? fs?.offset ?? 0.85;
-  const sigma = options.sigma ?? fs?.sigma ?? 6;
-  const source: PriceSource = options.source ?? fs?.source ?? "close";
+  options: {
+    period?: number;
+    offset?: number;
+    sigma?: number;
+    source?: PriceSource;
+  } = {},
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<AlmaState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<AlmaState>> {
+  const { params, state, reconfigured } = resolveResume<AlmaParams, AlmaState>({
+    indicator: "alma",
+    version: ALMA_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: ALMA_DEFAULTS,
+  });
+
+  // ALMA has full canonical defaults, so `requireParam` is used here
+  // for runtime range validation rather than missing-param detection.
+  const period = requireParam(
+    "alma",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const offset = requireParam(
+    "alma",
+    params,
+    "offset",
+    (v): v is number => typeof v === "number" && v >= 0 && v <= 1,
+    "must be in [0, 1]",
+  );
+  const sigma = requireParam(
+    "alma",
+    params,
+    "sigma",
+    (v): v is number => typeof v === "number" && v > 0,
+    "must be positive",
+  );
+  const source = params.source;
 
   // Pre-compute normalized Gaussian weights (Pine Script convention:
   // `m = offset * (period - 1)`, matching TradingView's `ta.alma()`).
-  // Some references use `m = offset * period` instead — the magnitude
-  // shift is small; we standardize on the Pine Script form.
+  // Recomputed on every construction — `weights` is a deterministic
+  // function of (period, offset, sigma) and not part of canonical state.
   const m = offset * (period - 1);
   const sd = period / sigma;
   const weights: number[] = new Array(period);
   let weightSum = 0;
-
   for (let i = 0; i < period; i++) {
     const w = Math.exp(-((i - m) * (i - m)) / (2 * sd * sd));
     weights[i] = w;
@@ -64,52 +132,35 @@ export function createAlma(
     weights[i] /= weightSum;
   }
 
-  // The snapshot stores raw source prices, not derived state. That
-  // means a *shape*-only parameter change on resume (period / offset /
-  // sigma) only invalidates the weights — the buffered prices remain
-  // valid input. Carry the latest min(snapshot.length, new period)
-  // prices into a buffer of the new capacity so re-parameterization
-  // can emit a value immediately when enough history is on hand.
-  //
-  // A `source` change is different: the old buffer holds numbers
-  // derived from the old source (e.g. `close`) and would mix
-  // mathematically with new source values (e.g. `high`) for the next
-  // `period` outputs. When source differs, the buffered prices have to
-  // be discarded — the new indicator starts a fresh warm-up.
-  const shapeMatchesSnapshot =
-    fs !== null && fs.period === period && fs.offset === offset && fs.sigma === sigma;
-  const sourceMatchesSnapshot = fs !== null && fs.source === source;
-  const snapshotMatches = shapeMatchesSnapshot && sourceMatchesSnapshot;
-
   let buffer: CircularBuffer<number>;
   let count: number;
 
-  if (fs !== null && snapshotMatches) {
-    buffer = CircularBuffer.fromSnapshot(fs.buffer);
-    count = fs.count;
-  } else if (fs !== null && sourceMatchesSnapshot) {
-    // Shape change only — buffered source prices stay valid.
-    buffer = new CircularBuffer<number>(period);
-    const oldBuffer = CircularBuffer.fromSnapshot(fs.buffer);
-    const available = oldBuffer.length;
-    const carryStart = Math.max(0, available - period);
-    for (let i = carryStart; i < available; i++) {
-      buffer.push(oldBuffer.get(i));
+  if (state !== null) {
+    if (reconfigured) {
+      // Shape change (period / offset / sigma). The snapshot stores
+      // raw source prices — they remain valid input for new weights.
+      // Carry forward the latest `min(snapshot.length, new period)`
+      // prices into a buffer of the new capacity. `count` preserves
+      // the public "candles processed so far" counter; warm-up
+      // gating uses `buffer.length` separately.
+      //
+      // (Source changes are refused by resolveResume before reaching
+      // here — buffer values are not transferrable across sources.)
+      const oldBuffer = CircularBuffer.fromSnapshot(state.buffer);
+      buffer = new CircularBuffer<number>(period);
+      const available = oldBuffer.length;
+      const carryStart = Math.max(0, available - period);
+      for (let i = carryStart; i < available; i++) {
+        buffer.push(oldBuffer.get(i));
+      }
+      count = state.count;
+    } else {
+      buffer = CircularBuffer.fromSnapshot(state.buffer);
+      count = state.count;
     }
-    // Preserve the public count contract — `count` is "candles
-    // processed so far" across the indicator's whole lifetime.
-    // Warm-up readiness uses `buffer.length >= period` instead, so a
-    // grown period correctly stays not-warmed-up even though count
-    // is large.
-    count = fs.count;
   } else {
-    // Fresh start (fs === null) — count begins at 0 by definition.
-    // For a source change we *also* discard buffered prices because
-    // their meaning shifts (close vs high vs hl2 etc.), but we keep
-    // `fs.count` so the public processed-candles counter stays
-    // monotonic across the reconfiguration.
     buffer = new CircularBuffer<number>(period);
-    count = fs?.count ?? 0;
+    count = 0;
   }
 
   function computeAlma(): number {
@@ -120,47 +171,40 @@ export function createAlma(
     return value;
   }
 
-  const indicator: IncrementalIndicator<number | null, AlmaState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<AlmaState>> = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
       count++;
       buffer.push(price);
 
-      // Warm-up is gated on the *buffer* having `period` samples, not
-      // on the public `count`. A shape-only resume can carry forward
-      // historical prices (so buffer is full and we emit immediately
-      // even though count is the old run's total), and a grown-period
-      // resume needs more bars even when count is already large.
+      // Warm-up gated on the buffer being full, not on `count`. A
+      // shape-only resume can carry forward historical prices (so
+      // buffer is full and we emit immediately even though count is
+      // the old run's total), and a grown-period resume needs more
+      // bars even when count is already large.
       if (buffer.length < period) {
         return { time: candle.time, value: null };
       }
-
       return { time: candle.time, value: computeAlma() };
     },
 
     peek(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
 
-      // Buffer-based warm-up gate (see next()'s comment). A simulated
-      // push grows length by 1 until the buffer is full, then it caps.
       const peekLength = Math.min(buffer.length + 1, period);
       if (peekLength < period) {
         return { time: candle.time, value: null };
       }
 
-      // Simulate buffer with new price appended
+      // Simulate buffer with new price appended.
       let value = 0;
       const len = buffer.length;
-
       if (len < period) {
-        // Buffer not yet full: existing items + new price
         for (let i = 0; i < len; i++) {
-          // Shift by 1: weight[i] → buffer[i] but offset since buffer is shorter
           value += weights[i] * buffer.get(i);
         }
         value += weights[len] * price;
       } else {
-        // Buffer full: oldest gets evicted, everything shifts left
         for (let i = 0; i < period - 1; i++) {
           value += weights[i] * buffer.get(i + 1);
         }
@@ -170,16 +214,13 @@ export function createAlma(
       return { time: candle.time, value };
     },
 
-    getState(): AlmaState {
-      return {
-        period,
-        offset,
-        sigma,
-        source,
-        weights: [...weights],
-        buffer: buffer.snapshot(),
-        count,
-      };
+    getState(): IndicatorSnapshot<AlmaState> {
+      return makeSnapshot(
+        "alma",
+        ALMA_VERSION,
+        { period, offset, sigma, source },
+        { buffer: buffer.snapshot(), count },
+      );
     },
 
     get count() {


### PR DESCRIPTION
## Summary

Second indicator migration on top of the State Contract foundation (`epic/state-contract`). ALMA is a **leaf Category A (Windowed)** — no internal users among indicators, so this PR is scoped to ALMA itself.

## Breaking changes

- `getState()` returns `IndicatorSnapshot<AlmaState>` (not bare `AlmaState`). Pre-0.4.0 snapshots throw on resume per `STATE_CONTRACT.md §5.3`.
- `AlmaState` shape narrows: `period` / `offset` / `sigma` / `source` / `weights` move out of bare state. Params live in `meta.params`. **`weights` is dropped entirely** — deterministic function of (period, offset, sigma), recomputed at construction.
- **Source change on resume now throws** (was: silently discarded buffer and re-warmed in Phase 2C ALMA, PR #190). Aligns with the library-wide Windowed source-change refuse rule. The Phase 2C `"source-change-discards-and-warms-up-fresh"` test is rewritten to expect a throw.
- Runtime range validation tightened: `period >= 1` integer, `offset ∈ [0, 1]`, `sigma > 0`. Previously unchecked.

## State Contract pattern applied

```ts
const { params, state, reconfigured } = resolveResume<AlmaParams, AlmaState>({
  indicator: "alma",
  version: ALMA_VERSION,
  category: "windowed",
  options,
  fromState: warmUpOptions?.fromState ?? null,
  defaults: { period: 9, offset: 0.85, sigma: 6, source: "close" },
});

const period = requireParam("alma", params, "period",
  (v): v is number => Number.isInteger(v) && v >= 1, "must be a positive integer");
const offset = requireParam("alma", params, "offset",
  (v): v is number => typeof v === "number" && v >= 0 && v <= 1, "must be in [0, 1]");
const sigma = requireParam("alma", params, "sigma",
  (v): v is number => typeof v === "number" && v > 0, "must be positive");
```

`requireParam` is used here for range validation (ALMA has full canonical defaults — unlike SMA's defaultless `period`). Pattern consistent with SMA cluster.

Snapshot built via `makeSnapshot("alma", ALMA_VERSION, params, state)`.

Carry-forward on shape change preserved (period / offset / sigma change). The snapshot's raw price buffer remains valid under new weights, so we carry forward the latest `min(snapshot.length, new period)` prices.

## Test updates

- 5 Phase 2C ALMA regression tests updated:
  - Path updates: `state.period` → `state.meta.params.period` (and similar for offset/sigma/source), `state.count` → `state.state.count`.
  - **Source-change test rewritten** to expect throw with `/source mismatch|incompatible snapshot/` rather than silent re-warm.
- `state-contract-integration.test.ts` adds ALMA registration with `describeContract` — 6/6 invariants pass. `reconfigParams` mix period grow/shrink plus offset/sigma changes to exercise non-period shape reconfig.

## Codex review note

Codex P1: "Preserve a fallback for pre-contract ALMA snapshots" — **held as intended behavior**:
- `STATE_CONTRACT.md §5.3` documents the pre-0.4.0 streaming session incompatibility explicitly
- Silent fallback would mask the breaking change and risk users not noticing their ALMA history was discarded
- Consistent with SMA cluster (#199) which adopted the same precedent
- Streaming-level "catch + log + per-indicator skip" is a separate concern, deferred to a follow-up "streaming session upgrade safety" PR within the 0.4.0 release window

## Test plan

- [x] `pnpm test` — 5172 tests green
- [x] `pnpm lint` — clean
- [x] `pnpm build` — green
- [x] `pnpm size-check` — within cap
- [x] `pnpm exec tsc -p packages/core/tsconfig.json --noEmit --ignoreDeprecations "6.0"` — incremental subgraph clean
- [x] `describeContract` invariants: 6/6 pass for ALMA

## Target branch

Targets `epic/state-contract`, not `main`. Will be rolled into the 0.4.0 epic merge at release time.