### PR TITLE
feat(core)!: migrate Returns/HighestLowest + formalize snapshotName contract (Wave 1 final, Bundle D)

### DIFF
--- a/packages/core/docs/STATE_CONTRACT.md
+++ b/packages/core/docs/STATE_CONTRACT.md
@@ -501,3 +501,98 @@ The following were agreed before Phase 0 finalization:
 5. ✓ Source change always refuses reconfig (even for Windowed).
 6. ✓ `fromState` type breaking change to `IndicatorSnapshot<S>` is
    accepted (0.x breaking-change allowance).
+## 10. `snapshotName` contract key (Wave 1 final)
+
+### 10.1. Purpose
+
+Every `LivePreset` exports `snapshotName(params)` — a string that
+identifies a specific configuration of an indicator. Two concerns
+share this key:
+
+1. **Internal uniqueness** — `connectIndicators` uses it as a duplicate
+   guard so the same `(indicator, params)` combination can only be
+   registered once per live session.
+2. **External persistence** — host applications use it as the
+   filename / cache key under which they serialize the snapshot
+   returned by `getState()`.
+
+These responsibilities are coupled: a key that is unstable for the
+host is fine as long as the same logical configuration always
+resolves to the same key. The bug pattern this section formalizes is
+**different param sets resolving to the same key** (silent
+overwrite) or **the same logical configuration resolving to different
+keys across versions** (silent cold-start).
+
+### 10.2. Contract
+
+For any preset whose `createFactory` accepts a parameter `P`,
+`snapshotName(params)` MUST satisfy:
+
+- **Surjective on variants.** If two `params` differ in any value
+  that `createFactory` forwards to the underlying `createXxx` (and
+  that value affects the indicator's state), they MUST produce
+  different `snapshotName` outputs. Otherwise resuming under one set
+  silently restores state from the other.
+- **Deterministic.** Same `params` → same output, always. No
+  timestamps, hashes of mutable state, or environment-dependent
+  values.
+- **Defaults-equivalent.** A `params` object that omits a default
+  field MUST produce the same `snapshotName` as one that explicitly
+  passes the canonical default. (i.e. `sma({ period: 20 })` and
+  `sma({ period: 20, source: "close" })` collapse to the same key
+  when `source` defaults to `"close"`.)
+
+### 10.3. Stability across releases (pre-1.0)
+
+- **Patch releases (`0.x.y` → `0.x.(y+1)`)** MUST NOT change
+  `snapshotName` output for any preset.
+- **Minor releases (`0.x.0` → `0.(x+1).0`)** MAY change
+  `snapshotName` output when accompanied by:
+  - A documented "snapshotName format change" entry in the CHANGELOG
+    `Breaking` section, listing the affected presets.
+  - A clear migration path (typically: discard prior state and
+    re-warm, matching the State Contract format-break policy in §5.3).
+- **The 0.4.0 release** is the first formal contract anchor: prior
+  to 0.4.0 the snapshotName format was conventionally stable but
+  never formally guaranteed.
+
+### 10.4. Recommended format
+
+To make audits mechanical and reduce per-preset bike-shedding, new
+presets should use the conventional form:
+
+```
+${kind}_${param1}_${param2}_...
+```
+
+Where each `paramN` is one of the values forwarded by `createFactory`.
+Defaults are applied before formatting so omitting a field produces
+the same key as passing the default explicitly. Param order matches
+the declaration order in the factory's `TParams`.
+
+Existing presets that pre-date 0.4.0 may use shorter / older formats;
+those are kept as-is unless they violate §10.2 (in which case they're
+fixed under the §10.3 minor-release allowance).
+
+### 10.5. 0.4.0 snapshotName changes
+
+Wave 1 final tightens the contract by fixing eleven presets whose
+prior keys violated §10.2 (Surjective on variants):
+
+| Preset | Old format | New format |
+|---|---|---|
+| `sma` | `sma${period}` | `sma_${source}_${period}` |
+| `dema` | `dema${period}` | `dema_${source}_${period}` |
+| `tema` | `tema${period}` | `tema_${source}_${period}` |
+| `zlema` | `zlema${period}` | `zlema_${source}_${period}` |
+| `frama` | `frama${period}` | `frama_${source}_${period}` |
+| `hv` | `hv${period}` | `hv_${source}_${period}_${annualFactor}` |
+| `ulcer` | `ulcer${period}` | `ulcer_${source}_${period}` |
+| `standardDeviation` | (not registered) | `stddev_${source}_${period}` |
+| `returns` | (not registered) | `returns_${type}_${period}` |
+| `kst` | `"kst"` | `kst_${source}_${signalPeriod}` |
+| `hurst` | `"hurst"` | `hurst_${source}_${minWindow}_${maxWindow}` |
+
+Other presets with similar latent collisions (static `snapshotName`
+for params they vary internally) exist; a separate audit + cleanup PR
+will address them under the same §10.3 minor-release allowance.

--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -17,6 +17,8 @@ import { type AlmaState, createAlma } from "../moving-average/alma";
 import { createSma, type SmaState } from "../moving-average/sma";
 import { createVwma, type VwmaState } from "../moving-average/vwma";
 import { createWma, type WmaState } from "../moving-average/wma";
+import { createHighestLowest, type HighestLowestState } from "../price/highest-lowest";
+import { createReturns, type ReturnsState } from "../price/returns";
 import { type ChoppinessIndexState, createChoppinessIndex } from "../volatility/choppiness-index";
 import { createDonchianChannel, type DonchianState } from "../volatility/donchian-channel";
 import {
@@ -251,4 +253,40 @@ type AnchoredVwapValueShape = {
   lower1?: number | null;
   upper2?: number | null;
   lower2?: number | null;
+};
+
+// ---- Bundle D (Wave 1 final): Returns / HighestLowest ----
+
+// Returns — Windowed, canonical defaults (period=1, type="simple"
+// match pandas / quantstats convention). The close buffer carries
+// forward as raw values across both period AND type changes — `type`
+// only affects the formula, not the buffered data.
+describeContract<number | null, ReturnsState>({
+  name: "returns",
+  create: (opts, warmUp) =>
+    createReturns(opts as { period?: number; type?: "simple" | "log" }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 1, type: "simple" },
+  reconfigParams: [{ period: 5 }, { period: 10 }, { type: "log" }],
+  makeCandles,
+  streamLength: 100,
+});
+
+// HighestLowest — Windowed, same shape as Donchian's high/low buffers.
+// `period` carries forward as raw high/low values.
+describeContract<HighestLowestValueShape, HighestLowestState>({
+  name: "highestLowest",
+  create: (opts, warmUp) => createHighestLowest(opts as { period?: number }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 20 },
+  reconfigParams: [{ period: 10 }, { period: 30 }],
+  makeCandles,
+  streamLength: 100,
+});
+
+type HighestLowestValueShape = {
+  highest: number | null;
+  lowest: number | null;
 };

--- a/packages/core/src/indicators/incremental/price/highest-lowest.ts
+++ b/packages/core/src/indicators/incremental/price/highest-lowest.ts
@@ -1,24 +1,42 @@
 /**
  * Incremental Highest/Lowest
  *
+ * State category: **Windowed** (raw high / low buffers).
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<HighestLowestState>` and `fromState` accepts the same.
+ *
  * Rolling maximum of highs and minimum of lows over a configurable period.
  * Uses CircularBuffer with O(n) scan per update (period is typically small).
+ *
+ * Defaults: `period` defaults to `20` (matching the live-presets
+ * convention and TradingView's `ta.highest` / `ta.lowest` typical usage).
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type HighestLowestValue = {
   highest: number | null;
   lowest: number | null;
 };
 
+/**
+ * Bare state shape for Highest/Lowest. Params (`period`) live in
+ * `meta.params` on the wire — they are not part of the bare state.
+ */
 export type HighestLowestState = {
-  period: number;
   highBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   lowBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   count: number;
+};
+
+/** Per-indicator schema version. Bump on any breaking state change. */
+export const HIGHEST_LOWEST_VERSION = 1;
+
+type HighestLowestParams = {
+  period: number;
 };
 
 /**
@@ -39,19 +57,51 @@ export type HighestLowestState = {
  */
 export function createHighestLowest(
   options: { period?: number } = {},
-  warmUpOptions?: WarmUpOptions<HighestLowestState>,
-): IncrementalIndicator<HighestLowestValue, HighestLowestState> {
-  const period = options.period ?? 20;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<HighestLowestState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<HighestLowestValue, IndicatorSnapshot<HighestLowestState>> {
+  const { params, state, reconfigured } = resolveResume<HighestLowestParams, HighestLowestState>({
+    indicator: "highestLowest",
+    version: HIGHEST_LOWEST_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 20 },
+  });
+
+  const period = params.period;
+  if (!Number.isInteger(period) || period < 1) {
+    throw new Error('highestLowest: option "period" must be a positive integer');
+  }
 
   let highBuffer: CircularBuffer<number>;
   let lowBuffer: CircularBuffer<number>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    highBuffer = CircularBuffer.fromSnapshot(s.highBuffer);
-    lowBuffer = CircularBuffer.fromSnapshot(s.lowBuffer);
-    count = s.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // Period change. Buffers are raw high / low values — no
+      // per-period derivation, so we carry forward the most recent
+      // min(snapshot.length, newPeriod) samples into buffers sized
+      // at the new period.
+      const oldHigh = CircularBuffer.fromSnapshot(state.highBuffer);
+      const oldLow = CircularBuffer.fromSnapshot(state.lowBuffer);
+      highBuffer = new CircularBuffer<number>(period);
+      lowBuffer = new CircularBuffer<number>(period);
+      const available = oldHigh.length;
+      const carryStart = Math.max(0, available - period);
+      for (let i = carryStart; i < available; i++) {
+        highBuffer.push(oldHigh.get(i));
+        lowBuffer.push(oldLow.get(i));
+      }
+      count = state.count;
+    } else {
+      highBuffer = CircularBuffer.fromSnapshot(state.highBuffer);
+      lowBuffer = CircularBuffer.fromSnapshot(state.lowBuffer);
+      count = state.count;
+    }
   } else {
     highBuffer = new CircularBuffer<number>(period);
     lowBuffer = new CircularBuffer<number>(period);
@@ -75,10 +125,13 @@ export function createHighestLowest(
 
   const nullValue: HighestLowestValue = { highest: null, lowest: null };
 
-  function compute(candle: NormalizedCandle): { time: number; value: HighestLowestValue } {
-    // Simulate adding to buffers without mutation
-    const newCount = count + 1;
-    if (newCount < period) {
+  function computePeek(candle: NormalizedCandle): { time: number; value: HighestLowestValue } {
+    // Simulate adding to buffers without mutation. Warm-up gated on
+    // buffer length (post-push), not raw count — after a
+    // period-growing resume, `count` is the snapshot's large value
+    // but the rebuilt buffer still needs new bars to fill.
+    const newLength = Math.min(highBuffer.length + 1, period);
+    if (newLength < period) {
       return { time: candle.time, value: nullValue };
     }
 
@@ -96,13 +149,18 @@ export function createHighestLowest(
     return { time: candle.time, value: { highest, lowest } };
   }
 
-  const indicator: IncrementalIndicator<HighestLowestValue, HighestLowestState> = {
+  const indicator: IncrementalIndicator<
+    HighestLowestValue,
+    IndicatorSnapshot<HighestLowestState>
+  > = {
     next(candle: NormalizedCandle) {
       highBuffer.push(candle.high);
       lowBuffer.push(candle.low);
       count++;
 
-      if (count < period) {
+      // Warm-up gated on buffer length so a period-growing resume
+      // correctly waits for new bars to roll in.
+      if (highBuffer.length < period) {
         return { time: candle.time, value: nullValue };
       }
 
@@ -110,16 +168,20 @@ export function createHighestLowest(
     },
 
     peek(candle: NormalizedCandle) {
-      return compute(candle);
+      return computePeek(candle);
     },
 
-    getState(): HighestLowestState {
-      return {
-        period,
-        highBuffer: highBuffer.snapshot(),
-        lowBuffer: lowBuffer.snapshot(),
-        count,
-      };
+    getState(): IndicatorSnapshot<HighestLowestState> {
+      return makeSnapshot(
+        "highestLowest",
+        HIGHEST_LOWEST_VERSION,
+        { period },
+        {
+          highBuffer: highBuffer.snapshot(),
+          lowBuffer: lowBuffer.snapshot(),
+          count,
+        },
+      );
     },
 
     get count() {
@@ -127,7 +189,7 @@ export function createHighestLowest(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      return highBuffer.length >= period;
     },
   };
 

--- a/packages/core/src/indicators/incremental/price/returns.ts
+++ b/packages/core/src/indicators/incremental/price/returns.ts
@@ -1,19 +1,40 @@
 /**
  * Incremental Returns
  *
+ * State category: **Windowed** (raw close buffer; the only state is
+ * the last `period` close values).
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<ReturnsState>` and `fromState` accepts the same.
+ *
  * n-period simple or log returns of close prices.
- * Holds the last `period` close values in a CircularBuffer.
+ *
+ * Defaults: `period` defaults to `1` (the universal pandas / NumPy /
+ * quantstats convention — `r_t = close_t / close_{t-1} - 1`).
+ * `type` defaults to `"simple"`. Reconfig may change either param;
+ * the close buffer carries forward as raw values and the new
+ * `period` / `type` apply from the next bar onward.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
+/**
+ * Bare state shape for Returns. Params (`period`, `type`) live in
+ * `meta.params` on the wire — they are not part of the bare state.
+ */
 export type ReturnsState = {
-  period: number;
-  type: "simple" | "log";
   buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   count: number;
+};
+
+/** Per-indicator schema version. Bump on any breaking state change. */
+export const RETURNS_VERSION = 1;
+
+type ReturnsParams = {
+  period: number;
+  type: "simple" | "log";
 };
 
 /**
@@ -33,13 +54,28 @@ export type ReturnsState = {
  */
 export function createReturns(
   options: { period?: number; type?: "simple" | "log" } = {},
-  warmUpOptions?: WarmUpOptions<ReturnsState>,
-): IncrementalIndicator<number | null, ReturnsState> {
-  const period = options.period ?? 1;
-  const type: "simple" | "log" = options.type ?? "simple";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<ReturnsState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<ReturnsState>> {
+  const { params, state, reconfigured } = resolveResume<ReturnsParams, ReturnsState>({
+    indicator: "returns",
+    version: RETURNS_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 1, type: "simple" },
+  });
 
-  if (period < 1) {
-    throw new Error("Returns period must be at least 1");
+  const period = params.period;
+  const type = params.type;
+
+  if (!Number.isInteger(period) || period < 1) {
+    throw new Error('returns: option "period" must be a positive integer');
+  }
+  if (type !== "simple" && type !== "log") {
+    throw new Error('returns: option "type" must be "simple" or "log"');
   }
 
   // Buffer holds the last `period` closes (i.e. closes at index t-period..t-1);
@@ -47,9 +83,25 @@ export function createReturns(
   let buffer: CircularBuffer<number>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    buffer = CircularBuffer.fromSnapshot(warmUpOptions.fromState.buffer);
-    count = warmUpOptions.fromState.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // Period change. Carry forward the most recent min(snapshot, newPeriod)
+      // raw closes into a buffer at the new capacity. No sums to recompute —
+      // the return computation reads the buffer's oldest slot directly.
+      // A `type` change leaves the buffer untouched (raw closes) but the
+      // returned values shift from simple to log formula from the next bar.
+      const oldBuffer = CircularBuffer.fromSnapshot(state.buffer);
+      buffer = new CircularBuffer<number>(period);
+      const available = oldBuffer.length;
+      const carryStart = Math.max(0, available - period);
+      for (let i = carryStart; i < available; i++) {
+        buffer.push(oldBuffer.get(i));
+      }
+      count = state.count;
+    } else {
+      buffer = CircularBuffer.fromSnapshot(state.buffer);
+      count = state.count;
+    }
   } else {
     buffer = new CircularBuffer<number>(period);
     count = 0;
@@ -60,7 +112,7 @@ export function createReturns(
     return type === "log" ? Math.log(current / prev) : (current - prev) / prev;
   }
 
-  const indicator: IncrementalIndicator<number | null, ReturnsState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<ReturnsState>> = {
     next(candle: NormalizedCandle) {
       const current = candle.close;
       let value: number | null = null;
@@ -78,8 +130,13 @@ export function createReturns(
       return { time: candle.time, value: calc(candle.close, buffer.oldest()) };
     },
 
-    getState(): ReturnsState {
-      return { period, type, buffer: buffer.snapshot(), count };
+    getState(): IndicatorSnapshot<ReturnsState> {
+      return makeSnapshot(
+        "returns",
+        RETURNS_VERSION,
+        { period, type },
+        { buffer: buffer.snapshot(), count },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/indicator-meta.ts
+++ b/packages/core/src/indicators/indicator-meta.ts
@@ -462,6 +462,16 @@ export const LINEAR_REG_META: SeriesMeta = {
 };
 
 // ============================================
+// Price-derived
+// ============================================
+
+export const RETURNS_META: SeriesMeta = {
+  kind: "returns",
+  overlay: false,
+  label: "Returns",
+};
+
+// ============================================
 // Additional Volume
 // ============================================
 

--- a/packages/core/src/streaming/indicator-presets.ts
+++ b/packages/core/src/streaming/indicator-presets.ts
@@ -139,7 +139,6 @@ import {
   ORDER_BLOCK_META,
   SESSION_BREAKOUT_META,
   SLOW_STOCH_META,
-  STD_DEV_META,
   SWING_POINTS_META,
   VOL_REGIME_META,
   VOLUME_MA_META,
@@ -1673,18 +1672,16 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
   // ============================================
   // Additional Volatility
   // ============================================
-  standardDeviation: {
-    meta: STD_DEV_META,
-    defaultParams: { period: 20 },
-    snapshotName: "stdDev",
-    compute: typedCompute<{ period?: number }>((c, p) =>
-      standardDeviation(c, { period: p.period ?? 20 }),
-    ),
-    category: "Volatility",
-    name: "Standard Deviation",
-    description: "Raw standard deviation of closing prices over a rolling window.",
-    paramSchema: [period(20)],
-  },
+  standardDeviation: withCompute<{ period?: number; source?: PriceSource }>(
+    "standardDeviation",
+    (c, p) => standardDeviation(c, { period: p.period ?? 20, source: p.source }),
+    {
+      category: "Volatility",
+      name: "Standard Deviation",
+      description: "Raw standard deviation of closing prices over a rolling window.",
+      paramSchema: [period(20)],
+    },
+  ),
   ewmaVol: withCompute<{ lambda?: number }>(
     "ewmaVol",
     (c, p) => {
@@ -2059,21 +2056,20 @@ export const indicatorPresets: Record<string, IndicatorPreset> = {
     description: "Rolling minimum of candle lows over N bars.",
     paramSchema: [period(20, 2, 500)],
   },
-  returns: {
-    meta: { kind: "returns", overlay: false, label: "Returns" },
-    defaultParams: { period: 1, type: "simple" },
-    snapshotName: (p: Record<string, unknown>) => `ret${p.period}-${p.type ?? "simple"}`,
-    compute: typedCompute<{ period?: number; type?: "simple" | "log" }>((c, p) =>
+  returns: withCompute<{ period?: number; type?: "simple" | "log" }>(
+    "returns",
+    (c, p) =>
       returns(c, {
         period: p.period ?? 1,
         type: p.type ?? "simple",
       }),
-    ),
-    category: "Price",
-    name: "Returns",
-    description: "Bar-over-bar percentage or log returns of close prices.",
-    paramSchema: [period(1, 1, 100)],
-  },
+    {
+      category: "Price",
+      name: "Returns",
+      description: "Bar-over-bar percentage or log returns of close prices.",
+      paramSchema: [period(1, 1, 100)],
+    },
+  ),
   cumulativeReturns: {
     meta: { kind: "cumulativeReturns", overlay: false, label: "Cum. Returns" },
     defaultParams: { type: "simple" },

--- a/packages/core/src/streaming/live-presets.ts
+++ b/packages/core/src/streaming/live-presets.ts
@@ -74,9 +74,11 @@ import {
   createPpo,
   createPvt,
   createQStick,
+  createReturns,
   createRoc,
   createRsi,
   createSma,
+  createStandardDeviation,
   createStc,
   createStochastics,
   createStochRsi,
@@ -160,10 +162,12 @@ import {
   PPO_META,
   PVT_META,
   QSTICK_META,
+  RETURNS_META,
   ROC_META,
   RSI_META,
   SMA_META,
   STC_META,
+  STD_DEV_META,
   STOCH_RSI_META,
   STOCHASTICS_META,
   SUPERTREND_META,
@@ -257,7 +261,7 @@ export const livePresets: Record<string, LivePreset> = {
   sma: {
     meta: SMA_META,
     defaultParams: { period: 20 },
-    snapshotName: (p) => `sma${p.period}`,
+    snapshotName: (p) => `sma_${p.source ?? "close"}_${p.period ?? 20}`,
     createFactory: factory<{ source?: PriceSource; period?: number }>()(createSma, (p) => ({
       period: p.period ?? 20,
       source: p.source,
@@ -318,7 +322,7 @@ export const livePresets: Record<string, LivePreset> = {
   dema: {
     meta: DEMA_META,
     defaultParams: { period: 20 },
-    snapshotName: (p) => `dema${p.period}`,
+    snapshotName: (p) => `dema_${p.source ?? "close"}_${p.period ?? 20}`,
     createFactory: factory<{ source?: PriceSource; period?: number }>()(createDema, (p) => ({
       period: p.period ?? 20,
       source: p.source,
@@ -327,7 +331,7 @@ export const livePresets: Record<string, LivePreset> = {
   tema: {
     meta: TEMA_META,
     defaultParams: { period: 20 },
-    snapshotName: (p) => `tema${p.period}`,
+    snapshotName: (p) => `tema_${p.source ?? "close"}_${p.period ?? 20}`,
     createFactory: factory<{ source?: PriceSource; period?: number }>()(createTema, (p) => ({
       period: p.period ?? 20,
       source: p.source,
@@ -336,7 +340,7 @@ export const livePresets: Record<string, LivePreset> = {
   zlema: {
     meta: ZLEMA_META,
     defaultParams: { period: 20 },
-    snapshotName: (p) => `zlema${p.period}`,
+    snapshotName: (p) => `zlema_${p.source ?? "close"}_${p.period ?? 20}`,
     createFactory: factory<{ source?: PriceSource; period?: number }>()(createZlema, (p) => ({
       period: p.period ?? 20,
       source: p.source,
@@ -361,7 +365,7 @@ export const livePresets: Record<string, LivePreset> = {
   frama: {
     meta: FRAMA_META,
     defaultParams: { period: 16 },
-    snapshotName: (p) => `frama${p.period}`,
+    snapshotName: (p) => `frama_${p.source ?? "close"}_${p.period ?? 16}`,
     createFactory: factory<{ source?: PriceSource; period?: number }>()(createFrama, (p) => ({
       period: p.period ?? 16,
       source: p.source,
@@ -599,7 +603,7 @@ export const livePresets: Record<string, LivePreset> = {
   kst: {
     meta: KST_META,
     defaultParams: { signalPeriod: 9 },
-    snapshotName: "kst",
+    snapshotName: (p) => `kst_${p.source ?? "close"}_${p.signalPeriod ?? 9}`,
     createFactory: factory<{ source?: PriceSource; signalPeriod?: number }>()(createKst, (p) => ({
       signalPeriod: p.signalPeriod ?? 9,
       source: p.source,
@@ -608,7 +612,7 @@ export const livePresets: Record<string, LivePreset> = {
   hurst: {
     meta: HURST_META,
     defaultParams: { minWindow: 20, maxWindow: 100 },
-    snapshotName: "hurst",
+    snapshotName: (p) => `hurst_${p.source ?? "close"}_${p.minWindow ?? 20}_${p.maxWindow ?? 100}`,
     createFactory: factory<{ source?: PriceSource; minWindow?: number; maxWindow?: number }>()(
       createHurst,
       (p) => ({
@@ -719,7 +723,7 @@ export const livePresets: Record<string, LivePreset> = {
   hv: {
     meta: HV_META,
     defaultParams: { period: 20 },
-    snapshotName: (p) => `hv${p.period}`,
+    snapshotName: (p) => `hv_${p.source ?? "close"}_${p.period ?? 20}_${p.annualFactor ?? 252}`,
     createFactory: factory<{ source?: PriceSource; period?: number; annualFactor?: number }>()(
       createHistoricalVolatility,
       (p) => ({
@@ -746,11 +750,25 @@ export const livePresets: Record<string, LivePreset> = {
   ulcer: {
     meta: ULCER_META,
     defaultParams: { period: 14 },
-    snapshotName: (p) => `ulcer${p.period}`,
+    snapshotName: (p) => `ulcer_${p.source ?? "close"}_${p.period ?? 14}`,
     createFactory: factory<{ source?: PriceSource; period?: number }>()(createUlcerIndex, (p) => ({
       period: p.period ?? 14,
       source: p.source,
     })),
+  },
+  standardDeviation: {
+    meta: STD_DEV_META,
+    defaultParams: { period: 20 },
+    // Key matches `STD_DEV_META.kind` so `livePresets.standardDeviation`
+    // and `indicatorPresets.standardDeviation` reach the same factory.
+    snapshotName: (p) => `stddev_${p.source ?? "close"}_${p.period ?? 20}`,
+    createFactory: factory<{ period?: number; source?: PriceSource }>()(
+      createStandardDeviation,
+      (p) => ({
+        period: p.period ?? 20,
+        source: p.source,
+      }),
+    ),
   },
 
   // Trend
@@ -949,6 +967,15 @@ export const livePresets: Record<string, LivePreset> = {
     snapshotName: (p) => `hilo${p.period}`,
     createFactory: factory<{ period?: number }>()(createHighestLowest, (p) => ({
       period: p.period ?? 20,
+    })),
+  },
+  returns: {
+    meta: RETURNS_META,
+    defaultParams: { period: 1, type: "simple" },
+    snapshotName: (p) => `returns_${p.type ?? "simple"}_${p.period ?? 1}`,
+    createFactory: factory<{ period?: number; type?: "simple" | "log" }>()(createReturns, (p) => ({
+      period: p.period ?? 1,
+      type: p.type ?? "simple",
     })),
   },
   pivotPoints: {


### PR DESCRIPTION
## Summary

Seventh and last Wave 1 migration on top of the State Contract foundation (`epic/state-contract`). Two leaf indicators, a long-standing gap in the live-preset registry, and a formal contract for the `snapshotName` key surface — closing Wave 1 of the epic.

**Wave 1 close-out**: all Windowed-category indicators are now on the State Contract.

| Indicator | Category | Version | Notes |
|---|---|---|---|
| **Returns** | Windowed | 1 | Defaults `{ period: 1, type: "simple" }` (pandas/quantstats convention). Buffer carries across both period and type reconfigs |
| **HighestLowest** | Windowed | 1 | Default period 20. Same pattern as Donchian Channel (Bundle C) |

## Live-preset registry cleanup

- `returns` and `standardDeviation` entries added to `livePresets` (both were available as factories but not registered).
- `RETURNS_META` added to `indicator-meta.ts`.
- `indicatorPresets.standardDeviation` and `indicatorPresets.returns` rewritten via `withCompute(...)` so the unified registry exposes both batch compute and incremental factory uniformly.
- The `standardDeviation` batch wrapper also now forwards `source` (was silently dropping it before).
- `livePresets.standardDeviation` (not `stddev`) keys to match `STD_DEV_META.kind`.

## snapshotName contract — STATE_CONTRACT.md §10 (new section)

Formalizes the dual purpose of `snapshotName`:
- **Internal uniqueness** — `connectIndicators` duplicate guard
- **External persistence** — host filename / cache key

Sets the formal contract:
- **Surjective on variants** — different param sets MUST produce different keys
- **Deterministic** — same params → same output, always
- **Defaults-equivalent** — omitting a default field matches passing it explicitly

Sets stability policy:
- Patch releases MUST NOT change `snapshotName` output
- Minor releases MAY, with a documented `Breaking` CHANGELOG entry
- Recommended canonical format: `${kind}_${param1}_${param2}_...`

## snapshotName fixes (11 presets total)

All eleven were violating §10.2 (surjective on variants). Old → new mapping is documented in §10.5:

| Preset | Old | New |
|---|---|---|
| `sma` | `sma${period}` | `sma_${source}_${period}` |
| `dema` | `dema${period}` | `dema_${source}_${period}` |
| `tema` | `tema${period}` | `tema_${source}_${period}` |
| `zlema` | `zlema${period}` | `zlema_${source}_${period}` |
| `frama` | `frama${period}` | `frama_${source}_${period}` |
| `hv` | `hv${period}` | `hv_${source}_${period}_${annualFactor}` |
| `ulcer` | `ulcer${period}` | `ulcer_${source}_${period}` |
| `standardDeviation` | (unregistered) | `stddev_${source}_${period}` |
| `returns` | (unregistered) | `returns_${type}_${period}` |
| `kst` | `"kst"` | `kst_${source}_${signalPeriod}` |
| `hurst` | `"hurst"` | `hurst_${source}_${minWindow}_${maxWindow}` |

**Breaking**: changes the persisted instance-id format for these eleven presets. 0.4.0 already invalidates pre-0.4.0 state via `STATE_CONTRACT.md` §5.3; this rides along under the same release boundary, now documented in §10.3 / §10.5.

**Out of scope**: a follow-up audit found ~30 more presets with static `snapshotName` for variant params (`macd`, `stochastics`, etc.). These share the same latent pattern but are deferred to a dedicated cleanup PR before Wave 2 begins.

## Test plan

- [x] `pnpm --filter trendcraft test` — 5236/5236 green
- [x] `pnpm lint` clean
- [x] `pnpm build` green
- [x] `pnpm --filter @trendcraft/chart size-check` within cap
- [x] `pnpm --filter trendcraft exec tsc -p tsconfig.json --noEmit --ignoreDeprecations "6.0"` — incremental subgraph clean (5 pre-existing errors in `strategy-dna` / `always-conditions` predate epic base, unrelated to this PR)
- [x] `describeContract` invariants: 77/77 across all 13 Wave 1 indicators (SMA / ALMA / WMA / VWMA / Choppiness / Ulcer / TWAP / StandardDeviation / VWAP / Donchian / AnchoredVwap / Returns / HighestLowest)