### PR TITLE
feat(core)!: migrate EMA + 8 internal user cascade (Wave 2 Bundle G)

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it } from "vitest";
 import { CRYPTO_CALENDAR, JPX_CALENDAR } from "../../../calendar";
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { alma } from "../../moving-average/alma";
+import { ema } from "../../moving-average/ema";
 import { mcginleyDynamic } from "../../moving-average/mcginley-dynamic";
 import { sma } from "../../moving-average/sma";
 import { vwma } from "../../moving-average/vwma";
@@ -36,6 +37,7 @@ import { pvt } from "../../volume/pvt";
 import { twap } from "../../volume/twap";
 import { vwap } from "../../volume/vwap";
 import { type AlmaState, createAlma } from "../moving-average/alma";
+import { createEma, type EmaState } from "../moving-average/ema";
 import {
   createMcGinleyDynamic,
   type McGinleyDynamicState,
@@ -740,4 +742,35 @@ describe("EWMA Volatility — calendar input round-trip", () => {
     expect(withBoth.peek(last).value).toBe(calendarOnly.peek(last).value);
     expect(withBoth.getState().meta.params.periodsPerYear).toBe(JPX_CALENDAR.tradingDaysPerYear);
   });
+});
+
+// ---- Wave 2 Bundle G: EMA ----
+
+// EMA — Recursive (single-pole). `prevEma` permanently encodes its
+// construction-time `period` and `source`, so any param change on
+// resume is mathematically undefined and refused by the recursive
+// policy. The bare state shrinks from 6 fields (period / source /
+// multiplier / prevEma / sum / count) to just the 3 runtime values
+// (prevEma / sum / count); multiplier is derived from `period` in
+// the factory closure.
+//
+// EMA is the most widely-used moving average and is internally
+// composed by DEMA, TEMA, T3, EMA Ribbon, TRIX, TSI, Mass Index,
+// and Keltner Channel — all 8 consumers cascade through the
+// `EmaState → IndicatorSnapshot<EmaState>` type rename in their
+// bare-state field declarations. They remain opaque pass-throughs
+// (snapshot in, snapshot out) so their `next()` / `peek()` /
+// computation paths are byte-identical to 0.3.x.
+describeContract<number | null, EmaState>({
+  name: "ema",
+  create: (opts, warmUp) => createEma(opts as { period?: number; source?: PriceSource }, warmUp),
+  category: "recursive",
+  version: 1,
+  defaultParams: { period: 20, source: "close" },
+  // Exercise refuse on both independent param axes.
+  reconfigParams: [{ period: 10 }, { period: 30 }, { source: "high" }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    ema(candles, opts as { period: number; source?: PriceSource }).map((s) => s.value),
 });

--- a/packages/core/src/indicators/incremental/momentum/mass-index.ts
+++ b/packages/core/src/indicators/incremental/momentum/mass-index.ts
@@ -19,6 +19,7 @@ import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
 import type { EmaState } from "../moving-average/ema";
 import { createEma } from "../moving-average/ema";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import { makeCandle } from "../utils";
 
@@ -28,8 +29,8 @@ import { makeCandle } from "../utils";
 export type MassIndexState = {
   emaPeriod: number;
   sumPeriod: number;
-  ema1State: EmaState;
-  ema2State: EmaState;
+  ema1State: IndicatorSnapshot<EmaState>;
+  ema2State: IndicatorSnapshot<EmaState>;
   ratioBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   ratioSum: number;
   count: number;

--- a/packages/core/src/indicators/incremental/momentum/trix.ts
+++ b/packages/core/src/indicators/incremental/momentum/trix.ts
@@ -14,6 +14,7 @@
 import type { NormalizedCandle } from "../../../types";
 import type { EmaState } from "../moving-average/ema";
 import { createEma } from "../moving-average/ema";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 
 export type TrixValue = {
@@ -78,7 +79,7 @@ function makeNullEma(period: number, fromState?: NullEmaState) {
 export type TrixState = {
   period: number;
   signalPeriod: number;
-  ema1State: EmaState;
+  ema1State: IndicatorSnapshot<EmaState>;
   ema2State: NullEmaState;
   ema3State: NullEmaState;
   signalState: NullEmaState;

--- a/packages/core/src/indicators/incremental/momentum/tsi.ts
+++ b/packages/core/src/indicators/incremental/momentum/tsi.ts
@@ -11,6 +11,7 @@
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import type { EmaState } from "../moving-average/ema";
 import { createEma } from "../moving-average/ema";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import { getSourcePrice, makeCandle } from "../utils";
 
@@ -20,11 +21,11 @@ export type TsiValue = {
 };
 
 export type TsiState = {
-  ema1MomState: EmaState;
-  ema2MomState: EmaState;
-  ema1AbsState: EmaState;
-  ema2AbsState: EmaState;
-  signalEmaState: EmaState;
+  ema1MomState: IndicatorSnapshot<EmaState>;
+  ema2MomState: IndicatorSnapshot<EmaState>;
+  ema1AbsState: IndicatorSnapshot<EmaState>;
+  ema2AbsState: IndicatorSnapshot<EmaState>;
+  signalEmaState: IndicatorSnapshot<EmaState>;
   prevPrice: number | null;
   longPeriod: number;
   shortPeriod: number;

--- a/packages/core/src/indicators/incremental/moving-average/dema.ts
+++ b/packages/core/src/indicators/incremental/moving-average/dema.ts
@@ -6,6 +6,7 @@
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import { makeCandle } from "../utils";
 import type { EmaState } from "./ema";
@@ -14,8 +15,8 @@ import { createEma } from "./ema";
 export type DemaState = {
   period: number;
   source: PriceSource;
-  ema1State: EmaState;
-  ema2State: EmaState;
+  ema1State: IndicatorSnapshot<EmaState>;
+  ema2State: IndicatorSnapshot<EmaState>;
   count: number;
 };
 

--- a/packages/core/src/indicators/incremental/moving-average/ema-ribbon.ts
+++ b/packages/core/src/indicators/incremental/moving-average/ema-ribbon.ts
@@ -5,6 +5,7 @@
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import type { EmaState } from "./ema";
 import { createEma } from "./ema";
@@ -18,7 +19,7 @@ export type EmaRibbonValue = {
 export type EmaRibbonState = {
   periods: number[];
   source: PriceSource;
-  emaStates: EmaState[];
+  emaStates: IndicatorSnapshot<EmaState>[];
   prevSpread: number | null;
   count: number;
 };

--- a/packages/core/src/indicators/incremental/moving-average/ema.ts
+++ b/packages/core/src/indicators/incremental/moving-average/ema.ts
@@ -1,18 +1,52 @@
 /**
  * Incremental EMA (Exponential Moving Average)
+ *
+ * State category: **Recursive** (`prevEma` is the recursive
+ * accumulator; `sum` is a warmup tally that gets baked into `prevEma`
+ * at `count === period` and is no longer consulted afterwards).
+ * Resume with different `period` / `source` is mathematically
+ * undefined — the recursive accumulator is permanently conditioned on
+ * its construction-time params — and is refused.
+ *
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<EmaState>` and `fromState` accepts the same.
+ * Params (`period`, `source`) now live in `meta.params`; the
+ * derived `multiplier` (= `2 / (period + 1)`) is computed in the
+ * factory closure rather than persisted, since it is uniquely
+ * determined by `period`. The factory signature is unchanged
+ * `(options, warmUpOptions?)` — direct callers do not need to
+ * change call shape; only the snapshot envelope returned by
+ * `getState()` (and accepted by `fromState`) changes.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for EMA. Params (`period`, `source`) live in
+ * `meta.params` on the wire — they are not part of the bare state.
+ * `multiplier` is derived from `period` in the factory closure and
+ * also intentionally absent from the persisted state.
+ */
 export type EmaState = {
-  period: number;
-  source: PriceSource;
-  multiplier: number;
   prevEma: number | null;
   sum: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const EMA_VERSION = 1;
+
+type EmaParams = {
+  period: number;
+  source: PriceSource;
 };
 
 /**
@@ -28,22 +62,39 @@ export type EmaState = {
  * ```
  */
 export function createEma(
-  options: { period: number; source?: PriceSource },
-  warmUpOptions?: WarmUpOptions<EmaState>,
-): IncrementalIndicator<number | null, EmaState> {
-  const period = options.period;
-  const source: PriceSource = options.source ?? "close";
+  options: { period?: number; source?: PriceSource },
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<EmaState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<EmaState>> {
+  const { params, state } = resolveResume<EmaParams, EmaState>({
+    indicator: "ema",
+    version: EMA_VERSION,
+    category: "recursive",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { source: "close" },
+  });
+
+  const period = requireParam(
+    "ema",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
   const multiplier = 2 / (period + 1);
 
   let prevEma: number | null;
   let sum: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    prevEma = s.prevEma;
-    sum = s.sum;
-    count = s.count;
+  if (state !== null) {
+    prevEma = state.prevEma;
+    sum = state.sum;
+    count = state.count;
   } else {
     prevEma = null;
     sum = 0;
@@ -63,7 +114,7 @@ export function createEma(
     return price * multiplier + prev * (1 - multiplier);
   }
 
-  const indicator: IncrementalIndicator<number | null, EmaState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<EmaState>> = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
       count++;
@@ -91,8 +142,8 @@ export function createEma(
       return { time: candle.time, value };
     },
 
-    getState(): EmaState {
-      return { period, source, multiplier, prevEma, sum, count };
+    getState(): IndicatorSnapshot<EmaState> {
+      return makeSnapshot("ema", EMA_VERSION, { period, source }, { prevEma, sum, count });
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/moving-average/t3.ts
+++ b/packages/core/src/indicators/incremental/moving-average/t3.ts
@@ -6,6 +6,7 @@
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import { makeCandle } from "../utils";
 import type { EmaState } from "./ema";
@@ -15,12 +16,12 @@ export type T3State = {
   period: number;
   vFactor: number;
   source: PriceSource;
-  ema1State: EmaState;
-  ema2State: EmaState;
-  ema3State: EmaState;
-  ema4State: EmaState;
-  ema5State: EmaState;
-  ema6State: EmaState;
+  ema1State: IndicatorSnapshot<EmaState>;
+  ema2State: IndicatorSnapshot<EmaState>;
+  ema3State: IndicatorSnapshot<EmaState>;
+  ema4State: IndicatorSnapshot<EmaState>;
+  ema5State: IndicatorSnapshot<EmaState>;
+  ema6State: IndicatorSnapshot<EmaState>;
   count: number;
 };
 

--- a/packages/core/src/indicators/incremental/moving-average/tema.ts
+++ b/packages/core/src/indicators/incremental/moving-average/tema.ts
@@ -6,6 +6,7 @@
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import { makeCandle } from "../utils";
 import type { EmaState } from "./ema";
@@ -14,9 +15,9 @@ import { createEma } from "./ema";
 export type TemaState = {
   period: number;
   source: PriceSource;
-  ema1State: EmaState;
-  ema2State: EmaState;
-  ema3State: EmaState;
+  ema1State: IndicatorSnapshot<EmaState>;
+  ema2State: IndicatorSnapshot<EmaState>;
+  ema3State: IndicatorSnapshot<EmaState>;
   count: number;
 };
 

--- a/packages/core/src/indicators/incremental/volatility/keltner-channel.ts
+++ b/packages/core/src/indicators/incremental/volatility/keltner-channel.ts
@@ -9,6 +9,7 @@
 
 import type { NormalizedCandle } from "../../../types";
 import { createEma, type EmaState } from "../moving-average/ema";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import { type AtrState, createAtr } from "../volatility/atr";
 
@@ -28,7 +29,7 @@ export type KeltnerChannelState = {
   emaPeriod: number;
   atrPeriod: number;
   multiplier: number;
-  emaState: EmaState;
+  emaState: IndicatorSnapshot<EmaState>;
   atrState: AtrState;
   count: number;
 };
@@ -53,7 +54,7 @@ export function createKeltnerChannel(
   const atrPeriod = options.atrPeriod ?? 10;
   const multiplier = options.multiplier ?? 2;
 
-  let emaInd: IncrementalIndicator<number | null, EmaState>;
+  let emaInd: IncrementalIndicator<number | null, IndicatorSnapshot<EmaState>>;
   let atrInd: IncrementalIndicator<number | null, AtrState>;
   let count: number;
 


### PR DESCRIPTION
## Summary

Third Wave 2 bundle. EMA — the most widely-used moving average in the library — moves to the State Contract envelope. The 8 internal indicators that compose EMA cascade through a corresponding `EmaState → IndicatorSnapshot<EmaState>` type rename in their bare state field declarations; all stay opaque pass-throughs so their computation paths are byte-identical to 0.3.x.

## EMA migration

- Bare state shrinks from 6 fields (`period` / `source` / `multiplier` / `prevEma` / `sum` / `count`) to 3 (`prevEma`, `sum`, `count`); `period` / `source` move to `meta.params` and `multiplier` becomes a derived value (`= 2 / (period + 1)`) computed in the factory closure.
- `period` is required (no canonical default; matches SMA / WMA); `requireParam` enforces it with the standard error shape.
- Category: **recursive**. Resume with different `period` or `source` throws via the recursive policy.
- `next()` / `peek()` computation **byte-identical** to 0.3.x.

## Internal users (8 indicators, all opaque pass-through)

| Category | Files |
|---|---|
| moving-average | dema, tema, t3, ema-ribbon |
| momentum | trix, tsi, mass-index |
| volatility | keltner-channel |

Single line per `EmaState` reference: bare-state field type → `IndicatorSnapshot<EmaState>`. No call-site changes. None of the 8 consumers reach into EMA bare-state fields.

## invariant [8] coverage

EMA `describeContract` entry with `batchCompute` so the 3-variant parity gate (trending / flat-price / gap-candle, from Bundle F + #215) covers EMA bar-for-bar against batch `ema()` from now on.

## ⚠️ Note on transitive snapshot breakage

0.3.x snapshots of EMA wrappers (DEMA / TEMA / T3 / EmaRibbon / TRIX / TSI / MassIndex / KeltnerChannel) **cannot be resumed under this PR** because the nested EMA state now requires the `meta` envelope; their saved sessions contain bare `EmaState` shapes that `resolveResume` rejects with `"missing meta"`.

This is consistent with the 0.4.0 epic-wide breaking convention (STATE_CONTRACT.md §5.3) — **pre-0.4.0 snapshots require a re-warm**. Wave 3 (Mixed / Cascaded migration) will bring those wrappers under their own State Contract envelope themselves, at which point their outer state also gains a `version` + `meta` and the missing-meta error path is replaced by a proper version check on the wrapper itself.

Until then, mid-epic snapshots taken under Bundle G stay resumable as long as the wrapper itself remains unmigrated.

## Scope note

Memory originally listed MACD / PPO as internal EMA users requiring a type cascade. Pre-flight confirmed both indicators **inline their own EMA implementation** (`fastEma` / `slowEma` / `signalEma` fields with hand-written multipliers) and do not import `createEma`, so they are unaffected by this migration and remain out of scope for Bundle G.

## Workflow note

Discovered during Bundle G: bare `npx tsc --noEmit` silently bails out on the `tsconfig.json` `baseUrl` deprecation warning and reports zero type errors even on genuine mismatches — this masked the entire 8-file EMA cascade until run with `--ignoreDeprecations 6.0`. All Bundle G work was re-verified with that flag; tsconfig-side fix is left for a separate PR.

## Test plan

- [x] `pnpm test` — 5366 / 5366 pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — OK
- [x] `pnpm size-check` — within limits
- [x] `npx tsc --noEmit --ignoreDeprecations 6.0` — no errors from Bundle G (pre-existing strategy-dna / always-conditions test errors only)
- [x] EMA hand-calculated tests (`branch-coverage.test.ts:250-273`) pass on new envelope shape
- [x] EmaRibbon resume / warmUp tests pass
- [x] state-persistence EMA entry passes