### PR TITLE
feat(core)!: migrate WMA to State Contract (Wave 1 WMA cluster)

### DIFF
--- a/packages/core/docs/STATE_CONTRACT.md
+++ b/packages/core/docs/STATE_CONTRACT.md
@@ -258,6 +258,61 @@ ALMA: incompatible snapshot, re-warm required (period mismatch: snapshot=9 reque
 `resolveResume` constructs the message; per-indicator code does not
 need to format it.
 
+### 4.1 Error-handling responsibility (library invariant)
+
+**The library propagates errors with context; the caller is
+responsible for catching them and deciding the recovery path.** This
+is a library-wide invariant — every Wave / every cluster / every
+future migration follows it. It exists because:
+
+- A composite indicator (HMA, Coppock, KST, DPO, …) embeds nested
+  leaf indicators. When a nested leaf throws (e.g. `wma:
+  incompatible snapshot`) the error reaches the caller through the
+  composite call. The library does **not** pre-translate the error
+  to the composite's name.
+- The caller's call site is the only place that has full context
+  (which indicator was invoked, what user-facing action triggered
+  it, what UX response is appropriate). The library cannot guess
+  that — and shouldn't try.
+- Per-wrapper translation shims (`if nested state is legacy, throw
+  with wrapper name`) would be reactive: every time a new composite
+  uses an existing leaf, the existing leaf or its callers would
+  need a new shim. That couples leaves to their consumers and
+  scales poorly across ~90 indicators.
+
+The implication: when you call `createXxx({}, { fromState })` and
+catch `Error("<indicator>: incompatible snapshot, ...")`, your code
+is the right place to handle it. Standard recovery paths:
+
+```ts
+// 1. Re-warm from candle history (most common).
+try {
+  ind = createHma({ period: 16 }, { fromState: savedHma });
+} catch (err) {
+  ind = createHma({ period: 16 });
+  for (const candle of warmUpCandles) ind.next(candle);
+}
+
+// 2. Fall back to a fresh instance with no warm-up.
+try {
+  ind = createHma({ period: 16 }, { fromState: savedHma });
+} catch {
+  ind = createHma({ period: 16 });
+}
+
+// 3. Surface to the operator with your own UI text.
+try {
+  ind = createHma({ period: 16 }, { fromState: savedHma });
+} catch (err) {
+  logger.warn("HMA state from older release; re-warming", err);
+  // ... your re-warm or skip logic
+}
+```
+
+Library code itself never catches `resolveResume` errors — that
+would conflate the library's job (detection + clear reporting) with
+the caller's job (recovery policy).
+
 ## 5. Migration guide (0.3.x → 0.4.0)
 
 For library consumers:
@@ -327,6 +382,39 @@ session snapshots persisted under 0.3.x cannot be resumed in
 Strategy JSON (`serializeStrategy` / `parseStrategy`) describes
 indicator *configurations*, not runtime state — it is unaffected by
 this change.
+
+### 5.4 Error surface for legacy nested snapshots (intentional)
+
+When a Wave-N migrated leaf indicator (e.g., WMA migrated in Wave 1)
+is embedded in an unmigrated wrapper (e.g., HMA / Coppock Curve,
+which migrate in their own Wave), resuming a pre-0.4.0 wrapper
+snapshot causes the inner leaf's `resolveResume()` to throw
+`<leaf>: incompatible snapshot, re-warm required` with `missing
+meta`. The caller sees a leaf-scoped error inside a wrapper call.
+
+**This is the intended behavior** and follows directly from §4.1's
+error-handling invariant: the library propagates errors with
+context, the caller decides recovery. We deliberately do not add
+per-wrapper legacy guards because:
+
+1. **It violates §4.1.** Per-wrapper guards translate / pre-handle
+   errors that should propagate to the caller's call site.
+2. **Symmetry across the library.** ALMA (a leaf with no wrapper)
+   only ever throws as itself. SMA (leaf) is wrapped by 7
+   indicators — those wrappers also surface the SMA error directly,
+   no shim. If WMA added per-wrapper guards in HMA/Coppock, the
+   contract would behave asymmetrically across migration waves and
+   would need a new shim every time a new composite is added.
+3. **The error message correctly identifies the failing leaf.**
+   `wma: incompatible snapshot` inside an HMA call tells the caller
+   exactly which nested state is the problem; §4.1's recovery
+   patterns (re-warm / fall back / surface) apply unchanged.
+
+When the wrapper itself is migrated in a later Wave, its own
+top-level `resolveResume()` will throw first (e.g., `hma:
+incompatible snapshot`) before reaching the nested leaf. At that
+point the user-facing error becomes wrapper-scoped naturally — no
+bridge code needed and nothing to delete.
 
 ## 6. Roadmap
 

--- a/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
@@ -283,7 +283,7 @@ describe("WMA mathematical correctness", () => {
     });
     // WMA = (10*1 + 20*2 + 30*3) / (1+2+3) = (10+40+90)/6 = 140/6
     const state = wma.getState();
-    expect(state.count).toBe(3);
+    expect(state.state.count).toBe(3);
   });
 
   it("WMA peek returns correct value without modifying internal state", () => {

--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -15,6 +15,7 @@
 import type { NormalizedCandle } from "../../../types";
 import { type AlmaState, createAlma } from "../moving-average/alma";
 import { createSma, type SmaState } from "../moving-average/sma";
+import { createWma, type WmaState } from "../moving-average/wma";
 import { describeContract } from "./contract-helper";
 
 // ---- Shared candle generator ----
@@ -69,6 +70,20 @@ describeContract<number | null, AlmaState>({
   // reconfig invariant exercises shape changes that aren't just
   // period grows/shrinks.
   reconfigParams: [{ period: 14 }, { period: 5 }, { offset: 0.5 }, { sigma: 3 }],
+  makeCandles,
+  streamLength: 100,
+});
+
+// ---- WMA (Wave 1 WMA cluster, Category Windowed, version 1) ----
+
+describeContract<number | null, WmaState>({
+  name: "wma",
+  create: (opts, warmUp) =>
+    createWma(opts as { period?: number; source?: "close" | "high" }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 20, source: "close" },
+  reconfigParams: [{ period: 10 }, { period: 30 }],
   makeCandles,
   streamLength: 100,
 });

--- a/packages/core/src/indicators/incremental/momentum/coppock-curve.ts
+++ b/packages/core/src/indicators/incremental/momentum/coppock-curve.ts
@@ -12,6 +12,7 @@
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import type { WmaState } from "../moving-average/wma";
 import { createWma } from "../moving-average/wma";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import { makeCandle } from "../utils";
 import type { RocState } from "./roc";
@@ -27,7 +28,7 @@ export type CoppockCurveState = {
   source: PriceSource;
   longRocState: RocState;
   shortRocState: RocState;
-  wmaState: WmaState;
+  wmaState: IndicatorSnapshot<WmaState>;
   count: number;
 };
 

--- a/packages/core/src/indicators/incremental/moving-average/hma.ts
+++ b/packages/core/src/indicators/incremental/moving-average/hma.ts
@@ -12,6 +12,7 @@
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import { makeCandle } from "../utils";
 import type { WmaState } from "./wma";
@@ -20,9 +21,9 @@ import { createWma } from "./wma";
 export type HmaState = {
   period: number;
   source: PriceSource;
-  halfWmaState: WmaState;
-  fullWmaState: WmaState;
-  finalWmaState: WmaState;
+  halfWmaState: IndicatorSnapshot<WmaState>;
+  fullWmaState: IndicatorSnapshot<WmaState>;
+  finalWmaState: IndicatorSnapshot<WmaState>;
   count: number;
 };
 

--- a/packages/core/src/indicators/incremental/moving-average/wma.ts
+++ b/packages/core/src/indicators/incremental/moving-average/wma.ts
@@ -1,20 +1,46 @@
 /**
  * Incremental WMA (Weighted Moving Average)
+ *
+ * State category: **Windowed** (raw price buffer + cached running
+ * sums for O(1) update). Migrated to the 0.4.0 State Contract:
+ * `getState()` returns `IndicatorSnapshot<WmaState>` and `fromState`
+ * accepts the same.
+ *
+ * Defaults: `source` defaults to `"close"`. `period` has no canonical
+ * default (Pine Script / TA-Lib / Tulip all require it from the
+ * caller); it must be supplied on first construction. On resume, it
+ * may be omitted to inherit from the snapshot.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for WMA. Params (`period`, `source`) live in
+ * `meta.params`. `weightDenominator` is recomputed at construction
+ * from `period` — it's a cache, not canonical state.
+ */
 export type WmaState = {
-  period: number;
-  source: PriceSource;
   buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   weightedSum: number;
   simpleSum: number;
-  weightDenominator: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bump on any breaking state change. */
+export const WMA_VERSION = 1;
+
+type WmaParams = {
+  period: number;
+  source: PriceSource;
 };
 
 /**
@@ -24,19 +50,41 @@ export type WmaState = {
  *
  * @example
  * ```ts
+ * // Fresh start — period is required on first call.
  * const wma10 = createWma({ period: 10 });
  * for (const candle of stream) {
  *   const { value } = wma10.next(candle);
  *   if (wma10.isWarmedUp) console.log(value);
  * }
+ *
+ * // Resume — period may be omitted; the snapshot supplies it.
+ * const resumed = createWma({}, { fromState: snapshot });
  * ```
  */
 export function createWma(
-  options: { period: number; source?: PriceSource },
-  warmUpOptions?: WarmUpOptions<WmaState>,
-): IncrementalIndicator<number | null, WmaState> {
-  const period = options.period;
-  const source: PriceSource = options.source ?? "close";
+  options: { period?: number; source?: PriceSource },
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<WmaState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<WmaState>> {
+  const { params, state, reconfigured } = resolveResume<WmaParams, WmaState>({
+    indicator: "wma",
+    version: WMA_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { source: "close" }, // `period` intentionally absent — no canonical default.
+  });
+
+  const period = requireParam(
+    "wma",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
   const weightDenominator = (period * (period + 1)) / 2;
 
   let buffer: CircularBuffer<number>;
@@ -44,12 +92,37 @@ export function createWma(
   let simpleSum: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    weightedSum = s.weightedSum;
-    simpleSum = s.simpleSum;
-    count = s.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // Period change. The snapshot's buffer is at the OLD capacity
+      // and its weightedSum / simpleSum reflect the OLD window
+      // weighting — neither carries forward as-is. Rebuild the
+      // buffer at the new capacity from the latest snapshot prices
+      // and recompute both sums from those carried samples.
+      //
+      // (Source changes are refused by resolveResume before reaching
+      // here.)
+      const oldBuffer = CircularBuffer.fromSnapshot(state.buffer);
+      buffer = new CircularBuffer<number>(period);
+      const available = oldBuffer.length;
+      const carryStart = Math.max(0, available - period);
+      weightedSum = 0;
+      simpleSum = 0;
+      let weightIdx = 0;
+      for (let i = carryStart; i < available; i++) {
+        const v = oldBuffer.get(i);
+        buffer.push(v);
+        weightedSum += v * (weightIdx + 1);
+        simpleSum += v;
+        weightIdx++;
+      }
+      count = state.count;
+    } else {
+      buffer = CircularBuffer.fromSnapshot(state.buffer);
+      weightedSum = state.weightedSum;
+      simpleSum = state.simpleSum;
+      count = state.count;
+    }
   } else {
     buffer = new CircularBuffer<number>(period);
     weightedSum = 0;
@@ -57,7 +130,7 @@ export function createWma(
     count = 0;
   }
 
-  const indicator: IncrementalIndicator<number | null, WmaState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<WmaState>> = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
       count++;
@@ -68,36 +141,34 @@ export function createWma(
         // simpleSum = simpleSum - oldest + newPrice
         weightedSum = weightedSum - simpleSum + price * period;
         simpleSum = simpleSum - buffer.oldest() + price;
-      } else {
-        // Building up the initial window
-        buffer.push(price); // push first so we can read length
-        // Recalculate from scratch during warmup for simplicity
-        weightedSum = 0;
-        simpleSum = 0;
-        const len = buffer.length;
-        for (let i = 0; i < len; i++) {
-          const w = i + 1;
-          weightedSum += buffer.get(i) * w;
-          simpleSum += buffer.get(i);
-        }
-
-        if (count < period) {
-          return { time: candle.time, value: null };
-        }
-
+        buffer.push(price);
         return { time: candle.time, value: weightedSum / weightDenominator };
       }
 
+      // Buffer not yet full — build up.
       buffer.push(price);
+      // Recompute from scratch during warmup (cheap, period bars max).
+      weightedSum = 0;
+      simpleSum = 0;
+      const len = buffer.length;
+      for (let i = 0; i < len; i++) {
+        const w = i + 1;
+        weightedSum += buffer.get(i) * w;
+        simpleSum += buffer.get(i);
+      }
 
+      // Warm-up gated on `buffer.length` (not `count`) so a
+      // period-growing resume waits for the rebuilt buffer to fill.
+      if (buffer.length < period) {
+        return { time: candle.time, value: null };
+      }
       return { time: candle.time, value: weightedSum / weightDenominator };
     },
 
     peek(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
-      const peekCount = count + 1;
-
-      if (peekCount < period) {
+      const peekLength = Math.min(buffer.length + 1, period);
+      if (peekLength < period) {
         return { time: candle.time, value: null };
       }
 
@@ -106,7 +177,7 @@ export function createWma(
         return { time: candle.time, value: newWeightedSum / weightDenominator };
       }
 
-      // During warmup phase, compute from scratch
+      // During warmup phase, compute from scratch.
       let ws = 0;
       const len = buffer.length;
       for (let i = 0; i < len; i++) {
@@ -117,16 +188,13 @@ export function createWma(
       return { time: candle.time, value: ws / wd };
     },
 
-    getState(): WmaState {
-      return {
-        period,
-        source,
-        buffer: buffer.snapshot(),
-        weightedSum,
-        simpleSum,
-        weightDenominator,
-        count,
-      };
+    getState(): IndicatorSnapshot<WmaState> {
+      return makeSnapshot(
+        "wma",
+        WMA_VERSION,
+        { period, source },
+        { buffer: buffer.snapshot(), weightedSum, simpleSum, count },
+      );
     },
 
     get count() {
@@ -134,7 +202,7 @@ export function createWma(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      return buffer.length >= period;
     },
   };
 


### PR DESCRIPTION
## Summary

Third indicator migration on top of the State Contract foundation (`epic/state-contract`). WMA is Category A (Windowed) with **two internal users** — HMA (3 nested WMAs) and Coppock Curve (1 nested WMA). Both wrappers receive type-field-only updates; their own State Contract migration is deferred to their respective waves.

## Breaking changes

- `getState()` returns `IndicatorSnapshot<WmaState>` (not bare `WmaState`). Pre-0.4.0 snapshots throw on resume per `STATE_CONTRACT.md §5.3`.
- `options.period` is now optional in TypeScript (was required). Same defaultless-param pattern as SMA — `period` has no canonical default across mainstream libraries; `requireParam` enforces it at runtime.
- `WmaState` shape narrows: `period` / `source` / `weightDenominator` move out of bare state. Params live in `meta.params`. **`weightDenominator` is dropped entirely** — deterministic function of `period`, recomputed at construction.
- **Source change on resume throws** (Windowed source-change refuse).
- **Reconfig (period change) carries forward** the latest snapshot prices and **recomputes both `weightedSum` and `simpleSum`** from carried samples (snapshot's sums reflect OLD weighted window).

## Internal users — type field updates only

- **HMA**: `halfWmaState`, `fullWmaState`, `finalWmaState` → `IndicatorSnapshot<WmaState>`
- **Coppock Curve**: `wmaState` → `IndicatorSnapshot<WmaState>`

Both are opaque pass-through (no `.buffer` / `.weightedSum` reach-in, confirmed via pre-flight grep). Their own State Contract migration is intentionally NOT in this PR.

## STATE_CONTRACT.md updates

### New §4.1 — Error-handling responsibility (library invariant)

Codifies the rule: **library propagates errors with context, caller decides recovery.** Documents the three standard recovery patterns (re-warm / fall back / surface) with try/catch examples.

```ts
try {
  ind = createHma({ period: 16 }, { fromState: savedHma });
} catch (err) {
  ind = createHma({ period: 16 });
  for (const candle of warmUpCandles) ind.next(candle);
}
```

This codifies the "no per-wrapper translation shims" rule as a library-wide invariant that applies to every Wave / every cluster — not just transitional migration. Added to prevent the recurring Codex feedback loop about "users see leaf-scoped errors inside wrapper calls — translate them at the wrapper": that suggestion violates §4.1 by definition and creates reactive coupling between leaves and consumers.

### §5.4 (transitional error surface) rewritten

Now derives from §4.1 — same conclusion, grounded in the library-wide invariant rather than the previous ad-hoc symmetry argument. Cross-references §4.1's recovery patterns explicitly.

## Codex review note

Codex P1: "Reject or migrate legacy HMA / Coppock snapshots before nesting WMA state". **Held**, with rationale now formally documented via §4.1's "library propagates, caller catches" invariant. Future migrations should pin §4.1 when the same suggestion appears.

## Test plan

- [x] `pnpm test` — full repo green
- [x] `pnpm lint` — clean
- [x] `pnpm build` — green
- [x] `pnpm size-check` — within cap
- [x] `pnpm exec tsc -p packages/core/tsconfig.json --noEmit --ignoreDeprecations "6.0"` — incremental subgraph clean
- [x] `describeContract` invariants: 6/6 pass for WMA

## Target branch

Targets `epic/state-contract`, not `main`. Will be rolled into the 0.4.0 epic merge at release time.