### PR TITLE
feat(core)!: migrate ZLEMA to State Contract (Wave 2 Bundle H)

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/new-indicators.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/new-indicators.test.ts
@@ -480,8 +480,8 @@ describe("ZLEMA incremental", () => {
   });
 
   it("throws on non-positive period", () => {
-    expect(() => createZlema({ period: 0 })).toThrow("ZLEMA period must be at least 1");
-    expect(() => createZlema({ period: -1 })).toThrow("ZLEMA period must be at least 1");
+    expect(() => createZlema({ period: 0 })).toThrow(/must be a positive integer/);
+    expect(() => createZlema({ period: -1 })).toThrow(/must be a positive integer/);
   });
 });
 

--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -21,6 +21,7 @@ import { mcginleyDynamic } from "../../moving-average/mcginley-dynamic";
 import { sma } from "../../moving-average/sma";
 import { vwma } from "../../moving-average/vwma";
 import { wma } from "../../moving-average/wma";
+import { zlema } from "../../moving-average/zlema";
 import { highest, lowest } from "../../price/highest-lowest";
 import { returns as returnsBatch } from "../../price/returns";
 import { choppinessIndex } from "../../volatility/choppiness-index";
@@ -45,6 +46,7 @@ import {
 import { createSma, type SmaState } from "../moving-average/sma";
 import { createVwma, type VwmaState } from "../moving-average/vwma";
 import { createWma, type WmaState } from "../moving-average/wma";
+import { createZlema, type ZlemaState } from "../moving-average/zlema";
 import { createHighestLowest, type HighestLowestState } from "../price/highest-lowest";
 import { createReturns, type ReturnsState } from "../price/returns";
 import { type ChoppinessIndexState, createChoppinessIndex } from "../volatility/choppiness-index";
@@ -773,4 +775,32 @@ describeContract<number | null, EmaState>({
   streamLength: 100,
   batchCompute: (opts, candles) =>
     ema(candles, opts as { period: number; source?: PriceSource }).map((s) => s.value),
+});
+
+// ---- Wave 2 Bundle H: ZLEMA ----
+
+// ZLEMA — Recursive (single-pole on adjusted price). `prevZlema`
+// carries the recursion; the fixed-size lag lookback ring buffer
+// (capacity = `floor((period - 1) / 2) + 1`) and `seedSum` /
+// `seedCount` together form the warmup tally consumed once the SMA
+// seed completes. Both the recursive accumulator and the lag-window
+// contents are permanently conditioned on construction-time `period`
+// and `source`, so any param change on resume is mathematically
+// undefined and refused by the recursive policy. The bare state
+// shrinks by removing the persisted `period` / `source` / `lag` /
+// `multiplier` fields (now in `meta.params` / derived in the factory
+// closure); `prevZlema` / `seedSum` / `seedCount` / `buffer` / `count`
+// remain on the wire.
+describeContract<number | null, ZlemaState>({
+  name: "zlema",
+  create: (opts, warmUp) => createZlema(opts as { period?: number; source?: PriceSource }, warmUp),
+  category: "recursive",
+  version: 1,
+  defaultParams: { period: 20, source: "close" },
+  // Exercise refuse on both independent param axes.
+  reconfigParams: [{ period: 10 }, { period: 30 }, { source: "high" }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    zlema(candles, opts as { period: number; source?: PriceSource }).map((s) => s.value),
 });

--- a/packages/core/src/indicators/incremental/moving-average/zlema.ts
+++ b/packages/core/src/indicators/incremental/moving-average/zlema.ts
@@ -4,18 +4,41 @@
  * ZLEMA = EMA(adjusted_price, period)
  * where adjusted_price = price + (price - price[lag])
  * and lag = floor((period - 1) / 2)
+ *
+ * State category: **Recursive** (`prevZlema` is the recursive
+ * accumulator; the fixed-size lag lookback buffer and `seedSum` /
+ * `seedCount` form the warmup tally that is consumed once the SMA
+ * seed completes). Resume with different `period` / `source` is
+ * mathematically undefined — both the recursive accumulator and the
+ * lag-window contents are permanently conditioned on construction-time
+ * params — and is refused.
+ *
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<ZlemaState>` and `fromState` accepts the same.
+ * Params (`period`, `source`) now live in `meta.params`; the
+ * derived `lag` (= `floor((period - 1) / 2)`) and `multiplier`
+ * (= `2 / (period + 1)`) are computed in the factory closure rather
+ * than persisted, since both are uniquely determined by `period`.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for ZLEMA. Params (`period`, `source`) live in
+ * `meta.params` on the wire — they are not part of the bare state.
+ * `lag` and `multiplier` are derived from `period` in the factory
+ * closure and intentionally absent from the persisted state.
+ */
 export type ZlemaState = {
-  period: number;
-  source: PriceSource;
-  lag: number;
-  multiplier: number;
   prevZlema: number | null;
   /** Sum of adjusted prices during SMA seed phase */
   seedSum: number;
@@ -23,6 +46,14 @@ export type ZlemaState = {
   seedCount: number;
   buffer: { data: number[]; head: number; length: number; capacity: number };
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const ZLEMA_VERSION = 1;
+
+type ZlemaParams = {
+  period: number;
+  source: PriceSource;
 };
 
 /**
@@ -39,13 +70,28 @@ export type ZlemaState = {
  */
 export function createZlema(
   options: { period?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<ZlemaState>,
-): IncrementalIndicator<number | null, ZlemaState> {
-  const period = options.period ?? 20;
-  if (period < 1) {
-    throw new Error("ZLEMA period must be at least 1");
-  }
-  const source: PriceSource = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<ZlemaState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<ZlemaState>> {
+  const { params, state } = resolveResume<ZlemaParams, ZlemaState>({
+    indicator: "zlema",
+    version: ZLEMA_VERSION,
+    category: "recursive",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 20, source: "close" },
+  });
+
+  const period = requireParam(
+    "zlema",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
   const lag = Math.floor((period - 1) / 2);
   const multiplier = 2 / (period + 1);
 
@@ -56,13 +102,12 @@ export function createZlema(
   let seedCount: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    prevZlema = s.prevZlema;
-    seedSum = s.seedSum;
-    seedCount = s.seedCount;
-    count = s.count;
+  if (state !== null) {
+    buffer = CircularBuffer.fromSnapshot(state.buffer);
+    prevZlema = state.prevZlema;
+    seedSum = state.seedSum;
+    seedCount = state.seedCount;
+    count = state.count;
   } else {
     buffer = new CircularBuffer<number>(lag + 1);
     prevZlema = null;
@@ -71,38 +116,7 @@ export function createZlema(
     count = 0;
   }
 
-  function _compute(price: number, currentCount: number, isPeek: boolean): number | null {
-    // Need at least lag+1 prices to compute adjusted price
-    if (currentCount <= lag) {
-      return null;
-    }
-
-    // Get the lagged price from the buffer
-    // In buffer: index 0 = oldest. We need the price from `lag` bars ago.
-    // After pushing current price, buffer has min(count, lag+1) items.
-    // The lagged price is at index 0 when buffer is full.
-    const lagPrice = isPeek ? buffer.get(buffer.length - lag) : buffer.get(buffer.length - 1 - lag);
-    const adjustedPrice = price + (price - lagPrice);
-
-    // SMA seed phase: need `period - lag` adjusted prices for seeding
-    const seedTarget = period - lag;
-    const currentSeedCount = isPeek ? seedCount + 1 : seedCount;
-    const currentSeedSum = isPeek ? seedSum + adjustedPrice : seedSum;
-
-    if (currentSeedCount < seedTarget) {
-      return null;
-    }
-
-    if (currentSeedCount === seedTarget) {
-      return currentSeedSum / seedTarget;
-    }
-
-    // Standard EMA on adjusted price
-    const prev = isPeek ? prevZlema : prevZlema;
-    return adjustedPrice * multiplier + (prev ?? 0) * (1 - multiplier);
-  }
-
-  const indicator: IncrementalIndicator<number | null, ZlemaState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<ZlemaState>> = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
       count++;
@@ -177,18 +191,19 @@ export function createZlema(
       return { time: candle.time, value };
     },
 
-    getState(): ZlemaState {
-      return {
-        period,
-        source,
-        lag,
-        multiplier,
-        prevZlema,
-        seedSum,
-        seedCount,
-        buffer: buffer.snapshot(),
-        count,
-      };
+    getState(): IndicatorSnapshot<ZlemaState> {
+      return makeSnapshot(
+        "zlema",
+        ZLEMA_VERSION,
+        { period, source },
+        {
+          prevZlema,
+          seedSum,
+          seedCount,
+          buffer: buffer.snapshot(),
+          count,
+        },
+      );
     },
 
     get count() {


### PR DESCRIPTION
## Summary

- Migrate incremental `createZlema` to the 0.4.0 State Contract envelope. `getState()` now returns `IndicatorSnapshot<ZlemaState>` and `fromState` accepts the same shape.
- `ZlemaState` shrinks to runtime-only fields (`prevZlema`, `seedSum`, `seedCount`, `buffer`, `count`). The `period` / `source` params move to `meta.params`; `lag` (= `floor((period - 1) / 2)`) and `multiplier` (= `2 / (period + 1)`) are derived in the factory closure.
- Category: `recursive`. Both the recursive accumulator (`prevZlema`) and the lag-window buffer contents are permanently conditioned on construction-time params, so any param change on resume is refused by `resolveResume`.
- `describeContract` entry added for `zlema`. Invariant [8] runs batch parity against the existing `zlema()` batch function across the standard trending / flat-price / gap-candle variants, pinning incremental ↔ batch agreement automatically.
- `next()` / `peek()` / runtime numeric paths are byte-identical to 0.3.x — this is a snapshot-envelope-only behavioral change.

## Wave 2 closes here

Pre-flight grep for the planned "Wilder smoother" half of Bundle H confirmed there is no standalone `createWilderSmoother` factory. The Wilder smoothing logic is inlined inside `packages/core/src/indicators/incremental/momentum/dmi.ts` only (DMI's TR/DM smoothing and ADX's DX smoothing, both closure-local). It will migrate together with the RSI / ATR / DMI cluster in Wave 3, where the decision between extracting a shared helper or migrating each indicator's inlined smoother independently can be made with the full cluster in view.

## Test plan

- [x] `pnpm test` — 5375/5375 passing (Bundle G baseline 5366 + 9 new from the ZLEMA contract invariants × 3 parity variants and friends)
- [x] `pnpm lint` — clean
- [x] `pnpm build` (core + chart) — green
- [x] `npx tsc --noEmit --ignoreDeprecations 6.0` — no new errors attributable to this diff (the 10 lines of pre-existing errors are unchanged by this PR)

## Breaking change scope

- Pre-0.4.0 `ZlemaState` bare snapshots (no `meta` envelope, with `period` / `source` / `lag` / `multiplier` as top-level fields) are not resumable. `resolveResume` throws the standard "incompatible snapshot, re-warm required (missing meta — pre-0.4.0 snapshots are not resumable)" message. Consistent with every other migrated indicator in this epic.

Base: `epic/state-contract` — part of the 0.4.0 State Contract epic.