### PR TITLE
feat(core)!: migrate VWMA/Choppiness/Ulcer/TWAP to State Contract (Wave 1 Bundle A)

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -15,7 +15,11 @@
 import type { NormalizedCandle } from "../../../types";
 import { type AlmaState, createAlma } from "../moving-average/alma";
 import { createSma, type SmaState } from "../moving-average/sma";
+import { createVwma, type VwmaState } from "../moving-average/vwma";
 import { createWma, type WmaState } from "../moving-average/wma";
+import { type ChoppinessIndexState, createChoppinessIndex } from "../volatility/choppiness-index";
+import { createUlcerIndex, type UlcerIndexState } from "../volatility/ulcer-index";
+import { createTwap, type TwapState } from "../volume/twap";
 import { describeContract } from "./contract-helper";
 
 // ---- Shared candle generator ----
@@ -84,6 +88,70 @@ describeContract<number | null, WmaState>({
   version: 1,
   defaultParams: { period: 20, source: "close" },
   reconfigParams: [{ period: 10 }, { period: 30 }],
+  makeCandles,
+  streamLength: 100,
+});
+
+// ---- Bundle A: VWMA / Choppiness Index / Ulcer Index / TWAP ----
+
+// VWMA — Windowed, same defaultless-period pattern as SMA/WMA.
+describeContract<number | null, VwmaState>({
+  name: "vwma",
+  create: (opts, warmUp) =>
+    createVwma(opts as { period?: number; source?: "close" | "high" }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 20, source: "close" },
+  reconfigParams: [{ period: 10 }, { period: 30 }],
+  makeCandles,
+  streamLength: 100,
+});
+
+// Choppiness Index — Windowed; `period` has a canonical default of 14
+// (Bill Dreiss). TR/H/L buffers carry forward as raw values.
+describeContract<number | null, ChoppinessIndexState>({
+  name: "choppinessIndex",
+  create: (opts, warmUp) => createChoppinessIndex(opts as { period?: number }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 14 },
+  reconfigParams: [{ period: 7 }, { period: 28 }],
+  makeCandles,
+  streamLength: 200,
+});
+
+// Ulcer Index — Windowed two-stage. On reconfig the `prices` buffer
+// carries forward but `drawdowns` is cleared and re-derived (each
+// drawdown is per-period). Effective re-warmup margin is therefore
+// up to `2 * newPeriod` post-resume bars.
+describeContract<number | null, UlcerIndexState>({
+  name: "ulcerIndex",
+  create: (opts, warmUp) =>
+    createUlcerIndex(opts as { period?: number; source?: "close" | "high" }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 14, source: "close" },
+  reconfigParams: [{ period: 7 }, { period: 28 }],
+  // Two-stage warmup: prices buffer + drawdowns buffer. After reconfig
+  // both must re-fill before the resumed series matches a fresh run.
+  // `2 * newPeriod` is the safe upper bound (worst case: oldPeriod=0).
+  reconfigMargin: (newOpts) => 2 * (newOpts.period as number),
+  makeCandles,
+  streamLength: 200,
+});
+
+// TWAP — Recursive (`cumTp` accumulator with session-boundary resets;
+// no raw-price window to carry forward). Any `sessionResetPeriod`
+// change throws via the recursive policy.
+describeContract<number | null, TwapState>({
+  name: "twap",
+  create: (opts, warmUp) => createTwap(opts as { sessionResetPeriod?: "session" | number }, warmUp),
+  category: "recursive",
+  version: 1,
+  defaultParams: { sessionResetPeriod: "session" },
+  // Exercise both directions: switch to a numeric session AND between
+  // two different numeric sessions.
+  reconfigParams: [{ sessionResetPeriod: 60 }, { sessionResetPeriod: 30 }],
   makeCandles,
   streamLength: 100,
 });

--- a/packages/core/src/indicators/incremental/__tests__/volatility-indicators.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/volatility-indicators.test.ts
@@ -209,11 +209,13 @@ describe("Ulcer Index incremental", () => {
     }
   });
 
-  it("legacy single-buffer state snapshot is rejected with a clear error", () => {
-    // Snapshot produced by the pre-canonical (single-buffer) code path
-    // that shipped in earlier versions. Restoring it under the new
-    // two-stage formula would silently produce wrong values, so the
-    // factory must throw a recognizable error instead.
+  it("pre-0.4.0 bare-state snapshot is rejected by the State Contract", () => {
+    // A pre-0.4.0 snapshot is bare state without the `meta` envelope.
+    // Includes the now-removed single-buffer field as well — both
+    // shapes flunk the same missing-meta check in resolveResume.
+    // The dedicated translation shim that used to live inside
+    // createUlcerIndex was removed (STATE_CONTRACT.md §4.1: per-
+    // indicator guards aren't added; resolveResume handles it).
     const legacyState = {
       period: 14,
       source: "close" as const,
@@ -221,7 +223,7 @@ describe("Ulcer Index incremental", () => {
       count: 3,
     };
     expect(() => createUlcerIndex({ period: 14 }, { fromState: legacyState as never })).toThrow(
-      /legacy state snapshot/i,
+      /incompatible snapshot|pre-0\.4\.0/i,
     );
   });
 });

--- a/packages/core/src/indicators/incremental/moving-average/vwma.ts
+++ b/packages/core/src/indicators/incremental/moving-average/vwma.ts
@@ -1,17 +1,34 @@
 /**
  * Incremental VWMA (Volume Weighted Moving Average)
  *
+ * State category: **Windowed** (raw price * volume + raw volume buffers).
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<VwmaState>` and `fromState` accepts the same.
+ *
  * VWMA = Sum(Price * Volume, n) / Sum(Volume, n)
+ *
+ * Defaults: `source` defaults to `"close"`. `period` has no canonical
+ * default (Pine Script / TA-Lib / Tulip all require it from the
+ * caller); it must be supplied on first construction. On resume, it
+ * may be omitted to inherit from the snapshot.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for VWMA. Params (`period`, `source`) live in
+ * `meta.params` on the wire — they are not part of the bare state.
+ */
 export type VwmaState = {
-  period: number;
-  source: PriceSource;
   pvBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   volBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   sumPV: number;
@@ -19,24 +36,55 @@ export type VwmaState = {
   count: number;
 };
 
+/** Per-indicator schema version. Bump on any breaking state change. */
+export const VWMA_VERSION = 1;
+
+type VwmaParams = {
+  period: number;
+  source: PriceSource;
+};
+
 /**
  * Create an incremental VWMA indicator
  *
  * @example
  * ```ts
+ * // Fresh start — period is required on first call.
  * const vwma20 = createVwma({ period: 20 });
  * for (const candle of stream) {
  *   const { value } = vwma20.next(candle);
  *   if (vwma20.isWarmedUp) console.log(value);
  * }
+ *
+ * // Resume from a saved snapshot — period may be omitted; the
+ * // snapshot supplies it.
+ * const resumed = createVwma({}, { fromState: snapshot });
  * ```
  */
 export function createVwma(
-  options: { period: number; source?: PriceSource },
-  warmUpOptions?: WarmUpOptions<VwmaState>,
-): IncrementalIndicator<number | null, VwmaState> {
-  const period = options.period;
-  const source: PriceSource = options.source ?? "close";
+  options: { period?: number; source?: PriceSource },
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<VwmaState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<VwmaState>> {
+  const { params, state, reconfigured } = resolveResume<VwmaParams, VwmaState>({
+    indicator: "vwma",
+    version: VWMA_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { source: "close" }, // `period` is intentionally absent — no canonical default.
+  });
+
+  const period = requireParam(
+    "vwma",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
 
   let pvBuffer: CircularBuffer<number>;
   let volBuffer: CircularBuffer<number>;
@@ -44,13 +92,37 @@ export function createVwma(
   let sumV: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    pvBuffer = CircularBuffer.fromSnapshot(s.pvBuffer);
-    volBuffer = CircularBuffer.fromSnapshot(s.volBuffer);
-    sumPV = s.sumPV;
-    sumV = s.sumV;
-    count = s.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // Period change. The snapshot's buffers are at the OLD capacity;
+      // we need buffers at the NEW capacity holding the most recent
+      // min(snapshot.length, newPeriod) samples. sumPV/sumV must be
+      // recomputed from those carried samples — the snapshot's sums
+      // were over the old window and would be wrong for the new one.
+      const oldPv = CircularBuffer.fromSnapshot(state.pvBuffer);
+      const oldVol = CircularBuffer.fromSnapshot(state.volBuffer);
+      pvBuffer = new CircularBuffer<number>(period);
+      volBuffer = new CircularBuffer<number>(period);
+      const available = oldPv.length;
+      const carryStart = Math.max(0, available - period);
+      sumPV = 0;
+      sumV = 0;
+      for (let i = carryStart; i < available; i++) {
+        const pv = oldPv.get(i);
+        const vol = oldVol.get(i);
+        pvBuffer.push(pv);
+        volBuffer.push(vol);
+        sumPV += pv;
+        sumV += vol;
+      }
+      count = state.count;
+    } else {
+      pvBuffer = CircularBuffer.fromSnapshot(state.pvBuffer);
+      volBuffer = CircularBuffer.fromSnapshot(state.volBuffer);
+      sumPV = state.sumPV;
+      sumV = state.sumV;
+      count = state.count;
+    }
   } else {
     pvBuffer = new CircularBuffer<number>(period);
     volBuffer = new CircularBuffer<number>(period);
@@ -59,38 +131,30 @@ export function createVwma(
     count = 0;
   }
 
-  function computeValue(pv: number, vol: number): number | null {
-    if (count + 1 < period) return null;
-    let newSumPV = sumPV + pv;
-    let newSumV = sumV + vol;
-    if (pvBuffer.isFull) {
-      newSumPV -= pvBuffer.oldest();
-      newSumV -= volBuffer.oldest();
-    }
-    return newSumV === 0 ? null : newSumPV / newSumV;
-  }
-
-  const indicator: IncrementalIndicator<number | null, VwmaState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<VwmaState>> = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
       const vol = candle.volume;
       const pv = price * vol;
-      count++;
 
       if (pvBuffer.isFull) {
-        sumPV -= pvBuffer.oldest();
-        sumV -= volBuffer.oldest();
+        sumPV = sumPV - pvBuffer.oldest() + pv;
+        sumV = sumV - volBuffer.oldest() + vol;
+      } else {
+        sumPV += pv;
+        sumV += vol;
       }
 
-      sumPV += pv;
-      sumV += vol;
       pvBuffer.push(pv);
       volBuffer.push(vol);
+      count++;
 
-      if (count < period) {
+      // Warm-up gated on the buffer being full, not on `count`. After
+      // a period-growing resume, `count` is the snapshot's large
+      // value but the rebuilt buffer needs more candles to fill.
+      if (pvBuffer.length < period) {
         return { time: candle.time, value: null };
       }
-
       return { time: candle.time, value: sumV === 0 ? null : sumPV / sumV };
     },
 
@@ -98,19 +162,26 @@ export function createVwma(
       const price = getSourcePrice(candle, source);
       const vol = candle.volume;
       const pv = price * vol;
-      return { time: candle.time, value: computeValue(pv, vol) };
+      const newSumPV = pvBuffer.isFull ? sumPV - pvBuffer.oldest() + pv : sumPV + pv;
+      const newSumV = volBuffer.isFull ? sumV - volBuffer.oldest() + vol : sumV + vol;
+      const newLength = Math.min(pvBuffer.length + 1, period);
+      if (newLength < period) return { time: candle.time, value: null };
+      return { time: candle.time, value: newSumV === 0 ? null : newSumPV / newSumV };
     },
 
-    getState(): VwmaState {
-      return {
-        period,
-        source,
-        pvBuffer: pvBuffer.snapshot(),
-        volBuffer: volBuffer.snapshot(),
-        sumPV,
-        sumV,
-        count,
-      };
+    getState(): IndicatorSnapshot<VwmaState> {
+      return makeSnapshot(
+        "vwma",
+        VWMA_VERSION,
+        { period, source },
+        {
+          pvBuffer: pvBuffer.snapshot(),
+          volBuffer: volBuffer.snapshot(),
+          sumPV,
+          sumV,
+          count,
+        },
+      );
     },
 
     get count() {
@@ -118,7 +189,7 @@ export function createVwma(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      return pvBuffer.length >= period;
     },
   };
 

--- a/packages/core/src/indicators/incremental/volatility/choppiness-index.ts
+++ b/packages/core/src/indicators/incremental/volatility/choppiness-index.ts
@@ -1,20 +1,46 @@
 /**
  * Incremental Choppiness Index
  *
+ * State category: **Windowed** (raw TR / high / low buffers).
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<ChoppinessIndexState>` and `fromState` accepts
+ * the same.
+ *
  * CHOP = 100 * LOG10(SUM(TR, period) / (HH - LL)) / LOG10(period)
+ *
+ * Defaults: `period` defaults to `14` (canonical Bill Dreiss value).
+ * Reconfig on resume carries the TR / high / low buffers forward
+ * (raw values, no per-period derivation needed).
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
+/**
+ * Bare state shape for Choppiness Index. Params (`period`) live in
+ * `meta.params` on the wire — they are not part of the bare state.
+ * `log10Period` is a derived cache and is recomputed at construction.
+ */
 export type ChoppinessIndexState = {
-  period: number;
   trBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   highBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   lowBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   prevClose: number | null;
   count: number;
+};
+
+/** Per-indicator schema version. Bump on any breaking state change. */
+export const CHOPPINESS_INDEX_VERSION = 1;
+
+type ChoppinessIndexParams = {
+  period: number;
 };
 
 /**
@@ -31,12 +57,30 @@ export type ChoppinessIndexState = {
  */
 export function createChoppinessIndex(
   options: { period?: number } = {},
-  warmUpOptions?: WarmUpOptions<ChoppinessIndexState>,
-): IncrementalIndicator<number | null, ChoppinessIndexState> {
-  const period = options.period ?? 14;
-  if (period < 2) {
-    throw new Error("Choppiness Index period must be at least 2");
-  }
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<ChoppinessIndexState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<ChoppinessIndexState>> {
+  const { params, state, reconfigured } = resolveResume<
+    ChoppinessIndexParams,
+    ChoppinessIndexState
+  >({
+    indicator: "choppinessIndex",
+    version: CHOPPINESS_INDEX_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 14 },
+  });
+
+  const period = requireParam(
+    "choppinessIndex",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 2,
+    "must be an integer >= 2",
+  );
   const log10Period = Math.log10(period);
 
   let trBuffer: CircularBuffer<number>;
@@ -45,13 +89,34 @@ export function createChoppinessIndex(
   let prevClose: number | null;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    trBuffer = CircularBuffer.fromSnapshot(s.trBuffer);
-    highBuffer = CircularBuffer.fromSnapshot(s.highBuffer);
-    lowBuffer = CircularBuffer.fromSnapshot(s.lowBuffer);
-    prevClose = s.prevClose;
-    count = s.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // Period change. Buffers are raw TR / high / low values — no
+      // per-period derivation, so we just carry forward the most
+      // recent min(snapshot.length, newPeriod) samples into buffers
+      // sized at the new period.
+      const oldTr = CircularBuffer.fromSnapshot(state.trBuffer);
+      const oldH = CircularBuffer.fromSnapshot(state.highBuffer);
+      const oldL = CircularBuffer.fromSnapshot(state.lowBuffer);
+      trBuffer = new CircularBuffer<number>(period);
+      highBuffer = new CircularBuffer<number>(period);
+      lowBuffer = new CircularBuffer<number>(period);
+      const available = oldTr.length;
+      const carryStart = Math.max(0, available - period);
+      for (let i = carryStart; i < available; i++) {
+        trBuffer.push(oldTr.get(i));
+        highBuffer.push(oldH.get(i));
+        lowBuffer.push(oldL.get(i));
+      }
+      prevClose = state.prevClose;
+      count = state.count;
+    } else {
+      trBuffer = CircularBuffer.fromSnapshot(state.trBuffer);
+      highBuffer = CircularBuffer.fromSnapshot(state.highBuffer);
+      lowBuffer = CircularBuffer.fromSnapshot(state.lowBuffer);
+      prevClose = state.prevClose;
+      count = state.count;
+    }
   } else {
     trBuffer = new CircularBuffer<number>(period);
     highBuffer = new CircularBuffer<number>(period);
@@ -83,7 +148,7 @@ export function createChoppinessIndex(
     return (100 * Math.log10(trSum / range)) / log10Period;
   }
 
-  const indicator: IncrementalIndicator<number | null, ChoppinessIndexState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<ChoppinessIndexState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -125,7 +190,12 @@ export function createChoppinessIndex(
       peekH.push(candle.high);
       peekL.push(candle.low);
 
-      if (peekTr.length < period) return { time: candle.time, value: null };
+      // Same gate as `compute()`: need a full buffer AND we must be
+      // past the first-bar TR=0 (count + 1 > period means at least
+      // one TR computed from a real prevClose has rolled in).
+      if (peekTr.length < period || count + 1 <= period) {
+        return { time: candle.time, value: null };
+      }
 
       let trSum = 0;
       let hh = Number.NEGATIVE_INFINITY;
@@ -142,15 +212,19 @@ export function createChoppinessIndex(
       return { time: candle.time, value: (100 * Math.log10(trSum / range)) / log10Period };
     },
 
-    getState(): ChoppinessIndexState {
-      return {
-        period,
-        trBuffer: trBuffer.snapshot(),
-        highBuffer: highBuffer.snapshot(),
-        lowBuffer: lowBuffer.snapshot(),
-        prevClose,
-        count,
-      };
+    getState(): IndicatorSnapshot<ChoppinessIndexState> {
+      return makeSnapshot(
+        "choppinessIndex",
+        CHOPPINESS_INDEX_VERSION,
+        { period },
+        {
+          trBuffer: trBuffer.snapshot(),
+          highBuffer: highBuffer.snapshot(),
+          lowBuffer: lowBuffer.snapshot(),
+          prevClose,
+          count,
+        },
+      );
     },
 
     get count() {
@@ -158,7 +232,7 @@ export function createChoppinessIndex(
     },
 
     get isWarmedUp() {
-      return trBuffer.isFull;
+      return trBuffer.length >= period && count > period;
     },
   };
 

--- a/packages/core/src/indicators/incremental/volatility/ulcer-index.ts
+++ b/packages/core/src/indicators/incremental/volatility/ulcer-index.ts
@@ -1,6 +1,10 @@
 /**
  * Incremental Ulcer Index (Peter Martin & Byron McCann, 1987 / 1989)
  *
+ * State category: **Windowed** (two-stage: rolling-max + drawdown^2 mean).
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<UlcerIndexState>` and `fromState` accepts the same.
+ *
  * Two-stage canonical formula:
  *   1. rolling_max[j] = max(prices[j-N+1..j])
  *   2. drawdown[j]    = (prices[j] - rolling_max[j]) / rolling_max[j] × 100
@@ -9,19 +13,38 @@
  * Each bar's drawdown is measured against ITS OWN rolling peak, not
  * a peak shared across the window. Warmup is `2 * period - 1` bars
  * (first non-null at count = 2 * period - 1).
+ *
+ * Reconfig on resume: `prices` is carried forward (raw closes, no
+ * period derivation). `drawdowns` is **cleared** — each drawdown is
+ * computed against a rolling-max window of the configured period, so
+ * the snapshot's drawdowns are invalid for the new period. The
+ * indicator re-warms its drawdown buffer naturally as new candles
+ * arrive (effective re-warmup = `period_new` bars after the prices
+ * buffer is full again).
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for Ulcer Index. Params (`period`, `source`) live
+ * in `meta.params` on the wire — they are not part of the bare state.
+ */
 export type UlcerIndexState = {
-  period: number;
-  source: PriceSource;
   prices: ReturnType<CircularBuffer<number>["snapshot"]>;
   drawdowns: ReturnType<CircularBuffer<number>["snapshot"]>;
   count: number;
+};
+
+/** Per-indicator schema version. Bump on any breaking state change. */
+export const ULCER_INDEX_VERSION = 1;
+
+type UlcerIndexParams = {
+  period: number;
+  source: PriceSource;
 };
 
 /**
@@ -38,42 +61,58 @@ export type UlcerIndexState = {
  */
 export function createUlcerIndex(
   options: { period?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<UlcerIndexState>,
-): IncrementalIndicator<number | null, UlcerIndexState> {
-  const period = options.period ?? 14;
-  const source: PriceSource = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<UlcerIndexState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<UlcerIndexState>> {
+  const { params, state, reconfigured } = resolveResume<UlcerIndexParams, UlcerIndexState>({
+    indicator: "ulcerIndex",
+    version: ULCER_INDEX_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 14, source: "close" },
+  });
+
+  const period = params.period;
+  const source = params.source;
 
   let prices: CircularBuffer<number>;
   let drawdowns: CircularBuffer<number>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    // Detect the legacy single-buffer snapshot shape (released
-    // before the canonical Peter Martin two-stage rewrite). We can't
-    // back-compute the per-bar drawdowns the new algorithm needs,
-    // so the only safe path is a clear error instead of silently
-    // returning wrong values.
-    const s = warmUpOptions.fromState as UlcerIndexState & {
-      buffer?: ReturnType<CircularBuffer<number>["snapshot"]>;
-    };
-    if (s.buffer !== undefined && (s.prices === undefined || s.drawdowns === undefined)) {
-      throw new Error(
-        "createUlcerIndex: legacy state snapshot detected (single 'buffer' field). " +
-          "Ulcer Index switched to the canonical Peter Martin two-stage formula and the state schema now uses 'prices' and 'drawdowns' buffers. " +
-          "Re-warm the indicator from candles instead of restoring from the old snapshot.",
-      );
+  if (state !== null) {
+    if (reconfigured) {
+      // Period change. Carry forward the last min(snapshot, newPeriod)
+      // raw prices into a buffer sized at the new period.
+      //
+      // Drawdowns are NOT carried — each snapshot drawdown was
+      // computed against a rolling-max window of the OLD period, so
+      // they don't represent the new period's per-bar drawdowns.
+      // We clear and re-derive going forward.
+      const oldPrices = CircularBuffer.fromSnapshot(state.prices);
+      prices = new CircularBuffer<number>(period);
+      const available = oldPrices.length;
+      const carryStart = Math.max(0, available - period);
+      for (let i = carryStart; i < available; i++) {
+        prices.push(oldPrices.get(i));
+      }
+      drawdowns = new CircularBuffer<number>(period);
+      count = state.count;
+    } else {
+      prices = CircularBuffer.fromSnapshot(state.prices);
+      drawdowns = CircularBuffer.fromSnapshot(state.drawdowns);
+      count = state.count;
     }
-    prices = CircularBuffer.fromSnapshot(s.prices);
-    drawdowns = CircularBuffer.fromSnapshot(s.drawdowns);
-    count = s.count;
   } else {
     prices = new CircularBuffer<number>(period);
     drawdowns = new CircularBuffer<number>(period);
     count = 0;
   }
 
-  function rollingMaxOf(buf: CircularBuffer<number>, withExtra?: number): number {
-    let m = withExtra !== undefined ? withExtra : Number.NEGATIVE_INFINITY;
+  function rollingMaxOf(buf: CircularBuffer<number>): number {
+    let m = Number.NEGATIVE_INFINITY;
     for (let i = 0; i < buf.length; i++) {
       const v = buf.get(i);
       if (v > m) m = v;
@@ -81,17 +120,16 @@ export function createUlcerIndex(
     return m;
   }
 
-  function sumSquares(buf: CircularBuffer<number>, withExtra?: number): number {
+  function sumSquares(buf: CircularBuffer<number>): number {
     let s = 0;
     for (let i = 0; i < buf.length; i++) {
       const v = buf.get(i);
       s += v * v;
     }
-    if (withExtra !== undefined) s += withExtra * withExtra;
     return s;
   }
 
-  const indicator: IncrementalIndicator<number | null, UlcerIndexState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<UlcerIndexState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const price = getSourcePrice(candle, source);
@@ -157,14 +195,17 @@ export function createUlcerIndex(
       return { time: candle.time, value: Math.sqrt(ss / period) };
     },
 
-    getState(): UlcerIndexState {
-      return {
-        period,
-        source,
-        prices: prices.snapshot(),
-        drawdowns: drawdowns.snapshot(),
-        count,
-      };
+    getState(): IndicatorSnapshot<UlcerIndexState> {
+      return makeSnapshot(
+        "ulcerIndex",
+        ULCER_INDEX_VERSION,
+        { period, source },
+        {
+          prices: prices.snapshot(),
+          drawdowns: drawdowns.snapshot(),
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/volume/twap.ts
+++ b/packages/core/src/indicators/incremental/volume/twap.ts
@@ -1,20 +1,43 @@
 /**
  * Incremental TWAP (Time-Weighted Average Price)
  *
+ * State category: **Recursive** (`cumTp` is a cumulative accumulator
+ * with session-boundary resets — there is no raw-price window that
+ * could be carried forward across a parameter change).
+ *
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<TwapState>` and `fromState` accepts the same.
+ *
  * TWAP = Cumulative Sum of Typical Prices / Count (within session)
  * Typical Price = (High + Low + Close) / 3
+ *
+ * Reconfig policy: any change to `sessionResetPeriod` throws. The
+ * `cumTp` accumulator's meaning is tied to session boundaries; the
+ * same cumTp value represents a different aggregation under a different
+ * `sessionResetPeriod`, so silent carry-forward would mislead consumers.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
+/**
+ * Bare state shape for TWAP. Params (`sessionResetPeriod`) live in
+ * `meta.params` on the wire — they are not part of the bare state.
+ */
 export type TwapState = {
-  sessionResetPeriod: "session" | number;
   cumTp: number;
   sessionCount: number;
   count: number;
   lastDayIndex: number;
   candlesSinceReset: number;
+};
+
+/** Per-indicator schema version. Bump on any breaking state change. */
+export const TWAP_VERSION = 1;
+
+type TwapParams = {
+  sessionResetPeriod: "session" | number;
 };
 
 /**
@@ -31,9 +54,21 @@ export type TwapState = {
  */
 export function createTwap(
   options: { sessionResetPeriod?: "session" | number } = {},
-  warmUpOptions?: WarmUpOptions<TwapState>,
-): IncrementalIndicator<number | null, TwapState> {
-  const sessionResetPeriod = options.sessionResetPeriod ?? "session";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<TwapState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<TwapState>> {
+  const { params, state } = resolveResume<TwapParams, TwapState>({
+    indicator: "twap",
+    version: TWAP_VERSION,
+    category: "recursive",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { sessionResetPeriod: "session" },
+  });
+
+  const sessionResetPeriod = params.sessionResetPeriod;
   const MS_PER_DAY = 86400000;
 
   let cumTp: number;
@@ -42,13 +77,12 @@ export function createTwap(
   let lastDayIndex: number;
   let candlesSinceReset: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    cumTp = s.cumTp;
-    sessionCount = s.sessionCount;
-    count = s.count;
-    lastDayIndex = s.lastDayIndex;
-    candlesSinceReset = s.candlesSinceReset;
+  if (state !== null) {
+    cumTp = state.cumTp;
+    sessionCount = state.sessionCount;
+    count = state.count;
+    lastDayIndex = state.lastDayIndex;
+    candlesSinceReset = state.candlesSinceReset;
   } else {
     cumTp = 0;
     sessionCount = 0;
@@ -90,7 +124,7 @@ export function createTwap(
     return localCumTp / localSessionCount;
   }
 
-  const indicator: IncrementalIndicator<number | null, TwapState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<TwapState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const value = processCandle(candle, true);
@@ -102,15 +136,19 @@ export function createTwap(
       return { time: candle.time, value };
     },
 
-    getState(): TwapState {
-      return {
-        sessionResetPeriod,
-        cumTp,
-        sessionCount,
-        count,
-        lastDayIndex,
-        candlesSinceReset,
-      };
+    getState(): IndicatorSnapshot<TwapState> {
+      return makeSnapshot(
+        "twap",
+        TWAP_VERSION,
+        { sessionResetPeriod },
+        {
+          cumTp,
+          sessionCount,
+          count,
+          lastDayIndex,
+          candlesSinceReset,
+        },
+      );
     },
 
     get count() {


### PR DESCRIPTION
## Summary

Fourth migration on top of the State Contract foundation (`epic/state-contract`). Bundles four leaf indicators with no internal `src/` users — all four are referenced only by `live-presets.ts` through the opaque factory wrapper, so no per-wrapper type updates are needed.

| Indicator | Category | Version | `period` default | Reconfig policy |
|---|---|---|---|---|
| **VWMA** | Windowed | 1 | none (Pine/TA-Lib pattern) | carry pv/vol buffers + recompute sumPV/sumV |
| **Choppiness Index** | Windowed | 1 | 14 (Bill Dreiss) | carry TR/H/L buffers as raw values |
| **Ulcer Index** | Windowed two-stage | 1 | 14 (Peter Martin) | carry `prices`, clear `drawdowns` (per-period derivation) |
| **TWAP** | **Recursive** | 1 | n/a (`sessionResetPeriod` default `"session"`) | any param change throws |

TWAP is reclassified from the initial Bundle A plan: `cumTp` is an accumulator with session-boundary resets — not a raw-price window that could be carried forward. The recursive category matches its actual state semantics and produces the throw-on-mismatch behavior we want.

## Breaking changes

- `getState()` returns `IndicatorSnapshot<State>` (not bare state). Pre-0.4.0 snapshots throw on resume per `STATE_CONTRACT.md` §5.3.
- `period` / `source` / `sessionResetPeriod` move out of bare state into `meta.params`.
- Source change on resume throws for Windowed indicators with a `source` parameter (VWMA, Ulcer).

## Per-indicator notes

### VWMA
- `period` has no canonical default; `requireParam` enforces it at runtime with the same defaultless-param pattern as SMA/WMA.
- Reconfig carries forward the pv/vol buffers and **recomputes `sumPV` / `sumV`** from the carried samples — the snapshot's sums reflect the OLD window.

### Choppiness Index
- `log10Period` is a derived cache; dropped from bare state and recomputed at construction.
- `isWarmedUp` now aligns with `compute()` (`trBuffer.length >= period && count > period`) instead of returning true one bar before the first non-null value.

### Ulcer Index
- Reconfig carries `prices` (raw closes) but **clears `drawdowns`** — each drawdown is computed against a rolling-max window of the configured period, so the snapshot's drawdowns are invalid for the new period. Effective re-warmup margin is `2 * newPeriod` post-resume bars.
- **Legacy single-buffer state detection removed.** STATE_CONTRACT.md §4.1 invariant: per-indicator translation shims are not added; the generic `resolveResume` missing-meta path covers pre-0.4.0 snapshots uniformly.

### TWAP
- Recursive policy. Any `sessionResetPeriod` change throws via the `resolveResume` recursive branch; `cumTp`'s meaning is tied to session boundaries and silent carry-forward would mislead consumers.

## Contract test integration

- 4 entries added to `state-contract-integration.test.ts`.
- Ulcer overrides `reconfigMargin: (newOpts) => 2 * newOpts.period` to cover its two-stage warmup (prices buffer + drawdowns buffer both must re-fill after reconfig).
- Existing per-indicator tests pass with only one fixup: Ulcer's legacy-state test updated to the generic `/incompatible snapshot|pre-0\.4\.0/i` pattern.

## Test plan

- [x] `pnpm --filter trendcraft test` — 5201/5201 green
- [x] `pnpm lint` — clean
- [x] `pnpm build` — green
- [x] `pnpm --filter @trendcraft/chart size-check` — within cap
- [x] `pnpm --filter trendcraft exec tsc -p tsconfig.json --noEmit --ignoreDeprecations "6.0"` — incremental subgraph clean (5 pre-existing errors in `strategy-dna` / `always-conditions` predate epic base `d263cda`, unrelated to this PR)
- [x] `describeContract` invariants: 42/42 across SMA/ALMA/WMA/VWMA/Choppiness/Ulcer/TWAP
- [x] Chart perf test passes on retry (known node-22 flaky test tracked in the project memory)