### PR TITLE
fix(core)!: EWMA annualization parity + State Contract audit findings

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/contract-helper.ts
+++ b/packages/core/src/indicators/incremental/__tests__/contract-helper.ts
@@ -136,6 +136,30 @@ export type ContractConfig<TValue, TState> = {
    * incremental — never to paper over algorithmic divergence.
    */
   consistencyTolerance?: number;
+  /**
+   * Custom "is this value the indicator's warmup gate?" predicate for
+   * invariant [7].
+   *
+   * The default (`isNullishValue`) treats a composite as null only
+   * when *every* present field is null/undefined. That's fine for
+   * indicators whose components warm up together (Donchian, BB, MACD
+   * variants with shared period). It breaks for indicators with
+   * *decoupled component warmup* — e.g., a hypothetical MACD where
+   * `macd` becomes non-null at `slowPeriod` but `signal` waits an
+   * additional `signalPeriod` bars: the default predicate would
+   * report "warmed up" the moment `macd` arrives, conflating with
+   * the indicator's own `isWarmedUp` getter (which usually waits for
+   * all components).
+   *
+   * Pass a predicate that returns `true` for any bar the indicator
+   * considers "still in warmup". The DSL then asserts `next`/`peek`
+   * agreement against this predicate instead of the all-null
+   * heuristic, and `isWarmedUp` against the first bar where the
+   * predicate returns `false`.
+   *
+   * Only override when the default is wrong; otherwise omit.
+   */
+  isNullishField?: (value: unknown) => boolean;
 };
 
 /**
@@ -355,6 +379,13 @@ export function describeContract<TValue, TState>(config: ContractConfig<TValue, 
       const parityCases: Array<{ label: string; candles: NormalizedCandle[] }> = [
         { label: "trending candles", candles },
         { label: "flat-price candles", candles: makeFlatCandles(streamLength) },
+        // Gap-candle variant: an isolated 10× upward jump mid-stream
+        // surfaces bugs that smooth datasets hide — McGinley's
+        // `(price/MD)^4` term divergence, EWMA's variance explosion,
+        // PVT/CVD multiplier overflow, etc. Trending + flat together
+        // never produce a discontinuity, so gap testing is the third
+        // axis of the regression net.
+        { label: "gap-candle stream", candles: makeGapCandles(streamLength) },
       ];
 
       for (const parityCase of parityCases) {
@@ -384,14 +415,15 @@ export function describeContract<TValue, TState>(config: ContractConfig<TValue, 
 
     it("[7] warmup gate consistency: next / peek / isWarmedUp align", () => {
       const ind = config.create({ ...config.defaultParams });
+      const isNullish = config.isNullishField ?? isNullishValue;
 
       let firstWarmupBar = -1;
       for (let i = 0; i < streamLength; i++) {
         const peeked = ind.peek(candles[i]);
-        const peekedNullBefore = isNullishValue(peeked.value);
+        const peekedNullBefore = isNullish(peeked.value);
 
         const advanced = ind.next(candles[i]);
-        const advancedNull = isNullishValue(advanced.value);
+        const advancedNull = isNullish(advanced.value);
 
         // peek and next must agree on null-ness at the same bar.
         expect(peekedNullBefore).toBe(advancedNull);
@@ -431,6 +463,36 @@ function makeFlatCandles(n: number): NormalizedCandle[] {
     close: 100,
     volume: 1000 + (i % 3),
   }));
+}
+
+/**
+ * Gap-candle generator: a mostly-flat stream with a single isolated
+ * 10× upward jump at the midpoint. Used by invariant [8] to surface
+ * discontinuity-sensitive bugs:
+ *
+ *   - McGinley Dynamic `(price/MD)^4` term divergence on extreme ratios
+ *   - EWMA variance explosion from a single large squared return
+ *   - PVT / CVD multiplier overflow on large `(close - prev) / prev`
+ *   - Donchian channel reset behavior when the gap exits the lookback
+ *
+ * The gap is placed at index `n/2` so warm-up has completed before it
+ * appears, ensuring the gap exercises the steady-state path rather
+ * than the seed path. Volume varies mildly so volume-weighted
+ * indicators get a non-degenerate signal.
+ */
+function makeGapCandles(n: number): NormalizedCandle[] {
+  const gapIndex = Math.floor(n / 2);
+  return Array.from({ length: n }, (_, i) => {
+    const base = i === gapIndex ? 1000 : 100;
+    return {
+      time: 1700000000000 + i * 86400000,
+      open: base,
+      high: base * 1.005,
+      low: base * 0.995,
+      close: base,
+      volume: 1000 + (i % 5) * 10,
+    };
+  });
 }
 
 /**

--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -12,6 +12,8 @@
  * migrated" registry.
  */
 
+import { describe, expect, it } from "vitest";
+import { CRYPTO_CALENDAR, JPX_CALENDAR } from "../../../calendar";
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { alma } from "../../moving-average/alma";
 import { mcginleyDynamic } from "../../moving-average/mcginley-dynamic";
@@ -509,4 +511,233 @@ describeContract<number | null, EwmaVolatilityState>({
     }
     return padded;
   },
+  // EWMA's output is annualized volatility (%) — typical magnitudes
+  // 10..60. The default 1e-10 absolute tolerance is ~1e-12 relative
+  // and trips on any future tweak to summation order (e.g., log-return
+  // clipping). Loosen to 1e-9 absolute (~1e-11 relative): still well
+  // below any meaningful divergence, but stable against benign FP
+  // reordering. Tighten if any test failure here ever surfaces a real
+  // algorithmic gap.
+  consistencyTolerance: 1e-9,
+});
+
+// EWMA parity at non-default params (lambda=0.97 — RiskMetrics monthly
+// convention; periodsPerYear=365 — crypto). Both flows must remain
+// bar-for-bar identical to batch when these options are passed; before
+// the Bundle G annualization fix the latter silently diverged because
+// incremental hard-coded sqrt(252). These extra contract entries lock
+// the API parity in regardless of `defaultParams`.
+describeContract<number | null, EwmaVolatilityState>({
+  name: "ewmaVolatility (lambda=0.97)",
+  create: (opts, warmUp) =>
+    createEwmaVolatility(
+      opts as { lambda?: number; source?: PriceSource; seedSize?: number },
+      warmUp,
+    ),
+  category: "recursive",
+  version: 1,
+  defaultParams: { lambda: 0.97, source: "close", seedSize: 10 },
+  reconfigParams: [],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) => {
+    const seedSize = (opts.seedSize as number) ?? 10;
+    const result = ewmaVolatilityFromCandles(
+      candles,
+      opts as { lambda?: number; source?: PriceSource },
+    );
+    const padded: (number | null)[] = new Array(candles.length).fill(null);
+    for (let i = seedSize - 1; i < result.length; i++) {
+      padded[i + 1] = result[i].value;
+    }
+    return padded;
+  },
+  consistencyTolerance: 1e-9,
+});
+
+describeContract<number | null, EwmaVolatilityState>({
+  name: "ewmaVolatility (crypto: periodsPerYear=365)",
+  create: (opts, warmUp) =>
+    createEwmaVolatility(
+      opts as {
+        lambda?: number;
+        source?: PriceSource;
+        seedSize?: number;
+        periodsPerYear?: number;
+      },
+      warmUp,
+    ),
+  category: "recursive",
+  version: 1,
+  defaultParams: { lambda: 0.94, source: "close", seedSize: 10, periodsPerYear: 365 },
+  reconfigParams: [],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) => {
+    const seedSize = (opts.seedSize as number) ?? 10;
+    const result = ewmaVolatilityFromCandles(
+      candles,
+      opts as { lambda?: number; source?: PriceSource; periodsPerYear?: number },
+    );
+    const padded: (number | null)[] = new Array(candles.length).fill(null);
+    for (let i = seedSize - 1; i < result.length; i++) {
+      padded[i + 1] = result[i].value;
+    }
+    return padded;
+  },
+  consistencyTolerance: 1e-9,
+});
+
+// Calendar input must work without breaking `getState()`. `TradingCalendar`
+// carries an optional `isTradingDay?(date)` predicate; if it leaked into
+// `meta.params` the snapshot deep-clone (`structuredClone` /
+// JSON round-trip) would throw `DataCloneError` or silently drop the
+// function. The constructor resolves `calendar` → numeric
+// `periodsPerYear` *before* snapshotting, so this scenario must produce
+// a JSON-safe snapshot and resume cleanly to the same numeric factor.
+describe("EWMA Volatility — calendar input round-trip", () => {
+  const candles = makeCandles(60);
+
+  it("calendar input resolves to numeric periodsPerYear and snapshots safely", () => {
+    const ind = createEwmaVolatility({ calendar: JPX_CALENDAR });
+    for (const c of candles) ind.next(c);
+    const snapshot = ind.getState();
+
+    // Snapshot must be JSON-serializable (no functions leaked through).
+    expect(() => JSON.parse(JSON.stringify(snapshot))).not.toThrow();
+    expect(snapshot.meta.params.periodsPerYear).toBe(JPX_CALENDAR.tradingDaysPerYear);
+    expect("calendar" in snapshot.meta.params).toBe(false);
+  });
+
+  it("calendar with custom isTradingDay function still produces a JSON-safe snapshot", () => {
+    const customCalendar = {
+      name: "custom",
+      tradingDaysPerYear: 250,
+      isTradingDay: (_d: Date) => true,
+    };
+    const ind = createEwmaVolatility({ calendar: customCalendar });
+    for (const c of candles) ind.next(c);
+    const snapshot = ind.getState();
+
+    // The function must NOT leak into params — JSON round-trip would
+    // throw or silently drop it otherwise.
+    const roundTripped = JSON.parse(JSON.stringify(snapshot));
+    expect(roundTripped.meta.params.periodsPerYear).toBe(250);
+    expect(roundTripped.meta.params.calendar).toBeUndefined();
+  });
+
+  it("resume with periodsPerYear matches resume with equivalent calendar", () => {
+    const ind = createEwmaVolatility({ calendar: JPX_CALENDAR });
+    for (const c of candles) ind.next(c);
+    const snapshot = ind.getState();
+
+    // Both forms must resolve to the same numeric factor and not trip
+    // the recursive-refuse policy.
+    expect(() =>
+      createEwmaVolatility({ calendar: JPX_CALENDAR }, { fromState: snapshot }),
+    ).not.toThrow();
+    expect(() =>
+      createEwmaVolatility(
+        { periodsPerYear: JPX_CALENDAR.tradingDaysPerYear },
+        { fromState: snapshot },
+      ),
+    ).not.toThrow();
+  });
+
+  it("resume with different calendar (different tradingDaysPerYear) is refused", () => {
+    const ind = createEwmaVolatility({ calendar: JPX_CALENDAR });
+    for (const c of candles) ind.next(c);
+    const snapshot = ind.getState();
+
+    expect(() =>
+      createEwmaVolatility({ calendar: CRYPTO_CALENDAR }, { fromState: snapshot }),
+    ).toThrow(/periodsPerYear|incompatible snapshot/);
+  });
+
+  it("legacy snapshot without periodsPerYear key resumes cleanly across the API change", () => {
+    // Initial Bundle F migration persisted `meta.params = {lambda,
+    // source, seedSize}` (no `periodsPerYear` key) and hard-coded
+    // sqrt(252) at compute time. After the annualization audit fix,
+    // snapshots always persist a numeric `periodsPerYear`. A caller
+    // holding such a *legacy-shape* snapshot must still be able to
+    // resume with `{ periodsPerYear: 252 }` (or US-equity calendar)
+    // without the recursive-refuse policy tripping. The constructor
+    // materializes the implicit 252 into the legacy snapshot before
+    // diff time; verify that explicit equivalent options no longer
+    // throw on this upgrade path.
+    const fresh = createEwmaVolatility({});
+    for (const c of candles) fresh.next(c);
+    const cur = fresh.getState();
+    // Strip `periodsPerYear` to simulate a snapshot saved by the
+    // pre-audit Bundle F code.
+    const { periodsPerYear: _ignored, ...legacyParams } = cur.meta.params as Record<
+      string,
+      unknown
+    >;
+    const legacySnapshot = {
+      meta: { ...cur.meta, params: legacyParams },
+      state: cur.state,
+    } as typeof cur;
+
+    expect("periodsPerYear" in legacySnapshot.meta.params).toBe(false);
+
+    // Explicit equivalent must NOT throw.
+    expect(() =>
+      createEwmaVolatility({ periodsPerYear: 252 }, { fromState: legacySnapshot }),
+    ).not.toThrow();
+    const usEquityLike = { name: "test", tradingDaysPerYear: 252 };
+    expect(() =>
+      createEwmaVolatility({ calendar: usEquityLike }, { fromState: legacySnapshot }),
+    ).not.toThrow();
+
+    // Non-equivalent explicit (different factor) must still throw —
+    // legacy assumed 252, options says 365, that's a real change.
+    expect(() =>
+      createEwmaVolatility({ periodsPerYear: 365 }, { fromState: legacySnapshot }),
+    ).toThrow(/periodsPerYear|incompatible snapshot/);
+  });
+
+  it("implicit-default snapshot resumes cleanly with the equivalent explicit option", () => {
+    // A snapshot built with no annualization option must accept
+    // resume with `periodsPerYear: 252` (or US_EQUITY_CALENDAR whose
+    // tradingDaysPerYear is also 252) — the effective factor is
+    // identical, so the recursive-refuse policy must not trip.
+    // Earlier the snapshot omitted `periodsPerYear` on the
+    // implicit-default path; resolveResume then saw "added param"
+    // when the resume supplied the equivalent number and refused.
+    const ind = createEwmaVolatility({});
+    for (const c of candles) ind.next(c);
+    const snapshot = ind.getState();
+
+    expect(snapshot.meta.params.periodsPerYear).toBe(252);
+    expect(() =>
+      createEwmaVolatility({ periodsPerYear: 252 }, { fromState: snapshot }),
+    ).not.toThrow();
+    // 252-day calendar (US equity) must also be accepted as equivalent.
+    const usEquityLike = { name: "test", tradingDaysPerYear: 252 };
+    expect(() =>
+      createEwmaVolatility({ calendar: usEquityLike }, { fromState: snapshot }),
+    ).not.toThrow();
+  });
+
+  it("when both calendar and periodsPerYear are supplied, calendar wins (matches batch)", () => {
+    // Batch `annualizationFactor` returns `calendar.tradingDaysPerYear`
+    // whenever a calendar is present, regardless of `periodsPerYear`.
+    // Incremental must match — otherwise a caller passing the
+    // conflicting pair gets different volatility scales between the
+    // two APIs. Snapshot must persist the calendar's number (245),
+    // not the periodsPerYear override (365).
+    const withBoth = createEwmaVolatility({
+      calendar: JPX_CALENDAR, // tradingDaysPerYear = 245 — must win
+      periodsPerYear: 365, // would shadow calendar if precedence were inverted
+    });
+    const calendarOnly = createEwmaVolatility({ calendar: JPX_CALENDAR });
+    for (const c of candles) {
+      withBoth.next(c);
+      calendarOnly.next(c);
+    }
+    const last = candles[candles.length - 1];
+    expect(withBoth.peek(last).value).toBe(calendarOnly.peek(last).value);
+    expect(withBoth.getState().meta.params.periodsPerYear).toBe(JPX_CALENDAR.tradingDaysPerYear);
+  });
 });

--- a/packages/core/src/indicators/incremental/moving-average/mcginley-dynamic.ts
+++ b/packages/core/src/indicators/incremental/moving-average/mcginley-dynamic.ts
@@ -14,6 +14,27 @@
  * the same. Params (`period`, `k`, `source`) now live in `meta.params`
  * — the hand-rolled resume guard from 0.3.x is replaced by the
  * library-wide `resolveResume` recursive policy.
+ *
+ * Extreme-gap behavior: the `(price / MD)^4` ratio is uncapped, which
+ * matches the canonical McGinley (1990) formulation as used by
+ * TradingView and StockCharts. On upward gaps the denominator grows
+ * fast, so the indicator simply lags more — graceful. On *downward*
+ * gaps the denominator shrinks to ~0 and the next MD can swing to a
+ * large negative value (e.g. `price = 0.1 × MD` → denom ≈ 8.4e-4,
+ * adjustment ≈ -1071 × MD). In practice price = 0 / extreme-down
+ * gaps mostly indicate dirty input rather than real moves; reject
+ * those upstream. Some third-party implementations clamp the ratio
+ * to `[0.5, 2.0]`; trendcraft does not, to remain bar-for-bar
+ * faithful to the published formula.
+ *
+ * Seeding asymmetry note (intentional): the batch sibling produces
+ * its first non-null value at index `period - 1` (`if i === period - 1`),
+ * while this incremental factory uses a post-incremented `count` so
+ * the first non-null is produced when `count === period`. Both refer
+ * to the same candle (the `period`-th one, 0-indexed `period - 1`);
+ * the formulations differ only because batch indexes the array
+ * directly while incremental counts calls. Invariant [8] enforces
+ * bar-for-bar parity.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";

--- a/packages/core/src/indicators/incremental/price/returns.ts
+++ b/packages/core/src/indicators/incremental/price/returns.ts
@@ -17,7 +17,12 @@
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
 import type { IncrementalIndicator } from "../types";
 
 /**
@@ -68,15 +73,25 @@ export function createReturns(
     defaults: { period: 1, type: "simple" },
   });
 
-  const period = params.period;
-  const type = params.type;
-
-  if (!Number.isInteger(period) || period < 1) {
-    throw new Error('returns: option "period" must be a positive integer');
-  }
-  if (type !== "simple" && type !== "log") {
-    throw new Error('returns: option "type" must be "simple" or "log"');
-  }
+  // Centralized requireParam keeps the error-message shape uniform
+  // across the migrated indicator surface (compare with sma.ts,
+  // donchian-channel.ts, ulcer-index.ts). Pre-fix this file threw a
+  // bespoke `returns: option "..." must be ...` message that diverged
+  // from the rest of the State Contract validation surface.
+  const period = requireParam(
+    "returns",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const type = requireParam(
+    "returns",
+    params,
+    "type",
+    (v): v is "simple" | "log" => v === "simple" || v === "log",
+    'must be "simple" or "log"',
+  );
 
   // Buffer holds the last `period` closes (i.e. closes at index t-period..t-1);
   // when a new close arrives, the oldest slot is the reference price.

--- a/packages/core/src/indicators/incremental/volatility/ewma-volatility.ts
+++ b/packages/core/src/indicators/incremental/volatility/ewma-volatility.ts
@@ -39,6 +39,7 @@
  * suppression + replay fixes both issues.
  */
 
+import { type AnnualizationOptions, annualizationFactor } from "../../../calendar";
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
 import type { IncrementalIndicator } from "../types";
@@ -64,6 +65,24 @@ type EwmaVolatilityParams = {
   lambda: number;
   source: PriceSource;
   seedSize: number;
+  /**
+   * Annualization scaling, stored only as the resolved numeric
+   * `periodsPerYear`. The constructor accepts either `periodsPerYear`
+   * (e.g. `365` for crypto) or `calendar: JPX_CALENDAR` (a
+   * `TradingCalendar` whose `tradingDaysPerYear` supplies the number);
+   * `calendar` is resolved to its numeric factor *before* the options
+   * reach `resolveResume`, so this field always holds a plain number.
+   *
+   * Why not persist the calendar object: `TradingCalendar` can carry an
+   * `isTradingDay?(date): boolean` function. `meta.params` is deep-cloned
+   * via `structuredClone` (or JSON round-trip), so a function value
+   * would either throw `DataCloneError` or silently disappear — both
+   * unacceptable for `getState()`. Storing only the resolved number
+   * keeps snapshots JSON-clean and round-trip-deterministic, and lets
+   * a caller resume with either input form as long as it resolves to
+   * the same `periodsPerYear`.
+   */
+  periodsPerYear?: number;
 };
 
 /**
@@ -82,24 +101,92 @@ type EwmaVolatilityParams = {
  * ```
  */
 export function createEwmaVolatility(
-  options: { lambda?: number; source?: PriceSource; seedSize?: number } = {},
+  options: {
+    lambda?: number;
+    source?: PriceSource;
+    seedSize?: number;
+    periodsPerYear?: number;
+    calendar?: AnnualizationOptions["calendar"];
+  } = {},
   warmUpOptions?: {
     fromState?: IndicatorSnapshot<EwmaVolatilityState>;
     warmUp?: NormalizedCandle[];
   },
 ): IncrementalIndicator<number | null, IndicatorSnapshot<EwmaVolatilityState>> {
+  // Resolve `calendar` → numeric `periodsPerYear` *before* handing the
+  // options bag to `resolveResume`. Reasoning:
+  //   1. `TradingCalendar` may include an `isTradingDay?(date)` function
+  //      that cannot survive `structuredClone` / JSON serialization;
+  //      keeping it out of `meta.params` makes snapshots round-trip-safe.
+  //   2. A caller may legitimately use `calendar: JPX_CALENDAR` on the
+  //      first run and `periodsPerYear: 245` on resume (or vice-versa).
+  //      Pre-resolving means the resume diff compares a single canonical
+  //      number, so equivalent inputs are not flagged as a param change.
+  //
+  // Precedence must match the batch sibling's `annualizationFactor`:
+  // `calendar` wins over `periodsPerYear` when both are supplied.
+  // Earlier this branch reversed the precedence by only consulting
+  // `calendar` when `periodsPerYear` was absent — that silently
+  // produced different volatility scales between batch and incremental
+  // for the same input. Always honor `calendar` first to stay aligned.
+  const { calendar, ...optionsWithoutCalendar } = options;
+  const resolvedOptions =
+    calendar !== undefined
+      ? { ...optionsWithoutCalendar, periodsPerYear: calendar.tradingDaysPerYear }
+      : optionsWithoutCalendar;
+
+  // Canonicalize legacy snapshots that pre-date annualization support.
+  // The initial Bundle F migration emitted `meta.params = {lambda, source,
+  // seedSize}` (no `periodsPerYear`) and hard-coded sqrt(252) at compute
+  // time. After this audit, snapshots always persist a numeric
+  // `periodsPerYear` — but a caller resuming an *old-shape* snapshot
+  // with an explicit `{periodsPerYear: 252}` (or equivalent calendar)
+  // would otherwise trip the recursive-refuse policy because the
+  // snapshot lacks the key while options has it. Materialize the
+  // implicit-252 default into the legacy snapshot *before* resolveResume
+  // computes its diff, so equivalent inputs round-trip cleanly across
+  // the API change without forcing a re-warm.
+  const incomingSnapshot = warmUpOptions?.fromState ?? null;
+  const normalizedFromState =
+    incomingSnapshot?.meta?.params &&
+    typeof incomingSnapshot.meta.params === "object" &&
+    !Array.isArray(incomingSnapshot.meta.params) &&
+    (incomingSnapshot.meta.params as Record<string, unknown>).periodsPerYear === undefined
+      ? {
+          meta: {
+            ...incomingSnapshot.meta,
+            params: { ...incomingSnapshot.meta.params, periodsPerYear: 252 },
+          },
+          state: incomingSnapshot.state,
+        }
+      : incomingSnapshot;
+
   const { params, state } = resolveResume<EwmaVolatilityParams, EwmaVolatilityState>({
     indicator: "ewmaVolatility",
     version: EWMA_VOLATILITY_VERSION,
     category: "recursive",
-    options,
-    fromState: warmUpOptions?.fromState ?? null,
+    options: resolvedOptions,
+    fromState: normalizedFromState,
     defaults: { lambda: 0.94, source: "close", seedSize: 10 },
   });
 
   const lambda = params.lambda;
   const source = params.source;
   const seedSize = params.seedSize;
+  // Resolve `periodsPerYear` to its concrete numeric value (calendar
+  // already pre-folded into options, snapshot value carried by
+  // resolveResume, default 252 if still unset). We persist *this*
+  // resolved number in `meta.params` rather than the optional input
+  // value — otherwise a snapshot taken with the implicit 252 default
+  // would have no `periodsPerYear` key, and resuming with an
+  // *equivalent* explicit option (`{ periodsPerYear: 252 }` or a
+  // 252-day calendar like `US_EQUITY_CALENDAR`) would be flagged as a
+  // param change and refused by the recursive policy even though the
+  // effective factor is identical.
+  const effectivePeriodsPerYear = annualizationFactor({
+    periodsPerYear: params.periodsPerYear,
+  });
+  const annualFactor = Math.sqrt(effectivePeriodsPerYear) * 100;
 
   let prevPrice: number | null;
   let prevVariance: number | null;
@@ -121,21 +208,29 @@ export function createEwmaVolatility(
     count = 0;
   }
 
-  const annualFactor = Math.sqrt(252) * 100;
-
   function sampleVariance(returns: number[]): number {
-    // Population variance (divide by N) with a 1e-10 floor to match
-    // the batch sibling's `ewmaVolatility` seed convention exactly.
+    // Centered population variance (Σ(r-μ)²/N) with a 1e-10 floor.
+    // Identical to the batch sibling's `ewmaVolatility` seed.
+    //
+    // Variant note: RiskMetrics Technical Document (1996) §5.3.2
+    // specifies the *uncentered* form (Σr²/N) with the mean assumed
+    // to be zero — for daily log returns this differs from the
+    // centered form by μ², a sub-basis-point effect. We pick the
+    // centered form because (a) it is what `Math.var`-style sample
+    // statistics imply and what pyfolio / quantstats use under the
+    // hood, and (b) it does not silently bake in a "returns are
+    // mean-zero" assumption that breaks on monthly / weekly bars
+    // where the drift is non-trivial. Batch and incremental MUST
+    // use the same form; invariant [8] enforces this bar-for-bar.
     //
     // Pre-0.4.0 incremental used Bessel-corrected sample variance
-    // (divide by N-1), which is statistically more rigorous but
-    // caused a permanent N/(N-1) divergence between batch and
-    // incremental output. It also lacked the zero floor, so a
-    // flat-price seed window emitted `0` while batch emitted a tiny
-    // positive value — and the recursive update then stayed at
-    // exact zero forever. Aligning on N + the floor keeps invariant
-    // [8] (batch parity) clean on every candle shape, including
-    // flat-price streams.
+    // (Σ(r-μ)²/(N-1)), which caused a permanent N/(N-1) divergence
+    // between batch and incremental output. It also lacked the
+    // 1e-10 zero floor, so a flat-price seed window emitted `0`
+    // while batch emitted a tiny positive value — and the recursive
+    // update then stayed at exact zero forever. Aligning on
+    // /N + the floor closes both gaps on every candle shape,
+    // including flat-price streams.
     const n = returns.length;
     if (n === 0) return 0;
     const mean = returns.reduce((a, b) => a + b, 0) / n;
@@ -186,7 +281,12 @@ export function createEwmaVolatility(
         return { time: candle.time, value: null };
       }
 
-      prevVariance = lambda * (prevVariance ?? 0) + (1 - lambda) * logReturn * logReturn;
+      // `seedDone` is true here, so `prevVariance` is necessarily a
+      // number set by the seed-replay branch above. The non-null
+      // assertion makes that invariant explicit — a defensive
+      // `?? 0` would silently bypass the 1e-10 floor installed by
+      // `sampleVariance` if the invariant were ever broken.
+      prevVariance = lambda * (prevVariance as number) + (1 - lambda) * logReturn * logReturn;
       return { time: candle.time, value: computeOutput(prevVariance) };
     },
 
@@ -214,7 +314,9 @@ export function createEwmaVolatility(
         return { time: candle.time, value: null };
       }
 
-      const v = lambda * (prevVariance ?? 0) + (1 - lambda) * logReturn * logReturn;
+      // Mirrors `next`: `seedDone` is true here so `prevVariance` is
+      // a number. Cast (not `??`) to keep the floor invariant intact.
+      const v = lambda * (prevVariance as number) + (1 - lambda) * logReturn * logReturn;
       return { time: candle.time, value: computeOutput(v) };
     },
 
@@ -222,7 +324,21 @@ export function createEwmaVolatility(
       return makeSnapshot(
         "ewmaVolatility",
         EWMA_VOLATILITY_VERSION,
-        { lambda, source, seedSize },
+        // Always persist the *resolved* `periodsPerYear` (incl. the
+        // 252 default) so resume-time diffing compares concrete
+        // numbers. Omitting it on the implicit-default path used to
+        // refuse a resume that re-specified the same factor
+        // explicitly — `{}` snapshot vs `{ periodsPerYear: 252 }`
+        // (or a 252-day calendar) options registered as a "change"
+        // even though the math was identical. `calendar` itself
+        // never enters `params`; only its numeric `tradingDaysPerYear`
+        // does, keeping the snapshot JSON-safe.
+        {
+          lambda,
+          source,
+          seedSize,
+          periodsPerYear: effectivePeriodsPerYear,
+        },
         {
           prevPrice,
           prevVariance,

--- a/packages/core/src/indicators/volatility/garch.ts
+++ b/packages/core/src/indicators/volatility/garch.ts
@@ -374,7 +374,18 @@ export function ewmaVolatility(returns: number[], options?: EwmaVolatilityOption
     }
   }
 
-  // Seed variance: variance of first min(10, T) returns
+  // Seed variance: centered population variance (Σ(r-μ)²/N) of the
+  // first min(10, T) returns, with a 1e-10 zero floor.
+  //
+  // Variant note: RiskMetrics Technical Document (1996) §5.3.2 uses
+  // the uncentered form Σr²/N (mean assumed zero). For daily log
+  // returns the two forms differ by μ² — a sub-basis-point effect.
+  // We pick centered because (a) it matches standard sample-variance
+  // semantics used by pyfolio / quantstats, and (b) it does not bake
+  // in a "returns are mean-zero" assumption that breaks on weekly /
+  // monthly bars where drift is non-trivial. The incremental
+  // sibling (createEwmaVolatility) MUST stay aligned; invariant [8]
+  // in the State Contract test DSL enforces this bar-for-bar.
   const seedCount = Math.min(10, T);
   let sigma2 = sampleVariance(returns.slice(0, seedCount));
   if (sigma2 === 0) sigma2 = 1e-10; // prevent zero variance


### PR DESCRIPTION
## Summary

Bundle F post-merge audit follow-up. Closes the EWMA API gap between batch and incremental, plus a handful of State Contract DSL / migration consistency improvements found alongside it.

## Headline issue

`createEwmaVolatility` hard-coded `Math.sqrt(252) * 100` for annualization, while the batch sibling `ewmaVolatility` / `garch` accepts an `AnnualizationOptions` bag (`calendar`, `periodsPerYear`). Any caller using a non-252 setup (crypto = 365, JPX = 245, etc.) on the batch API silently got a different volatility scale from the incremental API — and the State Contract resume layer never caught it because `periodsPerYear` was not in `meta.params` at all.

## Changes

### EWMA Volatility (`createEwmaVolatility`)

- Accepts `periodsPerYear` and `calendar`. Precedence matches `annualizationFactor()`: `calendar` wins when both are supplied.
- Resolves `calendar` → numeric `periodsPerYear` at construction time. `meta.params` persists only the resolved number, so `TradingCalendar.isTradingDay` (an optional function field) cannot break `structuredClone` or get silently dropped through JSON round-trip.
- Always persists the resolved `periodsPerYear` (including the 252 default), so resuming with the equivalent explicit option does not trip the recursive-refuse policy.
- Canonicalizes legacy snapshots (no `periodsPerYear` key) at resume time so the upgrade path stays smooth.
- `prevVariance as number` (was `?? 0`) so the 1e-10 seed floor invariant stays explicit instead of silently bypassed.

### Variance seed variant (batch + incremental)

Documents that the seed uses centered population variance (`Σ(r - μ)² / N`), differs from the RiskMetrics 1996 uncentered form by `μ²` (sub-bp for daily log returns), and that the two paths must stay in lockstep — invariant [8] enforces it.

### State Contract DSL (`describeContract`)

- `isNullishField` config override for composite indicators with decoupled component warmup (preparation for Bundle G+).
- Invariant [8] gains a gap-candle parity case alongside the existing trend + flat-price datasets, catching discontinuity-sensitive bugs the smooth datasets hide.

### Returns indicator (`returns.ts`)

Replaces bespoke inline validation with `requireParam` so the error-message shape matches the rest of the migrated indicator surface.

### McGinley Dynamic

Documents the extreme-gap behavior of the `(price / MD)^4` term and the intentional seeding-asymmetry between batch (`i === period - 1`) and incremental (`count === period`).

## Tests

+47 tests across:
- calendar round-trip (JSON-safe snapshot proof, including custom `isTradingDay`)
- calendar/`periodsPerYear` precedence (calendar wins when both supplied)
- equivalent-resume (implicit 252 default ↔ explicit `periodsPerYear: 252` ↔ 252-day calendar)
- legacy-upgrade-resume (pre-fix Bundle F snapshot with no `periodsPerYear` key)
- non-default contract entries: `lambda=0.97`, `periodsPerYear=365`
- gap-candle parity for every `batchCompute`-equipped indicator

All 5357 tests / lint / build green.

## Test plan

- [x] `pnpm test` — 5357 / 5357 pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — OK
- [ ] Reviewer to spot-check the resolve-time canonicalization sequence in `createEwmaVolatility` against the resume scenarios documented in the new tests.