### PR TITLE
feat(core)!: migrate Cascaded EMA wrappers to State Contract (Wave 3 Bundle I)

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -15,10 +15,17 @@
 import { describe, expect, it } from "vitest";
 import { CRYPTO_CALENDAR, JPX_CALENDAR } from "../../../calendar";
 import type { NormalizedCandle, PriceSource } from "../../../types";
+import { massIndex } from "../../momentum/mass-index";
+import { trix } from "../../momentum/trix";
+import { tsi } from "../../momentum/tsi";
 import { alma } from "../../moving-average/alma";
+import { dema } from "../../moving-average/dema";
 import { ema } from "../../moving-average/ema";
+import { emaRibbon } from "../../moving-average/ema-ribbon";
 import { mcginleyDynamic } from "../../moving-average/mcginley-dynamic";
 import { sma } from "../../moving-average/sma";
+import { t3 } from "../../moving-average/t3";
+import { tema } from "../../moving-average/tema";
 import { vwma } from "../../moving-average/vwma";
 import { wma } from "../../moving-average/wma";
 import { zlema } from "../../moving-average/zlema";
@@ -37,13 +44,24 @@ import { obv } from "../../volume/obv";
 import { pvt } from "../../volume/pvt";
 import { twap } from "../../volume/twap";
 import { vwap } from "../../volume/vwap";
+import { createMassIndex, type MassIndexState } from "../momentum/mass-index";
+import { createTrix, type TrixState, type TrixValue } from "../momentum/trix";
+import { createTsi, type TsiState, type TsiValue } from "../momentum/tsi";
 import { type AlmaState, createAlma } from "../moving-average/alma";
+import { createDema, type DemaState } from "../moving-average/dema";
 import { createEma, type EmaState } from "../moving-average/ema";
+import {
+  createEmaRibbon,
+  type EmaRibbonState,
+  type EmaRibbonValue,
+} from "../moving-average/ema-ribbon";
 import {
   createMcGinleyDynamic,
   type McGinleyDynamicState,
 } from "../moving-average/mcginley-dynamic";
 import { createSma, type SmaState } from "../moving-average/sma";
+import { createT3, type T3State } from "../moving-average/t3";
+import { createTema, type TemaState } from "../moving-average/tema";
 import { createVwma, type VwmaState } from "../moving-average/vwma";
 import { createWma, type WmaState } from "../moving-average/wma";
 import { createZlema, type ZlemaState } from "../moving-average/zlema";
@@ -803,4 +821,187 @@ describeContract<number | null, ZlemaState>({
   streamLength: 100,
   batchCompute: (opts, candles) =>
     zlema(candles, opts as { period: number; source?: PriceSource }).map((s) => s.value),
+});
+
+// ---- Wave 3 Bundle I: Cascaded EMA wrappers ----
+//
+// All seven entries below compose the migrated EMA factory (Bundle G).
+// Bare state holds only the inner EMA snapshots plus per-wrapper
+// accumulators (`prevSpread`, `prevEma3`, `prevPrice`, `ratioBuffer`,
+// etc.). Params live in `meta.params`. Resume with mismatched params
+// throws via the cascaded / mixed policy. `batchCompute` pins
+// invariant [8] across trending / flat / gap candle variants.
+
+// DEMA — Cascaded (2 EMAs). DEMA = 2 * EMA1 - EMA2.
+describeContract<number | null, DemaState>({
+  name: "dema",
+  create: (opts, warmUp) => createDema(opts as { period?: number; source?: PriceSource }, warmUp),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { period: 20, source: "close" },
+  reconfigParams: [{ period: 10 }, { period: 30 }, { source: "high" }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    dema(candles, opts as { period?: number; source?: PriceSource }).map((s) => s.value),
+});
+
+// TEMA — Cascaded (3 EMAs). TEMA = 3 * EMA1 - 3 * EMA2 + EMA3.
+describeContract<number | null, TemaState>({
+  name: "tema",
+  create: (opts, warmUp) => createTema(opts as { period?: number; source?: PriceSource }, warmUp),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { period: 20, source: "close" },
+  reconfigParams: [{ period: 10 }, { period: 30 }, { source: "high" }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    tema(candles, opts as { period?: number; source?: PriceSource }).map((s) => s.value),
+});
+
+// T3 (Tillson) — Cascaded (6 EMAs + volume factor coefficients).
+describeContract<number | null, T3State>({
+  name: "t3",
+  create: (opts, warmUp) =>
+    createT3(opts as { period?: number; vFactor?: number; source?: PriceSource }, warmUp),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { period: 5, vFactor: 0.7, source: "close" },
+  reconfigParams: [{ period: 8 }, { period: 10 }, { vFactor: 0.5 }, { source: "high" }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    t3(candles, opts as { period?: number; vFactor?: number; source?: PriceSource }).map(
+      (s) => s.value,
+    ),
+});
+
+// EMA Ribbon — Cascaded (parallel EMAs over the same input).
+// `periods` is an array key; the inner EMAs are sorted ascending by
+// period. `bullish` / `expanding` are derived from the composite values.
+//
+// The value object is never literally `null`: warmup bars emit
+// `{ values: [null, …], bullish: null, expanding: null }`. The default
+// `isNullishValue` predicate treats the embedded `values` array as a
+// non-null leaf so it would mis-classify warmup bars as warmed up.
+// Override with a predicate that treats the bar as nullish until
+// `bullish` is computed — that matches the indicator's `isWarmedUp`
+// (slowest EMA done warming).
+describeContract<EmaRibbonValue, EmaRibbonState>({
+  name: "emaRibbon",
+  create: (opts, warmUp) =>
+    createEmaRibbon(opts as { periods?: number[]; source?: PriceSource }, warmUp),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { periods: [8, 13, 21, 34, 55], source: "close" },
+  reconfigParams: [{ periods: [5, 10, 20] }, { periods: [8, 21, 55] }, { source: "high" }],
+  makeCandles,
+  streamLength: 100,
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { bullish: unknown }).bullish === null),
+  batchCompute: (opts, candles) =>
+    emaRibbon(candles, opts as { periods?: number[]; source?: PriceSource }).map((s) => s.value),
+});
+
+// Regression: EMA Ribbon has always treated `periods` as
+// order-insensitive (batch `emaRibbon([10, 3, 5])` sorts internally).
+// The Bundle I migration originally compared the raw `options.periods`
+// against the sorted `meta.params.periods`, causing resume with the
+// same unsorted array to throw an incompatible-snapshot error. The fix
+// normalizes `periods` before `resolveResume` so the resume path
+// remains order-insensitive — pinned here so the regression cannot
+// silently come back.
+describe("emaRibbon: unsorted periods order-insensitive resume", () => {
+  it("accepts resume when fromState was created with an unsorted periods array", () => {
+    const candles = makeCandles(80);
+    const seed = createEmaRibbon({ periods: [10, 3, 5] });
+    for (const c of candles) seed.next(c);
+    const snapshot = seed.getState();
+    // Same array, same order — must not throw.
+    expect(() => createEmaRibbon({ periods: [10, 3, 5] }, { fromState: snapshot })).not.toThrow();
+    // Same set of periods in a different order — also must not throw.
+    expect(() => createEmaRibbon({ periods: [5, 3, 10] }, { fromState: snapshot })).not.toThrow();
+    expect(() => createEmaRibbon({ periods: [3, 5, 10] }, { fromState: snapshot })).not.toThrow();
+  });
+
+  it("still refuses resume when periods set actually differs", () => {
+    const candles = makeCandles(80);
+    const seed = createEmaRibbon({ periods: [10, 3, 5] });
+    for (const c of candles) seed.next(c);
+    const snapshot = seed.getState();
+    expect(() => createEmaRibbon({ periods: [10, 3, 7] }, { fromState: snapshot })).toThrow();
+    expect(() => createEmaRibbon({ periods: [10, 3] }, { fromState: snapshot })).toThrow();
+  });
+});
+
+// TRIX — Cascaded (1 createEma stage + 3 internal null-propagating EMA
+// stages). Composite output `{ trix, signal }`.
+describeContract<TrixValue, TrixState>({
+  name: "trix",
+  create: (opts, warmUp) => createTrix(opts as { period?: number; signalPeriod?: number }, warmUp),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { period: 15, signalPeriod: 9 },
+  reconfigParams: [{ period: 10 }, { period: 20 }, { signalPeriod: 5 }],
+  makeCandles,
+  streamLength: 120,
+  batchCompute: (opts, candles) =>
+    trix(candles, opts as { period?: number; signalPeriod?: number }).map((s) => s.value),
+});
+
+// TSI — Cascaded (5 EMAs over momentum / abs-momentum paths + signal
+// line). Composite output `{ tsi, signal } | null`. `prevPrice`
+// initializes the momentum recursion on the first candle.
+describeContract<TsiValue | null, TsiState>({
+  name: "tsi",
+  create: (opts, warmUp) =>
+    createTsi(
+      opts as {
+        longPeriod?: number;
+        shortPeriod?: number;
+        signalPeriod?: number;
+        source?: PriceSource;
+      },
+      warmUp,
+    ),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { longPeriod: 25, shortPeriod: 13, signalPeriod: 7, source: "close" },
+  reconfigParams: [
+    { longPeriod: 20 },
+    { shortPeriod: 10 },
+    { signalPeriod: 5 },
+    { source: "high" },
+  ],
+  makeCandles,
+  streamLength: 120,
+  batchCompute: (opts, candles) =>
+    tsi(
+      candles,
+      opts as {
+        longPeriod?: number;
+        shortPeriod?: number;
+        signalPeriod?: number;
+        source?: PriceSource;
+      },
+    ).map((s) => s.value),
+});
+
+// Mass Index — Mixed (2 cascaded EMAs + a windowed ratio sum buffer).
+// The mixed policy refuses any param change on resume.
+describeContract<number | null, MassIndexState>({
+  name: "massIndex",
+  create: (opts, warmUp) =>
+    createMassIndex(opts as { emaPeriod?: number; sumPeriod?: number }, warmUp),
+  category: "mixed",
+  version: 1,
+  defaultParams: { emaPeriod: 9, sumPeriod: 25 },
+  reconfigParams: [{ emaPeriod: 7 }, { sumPeriod: 20 }],
+  makeCandles,
+  streamLength: 120,
+  batchCompute: (opts, candles) =>
+    massIndex(candles, opts as { emaPeriod?: number; sumPeriod?: number }).map((s) => s.value),
 });

--- a/packages/core/src/indicators/incremental/momentum/mass-index.ts
+++ b/packages/core/src/indicators/incremental/momentum/mass-index.ts
@@ -12,28 +12,38 @@
  *
  * A "reversal bulge" occurs when Mass Index rises above 27 then drops below 26.5.
  *
- * Composes: 2x EMA (cascaded) + CircularBuffer for ratio sum
+ * State category: **Mixed** (two cascaded EMAs plus a windowed ratio
+ * buffer). Resume with different `emaPeriod` / `sumPeriod` is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
 import type { EmaState } from "../moving-average/ema";
 import { createEma } from "../moving-average/ema";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { makeCandle } from "../utils";
 
-/**
- * State for incremental Mass Index
- */
 export type MassIndexState = {
-  emaPeriod: number;
-  sumPeriod: number;
   ema1State: IndicatorSnapshot<EmaState>;
   ema2State: IndicatorSnapshot<EmaState>;
   ratioBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   ratioSum: number;
   count: number;
+};
+
+export const MASS_INDEX_VERSION = 1;
+
+type MassIndexParams = {
+  emaPeriod: number;
+  sumPeriod: number;
 };
 
 /**
@@ -50,10 +60,34 @@ export type MassIndexState = {
  */
 export function createMassIndex(
   options: { emaPeriod?: number; sumPeriod?: number } = {},
-  warmUpOptions?: WarmUpOptions<MassIndexState>,
-): IncrementalIndicator<number | null, MassIndexState> {
-  const emaPeriod = options.emaPeriod ?? 9;
-  const sumPeriod = options.sumPeriod ?? 25;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<MassIndexState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<MassIndexState>> {
+  const { params, state } = resolveResume<MassIndexParams, MassIndexState>({
+    indicator: "massIndex",
+    version: MASS_INDEX_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { emaPeriod: 9, sumPeriod: 25 },
+  });
+
+  const emaPeriod = requireParam(
+    "massIndex",
+    params,
+    "emaPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const sumPeriod = requireParam(
+    "massIndex",
+    params,
+    "sumPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
 
   let ema1: ReturnType<typeof createEma>;
   let ema2: ReturnType<typeof createEma>;
@@ -61,13 +95,12 @@ export function createMassIndex(
   let ratioSum: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    ema1 = createEma({ period: emaPeriod }, { fromState: s.ema1State });
-    ema2 = createEma({ period: emaPeriod }, { fromState: s.ema2State });
-    ratioBuffer = CircularBuffer.fromSnapshot(s.ratioBuffer);
-    ratioSum = s.ratioSum;
-    count = s.count;
+  if (state !== null) {
+    ema1 = createEma({ period: emaPeriod }, { fromState: state.ema1State });
+    ema2 = createEma({ period: emaPeriod }, { fromState: state.ema2State });
+    ratioBuffer = CircularBuffer.fromSnapshot(state.ratioBuffer);
+    ratioSum = state.ratioSum;
+    count = state.count;
   } else {
     ema1 = createEma({ period: emaPeriod });
     ema2 = createEma({ period: emaPeriod });
@@ -76,7 +109,7 @@ export function createMassIndex(
     count = 0;
   }
 
-  const indicator: IncrementalIndicator<number | null, MassIndexState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<MassIndexState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -134,16 +167,19 @@ export function createMassIndex(
       return { time: candle.time, value: null };
     },
 
-    getState(): MassIndexState {
-      return {
-        emaPeriod,
-        sumPeriod,
-        ema1State: ema1.getState(),
-        ema2State: ema2.getState(),
-        ratioBuffer: ratioBuffer.snapshot(),
-        ratioSum,
-        count,
-      };
+    getState(): IndicatorSnapshot<MassIndexState> {
+      return makeSnapshot(
+        "massIndex",
+        MASS_INDEX_VERSION,
+        { emaPeriod, sumPeriod },
+        {
+          ema1State: ema1.getState(),
+          ema2State: ema2.getState(),
+          ratioBuffer: ratioBuffer.snapshot(),
+          ratioSum,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/trix.ts
+++ b/packages/core/src/indicators/incremental/momentum/trix.ts
@@ -9,13 +9,24 @@
  *
  * The non-leading EMA stages skip null inputs and seed from the first
  * `period` consecutive non-null upstream samples (matches batch trix()).
+ *
+ * State category: **Cascaded** (one leading createEma stage plus three
+ * internal null-propagating EMA stages, all conditioned on
+ * construction-time periods). Resume with different periods is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import type { EmaState } from "../moving-average/ema";
 import { createEma } from "../moving-average/ema";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type TrixValue = {
   trix: number | null;
@@ -77,14 +88,19 @@ function makeNullEma(period: number, fromState?: NullEmaState) {
 }
 
 export type TrixState = {
-  period: number;
-  signalPeriod: number;
   ema1State: IndicatorSnapshot<EmaState>;
   ema2State: NullEmaState;
   ema3State: NullEmaState;
   signalState: NullEmaState;
   prevEma3: number | null;
   count: number;
+};
+
+export const TRIX_VERSION = 1;
+
+type TrixParams = {
+  period: number;
+  signalPeriod: number;
 };
 
 /**
@@ -101,10 +117,34 @@ export type TrixState = {
  */
 export function createTrix(
   options: { period?: number; signalPeriod?: number } = {},
-  warmUpOptions?: WarmUpOptions<TrixState>,
-): IncrementalIndicator<TrixValue, TrixState> {
-  const period = options.period ?? 15;
-  const signalPeriod = options.signalPeriod ?? 9;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<TrixState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<TrixValue, IndicatorSnapshot<TrixState>> {
+  const { params, state } = resolveResume<TrixParams, TrixState>({
+    indicator: "trix",
+    version: TRIX_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 15, signalPeriod: 9 },
+  });
+
+  const period = requireParam(
+    "trix",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const signalPeriod = requireParam(
+    "trix",
+    params,
+    "signalPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
 
   let ema1: ReturnType<typeof createEma>;
   let ema2: ReturnType<typeof makeNullEma>;
@@ -113,14 +153,13 @@ export function createTrix(
   let prevEma3: number | null;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    ema1 = createEma({ period }, { fromState: s.ema1State });
-    ema2 = makeNullEma(period, s.ema2State);
-    ema3 = makeNullEma(period, s.ema3State);
-    signalEma = makeNullEma(signalPeriod, s.signalState);
-    prevEma3 = s.prevEma3;
-    count = s.count;
+  if (state !== null) {
+    ema1 = createEma({ period }, { fromState: state.ema1State });
+    ema2 = makeNullEma(period, state.ema2State);
+    ema3 = makeNullEma(period, state.ema3State);
+    signalEma = makeNullEma(signalPeriod, state.signalState);
+    prevEma3 = state.prevEma3;
+    count = state.count;
   } else {
     ema1 = createEma({ period });
     ema2 = makeNullEma(period);
@@ -130,7 +169,7 @@ export function createTrix(
     count = 0;
   }
 
-  const indicator: IncrementalIndicator<TrixValue, TrixState> = {
+  const indicator: IncrementalIndicator<TrixValue, IndicatorSnapshot<TrixState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -166,17 +205,20 @@ export function createTrix(
       return { time: candle.time, value: { trix: trixVal, signal: signalVal } };
     },
 
-    getState(): TrixState {
-      return {
-        period,
-        signalPeriod,
-        ema1State: ema1.getState(),
-        ema2State: ema2.getState(),
-        ema3State: ema3.getState(),
-        signalState: signalEma.getState(),
-        prevEma3,
-        count,
-      };
+    getState(): IndicatorSnapshot<TrixState> {
+      return makeSnapshot(
+        "trix",
+        TRIX_VERSION,
+        { period, signalPeriod },
+        {
+          ema1State: ema1.getState(),
+          ema2State: ema2.getState(),
+          ema3State: ema3.getState(),
+          signalState: signalEma.getState(),
+          prevEma3,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/tsi.ts
+++ b/packages/core/src/indicators/incremental/momentum/tsi.ts
@@ -6,13 +6,24 @@
  *
  * Uses 5 internal EMAs: 2 for the momentum path, 2 for the absolute momentum path,
  * and 1 for the signal line.
+ *
+ * State category: **Cascaded** (five recursive EMA stages plus the
+ * `prevPrice` recursive accumulator). Resume with different periods /
+ * source is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import type { EmaState } from "../moving-average/ema";
 import { createEma } from "../moving-average/ema";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice, makeCandle } from "../utils";
 
 export type TsiValue = {
@@ -27,11 +38,16 @@ export type TsiState = {
   ema2AbsState: IndicatorSnapshot<EmaState>;
   signalEmaState: IndicatorSnapshot<EmaState>;
   prevPrice: number | null;
+  count: number;
+};
+
+export const TSI_VERSION = 1;
+
+type TsiParams = {
   longPeriod: number;
   shortPeriod: number;
   signalPeriod: number;
   source: PriceSource;
-  count: number;
 };
 
 /**
@@ -53,12 +69,42 @@ export function createTsi(
     signalPeriod?: number;
     source?: PriceSource;
   } = {},
-  warmUpOptions?: WarmUpOptions<TsiState>,
-): IncrementalIndicator<TsiValue | null, TsiState> {
-  const longPeriod = options.longPeriod ?? 25;
-  const shortPeriod = options.shortPeriod ?? 13;
-  const signalPeriod = options.signalPeriod ?? 7;
-  const source: PriceSource = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<TsiState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<TsiValue | null, IndicatorSnapshot<TsiState>> {
+  const { params, state } = resolveResume<TsiParams, TsiState>({
+    indicator: "tsi",
+    version: TSI_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { longPeriod: 25, shortPeriod: 13, signalPeriod: 7, source: "close" },
+  });
+
+  const longPeriod = requireParam(
+    "tsi",
+    params,
+    "longPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const shortPeriod = requireParam(
+    "tsi",
+    params,
+    "shortPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const signalPeriod = requireParam(
+    "tsi",
+    params,
+    "signalPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
 
   let ema1Mom: ReturnType<typeof createEma>;
   let ema2Mom: ReturnType<typeof createEma>;
@@ -68,15 +114,14 @@ export function createTsi(
   let prevPrice: number | null;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    ema1Mom = createEma({ period: longPeriod }, { fromState: s.ema1MomState });
-    ema2Mom = createEma({ period: shortPeriod }, { fromState: s.ema2MomState });
-    ema1Abs = createEma({ period: longPeriod }, { fromState: s.ema1AbsState });
-    ema2Abs = createEma({ period: shortPeriod }, { fromState: s.ema2AbsState });
-    signalEma = createEma({ period: signalPeriod }, { fromState: s.signalEmaState });
-    prevPrice = s.prevPrice;
-    count = s.count;
+  if (state !== null) {
+    ema1Mom = createEma({ period: longPeriod }, { fromState: state.ema1MomState });
+    ema2Mom = createEma({ period: shortPeriod }, { fromState: state.ema2MomState });
+    ema1Abs = createEma({ period: longPeriod }, { fromState: state.ema1AbsState });
+    ema2Abs = createEma({ period: shortPeriod }, { fromState: state.ema2AbsState });
+    signalEma = createEma({ period: signalPeriod }, { fromState: state.signalEmaState });
+    prevPrice = state.prevPrice;
+    count = state.count;
   } else {
     ema1Mom = createEma({ period: longPeriod });
     ema2Mom = createEma({ period: shortPeriod });
@@ -145,7 +190,7 @@ export function createTsi(
     return { time: candle.time, value: { tsi: tsiVal, signal: sigResult } };
   }
 
-  const indicator: IncrementalIndicator<TsiValue | null, TsiState> = {
+  const indicator: IncrementalIndicator<TsiValue | null, IndicatorSnapshot<TsiState>> = {
     next(candle: NormalizedCandle) {
       return compute(candle, true);
     },
@@ -154,20 +199,21 @@ export function createTsi(
       return compute(candle, false);
     },
 
-    getState(): TsiState {
-      return {
-        ema1MomState: ema1Mom.getState(),
-        ema2MomState: ema2Mom.getState(),
-        ema1AbsState: ema1Abs.getState(),
-        ema2AbsState: ema2Abs.getState(),
-        signalEmaState: signalEma.getState(),
-        prevPrice,
-        longPeriod,
-        shortPeriod,
-        signalPeriod,
-        source,
-        count,
-      };
+    getState(): IndicatorSnapshot<TsiState> {
+      return makeSnapshot(
+        "tsi",
+        TSI_VERSION,
+        { longPeriod, shortPeriod, signalPeriod, source },
+        {
+          ema1MomState: ema1Mom.getState(),
+          ema2MomState: ema2Mom.getState(),
+          ema1AbsState: ema1Abs.getState(),
+          ema2AbsState: ema2Abs.getState(),
+          signalEmaState: signalEma.getState(),
+          prevPrice,
+          count,
+        },
+      );
     },
 
     get count() {
@@ -175,7 +221,13 @@ export function createTsi(
     },
 
     get isWarmedUp() {
-      return signalEma.isWarmedUp;
+      // First non-null literal value emerges when both ema2Mom and
+      // ema2Abs warm up — `compute()` returns a `null` literal until
+      // then. Aligning isWarmedUp to that boundary matches the
+      // contract DSL invariant [7]. `signalEma` warms up later but
+      // only affects the inner `signal` field; the outer value is
+      // already non-null when `tsi` first emerges.
+      return ema2Mom.isWarmedUp && ema2Abs.isWarmedUp;
     },
   };
 

--- a/packages/core/src/indicators/incremental/moving-average/dema.ts
+++ b/packages/core/src/indicators/incremental/moving-average/dema.ts
@@ -3,21 +3,41 @@
  *
  * DEMA = 2 * EMA1 - EMA2
  * where EMA2 = EMA(EMA1, period)
+ *
+ * State category: **Cascaded** (two recursive EMA stages composed in
+ * series). Resume with different `period` / `source` is refused — both
+ * inner EMAs are permanently conditioned on their construction-time
+ * params.
+ *
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<DemaState>` and `fromState` accepts the same.
+ * Params (`period`, `source`) live in `meta.params`; the bare state
+ * holds only the two inner EMA snapshots plus `count`.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { makeCandle } from "../utils";
 import type { EmaState } from "./ema";
 import { createEma } from "./ema";
 
 export type DemaState = {
-  period: number;
-  source: PriceSource;
   ema1State: IndicatorSnapshot<EmaState>;
   ema2State: IndicatorSnapshot<EmaState>;
   count: number;
+};
+
+export const DEMA_VERSION = 1;
+
+type DemaParams = {
+  period: number;
+  source: PriceSource;
 };
 
 /**
@@ -34,20 +54,37 @@ export type DemaState = {
  */
 export function createDema(
   options: { period?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<DemaState>,
-): IncrementalIndicator<number | null, DemaState> {
-  const period = options.period ?? 20;
-  const source: PriceSource = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<DemaState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<DemaState>> {
+  const { params, state } = resolveResume<DemaParams, DemaState>({
+    indicator: "dema",
+    version: DEMA_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 20, source: "close" },
+  });
+
+  const period = requireParam(
+    "dema",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
 
   let ema1: ReturnType<typeof createEma>;
   let ema2: ReturnType<typeof createEma>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    ema1 = createEma({ period, source }, { fromState: s.ema1State });
-    ema2 = createEma({ period }, { fromState: s.ema2State });
-    count = s.count;
+  if (state !== null) {
+    ema1 = createEma({ period, source }, { fromState: state.ema1State });
+    ema2 = createEma({ period }, { fromState: state.ema2State });
+    count = state.count;
   } else {
     ema1 = createEma({ period, source });
     ema2 = createEma({ period });
@@ -65,7 +102,7 @@ export function createDema(
     return 2 * v1 - v2;
   }
 
-  const indicator: IncrementalIndicator<number | null, DemaState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<DemaState>> = {
     next(candle: NormalizedCandle) {
       count++;
       return { time: candle.time, value: cascade(candle, false) };
@@ -75,14 +112,17 @@ export function createDema(
       return { time: candle.time, value: cascade(candle, true) };
     },
 
-    getState(): DemaState {
-      return {
-        period,
-        source,
-        ema1State: ema1.getState(),
-        ema2State: ema2.getState(),
-        count,
-      };
+    getState(): IndicatorSnapshot<DemaState> {
+      return makeSnapshot(
+        "dema",
+        DEMA_VERSION,
+        { period, source },
+        {
+          ema1State: ema1.getState(),
+          ema2State: ema2.getState(),
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/moving-average/ema-ribbon.ts
+++ b/packages/core/src/indicators/incremental/moving-average/ema-ribbon.ts
@@ -2,11 +2,23 @@
  * Incremental EMA Ribbon
  *
  * Multiple EMAs to visualize trend strength and direction.
+ *
+ * State category: **Cascaded** (parallel recursive EMA stages, each
+ * processed independently from the same input). Resume with different
+ * `periods` / `source` is refused — periods is an array of construction
+ * keys, every inner EMA is permanently bound to its period.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import type { EmaState } from "./ema";
 import { createEma } from "./ema";
 
@@ -17,11 +29,16 @@ export type EmaRibbonValue = {
 };
 
 export type EmaRibbonState = {
-  periods: number[];
-  source: PriceSource;
   emaStates: IndicatorSnapshot<EmaState>[];
   prevSpread: number | null;
   count: number;
+};
+
+export const EMA_RIBBON_VERSION = 1;
+
+type EmaRibbonParams = {
+  periods: number[];
+  source: PriceSource;
 };
 
 /**
@@ -38,20 +55,51 @@ export type EmaRibbonState = {
  */
 export function createEmaRibbon(
   options: { periods?: number[]; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<EmaRibbonState>,
-): IncrementalIndicator<EmaRibbonValue, EmaRibbonState> {
-  const periods = [...(options.periods ?? [8, 13, 21, 34, 55])].sort((a, b) => a - b);
-  const source: PriceSource = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<EmaRibbonState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<EmaRibbonValue, IndicatorSnapshot<EmaRibbonState>> {
+  // Normalize `periods` before resolveResume so that resuming from a
+  // snapshot created with the same unsorted array (e.g.
+  // `createEmaRibbon({ periods: [10, 3, 5] })`) does not throw.
+  // `meta.params.periods` is stored sorted (see `getState()` below), so
+  // comparing the raw `options.periods` against the snapshot would
+  // false-positive on order-only differences even though the indicator
+  // has always been order-insensitive (matches batch `emaRibbon`).
+  const normalizedOptions = options.periods
+    ? { ...options, periods: [...options.periods].sort((a, b) => a - b) }
+    : options;
+
+  const { params, state } = resolveResume<EmaRibbonParams, EmaRibbonState>({
+    indicator: "emaRibbon",
+    version: EMA_RIBBON_VERSION,
+    category: "cascaded",
+    options: normalizedOptions,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { periods: [8, 13, 21, 34, 55], source: "close" },
+  });
+
+  const periods = requireParam(
+    "emaRibbon",
+    params,
+    "periods",
+    (v): v is number[] =>
+      Array.isArray(v) && v.length > 0 && v.every((n) => Number.isInteger(n) && n >= 1),
+    "must be a non-empty array of positive integers",
+  );
+  const source = params.source;
 
   let emas: ReturnType<typeof createEma>[];
   let prevSpread: number | null;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    emas = s.emaStates.map((st, i) => createEma({ period: periods[i], source }, { fromState: st }));
-    prevSpread = s.prevSpread;
-    count = s.count;
+  if (state !== null) {
+    emas = state.emaStates.map((st, i) =>
+      createEma({ period: periods[i], source }, { fromState: st }),
+    );
+    prevSpread = state.prevSpread;
+    count = state.count;
   } else {
     emas = periods.map((p) => createEma({ period: p, source }));
     prevSpread = null;
@@ -85,7 +133,7 @@ export function createEmaRibbon(
     return { bullish, expanding };
   }
 
-  const indicator: IncrementalIndicator<EmaRibbonValue, EmaRibbonState> = {
+  const indicator: IncrementalIndicator<EmaRibbonValue, IndicatorSnapshot<EmaRibbonState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const values = emas.map((e) => e.next(candle).value);
@@ -126,14 +174,17 @@ export function createEmaRibbon(
       return { time: candle.time, value: { values, bullish, expanding } };
     },
 
-    getState(): EmaRibbonState {
-      return {
-        periods,
-        source,
-        emaStates: emas.map((e) => e.getState()),
-        prevSpread,
-        count,
-      };
+    getState(): IndicatorSnapshot<EmaRibbonState> {
+      return makeSnapshot(
+        "emaRibbon",
+        EMA_RIBBON_VERSION,
+        { periods, source },
+        {
+          emaStates: emas.map((e) => e.getState()),
+          prevSpread,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/moving-average/t3.ts
+++ b/packages/core/src/indicators/incremental/moving-average/t3.ts
@@ -3,19 +3,27 @@
  *
  * T3 = c1*e6 + c2*e5 + c3*e4 + c4*e3
  * where e1..e6 are cascaded EMAs and c1..c4 are volume factor coefficients.
+ *
+ * State category: **Cascaded** (six recursive EMA stages composed in
+ * series). Resume with different `period` / `vFactor` / `source` is
+ * refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { makeCandle } from "../utils";
 import type { EmaState } from "./ema";
 import { createEma } from "./ema";
 
 export type T3State = {
-  period: number;
-  vFactor: number;
-  source: PriceSource;
   ema1State: IndicatorSnapshot<EmaState>;
   ema2State: IndicatorSnapshot<EmaState>;
   ema3State: IndicatorSnapshot<EmaState>;
@@ -23,6 +31,14 @@ export type T3State = {
   ema5State: IndicatorSnapshot<EmaState>;
   ema6State: IndicatorSnapshot<EmaState>;
   count: number;
+};
+
+export const T3_VERSION = 1;
+
+type T3Params = {
+  period: number;
+  vFactor: number;
+  source: PriceSource;
 };
 
 /**
@@ -39,11 +55,29 @@ export type T3State = {
  */
 export function createT3(
   options: { period?: number; vFactor?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<T3State>,
-): IncrementalIndicator<number | null, T3State> {
-  const period = options.period ?? 5;
-  const vFactor = options.vFactor ?? 0.7;
-  const source: PriceSource = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<T3State>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<T3State>> {
+  const { params, state } = resolveResume<T3Params, T3State>({
+    indicator: "t3",
+    version: T3_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 5, vFactor: 0.7, source: "close" },
+  });
+
+  const period = requireParam(
+    "t3",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const vFactor = params.vFactor;
+  const source = params.source;
 
   // T3 coefficients derived from volume factor
   const v2 = vFactor * vFactor;
@@ -61,15 +95,14 @@ export function createT3(
   let ema6: ReturnType<typeof createEma>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    ema1 = createEma({ period, source }, { fromState: s.ema1State });
-    ema2 = createEma({ period }, { fromState: s.ema2State });
-    ema3 = createEma({ period }, { fromState: s.ema3State });
-    ema4 = createEma({ period }, { fromState: s.ema4State });
-    ema5 = createEma({ period }, { fromState: s.ema5State });
-    ema6 = createEma({ period }, { fromState: s.ema6State });
-    count = s.count;
+  if (state !== null) {
+    ema1 = createEma({ period, source }, { fromState: state.ema1State });
+    ema2 = createEma({ period }, { fromState: state.ema2State });
+    ema3 = createEma({ period }, { fromState: state.ema3State });
+    ema4 = createEma({ period }, { fromState: state.ema4State });
+    ema5 = createEma({ period }, { fromState: state.ema5State });
+    ema6 = createEma({ period }, { fromState: state.ema6State });
+    count = state.count;
   } else {
     ema1 = createEma({ period, source });
     ema2 = createEma({ period });
@@ -108,30 +141,31 @@ export function createT3(
     return c1 * v6 + c2 * v5 + c3 * v4 + c4 * v3;
   }
 
-  const indicator: IncrementalIndicator<number | null, T3State> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<T3State>> = {
     next(candle: NormalizedCandle) {
       count++;
-      const value = cascade(candle, false);
-      return { time: candle.time, value };
+      return { time: candle.time, value: cascade(candle, false) };
     },
 
     peek(candle: NormalizedCandle) {
       return { time: candle.time, value: cascade(candle, true) };
     },
 
-    getState(): T3State {
-      return {
-        period,
-        vFactor,
-        source,
-        ema1State: ema1.getState(),
-        ema2State: ema2.getState(),
-        ema3State: ema3.getState(),
-        ema4State: ema4.getState(),
-        ema5State: ema5.getState(),
-        ema6State: ema6.getState(),
-        count,
-      };
+    getState(): IndicatorSnapshot<T3State> {
+      return makeSnapshot(
+        "t3",
+        T3_VERSION,
+        { period, vFactor, source },
+        {
+          ema1State: ema1.getState(),
+          ema2State: ema2.getState(),
+          ema3State: ema3.getState(),
+          ema4State: ema4.getState(),
+          ema5State: ema5.getState(),
+          ema6State: ema6.getState(),
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/moving-average/tema.ts
+++ b/packages/core/src/indicators/incremental/moving-average/tema.ts
@@ -3,22 +3,37 @@
  *
  * TEMA = 3 * EMA1 - 3 * EMA2 + EMA3
  * where EMA2 = EMA(EMA1, period), EMA3 = EMA(EMA2, period)
+ *
+ * State category: **Cascaded** (three recursive EMA stages composed in
+ * series). Resume with different `period` / `source` is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { makeCandle } from "../utils";
 import type { EmaState } from "./ema";
 import { createEma } from "./ema";
 
 export type TemaState = {
-  period: number;
-  source: PriceSource;
   ema1State: IndicatorSnapshot<EmaState>;
   ema2State: IndicatorSnapshot<EmaState>;
   ema3State: IndicatorSnapshot<EmaState>;
   count: number;
+};
+
+export const TEMA_VERSION = 1;
+
+type TemaParams = {
+  period: number;
+  source: PriceSource;
 };
 
 /**
@@ -35,22 +50,39 @@ export type TemaState = {
  */
 export function createTema(
   options: { period?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<TemaState>,
-): IncrementalIndicator<number | null, TemaState> {
-  const period = options.period ?? 20;
-  const source: PriceSource = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<TemaState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<TemaState>> {
+  const { params, state } = resolveResume<TemaParams, TemaState>({
+    indicator: "tema",
+    version: TEMA_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 20, source: "close" },
+  });
+
+  const period = requireParam(
+    "tema",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
 
   let ema1: ReturnType<typeof createEma>;
   let ema2: ReturnType<typeof createEma>;
   let ema3: ReturnType<typeof createEma>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    ema1 = createEma({ period, source }, { fromState: s.ema1State });
-    ema2 = createEma({ period }, { fromState: s.ema2State });
-    ema3 = createEma({ period }, { fromState: s.ema3State });
-    count = s.count;
+  if (state !== null) {
+    ema1 = createEma({ period, source }, { fromState: state.ema1State });
+    ema2 = createEma({ period }, { fromState: state.ema2State });
+    ema3 = createEma({ period }, { fromState: state.ema3State });
+    count = state.count;
   } else {
     ema1 = createEma({ period, source });
     ema2 = createEma({ period });
@@ -72,7 +104,7 @@ export function createTema(
     return 3 * v1 - 3 * v2 + v3;
   }
 
-  const indicator: IncrementalIndicator<number | null, TemaState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<TemaState>> = {
     next(candle: NormalizedCandle) {
       count++;
       return { time: candle.time, value: cascade(candle, false) };
@@ -82,15 +114,18 @@ export function createTema(
       return { time: candle.time, value: cascade(candle, true) };
     },
 
-    getState(): TemaState {
-      return {
-        period,
-        source,
-        ema1State: ema1.getState(),
-        ema2State: ema2.getState(),
-        ema3State: ema3.getState(),
-        count,
-      };
+    getState(): IndicatorSnapshot<TemaState> {
+      return makeSnapshot(
+        "tema",
+        TEMA_VERSION,
+        { period, source },
+        {
+          ema1State: ema1.getState(),
+          ema2State: ema2.getState(),
+          ema3State: ema3.getState(),
+          count,
+        },
+      );
     },
 
     get count() {


### PR DESCRIPTION
## Summary

Wave 3 Bundle I migrates the seven Cascaded EMA wrappers to the 0.4.0 State Contract: **DEMA, TEMA, T3, EMA Ribbon, TRIX, TSI, Mass Index**.

- `getState()` returns `IndicatorSnapshot<S>`; `fromState` accepts the same envelope. Params move into `meta.params`; bare state holds only the inner EMA snapshots plus per-wrapper accumulators.
- Resume with mismatched params is refused via the cascaded / mixed policy (per STATE_CONTRACT.md §2.3). No per-wrapper translation shims (§4.1).
- Each wrapper composes the migrated EMA factory (Bundle G) and registers a `describeContract` entry with `batchCompute`, so invariant [8] pins batch/incremental parity across trending / flat / gap candle variants.

## Latent issues surfaced by the contract DSL (fixed)

- **TSI `isWarmedUp`** tracked the signal EMA, but the outer value emerges ~`signalPeriod` bars earlier when the momentum EMAs warm up. Realigned to the actual first non-null emission (invariant [7]).
- **EMA Ribbon** emits a composite object whose `values` array misleads the default null predicate; its `describeContract` entry overrides `isNullishField` to gate on `bullish`.
- **EMA Ribbon `periods` normalization**: an audit pass found that resuming from a snapshot created with an unsorted `periods` array (e.g. `[10, 3, 5]`) threw an incompatible-snapshot error, since `meta.params.periods` is stored sorted. The indicator has always been order-insensitive (matches batch `emaRibbon`). Fixed by normalizing `periods` before `resolveResume`; regression test added.

## Test plan

- [x] `pnpm test` — 5440 passing (regression test +2)
- [x] `pnpm lint` — clean
- [x] `pnpm build` — success
- [x] `tsc --noEmit --ignoreDeprecations 6.0` — 10 pre-existing errors only, 0 new