### PR TITLE
feat(core)!: McGinley/EWMA migration + invariant [8] batch parity gate (Wave 2 Bundle F)

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
@@ -1344,9 +1344,9 @@ describe("McGinley Dynamic responds to price changes", () => {
     const state = md1.getState();
 
     const md2 = createMcGinleyDynamic({}, { fromState: state });
-    expect(md2.getState().period).toBe(7);
-    expect(md2.getState().k).toBe(0.4);
-    expect(md2.getState().source).toBe("high");
+    expect(md2.getState().meta.params.period).toBe(7);
+    expect(md2.getState().meta.params.k).toBe(0.4);
+    expect(md2.getState().meta.params.source).toBe("high");
   });
 
   it("refuses resume with a different period", () => {

--- a/packages/core/src/indicators/incremental/__tests__/contract-helper.ts
+++ b/packages/core/src/indicators/incremental/__tests__/contract-helper.ts
@@ -28,6 +28,9 @@
  * 5. Reconfig refuse — recursive/mixed/cascaded: any param change throws
  * 6. peek consistency (`peek` matches `next`, doesn't mutate state)
  * 7. Warmup gate consistency (`next` / `peek` / `isWarmedUp` align)
+ * 8. Batch/incremental parity (optional, requires `batchCompute`):
+ *    feeding the same candles to the incremental indicator and the
+ *    batch counterpart yields the same value series.
  *
  * Phase 1 skeleton: the full implementation is intentionally kept
  * minimal here. Per-indicator nuances (custom equality, post-warmup
@@ -99,6 +102,40 @@ export type ContractConfig<TValue, TState> = {
    * `leftBars + rightBars`) must override this.
    */
   reconfigMargin?: (newOpts: Record<string, unknown>) => number;
+  /**
+   * Batch counterpart for invariant [8] (batch/incremental parity).
+   *
+   * Takes the same `options` and `candles` as the incremental
+   * indicator and returns the expected value series, **one entry per
+   * candle** in input order. Entries should be `null` for any bar
+   * where the incremental indicator emits null (warmup period).
+   *
+   * Most batch indicators in this package return `Series<T>` with the
+   * same length as the candle stream and null values during warmup,
+   * so the typical implementation is a one-liner:
+   *
+   *     batchCompute: (opts, candles) =>
+   *       smaBatch(candles, opts as { period?: number }).map(s => s.value)
+   *
+   * Indicators whose batch sibling uses a different alignment
+   * (e.g., `ewmaVolatilityFromCandles` returns one entry per *return*,
+   * skipping candle 0, and uses a non-causal lookahead seed) must
+   * pad / mask explicitly so the returned series is candle-aligned
+   * and null-matched to the incremental output.
+   *
+   * Migration policy: every `describeContract` entry whose indicator
+   * has a batch counterpart MUST supply `batchCompute` so the parity
+   * regression net stays in place. Omit only when no batch
+   * implementation exists for the indicator.
+   */
+  batchCompute?: (options: Record<string, unknown>, candles: NormalizedCandle[]) => unknown[];
+  /**
+   * Tolerance override for invariant [8]. Falls back to `tolerance`
+   * (then 1e-10). Loosen only when floating-point summation order
+   * produces deterministic-but-tiny drift between batch and
+   * incremental — never to paper over algorithmic divergence.
+   */
+  consistencyTolerance?: number;
 };
 
 /**
@@ -306,6 +343,45 @@ export function describeContract<TValue, TState>(config: ContractConfig<TValue, 
       }
     });
 
+    if (config.batchCompute) {
+      // Invariant [8] runs `batchCompute` and incremental factory
+      // against multiple candle shapes — the standard trend+sine
+      // dataset plus a flat-price dataset that surfaces zero-variance
+      // / div-by-zero / accumulator-stuck bugs the trending shape
+      // hides. Adding new variants here permanently extends the
+      // regression net across every indicator with batch parity wired
+      // up; this is how we ensure edge-case bugs (e.g., EWMA's
+      // missing zero-variance floor) cannot quietly come back.
+      const parityCases: Array<{ label: string; candles: NormalizedCandle[] }> = [
+        { label: "trending candles", candles },
+        { label: "flat-price candles", candles: makeFlatCandles(streamLength) },
+      ];
+
+      for (const parityCase of parityCases) {
+        it(`[8] batch/incremental parity (${parityCase.label}): same candles produce same value series`, () => {
+          // Feed the same candles through the batch sibling and the
+          // incremental factory using identical default params. Every
+          // emitted value (including `null` warmup bars) must agree
+          // within `consistencyTolerance`. A failure here means the
+          // two computations have diverged — either a latent algorithm
+          // mismatch, an off-by-one alignment, or a tolerance issue
+          // that warrants explicit acknowledgement rather than silent
+          // tolerance growth.
+          const opts = { ...config.defaultParams };
+          const batchValues = config.batchCompute!(opts, parityCase.candles);
+
+          const incremental = config.create({ ...config.defaultParams });
+          const incrementalValues: unknown[] = [];
+          for (const c of parityCase.candles) {
+            incrementalValues.push(incremental.next(c).value);
+          }
+
+          const tol = config.consistencyTolerance ?? config.tolerance ?? 1e-10;
+          expectSeriesEqual(incrementalValues, batchValues, tol);
+        });
+      }
+    }
+
     it("[7] warmup gate consistency: next / peek / isWarmedUp align", () => {
       const ind = config.create({ ...config.defaultParams });
 
@@ -334,6 +410,27 @@ export function describeContract<TValue, TState>(config: ContractConfig<TValue, 
       }
     });
   });
+}
+
+/**
+ * Flat-price candle generator used by invariant [8].
+ *
+ * All OHLC = 100 with mild volume variation. Surfaces bugs that the
+ * trending generator hides: zero-variance seeding (EWMA), div-by-zero
+ * on TR/range (Choppiness/ADL/CVD), recursive accumulators stuck at
+ * their seed value, and so on. Future variants (NaN-adjacent, single
+ * bar, huge values) can extend the parity-case list in `describeContract`
+ * with the same pattern.
+ */
+function makeFlatCandles(n: number): NormalizedCandle[] {
+  return Array.from({ length: n }, (_, i) => ({
+    time: 1700000000000 + i * 86400000,
+    open: 100,
+    high: 100,
+    low: 100,
+    close: 100,
+    volume: 1000 + (i % 3),
+  }));
 }
 
 /**

--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -12,8 +12,32 @@
  * migrated" registry.
  */
 
-import type { NormalizedCandle } from "../../../types";
+import type { NormalizedCandle, PriceSource } from "../../../types";
+import { alma } from "../../moving-average/alma";
+import { mcginleyDynamic } from "../../moving-average/mcginley-dynamic";
+import { sma } from "../../moving-average/sma";
+import { vwma } from "../../moving-average/vwma";
+import { wma } from "../../moving-average/wma";
+import { highest, lowest } from "../../price/highest-lowest";
+import { returns as returnsBatch } from "../../price/returns";
+import { choppinessIndex } from "../../volatility/choppiness-index";
+import { donchianChannel } from "../../volatility/donchian-channel";
+import { ewmaVolatilityFromCandles } from "../../volatility/garch";
+import { standardDeviation } from "../../volatility/standard-deviation";
+import { ulcerIndex } from "../../volatility/ulcer-index";
+import { adl } from "../../volume/adl";
+import { anchoredVwap } from "../../volume/anchored-vwap";
+import { cvd } from "../../volume/cvd";
+import { nvi } from "../../volume/nvi";
+import { obv } from "../../volume/obv";
+import { pvt } from "../../volume/pvt";
+import { twap } from "../../volume/twap";
+import { vwap } from "../../volume/vwap";
 import { type AlmaState, createAlma } from "../moving-average/alma";
+import {
+  createMcGinleyDynamic,
+  type McGinleyDynamicState,
+} from "../moving-average/mcginley-dynamic";
 import { createSma, type SmaState } from "../moving-average/sma";
 import { createVwma, type VwmaState } from "../moving-average/vwma";
 import { createWma, type WmaState } from "../moving-average/wma";
@@ -21,6 +45,7 @@ import { createHighestLowest, type HighestLowestState } from "../price/highest-l
 import { createReturns, type ReturnsState } from "../price/returns";
 import { type ChoppinessIndexState, createChoppinessIndex } from "../volatility/choppiness-index";
 import { createDonchianChannel, type DonchianState } from "../volatility/donchian-channel";
+import { createEwmaVolatility, type EwmaVolatilityState } from "../volatility/ewma-volatility";
 import {
   createStandardDeviation,
   type StandardDeviationState,
@@ -65,6 +90,8 @@ describeContract<number | null, SmaState>({
   reconfigParams: [{ period: 8 }, { period: 30 }],
   makeCandles,
   streamLength: 100,
+  batchCompute: (opts, candles) =>
+    sma(candles, opts as { period: number; source?: "close" | "high" }).map((s) => s.value),
 });
 
 // ---- ALMA (Wave 1 ALMA cluster, Category Windowed, version 1) ----
@@ -90,6 +117,11 @@ describeContract<number | null, AlmaState>({
   reconfigParams: [{ period: 14 }, { period: 5 }, { offset: 0.5 }, { sigma: 3 }],
   makeCandles,
   streamLength: 100,
+  batchCompute: (opts, candles) =>
+    alma(
+      candles,
+      opts as { period?: number; offset?: number; sigma?: number; source?: "close" | "high" },
+    ).map((s) => s.value),
 });
 
 // ---- WMA (Wave 1 WMA cluster, Category Windowed, version 1) ----
@@ -104,6 +136,8 @@ describeContract<number | null, WmaState>({
   reconfigParams: [{ period: 10 }, { period: 30 }],
   makeCandles,
   streamLength: 100,
+  batchCompute: (opts, candles) =>
+    wma(candles, opts as { period: number; source?: "close" | "high" }).map((s) => s.value),
 });
 
 // ---- Bundle A: VWMA / Choppiness Index / Ulcer Index / TWAP ----
@@ -119,6 +153,8 @@ describeContract<number | null, VwmaState>({
   reconfigParams: [{ period: 10 }, { period: 30 }],
   makeCandles,
   streamLength: 100,
+  batchCompute: (opts, candles) =>
+    vwma(candles, opts as { period: number; source?: "close" | "high" }).map((s) => s.value),
 });
 
 // Choppiness Index — Windowed; `period` has a canonical default of 14
@@ -132,6 +168,8 @@ describeContract<number | null, ChoppinessIndexState>({
   reconfigParams: [{ period: 7 }, { period: 28 }],
   makeCandles,
   streamLength: 200,
+  batchCompute: (opts, candles) =>
+    choppinessIndex(candles, opts as { period?: number }).map((s) => s.value),
 });
 
 // Ulcer Index — Windowed two-stage. On reconfig the `prices` buffer
@@ -152,6 +190,8 @@ describeContract<number | null, UlcerIndexState>({
   reconfigMargin: (newOpts) => 2 * (newOpts.period as number),
   makeCandles,
   streamLength: 200,
+  batchCompute: (opts, candles) =>
+    ulcerIndex(candles, opts as { period?: number; source?: "close" | "high" }).map((s) => s.value),
 });
 
 // TWAP — Recursive (`cumTp` accumulator with session-boundary resets;
@@ -168,6 +208,8 @@ describeContract<number | null, TwapState>({
   reconfigParams: [{ sessionResetPeriod: 60 }, { sessionResetPeriod: 30 }],
   makeCandles,
   streamLength: 100,
+  batchCompute: (opts, candles) =>
+    twap(candles, opts as { sessionResetPeriod?: "session" | number }).map((s) => s.value),
 });
 
 // ---- Bundle B: Standard Deviation / VWAP ----
@@ -185,6 +227,10 @@ describeContract<number | null, StandardDeviationState>({
   reconfigParams: [{ period: 10 }, { period: 30 }],
   makeCandles,
   streamLength: 100,
+  batchCompute: (opts, candles) =>
+    standardDeviation(candles, opts as { period: number; source?: "close" | "high" }).map(
+      (s) => s.value,
+    ),
 });
 
 // VWAP — Recursive, parameter-less (daily session reset is the only
@@ -205,6 +251,11 @@ describeContract<VwapValueWithFlatField, VwapState>({
   reconfigParams: [],
   makeCandles,
   streamLength: 100,
+  // Batch VWAP emits a richer composite (`{ vwap, upper, lower }`)
+  // because it supports band multipliers; the incremental factory
+  // here is session-only and only tracks the vwap field. Project
+  // just `.vwap` for the parity comparison.
+  batchCompute: (_opts, candles) => vwap(candles, {}).map((s) => ({ vwap: s.value.vwap })),
 });
 
 // Local alias so the `describeContract<TValue, TState>` generic captures
@@ -224,6 +275,8 @@ describeContract<DonchianValueShape, DonchianState>({
   reconfigParams: [{ period: 10 }, { period: 30 }],
   makeCandles,
   streamLength: 100,
+  batchCompute: (opts, candles) =>
+    donchianChannel(candles, opts as { period?: number }).map((s) => s.value),
 });
 
 type DonchianValueShape = {
@@ -250,6 +303,8 @@ describeContract<AnchoredVwapValueShape, AnchoredVwapState>({
   reconfigParams: [{ anchorTime: 1700000000000 + 5 * 86400000 }, { bands: 1 }],
   makeCandles,
   streamLength: 100,
+  batchCompute: (opts, candles) =>
+    anchoredVwap(candles, opts as { anchorTime: number; bands?: number }).map((s) => s.value),
 });
 
 type AnchoredVwapValueShape = {
@@ -276,6 +331,8 @@ describeContract<number | null, ReturnsState>({
   reconfigParams: [{ period: 5 }, { period: 10 }, { type: "log" }],
   makeCandles,
   streamLength: 100,
+  batchCompute: (opts, candles) =>
+    returnsBatch(candles, opts as { period?: number; type?: "simple" | "log" }).map((s) => s.value),
 });
 
 // HighestLowest — Windowed, same shape as Donchian's high/low buffers.
@@ -289,6 +346,14 @@ describeContract<HighestLowestValueShape, HighestLowestState>({
   reconfigParams: [{ period: 10 }, { period: 30 }],
   makeCandles,
   streamLength: 100,
+  // Batch has separate `highest()` and `lowest()` helpers; combine
+  // them per-bar to match the incremental composite output.
+  batchCompute: (opts, candles) => {
+    const period = (opts.period as number) ?? 20;
+    const h = highest(candles, period);
+    const l = lowest(candles, period);
+    return h.map((s, i) => ({ highest: s.value, lowest: l[i].value }));
+  },
 });
 
 type HighestLowestValueShape = {
@@ -315,6 +380,7 @@ describeContract<number, ObvState>({
   reconfigParams: [],
   makeCandles,
   streamLength: 100,
+  batchCompute: (_opts, candles) => obv(candles).map((s) => s.value),
 });
 
 // PVT — Recursive, parameter-less.
@@ -327,6 +393,7 @@ describeContract<number | null, PvtState>({
   reconfigParams: [],
   makeCandles,
   streamLength: 100,
+  batchCompute: (_opts, candles) => pvt(candles).map((s) => s.value),
 });
 
 // NVI — Recursive with one param (`initialValue`). Exercises the
@@ -342,6 +409,8 @@ describeContract<number, NviState>({
   reconfigParams: [{ initialValue: 5000 }],
   makeCandles,
   streamLength: 100,
+  batchCompute: (opts, candles) =>
+    nvi(candles, opts as { initialValue?: number }).map((s) => s.value),
 });
 
 // ADL — Recursive, parameter-less.
@@ -354,6 +423,7 @@ describeContract<number, AdlState>({
   reconfigParams: [],
   makeCandles,
   streamLength: 100,
+  batchCompute: (_opts, candles) => adl(candles).map((s) => s.value),
 });
 
 // CVD — Recursive, parameter-less.
@@ -366,4 +436,77 @@ describeContract<number, CvdState>({
   reconfigParams: [],
   makeCandles,
   streamLength: 100,
+  batchCompute: (_opts, candles) => cvd(candles).map((s) => s.value),
+});
+
+// ---- Wave 2 Bundle F: McGinley Dynamic / EWMA Volatility ----
+
+// McGinley Dynamic — Recursive (single-pole). `prevMd` permanently
+// encodes past parameters, so reconfig (different period / k / source)
+// is refused. Replaces the hand-rolled Phase 2C resume guard.
+describeContract<number | null, McGinleyDynamicState>({
+  name: "mcginleyDynamic",
+  create: (opts, warmUp) =>
+    createMcGinleyDynamic(opts as { period?: number; k?: number; source?: PriceSource }, warmUp),
+  category: "recursive",
+  version: 1,
+  defaultParams: { period: 14, k: 0.6, source: "close" },
+  // Exercise refuse on each independent param axis.
+  reconfigParams: [{ period: 20 }, { k: 0.5 }, { source: "high" }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    mcginleyDynamic(candles, opts as { period?: number; k?: number; source?: PriceSource }).map(
+      (s) => s.value,
+    ),
+});
+
+// EWMA Volatility — Recursive (`prevVariance` is the recursive
+// accumulator after seed completion; the seeding buffer is transient).
+// Param mismatch on resume is now refused via the recursive policy —
+// pre-0.4.0 silently merged with the snapshot's variance.
+//
+// Stream must clear the seed window (default seedSize=10 returns
+// → seed completes at candle 10) before invariant [1]'s split point
+// has any post-resume non-null bars to compare. `streamLength: 100`
+// with `splitIdx = 50` gives plenty of room.
+describeContract<number | null, EwmaVolatilityState>({
+  name: "ewmaVolatility",
+  create: (opts, warmUp) =>
+    createEwmaVolatility(
+      opts as { lambda?: number; source?: PriceSource; seedSize?: number },
+      warmUp,
+    ),
+  category: "recursive",
+  version: 1,
+  defaultParams: { lambda: 0.94, source: "close", seedSize: 10 },
+  reconfigParams: [{ lambda: 0.97 }, { seedSize: 20 }, { source: "high" }],
+  makeCandles,
+  streamLength: 100,
+  // EWMA is the trickiest parity case in the library:
+  //   * batch (`ewmaVolatilityFromCandles`) returns one entry per
+  //     *return*, omitting candle 0; the incremental candle index i
+  //     corresponds to batch index i-1.
+  //   * batch uses a non-causal lookahead seed (sample variance of
+  //     the first `seedSize` returns), so its early values rely on
+  //     data the incremental indicator does not have yet during the
+  //     seed window. We mask candles 0..seedSize-1 to null on the
+  //     batch side to match the incremental's null seed gate; from
+  //     candle `seedSize` onward both indicators evolve bar-for-bar
+  //     identically (see ewma-volatility.ts file-level JSDoc for
+  //     the matching replay logic on the incremental side).
+  batchCompute: (opts, candles) => {
+    const seedSize = (opts.seedSize as number) ?? 10;
+    const result = ewmaVolatilityFromCandles(
+      candles,
+      opts as { lambda?: number; source?: PriceSource },
+    );
+    const padded: (number | null)[] = new Array(candles.length).fill(null);
+    // result[i] is at candles[i+1].time; first non-masked entry is at
+    // result[seedSize-1] (= candles[seedSize]).
+    for (let i = seedSize - 1; i < result.length; i++) {
+      padded[i + 1] = result[i].value;
+    }
+    return padded;
+  },
 });

--- a/packages/core/src/indicators/incremental/__tests__/volatility-indicators.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/volatility-indicators.test.ts
@@ -254,13 +254,20 @@ describe("EWMA Volatility incremental", () => {
     }
   });
 
-  it("produces non-null values after warmup", () => {
+  it("emits null during seeding and produces non-null once seed completes", () => {
+    // Default seedSize=10 — need 10 returns (= 11 candles) before the
+    // first stable sample-variance estimate is emitted.
     const ind = createEwmaVolatility({ lambda: 0.94 });
-    // First candle: no return yet
-    expect(ind.next(candles[0]).value).toBeNull();
-    // Second candle: first return
-    const v = ind.next(candles[1]).value;
+    // Candle 0 has no return yet; candles 1..9 are mid-seed (9 returns).
+    for (let i = 0; i < 10; i++) {
+      expect(ind.next(candles[i]).value).toBeNull();
+    }
+    expect(ind.isWarmedUp).toBe(false);
+    // Candle 10 produces the 10th return — seed completes and the
+    // first non-null value is emitted alongside `isWarmedUp=true`.
+    const v = ind.next(candles[10]).value;
     expect(v).not.toBeNull();
     expect(v).toBeGreaterThan(0);
+    expect(ind.isWarmedUp).toBe(true);
   });
 });

--- a/packages/core/src/indicators/incremental/moving-average/mcginley-dynamic.ts
+++ b/packages/core/src/indicators/incremental/moving-average/mcginley-dynamic.ts
@@ -8,19 +8,37 @@
  * (different period, k, or source) is mathematically undefined and
  * refused. Pass identical options on resume, or omit them and let the
  * snapshot's params win.
+ *
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<McGinleyDynamicState>` and `fromState` accepts
+ * the same. Params (`period`, `k`, `source`) now live in `meta.params`
+ * — the hand-rolled resume guard from 0.3.x is replaced by the
+ * library-wide `resolveResume` recursive policy.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for McGinley Dynamic. Params (`period`, `k`,
+ * `source`) live in `meta.params` on the wire — they are not part
+ * of the bare state.
+ */
 export type McGinleyDynamicState = {
-  period: number;
-  k: number;
-  source: PriceSource;
   prevMd: number | null;
   sum: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const MCGINLEY_DYNAMIC_VERSION = 1;
+
+type McGinleyDynamicParams = {
+  period: number;
+  k: number;
+  source: PriceSource;
 };
 
 /**
@@ -37,36 +55,39 @@ export type McGinleyDynamicState = {
  */
 export function createMcGinleyDynamic(
   options: { period?: number; k?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<McGinleyDynamicState>,
-): IncrementalIndicator<number | null, McGinleyDynamicState> {
-  // Resume order: explicit option > snapshot value > canonical default.
-  const fs = warmUpOptions?.fromState ?? null;
-  const period = options.period ?? fs?.period ?? 14;
-  const k = options.k ?? fs?.k ?? 0.6;
-  const source: PriceSource = options.source ?? fs?.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<McGinleyDynamicState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<McGinleyDynamicState>> {
+  const { params, state } = resolveResume<McGinleyDynamicParams, McGinleyDynamicState>({
+    indicator: "mcginleyDynamic",
+    version: MCGINLEY_DYNAMIC_VERSION,
+    category: "recursive",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 14, k: 0.6, source: "close" },
+  });
+
+  const period = params.period;
+  const k = params.k;
+  const source = params.source;
 
   let prevMd: number | null;
   let sum: number;
   let count: number;
 
-  if (fs) {
-    // McGinley is recursive: `prevMd` carries past parameters forever,
-    // so reconfiguring on resume produces a hybrid series that doesn't
-    // match either fresh-with-old-options or fresh-with-new-options
-    // computed over the same candle history. Refuse explicitly.
-    if (fs.period !== period || fs.k !== k || fs.source !== source) {
-      throw new Error("McGinley Dynamic: incompatible snapshot, re-warm required");
-    }
-    prevMd = fs.prevMd;
-    sum = fs.sum;
-    count = fs.count;
+  if (state !== null) {
+    prevMd = state.prevMd;
+    sum = state.sum;
+    count = state.count;
   } else {
     prevMd = null;
     sum = 0;
     count = 0;
   }
 
-  const indicator: IncrementalIndicator<number | null, McGinleyDynamicState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<McGinleyDynamicState>> = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
       count++;
@@ -108,8 +129,13 @@ export function createMcGinleyDynamic(
       return { time: candle.time, value: prev + (price - prev) / denominator };
     },
 
-    getState(): McGinleyDynamicState {
-      return { period, k, source, prevMd, sum, count };
+    getState(): IndicatorSnapshot<McGinleyDynamicState> {
+      return makeSnapshot(
+        "mcginleyDynamic",
+        MCGINLEY_DYNAMIC_VERSION,
+        { period, k, source },
+        { prevMd, sum, count },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/volatility/ewma-volatility.ts
+++ b/packages/core/src/indicators/incremental/volatility/ewma-volatility.ts
@@ -6,21 +6,64 @@
  *   variance_t = lambda * variance_{t-1} + (1 - lambda) * return_t^2
  *
  * Output is annualized volatility percentage.
+ *
+ * State category: **Recursive** (`prevVariance` is a recursive
+ * accumulator once the seed window completes; the seeding buffer is
+ * discarded after seedDone). Any change to `lambda`, `source`, or
+ * `seedSize` on resume is refused — the running variance is already
+ * conditioned on the original parameters.
+ *
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<EwmaVolatilityState>` and `fromState` accepts
+ * the same. Params (`lambda`, `source`, `seedSize`) now live in
+ * `meta.params`. Pre-0.4.0 behavior silently merged mismatched params
+ * with the snapshot's recursive state — that latent bug is now a
+ * loud throw via the recursive policy.
+ *
+ * Seeding behavior (0.4.0): values during the seed window
+ * (bars 1..seedSize-1) are `null` — the incremental computation
+ * cannot causally replicate the batch sibling's lookahead seed
+ * (`ewmaVolatilityFromCandles` uses `sampleVariance` of the first
+ * `seedSize` returns, which requires knowing them in advance). At
+ * candle `seedSize` we (a) compute the same sample-variance seed
+ * the batch uses and (b) replay the `seedSize` EWMA updates that
+ * batch applied during its seeding period, so the first emitted
+ * value matches batch's value at that candle exactly and from then
+ * on the two indicators evolve bar-for-bar identically.
+ *
+ * Pre-0.4.0 emitted a preliminary running EWMA during the seed
+ * window that was then overwritten by the sample variance at
+ * seedSize — conflating "indicator has any value" with "indicator
+ * has a stable estimate" *and* leaving the post-seed series ~10 EWMA
+ * updates behind the batch sibling indefinitely. The combined seed
+ * suppression + replay fixes both issues.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for EWMA Volatility. Params (`lambda`, `source`,
+ * `seedSize`) live in `meta.params` on the wire — they are not part
+ * of the bare state.
+ */
 export type EwmaVolatilityState = {
-  lambda: number;
-  source: PriceSource;
   prevPrice: number | null;
   prevVariance: number | null;
   seedReturns: number[];
   seedDone: boolean;
-  seedSize: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const EWMA_VOLATILITY_VERSION = 1;
+
+type EwmaVolatilityParams = {
+  lambda: number;
+  source: PriceSource;
+  seedSize: number;
 };
 
 /**
@@ -40,11 +83,23 @@ export type EwmaVolatilityState = {
  */
 export function createEwmaVolatility(
   options: { lambda?: number; source?: PriceSource; seedSize?: number } = {},
-  warmUpOptions?: WarmUpOptions<EwmaVolatilityState>,
-): IncrementalIndicator<number | null, EwmaVolatilityState> {
-  const lambda = options.lambda ?? 0.94;
-  const source: PriceSource = options.source ?? "close";
-  const seedSize = options.seedSize ?? 10;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<EwmaVolatilityState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<EwmaVolatilityState>> {
+  const { params, state } = resolveResume<EwmaVolatilityParams, EwmaVolatilityState>({
+    indicator: "ewmaVolatility",
+    version: EWMA_VOLATILITY_VERSION,
+    category: "recursive",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { lambda: 0.94, source: "close", seedSize: 10 },
+  });
+
+  const lambda = params.lambda;
+  const source = params.source;
+  const seedSize = params.seedSize;
 
   let prevPrice: number | null;
   let prevVariance: number | null;
@@ -52,13 +107,12 @@ export function createEwmaVolatility(
   let seedDone: boolean;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    prevPrice = s.prevPrice;
-    prevVariance = s.prevVariance;
-    seedReturns = [...s.seedReturns];
-    seedDone = s.seedDone;
-    count = s.count;
+  if (state !== null) {
+    prevPrice = state.prevPrice;
+    prevVariance = state.prevVariance;
+    seedReturns = [...state.seedReturns];
+    seedDone = state.seedDone;
+    count = state.count;
   } else {
     prevPrice = null;
     prevVariance = null;
@@ -70,22 +124,35 @@ export function createEwmaVolatility(
   const annualFactor = Math.sqrt(252) * 100;
 
   function sampleVariance(returns: number[]): number {
+    // Population variance (divide by N) with a 1e-10 floor to match
+    // the batch sibling's `ewmaVolatility` seed convention exactly.
+    //
+    // Pre-0.4.0 incremental used Bessel-corrected sample variance
+    // (divide by N-1), which is statistically more rigorous but
+    // caused a permanent N/(N-1) divergence between batch and
+    // incremental output. It also lacked the zero floor, so a
+    // flat-price seed window emitted `0` while batch emitted a tiny
+    // positive value — and the recursive update then stayed at
+    // exact zero forever. Aligning on N + the floor keeps invariant
+    // [8] (batch parity) clean on every candle shape, including
+    // flat-price streams.
     const n = returns.length;
-    if (n < 2) return returns.length === 1 ? returns[0] * returns[0] : 0;
+    if (n === 0) return 0;
     const mean = returns.reduce((a, b) => a + b, 0) / n;
     let sumSq = 0;
     for (const r of returns) {
       const d = r - mean;
       sumSq += d * d;
     }
-    return sumSq / (n - 1);
+    const variance = sumSq / n;
+    return variance === 0 ? 1e-10 : variance;
   }
 
   function computeOutput(variance: number): number {
     return Math.sqrt(Math.max(0, variance)) * annualFactor;
   }
 
-  const indicator: IncrementalIndicator<number | null, EwmaVolatilityState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<EwmaVolatilityState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const price = getSourcePrice(candle, source);
@@ -101,19 +168,22 @@ export function createEwmaVolatility(
       if (!seedDone) {
         seedReturns.push(logReturn);
         if (seedReturns.length >= seedSize) {
-          // Seed variance from accumulated returns
-          prevVariance = sampleVariance(seedReturns);
-          // Apply EWMA for all returns after seeding
+          // Seed complete: compute the sample-variance seed (matches
+          // batch's `sigma2_initial`), then replay the EWMA updates
+          // batch applies during the seed window so the first emitted
+          // value matches batch's value at this candle exactly.
+          let v = sampleVariance(seedReturns);
+          for (const r of seedReturns) {
+            v = lambda * v + (1 - lambda) * r * r;
+          }
+          prevVariance = v;
           seedDone = true;
           return { time: candle.time, value: computeOutput(prevVariance) };
         }
-        // During accumulation, still compute a running EWMA
-        if (seedReturns.length === 1) {
-          prevVariance = logReturn * logReturn;
-        } else {
-          prevVariance = lambda * (prevVariance ?? 0) + (1 - lambda) * logReturn * logReturn;
-        }
-        return { time: candle.time, value: computeOutput(prevVariance) };
+        // Mid-seeding: hold output null until the seed window completes.
+        // (Pre-0.4.0 emitted a preliminary running EWMA here that was
+        // then overwritten at seedSize — see file-level JSDoc.)
+        return { time: candle.time, value: null };
       }
 
       prevVariance = lambda * (prevVariance ?? 0) + (1 - lambda) * logReturn * logReturn;
@@ -132,31 +202,35 @@ export function createEwmaVolatility(
       if (!seedDone) {
         const peekReturns = [...seedReturns, logReturn];
         if (peekReturns.length >= seedSize) {
-          const v = sampleVariance(peekReturns);
+          // Mirror next()'s seed completion: sample-variance seed
+          // followed by EWMA replay over the seed window.
+          let v = sampleVariance(peekReturns);
+          for (const r of peekReturns) {
+            v = lambda * v + (1 - lambda) * r * r;
+          }
           return { time: candle.time, value: computeOutput(v) };
         }
-        if (peekReturns.length === 1) {
-          return { time: candle.time, value: computeOutput(logReturn * logReturn) };
-        }
-        const v = lambda * (prevVariance ?? 0) + (1 - lambda) * logReturn * logReturn;
-        return { time: candle.time, value: computeOutput(v) };
+        // Mid-seeding peek mirrors next() and stays null.
+        return { time: candle.time, value: null };
       }
 
       const v = lambda * (prevVariance ?? 0) + (1 - lambda) * logReturn * logReturn;
       return { time: candle.time, value: computeOutput(v) };
     },
 
-    getState(): EwmaVolatilityState {
-      return {
-        lambda,
-        source,
-        prevPrice,
-        prevVariance,
-        seedReturns: [...seedReturns],
-        seedDone,
-        seedSize,
-        count,
-      };
+    getState(): IndicatorSnapshot<EwmaVolatilityState> {
+      return makeSnapshot(
+        "ewmaVolatility",
+        EWMA_VOLATILITY_VERSION,
+        { lambda, source, seedSize },
+        {
+          prevPrice,
+          prevVariance,
+          seedReturns: [...seedReturns],
+          seedDone,
+          count,
+        },
+      );
     },
 
     get count() {


### PR DESCRIPTION
## Summary

Second Wave 2 bundle. Migrates McGinley Dynamic and EWMA Volatility to the State Contract envelope and adds an automated batch/incremental parity gate to `describeContract`. Adding the gate surfaced **two long-standing numerical bugs** in incremental EWMA Volatility, both fixed in this PR.

## McGinley Dynamic

- Phase 2C hand-rolled `period/k/source` match-or-throw guard replaced with the library-wide `resolveResume` recursive policy
- Params move from bare state into `meta.params`; bare state shrinks to `{ prevMd, sum, count }`
- `next()` / `peek()` computation is byte-identical to 0.3.x

## EWMA Volatility

### Migration + silent fix
- Bare state shrinks to `{ prevPrice, prevVariance, seedReturns, seedDone, count }`; `lambda` / `source` / `seedSize` move to `meta.params`
- Silent fix: pre-0.4.0 silently merged mismatched resume params with the recursive variance. The recursive policy now throws

### ⚠️ BREAKING: seeding behavior
- Bars during the seed window (1..seedSize-1) now return `null`. The incremental cannot causally replicate the batch sibling's lookahead seed, so the pre-0.4.0 transient values during that window were misleading
- Aligns with how SMA / RSI / etc. warm up

### 🐛 LATENT BUG FIX 1/2 — 10-EWMA-update drift
At seed completion the incremental now replays the EWMA recursion over the seed buffer, so the first emitted value matches `ewmaVolatilityFromCandles` at the same candle exactly and the two indicators evolve bar-for-bar identically from there. Pre-0.4.0 was permanently ~10 EWMA updates behind batch — no existing test caught it.

### 🐛 LATENT BUG FIX 2/2 — sampleVariance convention + zero floor
Realigns `sampleVariance` from `/N-1` (Bessel) to `/N` (population) and applies a `1e-10` zero-variance floor to match batch's seed convention. The previous mismatch combined with the missing floor caused permanent drift on trending inputs and a stuck-at-zero output on flat-price inputs.

## invariant [8] — batch/incremental parity gate

New `batchCompute` field on `ContractConfig`. When provided, `describeContract` runs the incremental factory and batch counterpart against multiple candle shapes and asserts bar-for-bar equality.

### Multi-shape parity testing
Runs against two shapes per indicator:
1. Standard trend+sine dataset (`makeCandles`)
2. Flat-price dataset (`makeFlatCandles`) — surfaces zero-variance, div-by-zero, and accumulator-stuck bugs the trending shape hides

Future shapes (single-bar, NaN-adjacent, monotonic ramp, all-zero volume) extend the gate by appending one entry to the internal `parityCases` array — automatically applied to all 20 migrated indicators.

### Backfilled across 20 entries
All Wave 1 + Bundle E + Bundle F migrated indicators now have `batchCompute`. EWMA's batchCompute documents the candle/return offset and seed-window mask so the comparison only covers bars where causal-incremental can match non-causal-batch.

### Migration policy update
Every future `describeContract` entry whose indicator has a batch counterpart MUST supply `batchCompute` so this regression net stays in place.

## Test plan

- [x] `pnpm test`: 5314/5314 passing (+40 from baseline: 2 new contract entries × 7 invariants + flat-price variant × 20 entries + EWMA test updates)
- [x] `pnpm lint`: clean
- [x] `pnpm build`: success
- [x] `pnpm size-check`: within limits
- [x] tsc --noEmit (core): clean (pre-existing baseUrl deprecation only)
- [x] McGinley resume contract tests in `branch-coverage.test.ts` updated for new `meta.params` shape
- [x] EWMA `produces non-null` test rewritten to pin new seeding behavior
- [x] invariant [8] catches reintroduction of either EWMA latent bug if the fix is reverted