### PR TITLE
feat(core)!: migrate StandardDeviation/VWAP to State Contract (Wave 1 Bundle B)

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -18,8 +18,13 @@ import { createSma, type SmaState } from "../moving-average/sma";
 import { createVwma, type VwmaState } from "../moving-average/vwma";
 import { createWma, type WmaState } from "../moving-average/wma";
 import { type ChoppinessIndexState, createChoppinessIndex } from "../volatility/choppiness-index";
+import {
+  createStandardDeviation,
+  type StandardDeviationState,
+} from "../volatility/standard-deviation";
 import { createUlcerIndex, type UlcerIndexState } from "../volatility/ulcer-index";
 import { createTwap, type TwapState } from "../volume/twap";
+import { createVwap, type VwapState } from "../volume/vwap";
 import { describeContract } from "./contract-helper";
 
 // ---- Shared candle generator ----
@@ -155,3 +160,44 @@ describeContract<number | null, TwapState>({
   makeCandles,
   streamLength: 100,
 });
+
+// ---- Bundle B: Standard Deviation / VWAP ----
+
+// Standard Deviation — Windowed, same defaultless-period pattern as
+// SMA / WMA / VWMA. Buffer carries forward on reconfig; sum / sumSq
+// are recomputed from the carried samples.
+describeContract<number | null, StandardDeviationState>({
+  name: "standardDeviation",
+  create: (opts, warmUp) =>
+    createStandardDeviation(opts as { period?: number; source?: "close" | "high" }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 20, source: "close" },
+  reconfigParams: [{ period: 10 }, { period: 30 }],
+  makeCandles,
+  streamLength: 100,
+});
+
+// VWAP — Recursive, parameter-less (daily session reset is the only
+// "reconfig" knob and it's hardcoded). `meta.params` is always `{}`,
+// so reconfig is structurally impossible and the recursive-refuse
+// invariant is skipped via an empty `reconfigParams`. The remaining
+// invariants (round-trip, name guard, version guard, peek, warmup)
+// still cover the meaningful contract surface.
+describeContract<VwapValueWithFlatField, VwapState>({
+  name: "vwap",
+  // describeContract compares values via `expectValueEqual` which
+  // recurses into nested object keys, so the `{ vwap: ... }` output
+  // works without flattening.
+  create: (opts, warmUp) => createVwap(opts as Record<string, never>, warmUp),
+  category: "recursive",
+  version: 1,
+  defaultParams: {},
+  reconfigParams: [],
+  makeCandles,
+  streamLength: 100,
+});
+
+// Local alias so the `describeContract<TValue, TState>` generic captures
+// the composite VWAP value type without polluting public exports.
+type VwapValueWithFlatField = { vwap: number | null };

--- a/packages/core/src/indicators/incremental/__tests__/state-persistence.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-persistence.test.ts
@@ -162,7 +162,7 @@ describe("State persistence", () => {
   testStatePersistence(
     "VWAP",
     () => createVwap(),
-    (s) => createVwap({ fromState: s as any }),
+    (s) => createVwap({}, { fromState: s as any }),
   );
 
   testStatePersistence(

--- a/packages/core/src/indicators/incremental/volatility/standard-deviation.ts
+++ b/packages/core/src/indicators/incremental/volatility/standard-deviation.ts
@@ -1,24 +1,48 @@
 /**
  * Incremental Standard Deviation
  *
- * Rolling population standard deviation (divides by N, matching the batch
- * `standardDeviation()` and TA-Lib convention). Maintains running sum and
- * sum-of-squares plus a CircularBuffer of the last `period` prices, so
- * each `next()` call is O(1).
+ * State category: **Windowed** (raw price buffer + running sum and sum-of-
+ * squares for O(1) per-candle variance).
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<StandardDeviationState>` and `fromState` accepts
+ * the same.
+ *
+ * Rolling population standard deviation (divides by N, matching the
+ * batch `standardDeviation()` and TA-Lib convention).
+ *
+ * Defaults: `source` defaults to `"close"`. `period` has no canonical
+ * default — TA-Lib's `STDDEV` requires it from the caller; aligned
+ * with the SMA / WMA / VWMA migration pattern.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for Standard Deviation. Params (`period`, `source`)
+ * live in `meta.params` on the wire — they are not part of the bare state.
+ */
 export type StandardDeviationState = {
-  period: number;
-  source: PriceSource;
   buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   sum: number;
   sumSq: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bump on any breaking state change. */
+export const STANDARD_DEVIATION_VERSION = 1;
+
+type StandardDeviationParams = {
+  period: number;
+  source: PriceSource;
 };
 
 /**
@@ -26,37 +50,77 @@ export type StandardDeviationState = {
  *
  * @example
  * ```ts
+ * // Fresh start — period is required on first call.
  * const sd = createStandardDeviation({ period: 20 });
  * for (const candle of stream) {
  *   const { value } = sd.next(candle);
  *   if (sd.isWarmedUp) console.log(value);
  * }
+ *
+ * // Resume from a saved snapshot — period may be omitted; the
+ * // snapshot supplies it.
+ * const resumed = createStandardDeviation({}, { fromState: snapshot });
  * ```
  */
 export function createStandardDeviation(
   options: { period?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<StandardDeviationState>,
-): IncrementalIndicator<number | null, StandardDeviationState> {
-  // Saved snapshot wins so resumed sums match the configuration they were
-  // computed under, even if the caller forgets to pass period / source again.
-  const period = warmUpOptions?.fromState?.period ?? options.period ?? 20;
-  const source: PriceSource = warmUpOptions?.fromState?.source ?? options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<StandardDeviationState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<StandardDeviationState>> {
+  const { params, state, reconfigured } = resolveResume<
+    StandardDeviationParams,
+    StandardDeviationState
+  >({
+    indicator: "standardDeviation",
+    version: STANDARD_DEVIATION_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { source: "close" }, // `period` is intentionally absent — no canonical default.
+  });
 
-  if (period < 1) {
-    throw new Error("Standard Deviation period must be at least 1");
-  }
+  const period = requireParam(
+    "standardDeviation",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
 
   let buffer: CircularBuffer<number>;
   let sum: number;
   let sumSq: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    sum = s.sum;
-    sumSq = s.sumSq;
-    count = s.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // Period change. The snapshot's buffer is at the OLD capacity;
+      // rebuild at the NEW capacity holding the most recent
+      // min(snapshot.length, newPeriod) samples. sum / sumSq must be
+      // recomputed from those carried samples — the snapshot's running
+      // totals were over the old window.
+      const oldBuffer = CircularBuffer.fromSnapshot(state.buffer);
+      buffer = new CircularBuffer<number>(period);
+      const available = oldBuffer.length;
+      const carryStart = Math.max(0, available - period);
+      sum = 0;
+      sumSq = 0;
+      for (let i = carryStart; i < available; i++) {
+        const v = oldBuffer.get(i);
+        buffer.push(v);
+        sum += v;
+        sumSq += v * v;
+      }
+      count = state.count;
+    } else {
+      buffer = CircularBuffer.fromSnapshot(state.buffer);
+      sum = state.sum;
+      sumSq = state.sumSq;
+      count = state.count;
+    }
   } else {
     buffer = new CircularBuffer<number>(period);
     sum = 0;
@@ -65,14 +129,17 @@ export function createStandardDeviation(
   }
 
   function compute(): number | null {
-    if (count < period) return null;
+    if (buffer.length < period) return null;
     const mean = sum / period;
     // Variance = E[X²] - (E[X])²; clamp tiny negatives from float error.
     const variance = Math.max(0, sumSq / period - mean * mean);
     return Math.sqrt(variance);
   }
 
-  const indicator: IncrementalIndicator<number | null, StandardDeviationState> = {
+  const indicator: IncrementalIndicator<
+    number | null,
+    IndicatorSnapshot<StandardDeviationState>
+  > = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
       if (buffer.isFull) {
@@ -92,15 +159,20 @@ export function createStandardDeviation(
       const willEvict = buffer.isFull;
       const peekSum = sum + price - (willEvict ? buffer.oldest() : 0);
       const peekSumSq = sumSq + price * price - (willEvict ? buffer.oldest() * buffer.oldest() : 0);
-      const peekCount = count + 1;
-      if (peekCount < period) return { time: candle.time, value: null };
+      const peekLength = Math.min(buffer.length + 1, period);
+      if (peekLength < period) return { time: candle.time, value: null };
       const mean = peekSum / period;
       const variance = Math.max(0, peekSumSq / period - mean * mean);
       return { time: candle.time, value: Math.sqrt(variance) };
     },
 
-    getState(): StandardDeviationState {
-      return { period, source, buffer: buffer.snapshot(), sum, sumSq, count };
+    getState(): IndicatorSnapshot<StandardDeviationState> {
+      return makeSnapshot(
+        "standardDeviation",
+        STANDARD_DEVIATION_VERSION,
+        { period, source },
+        { buffer: buffer.snapshot(), sum, sumSq, count },
+      );
     },
 
     get count() {
@@ -108,7 +180,7 @@ export function createStandardDeviation(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      return buffer.length >= period;
     },
   };
 

--- a/packages/core/src/indicators/incremental/volume/vwap.ts
+++ b/packages/core/src/indicators/incremental/volume/vwap.ts
@@ -1,12 +1,30 @@
 /**
  * Incremental VWAP (Volume Weighted Average Price)
  *
+ * State category: **Recursive** (cumulative TPV / volume accumulators
+ * with daily session-boundary resets — no raw-price window to carry
+ * forward across a parameter change). VWAP itself takes no parameters,
+ * so reconfig is structurally impossible; the recursive category is
+ * the semantically correct slot.
+ *
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<VwapState>` and `fromState` accepts the same.
+ * The factory signature now takes `(options, warmUpOptions)` to match
+ * the rest of the library; previous direct callers that used the
+ * single-argument form (`createVwap({ fromState })`) must add an empty
+ * options object: `createVwap({}, { fromState })`.
+ *
  * Session-based VWAP with daily reset (simplified for incremental use).
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
+/**
+ * Bare state shape for VWAP. VWAP has no params, so `meta.params` is
+ * always `{}` on the wire.
+ */
 export type VwapState = {
   cumulativeTpv: number;
   cumulativeVolume: number;
@@ -17,6 +35,9 @@ export type VwapState = {
 export type VwapValue = {
   vwap: number | null;
 };
+
+/** Per-indicator schema version. Bump on any breaking state change. */
+export const VWAP_VERSION = 1;
 
 const MS_PER_DAY = 86400000;
 
@@ -33,19 +54,31 @@ const MS_PER_DAY = 86400000;
  * ```
  */
 export function createVwap(
-  warmUpOptions?: WarmUpOptions<VwapState>,
-): IncrementalIndicator<VwapValue, VwapState> {
+  _options: Record<string, never> = {},
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<VwapState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<VwapValue, IndicatorSnapshot<VwapState>> {
+  const { state } = resolveResume<Record<string, never>, VwapState>({
+    indicator: "vwap",
+    version: VWAP_VERSION,
+    category: "recursive",
+    options: _options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: {},
+  });
+
   let cumulativeTpv: number;
   let cumulativeVolume: number;
   let count: number;
   let currentDay: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    cumulativeTpv = s.cumulativeTpv;
-    cumulativeVolume = s.cumulativeVolume;
-    count = s.count;
-    currentDay = s.currentDay;
+  if (state !== null) {
+    cumulativeTpv = state.cumulativeTpv;
+    cumulativeVolume = state.cumulativeVolume;
+    count = state.count;
+    currentDay = state.currentDay;
   } else {
     cumulativeTpv = 0;
     cumulativeVolume = 0;
@@ -71,7 +104,7 @@ export function createVwap(
     return { vwap };
   }
 
-  const indicator: IncrementalIndicator<VwapValue, VwapState> = {
+  const indicator: IncrementalIndicator<VwapValue, IndicatorSnapshot<VwapState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const value = processCandle(candle);
@@ -96,8 +129,13 @@ export function createVwap(
       return { time: candle.time, value: { vwap } };
     },
 
-    getState(): VwapState {
-      return { cumulativeTpv, cumulativeVolume, count, currentDay };
+    getState(): IndicatorSnapshot<VwapState> {
+      return makeSnapshot(
+        "vwap",
+        VWAP_VERSION,
+        {},
+        { cumulativeTpv, cumulativeVolume, count, currentDay },
+      );
     },
 
     get count() {


### PR DESCRIPTION
## Summary

Fifth migration on top of the State Contract foundation (`epic/state-contract`). Two leaf indicators with no internal `src/` users — both are referenced only by tests and (for VWAP) the live-presets factory wrapper.

| Indicator | Category | Version | Notes |
|---|---|---|---|
| **Standard Deviation** | Windowed | 1 | `period` is now defaultless (TA-Lib STDDEV pattern); buffer carry-forward + `sum`/`sumSq` recomputation on reconfig |
| **VWAP** | Recursive | 1 | No params (daily session reset is hardcoded). **Signature change: `(warmUpOptions)` → `(options, warmUpOptions)`** to align with the rest of the library |

## Breaking changes

- `getState()` returns `IndicatorSnapshot<State>` (not bare state). Pre-0.4.0 snapshots throw on resume per `STATE_CONTRACT.md` §5.3.
- **StandardDeviation**: `period` is now defaultless (was `?? 20`). TA-Lib STDDEV is caller-specified; aligned with the SMA / WMA / VWMA migration pattern. `requireParam` enforces it at runtime.
- StandardDeviation: `period` / `source` move out of bare state into `meta.params`.
- **VWAP signature**: `createVwap(warmUpOptions)` → `createVwap(options = {}, warmUpOptions?)` to align with every other State Contract indicator (and to let the live-presets factory's `create(mapParams(p), restoreState(state))` call actually reach `fromState`, which the old single-arg signature silently dropped).
- Source change on resume throws for Standard Deviation (Windowed source-refuse).

## Per-indicator notes

### Standard Deviation
- Reconfig (period change) carries the buffer forward and **recomputes both `sum` and `sumSq`** from the carried samples — the snapshot's running totals were over the old window.
- `isWarmedUp` re-grounded on `buffer.length >= period` so it aligns with `compute()` (consistent with the SMA pattern).

### VWAP
- Has no params, so `meta.params` is always `{}`. `reconfigParams` in the contract test is empty; the recursive-refuse invariant is skipped while round-trip / name guard / version guard / peek / warmup still cover the meaningful contract surface.
- Internal caller updated: `state-persistence.test.ts` now passes the empty options object first (the only direct in-repo caller of `createVwap({ fromState })`).

## Held concern

Review surfaced that VWAP's new two-argument signature will silently restart from zero if an external untyped JS caller still uses the legacy single-argument form `createVwap({ fromState })`. The new shape is:

- Enforced statically for typed callers via `_options: Record<string, never>`
- Documented in the JSDoc and this PR description
- The only meaningful breaking-release window for this signature alignment (0.4.0)

Per `STATE_CONTRACT.md` §4.1 we don't add per-indicator runtime translation shims. The only in-repo legacy caller (`state-persistence.test.ts`) is updated in this PR.

## Test plan

- [x] `pnpm --filter trendcraft test` — 5212/5212 green
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] `pnpm --filter @trendcraft/chart size-check` within cap
- [x] `pnpm --filter trendcraft exec tsc -p tsconfig.json --noEmit --ignoreDeprecations "6.0"` — incremental subgraph clean (5 pre-existing errors in `strategy-dna` / `always-conditions` predate epic base, unrelated to this PR)
- [x] `describeContract` invariants: 53/53 across SMA/ALMA/WMA/VWMA/Choppiness/Ulcer/TWAP/StandardDeviation/VWAP