### PR TITLE
feat(core)!: migrate DonchianChannel/AnchoredVwap to State Contract (Wave 1 Bundle C)

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/contract-helper.ts
+++ b/packages/core/src/indicators/incremental/__tests__/contract-helper.ts
@@ -312,10 +312,10 @@ export function describeContract<TValue, TState>(config: ContractConfig<TValue, 
       let firstWarmupBar = -1;
       for (let i = 0; i < streamLength; i++) {
         const peeked = ind.peek(candles[i]);
-        const peekedNullBefore = peeked.value === null;
+        const peekedNullBefore = isNullishValue(peeked.value);
 
         const advanced = ind.next(candles[i]);
-        const advancedNull = advanced.value === null;
+        const advancedNull = isNullishValue(advanced.value);
 
         // peek and next must agree on null-ness at the same bar.
         expect(peekedNullBefore).toBe(advancedNull);
@@ -334,6 +334,26 @@ export function describeContract<TValue, TState>(config: ContractConfig<TValue, 
       }
     });
   });
+}
+
+/**
+ * "Looks like a null value" predicate that handles both primitive
+ * `null` (used by `number | null` outputs like SMA / RSI) and
+ * composite-all-null objects (used by multi-field outputs like
+ * Donchian's `{ upper, middle, lower }`). During warmup, composite
+ * indicators emit an object whose fields are all `null` rather than
+ * the bare value `null`; without this normalization the warmup-gate
+ * invariant treats those bars as already non-null.
+ */
+function isNullishValue(v: unknown): boolean {
+  if (v === null || v === undefined) return true;
+  if (typeof v !== "object" || Array.isArray(v)) return false;
+  const values = Object.values(v as Record<string, unknown>);
+  if (values.length === 0) return false;
+  // Treat an object as null when every present field is null.
+  // Optional fields that are simply absent (undefined) don't count
+  // against this — only fields explicitly emitted as null do.
+  return values.every((x) => x === null || x === undefined);
 }
 
 // ---- Internal helpers ----

--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -18,11 +18,13 @@ import { createSma, type SmaState } from "../moving-average/sma";
 import { createVwma, type VwmaState } from "../moving-average/vwma";
 import { createWma, type WmaState } from "../moving-average/wma";
 import { type ChoppinessIndexState, createChoppinessIndex } from "../volatility/choppiness-index";
+import { createDonchianChannel, type DonchianState } from "../volatility/donchian-channel";
 import {
   createStandardDeviation,
   type StandardDeviationState,
 } from "../volatility/standard-deviation";
 import { createUlcerIndex, type UlcerIndexState } from "../volatility/ulcer-index";
+import { type AnchoredVwapState, createAnchoredVwap } from "../volume/anchored-vwap";
 import { createTwap, type TwapState } from "../volume/twap";
 import { createVwap, type VwapState } from "../volume/vwap";
 import { describeContract } from "./contract-helper";
@@ -201,3 +203,52 @@ describeContract<VwapValueWithFlatField, VwapState>({
 // Local alias so the `describeContract<TValue, TState>` generic captures
 // the composite VWAP value type without polluting public exports.
 type VwapValueWithFlatField = { vwap: number | null };
+
+// ---- Bundle C: Donchian Channel / Anchored VWAP ----
+
+// Donchian Channel — Windowed, same defaultless-period pattern as
+// SMA / WMA / VWMA / SD. high/low buffers carry forward as raw values.
+describeContract<DonchianValueShape, DonchianState>({
+  name: "donchianChannel",
+  create: (opts, warmUp) => createDonchianChannel(opts as { period?: number }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 20 },
+  reconfigParams: [{ period: 10 }, { period: 30 }],
+  makeCandles,
+  streamLength: 100,
+});
+
+type DonchianValueShape = {
+  upper: number | null;
+  middle: number | null;
+  lower: number | null;
+};
+
+// Anchored VWAP — Recursive (cumulative TPV/volume accumulators from
+// a fixed anchor time). Any `anchorTime` or `bands` change throws via
+// the recursive policy.
+//
+// `anchorTime: 1700000000000` matches the start of `makeCandles`, so
+// the indicator anchors on the first candle and produces a non-null
+// value immediately (satisfying invariant [7]).
+describeContract<AnchoredVwapValueShape, AnchoredVwapState>({
+  name: "anchoredVwap",
+  create: (opts, warmUp) =>
+    createAnchoredVwap(opts as { anchorTime?: number; bands?: number }, warmUp),
+  category: "recursive",
+  version: 1,
+  defaultParams: { anchorTime: 1700000000000, bands: 0 },
+  // Exercise refuse on both anchor and band changes.
+  reconfigParams: [{ anchorTime: 1700000000000 + 5 * 86400000 }, { bands: 1 }],
+  makeCandles,
+  streamLength: 100,
+});
+
+type AnchoredVwapValueShape = {
+  vwap: number | null;
+  upper1?: number | null;
+  lower1?: number | null;
+  upper2?: number | null;
+  lower2?: number | null;
+};

--- a/packages/core/src/indicators/incremental/volatility/donchian-channel.ts
+++ b/packages/core/src/indicators/incremental/volatility/donchian-channel.ts
@@ -1,13 +1,28 @@
 /**
  * Incremental Donchian Channel
  *
+ * State category: **Windowed** (raw high / low buffers).
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<DonchianState>` and `fromState` accepts the same.
+ *
  * Shows highest high and lowest low over N periods.
  * Uses CircularBuffer with linear scan for min/max.
+ *
+ * Defaults: `period` has no canonical default (Pine `ta.donchian`
+ * requires it from the caller); aligned with the SMA / WMA / VWMA / SD
+ * migration pattern. On resume, `period` may be omitted to inherit
+ * from the snapshot.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 /**
  * Donchian Channel output value
@@ -19,13 +34,20 @@ export type DonchianValue = {
 };
 
 /**
- * State for incremental Donchian Channel
+ * Bare state shape for Donchian Channel. Params (`period`) live in
+ * `meta.params` on the wire — they are not part of the bare state.
  */
 export type DonchianState = {
-  period: number;
   highBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   lowBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   count: number;
+};
+
+/** Per-indicator schema version. Bump on any breaking state change. */
+export const DONCHIAN_VERSION = 1;
+
+type DonchianParams = {
+  period: number;
 };
 
 /**
@@ -33,40 +55,78 @@ export type DonchianState = {
  *
  * @example
  * ```ts
+ * // Fresh start — period is required on first call.
  * const dc = createDonchianChannel({ period: 20 });
  * for (const candle of stream) {
  *   const { value } = dc.next(candle);
  *   if (dc.isWarmedUp) console.log(value.upper, value.middle, value.lower);
  * }
+ *
+ * // Resume from a saved snapshot — period may be omitted; the
+ * // snapshot supplies it.
+ * const resumed = createDonchianChannel({}, { fromState: snapshot });
  * ```
  */
 export function createDonchianChannel(
-  options: { period: number },
-  warmUpOptions?: WarmUpOptions<DonchianState>,
-): IncrementalIndicator<DonchianValue, DonchianState> {
-  const period = options.period;
+  options: { period?: number } = {},
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<DonchianState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<DonchianValue, IndicatorSnapshot<DonchianState>> {
+  const { params, state, reconfigured } = resolveResume<DonchianParams, DonchianState>({
+    indicator: "donchianChannel",
+    version: DONCHIAN_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: {}, // `period` is intentionally absent — no canonical default.
+  });
+
+  const period = requireParam(
+    "donchianChannel",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
 
   let highBuffer: CircularBuffer<number>;
   let lowBuffer: CircularBuffer<number>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    highBuffer = CircularBuffer.fromSnapshot(s.highBuffer);
-    lowBuffer = CircularBuffer.fromSnapshot(s.lowBuffer);
-    count = s.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // Period change. Buffers are raw high / low values — no
+      // per-period derivation, so we just carry forward the most
+      // recent min(snapshot.length, newPeriod) samples.
+      const oldHigh = CircularBuffer.fromSnapshot(state.highBuffer);
+      const oldLow = CircularBuffer.fromSnapshot(state.lowBuffer);
+      highBuffer = new CircularBuffer<number>(period);
+      lowBuffer = new CircularBuffer<number>(period);
+      const available = oldHigh.length;
+      const carryStart = Math.max(0, available - period);
+      for (let i = carryStart; i < available; i++) {
+        highBuffer.push(oldHigh.get(i));
+        lowBuffer.push(oldLow.get(i));
+      }
+      count = state.count;
+    } else {
+      highBuffer = CircularBuffer.fromSnapshot(state.highBuffer);
+      lowBuffer = CircularBuffer.fromSnapshot(state.lowBuffer);
+      count = state.count;
+    }
   } else {
     highBuffer = new CircularBuffer<number>(period);
     lowBuffer = new CircularBuffer<number>(period);
     count = 0;
   }
 
-  function compute(
-    hBuf: CircularBuffer<number>,
-    lBuf: CircularBuffer<number>,
-    n: number,
-  ): DonchianValue {
-    if (n < period) {
+  function compute(hBuf: CircularBuffer<number>, lBuf: CircularBuffer<number>): DonchianValue {
+    // Warm-up gated on buffers being full at the current period, not on
+    // `count`. After a period-growing resume, `count` is the snapshot's
+    // large value but the rebuilt buffer needs more candles to fill.
+    if (hBuf.length < period) {
       return { upper: null, middle: null, lower: null };
     }
 
@@ -88,13 +148,13 @@ export function createDonchianChannel(
     };
   }
 
-  const indicator: IncrementalIndicator<DonchianValue, DonchianState> = {
+  const indicator: IncrementalIndicator<DonchianValue, IndicatorSnapshot<DonchianState>> = {
     next(candle: NormalizedCandle) {
       highBuffer.push(candle.high);
       lowBuffer.push(candle.low);
       count++;
 
-      return { time: candle.time, value: compute(highBuffer, lowBuffer, count) };
+      return { time: candle.time, value: compute(highBuffer, lowBuffer) };
     },
 
     peek(candle: NormalizedCandle) {
@@ -103,16 +163,20 @@ export function createDonchianChannel(
       tempHigh.push(candle.high);
       tempLow.push(candle.low);
 
-      return { time: candle.time, value: compute(tempHigh, tempLow, count + 1) };
+      return { time: candle.time, value: compute(tempHigh, tempLow) };
     },
 
-    getState(): DonchianState {
-      return {
-        period,
-        highBuffer: highBuffer.snapshot(),
-        lowBuffer: lowBuffer.snapshot(),
-        count,
-      };
+    getState(): IndicatorSnapshot<DonchianState> {
+      return makeSnapshot(
+        "donchianChannel",
+        DONCHIAN_VERSION,
+        { period },
+        {
+          highBuffer: highBuffer.snapshot(),
+          lowBuffer: lowBuffer.snapshot(),
+          count,
+        },
+      );
     },
 
     get count() {
@@ -120,7 +184,7 @@ export function createDonchianChannel(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      return highBuffer.length >= period;
     },
   };
 

--- a/packages/core/src/indicators/incremental/volume/anchored-vwap.ts
+++ b/packages/core/src/indicators/incremental/volume/anchored-vwap.ts
@@ -1,12 +1,36 @@
 /**
  * Incremental Anchored VWAP
  *
+ * State category: **Recursive** (cumulative TPV / volume accumulators
+ * from a fixed anchor time; no raw-price window to carry forward).
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<AnchoredVwapState>` and `fromState` accepts the same.
+ *
  * VWAP = Sum(TP * Volume) / Sum(Volume) starting from an anchor time.
  * Optionally includes standard deviation bands.
+ *
+ * Reconfig policy: any `anchorTime` or `bands` change throws via the
+ * resolveResume recursive branch. anchorTime change means a different
+ * aggregation window; bands change means a different output shape
+ * (upper1/lower1/upper2/lower2 keys appear or disappear). Both are
+ * unsafe to silently carry forward.
+ *
+ * Known limitation (out of scope for this migration): when `bands > 0`,
+ * `tpvHistory` grows unboundedly from the anchor onward — it retains
+ * per-candle (tp, volume) pairs to compute the volume-weighted variance.
+ * Long-running sessions accumulate proportionally to candle count.
+ * A future running-variance refactor (Welford / similar) would let us
+ * drop the history.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type AnchoredVwapValue = {
   vwap: number | null;
@@ -16,14 +40,24 @@ export type AnchoredVwapValue = {
   lower2?: number | null;
 };
 
+/**
+ * Bare state shape for Anchored VWAP. Params (`anchorTime`, `bands`)
+ * live in `meta.params` on the wire — they are not part of the bare state.
+ */
 export type AnchoredVwapState = {
-  anchorTime: number;
-  bands: number;
   cumTPV: number;
   cumVol: number;
   tpvHistory: { tp: number; volume: number }[];
   isAnchored: boolean;
   count: number;
+};
+
+/** Per-indicator schema version. Bump on any breaking state change. */
+export const ANCHORED_VWAP_VERSION = 1;
+
+type AnchoredVwapParams = {
+  anchorTime: number;
+  bands: number;
 };
 
 /**
@@ -43,11 +77,35 @@ export type AnchoredVwapState = {
  * ```
  */
 export function createAnchoredVwap(
-  options: { anchorTime: number; bands?: number },
-  warmUpOptions?: WarmUpOptions<AnchoredVwapState>,
-): IncrementalIndicator<AnchoredVwapValue, AnchoredVwapState> {
-  const anchorTime = options.anchorTime;
-  const bands = options.bands ?? 0;
+  options: { anchorTime?: number; bands?: number } = {},
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<AnchoredVwapState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<AnchoredVwapValue, IndicatorSnapshot<AnchoredVwapState>> {
+  const { params, state } = resolveResume<AnchoredVwapParams, AnchoredVwapState>({
+    indicator: "anchoredVwap",
+    version: ANCHORED_VWAP_VERSION,
+    category: "recursive",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { bands: 0 }, // `anchorTime` is intentionally absent — no canonical default.
+  });
+
+  const anchorTime = requireParam(
+    "anchoredVwap",
+    params,
+    "anchorTime",
+    (v): v is number => Number.isFinite(v) && v >= 0,
+    "must be a non-negative finite timestamp",
+  );
+  const bands = requireParam(
+    "anchoredVwap",
+    params,
+    "bands",
+    (v): v is number => Number.isInteger(v) && v >= 0 && v <= 2,
+    "must be 0, 1, or 2",
+  );
 
   let cumTPV: number;
   let cumVol: number;
@@ -55,13 +113,14 @@ export function createAnchoredVwap(
   let isAnchored: boolean;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    cumTPV = s.cumTPV;
-    cumVol = s.cumVol;
-    tpvHistory = s.tpvHistory.map((h) => ({ ...h }));
-    isAnchored = s.isAnchored;
-    count = s.count;
+  if (state !== null) {
+    cumTPV = state.cumTPV;
+    cumVol = state.cumVol;
+    // Defensive copy so subsequent next() mutations don't reach back
+    // into a snapshot the caller may still hold.
+    tpvHistory = state.tpvHistory.map((h) => ({ ...h }));
+    isAnchored = state.isAnchored;
+    count = state.count;
   } else {
     cumTPV = 0;
     cumVol = 0;
@@ -116,7 +175,7 @@ export function createAnchoredVwap(
     return result;
   }
 
-  const indicator: IncrementalIndicator<AnchoredVwapValue, AnchoredVwapState> = {
+  const indicator: IncrementalIndicator<AnchoredVwapValue, IndicatorSnapshot<AnchoredVwapState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -199,16 +258,21 @@ export function createAnchoredVwap(
       return { time: candle.time, value: result };
     },
 
-    getState(): AnchoredVwapState {
-      return {
-        anchorTime,
-        bands,
-        cumTPV,
-        cumVol,
-        tpvHistory: tpvHistory.map((h) => ({ ...h })),
-        isAnchored,
-        count,
-      };
+    getState(): IndicatorSnapshot<AnchoredVwapState> {
+      return makeSnapshot(
+        "anchoredVwap",
+        ANCHORED_VWAP_VERSION,
+        { anchorTime, bands },
+        {
+          cumTPV,
+          cumVol,
+          // Defensive copy so the caller's snapshot isn't mutated by
+          // later next() calls (tpvHistory is pushed in place).
+          tpvHistory: tpvHistory.map((h) => ({ ...h })),
+          isAnchored,
+          count,
+        },
+      );
     },
 
     get count() {


### PR DESCRIPTION
## Summary

Sixth migration on top of the State Contract foundation (`epic/state-contract`). Two leaf indicators with no internal `src/` users — both are referenced only by live-presets (and Donchian by the trading-simulator example, opaque pass-through).

| Indicator | Category | Version | Notes |
|---|---|---|---|
| **Donchian Channel** | Windowed | 1 | `period` is now defaultless (Pine `ta.donchian` pattern). high/low buffers carry forward as raw values |
| **Anchored VWAP** | Recursive | 1 | `anchorTime` required via `requireParam`. Both `anchorTime` and `bands` changes throw on resume |

## Breaking changes

- `getState()` returns `IndicatorSnapshot<State>` (not bare state). Pre-0.4.0 snapshots throw on resume per `STATE_CONTRACT.md` §5.3.
- **DonchianChannel**: `period` is now defaultless and `options.period` becomes optional in TypeScript (was required). Pine `ta.donchian` is caller-specified; aligned with SMA / WMA / VWMA / SD pattern. `requireParam` enforces it at runtime.
- **AnchoredVwap**: `anchorTime` is required via `requireParam` (was effectively required, no default); `bands` validates as 0/1/2. Both `anchorTime` and `bands` move from bare state into `meta.params`. Any change of either on resume throws via the recursive policy.

## Per-indicator notes

### Donchian Channel
- Reconfig (period change) carries forward the most recent high/low samples — raw values, no per-period derivation.
- `isWarmedUp` re-grounded on `highBuffer.length >= period` so it aligns with `compute()` after a period-growing resume.

### Anchored VWAP
- `tpvHistory` is deep-copied on both restore and `getState` so callers' held snapshots can't be mutated by later `next()` pushes.
- **Known limitation (out of scope for this PR)**: `tpvHistory` grows unboundedly from the anchor when `bands > 0`. A follow-up will switch to Welford's online algorithm to drop the per-candle history.

## Contract helper update

`contract-helper.ts` now uses `isNullishValue` (treating an all-fields-null object as "null") for the warmup-gate invariant. Composite outputs like Donchian's `{ upper, middle, lower }` emit an object with every field null during warmup; the previous `value === null` check would incorrectly flag the first warmup bar as "non-null" and demand `isWarmedUp = true` before the buffer was full. The new predicate covers both primitive-null and composite-all-null cases without changing behavior for indicators that return `number | null`.

## Test plan

- [x] `pnpm --filter trendcraft test` — 5224/5224 green
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] `pnpm --filter @trendcraft/chart size-check` within cap
- [x] `pnpm --filter trendcraft exec tsc -p tsconfig.json --noEmit --ignoreDeprecations "6.0"` — incremental subgraph clean (5 pre-existing errors in `strategy-dna` / `always-conditions` predate epic base, unrelated to this PR)
- [x] `describeContract` invariants: 65/65 across SMA/ALMA/WMA/VWMA/Choppiness/Ulcer/TWAP/StandardDeviation/VWAP/Donchian/AnchoredVwap