### PR TITLE
feat(core)!: migrate Wilder cluster to State Contract + add param-role axis (Wave 3 Bundle J)

### DIFF
--- a/packages/core/docs/STATE_CONTRACT.md
+++ b/packages/core/docs/STATE_CONTRACT.md
@@ -106,6 +106,32 @@ period change on resume (carry forward what fits) while FRAMA cannot.
 - Restore event list verbatim
 - Params change → continue appending; past events keep their original-param interpretation (they are timestamped facts, not derived state)
 
+**Param-role axis (orthogonal to category)**:
+
+The five categories above classify an indicator by its *state
+structure*. A second, independent axis classifies each *param* by its
+*role*:
+
+- **State-shaping params** (`period`, `source`, …) determine the
+  structure or contents of the saved state. Changing one on resume
+  follows the per-category rule above (Windowed carries forward;
+  Recursive / Mixed / Cascaded throw).
+- **Resume-invariant params** scale only the state→output projection
+  and never touch the state itself — e.g. the band-width `multiplier`
+  in Keltner Channel's `EMA ± multiplier × ATR`. Changing one on
+  resume is mathematically safe *regardless of category*: the saved
+  state is reused verbatim and the new value takes effect immediately.
+
+A `mixed` indicator can still have resume-invariant params — the two
+axes are independent. `resolveResume` accepts an explicit
+`resumeInvariantParams` list; listed params are dropped from the
+resume compatibility check (their new value still flows into the
+merged `params`). `source` is never eligible — it changes the input
+series, so the saved state corresponds to different data — and is
+refused even if mistakenly listed. The contract test DSL verifies
+resume-invariant params via invariant [9] (a projection-only change
+resumes without throwing and matches a fresh run with the new value).
+
 ### 2.5 API surface — `createXxx(options, { fromState })` retained
 
 The existing API is preserved; only the semantics inside `fromState`

--- a/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import type { NormalizedCandle, PriceSource } from "../../../types";
+import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
 import { createAdxr } from "../momentum/adxr";
 import { createAroon } from "../momentum/aroon";
@@ -1653,10 +1653,10 @@ describe("Connors RSI streak tracking and composite value", () => {
     const state = c1.getState();
 
     const c2 = createConnorsRsi({}, { fromState: state });
-    expect(c2.getState().rsiPeriod).toBe(3);
-    expect(c2.getState().streakPeriod).toBe(2);
-    expect(c2.getState().rocPeriod).toBe(5);
-    expect(c2.getState().source).toBe("high");
+    expect(c2.getState().meta.params.rsiPeriod).toBe(3);
+    expect(c2.getState().meta.params.streakPeriod).toBe(2);
+    expect(c2.getState().meta.params.rocPeriod).toBe(5);
+    expect(c2.getState().meta.params.source).toBe("high");
   });
 
   it("refuses resume with a different rsiPeriod", () => {
@@ -1718,20 +1718,16 @@ describe("Connors RSI streak tracking and composite value", () => {
     }
   });
 
-  // Pre-this-PR snapshots have no `source` field. They are not
-  // resumable — re-warm is required. (The natural source-equality
-  // check throws since `undefined !== <any-string>`.)
-  it("rejects pre-source snapshots regardless of options.source", () => {
+  // Pre-0.4.0 snapshots have no `meta` envelope. They are not
+  // resumable — `resolveResume` refuses them and forces a re-warm.
+  it("rejects pre-0.4.0 (meta-less) snapshots", () => {
     const fresh = createConnorsRsi({ rsiPeriod: 3, streakPeriod: 2, rocPeriod: 5 });
     for (let i = 0; i < 10; i++) fresh.next(makeCandle(i));
-    const legacy = { ...fresh.getState(), source: undefined as unknown as PriceSource };
+    // The bare 0.3.x state shape (no `meta` envelope).
+    const legacy = fresh.getState().state as unknown as ReturnType<
+      ReturnType<typeof createConnorsRsi>["getState"]
+    >;
     expect(() => createConnorsRsi({}, { fromState: legacy })).toThrow(/incompatible snapshot/);
-    expect(() =>
-      createConnorsRsi(
-        { rsiPeriod: 3, streakPeriod: 2, rocPeriod: 5, source: "close" },
-        { fromState: legacy },
-      ),
-    ).toThrow(/incompatible snapshot/);
   });
 });
 

--- a/packages/core/src/indicators/incremental/__tests__/contract-helper.ts
+++ b/packages/core/src/indicators/incremental/__tests__/contract-helper.ts
@@ -160,6 +160,19 @@ export type ContractConfig<TValue, TState> = {
    * Only override when the default is wrong; otherwise omit.
    */
   isNullishField?: (value: unknown) => boolean;
+  /**
+   * Reconfig overrides that change only **resume-invariant params**
+   * (the param-role axis — params that scale the state→output
+   * projection but never touch state, e.g. a band-width `multiplier`
+   * in `EMA ± multiplier × ATR`).
+   *
+   * Unlike `reconfigParams` — which the recursive/mixed/cascaded
+   * invariant [5] expects to *throw* — these MUST resume without
+   * throwing, and the resumed series must match an indicator built
+   * with the new param from the start (proving the param never
+   * poisoned the saved state). Omit when the indicator has none.
+   */
+  resumeInvariantReconfig?: Record<string, unknown>[];
 };
 
 /**
@@ -441,6 +454,46 @@ export function describeContract<TValue, TState>(config: ContractConfig<TValue, 
         }
       }
     });
+
+    if (config.resumeInvariantReconfig && config.resumeInvariantReconfig.length > 0) {
+      it("[9] resume-invariant reconfig: a projection-only param change resumes without throw and matches a fresh run", () => {
+        // Resume-invariant params (the param-role axis) scale only the
+        // state→output projection. Changing one on resume must NOT
+        // throw — even for recursive/mixed/cascaded indicators — and
+        // the resumed series must equal an indicator constructed with
+        // the new param from the start, since the saved state is
+        // identical regardless of the param's value.
+        const splitIdx = Math.floor(streamLength / 2);
+        const reconfigs = config.resumeInvariantReconfig ?? [];
+
+        for (const reconfig of reconfigs) {
+          const warmInd = config.create({ ...config.defaultParams });
+          for (let i = 0; i < splitIdx; i++) warmInd.next(candles[i]);
+          const snapshot = warmInd.getState();
+
+          const newOpts = { ...config.defaultParams, ...reconfig };
+          let resumed: ReturnType<typeof config.create> | undefined;
+          expect(
+            () => {
+              resumed = config.create(newOpts, { fromState: snapshot });
+            },
+            `resume-invariant reconfig must not throw (${JSON.stringify(reconfig)})`,
+          ).not.toThrow();
+
+          // Reference: the same new param applied from candle 0.
+          // Because the param never touches state, the reference's
+          // internal state at splitIdx equals the resumed one's.
+          const reference = config.create(newOpts);
+          for (let i = 0; i < splitIdx; i++) reference.next(candles[i]);
+
+          for (let i = splitIdx; i < streamLength; i++) {
+            const r = resumed!.next(candles[i]).value;
+            const ref = reference.next(candles[i]).value;
+            expectValueEqual(r, ref, tolerance, `[9] i=${i} reconfig=${JSON.stringify(reconfig)}`);
+          }
+        }
+      });
+    }
   });
 }
 

--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -15,7 +15,13 @@
 import { describe, expect, it } from "vitest";
 import { CRYPTO_CALENDAR, JPX_CALENDAR } from "../../../calendar";
 import type { NormalizedCandle, PriceSource } from "../../../types";
+import { adxr } from "../../momentum/adxr";
+import { cmo } from "../../momentum/cmo";
+import { connorsRsi } from "../../momentum/connors-rsi";
+import { dmi } from "../../momentum/dmi";
 import { massIndex } from "../../momentum/mass-index";
+import { rsi } from "../../momentum/rsi";
+import { stochRsi } from "../../momentum/stoch-rsi";
 import { trix } from "../../momentum/trix";
 import { tsi } from "../../momentum/tsi";
 import { alma } from "../../moving-average/alma";
@@ -31,9 +37,11 @@ import { wma } from "../../moving-average/wma";
 import { zlema } from "../../moving-average/zlema";
 import { highest, lowest } from "../../price/highest-lowest";
 import { returns as returnsBatch } from "../../price/returns";
+import { atr } from "../../volatility/atr";
 import { choppinessIndex } from "../../volatility/choppiness-index";
 import { donchianChannel } from "../../volatility/donchian-channel";
 import { ewmaVolatilityFromCandles } from "../../volatility/garch";
+import { keltnerChannel } from "../../volatility/keltner-channel";
 import { standardDeviation } from "../../volatility/standard-deviation";
 import { ulcerIndex } from "../../volatility/ulcer-index";
 import { adl } from "../../volume/adl";
@@ -44,7 +52,17 @@ import { obv } from "../../volume/obv";
 import { pvt } from "../../volume/pvt";
 import { twap } from "../../volume/twap";
 import { vwap } from "../../volume/vwap";
+import { type AdxrState, createAdxr } from "../momentum/adxr";
+import { type CmoState, createCmo } from "../momentum/cmo";
+import {
+  type ConnorsRsiState,
+  type ConnorsRsiValue,
+  createConnorsRsi,
+} from "../momentum/connors-rsi";
+import { createDmi, type DmiState, type DmiValue } from "../momentum/dmi";
 import { createMassIndex, type MassIndexState } from "../momentum/mass-index";
+import { createRsi, type RsiState } from "../momentum/rsi";
+import { createStochRsi, type StochRsiState, type StochRsiValue } from "../momentum/stoch-rsi";
 import { createTrix, type TrixState, type TrixValue } from "../momentum/trix";
 import { createTsi, type TsiState, type TsiValue } from "../momentum/tsi";
 import { type AlmaState, createAlma } from "../moving-average/alma";
@@ -67,9 +85,15 @@ import { createWma, type WmaState } from "../moving-average/wma";
 import { createZlema, type ZlemaState } from "../moving-average/zlema";
 import { createHighestLowest, type HighestLowestState } from "../price/highest-lowest";
 import { createReturns, type ReturnsState } from "../price/returns";
+import { type AtrState, createAtr } from "../volatility/atr";
 import { type ChoppinessIndexState, createChoppinessIndex } from "../volatility/choppiness-index";
 import { createDonchianChannel, type DonchianState } from "../volatility/donchian-channel";
 import { createEwmaVolatility, type EwmaVolatilityState } from "../volatility/ewma-volatility";
+import {
+  createKeltnerChannel,
+  type KeltnerChannelState,
+  type KeltnerChannelValue,
+} from "../volatility/keltner-channel";
 import {
   createStandardDeviation,
   type StandardDeviationState,
@@ -1004,4 +1028,195 @@ describeContract<number | null, MassIndexState>({
   streamLength: 120,
   batchCompute: (opts, candles) =>
     massIndex(candles, opts as { emaPeriod?: number; sumPeriod?: number }).map((s) => s.value),
+});
+
+// ---- Wave 3 Bundle J: Wilder smoother cluster ----
+//
+// RSI / ATR / DMI / CMO are recursive (Wilder accumulators + warmup
+// tally). ADXR / Keltner / StochRSI / Connors RSI compose them and are
+// mixed. No standalone Wilder helper is extracted — the smoothing is a
+// one-line expression and the seed phases / state shapes differ per
+// indicator, so each is migrated independently. `batchCompute` pins
+// invariant [8] across trending / flat / gap variants.
+
+// RSI — Recursive (Wilder avgGain/avgLoss + initialGains/Losses tally).
+describeContract<number | null, RsiState>({
+  name: "rsi",
+  create: (opts, warmUp) => createRsi(opts as { period?: number; source?: PriceSource }, warmUp),
+  category: "recursive",
+  version: 1,
+  defaultParams: { period: 14, source: "close" },
+  reconfigParams: [{ period: 10 }, { period: 21 }, { source: "high" }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    rsi(candles, opts as { period?: number; source?: PriceSource }).map((s) => s.value),
+});
+
+// ATR — Recursive (Wilder TR smoother + trSum tally).
+describeContract<number | null, AtrState>({
+  name: "atr",
+  create: (opts, warmUp) => createAtr(opts as { period?: number }, warmUp),
+  category: "recursive",
+  version: 1,
+  defaultParams: { period: 14 },
+  reconfigParams: [{ period: 10 }, { period: 21 }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) => atr(candles, opts as { period?: number }).map((s) => s.value),
+});
+
+// DMI — Recursive. TR/DM use the sum-form Wilder smoother, ADX uses
+// the average form. Composite output `{ plusDi, minusDi, adx }`; +DI
+// emerges before ADX, so the null predicate gates on `adx` to align
+// with `isWarmedUp` (= adx non-null).
+describeContract<DmiValue, DmiState>({
+  name: "dmi",
+  create: (opts, warmUp) => createDmi(opts as { period?: number; adxPeriod?: number }, warmUp),
+  category: "recursive",
+  version: 1,
+  defaultParams: { period: 14, adxPeriod: 14 },
+  reconfigParams: [{ period: 10 }, { adxPeriod: 21 }],
+  makeCandles,
+  streamLength: 120,
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { adx: unknown }).adx === null),
+  batchCompute: (opts, candles) =>
+    dmi(candles, opts as { period?: number; adxPeriod?: number }).map((s) => s.value),
+});
+
+// CMO — Recursive (Wilder avgUp/avgDown + initialUps/Downs tally).
+describeContract<number | null, CmoState>({
+  name: "cmo",
+  create: (opts, warmUp) => createCmo(opts as { period?: number; source?: PriceSource }, warmUp),
+  category: "recursive",
+  version: 1,
+  defaultParams: { period: 14, source: "close" },
+  reconfigParams: [{ period: 10 }, { period: 21 }, { source: "high" }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    cmo(candles, opts as { period?: number; source?: PriceSource }).map((s) => s.value),
+});
+
+// ADXR — Mixed (inner DMI snapshot + windowed ADX lag-lookback buffer).
+describeContract<number | null, AdxrState>({
+  name: "adxr",
+  create: (opts, warmUp) =>
+    createAdxr(opts as { period?: number; dmiPeriod?: number; adxPeriod?: number }, warmUp),
+  category: "mixed",
+  version: 1,
+  defaultParams: { period: 14, dmiPeriod: 14, adxPeriod: 14 },
+  reconfigParams: [{ period: 10 }, { dmiPeriod: 10 }, { adxPeriod: 21 }],
+  makeCandles,
+  streamLength: 140,
+  batchCompute: (opts, candles) =>
+    adxr(candles, opts as { period?: number; dmiPeriod?: number; adxPeriod?: number }).map(
+      (s) => s.value,
+    ),
+});
+
+// Keltner Channel — Mixed (inner EMA snapshot + inner ATR snapshot).
+// Composite output; EMA and ATR warm up together (computeValue gates
+// on both), so the default null predicate aligns with `isWarmedUp`.
+//
+// `emaPeriod` / `atrPeriod` are state-shaping → reconfig refused
+// (invariant [5]). `multiplier` is resume-invariant (param-role axis)
+// → it scales only the band width and is checked by invariant [9].
+describeContract<KeltnerChannelValue, KeltnerChannelState>({
+  name: "keltnerChannel",
+  create: (opts, warmUp) =>
+    createKeltnerChannel(
+      opts as { emaPeriod?: number; atrPeriod?: number; multiplier?: number },
+      warmUp,
+    ),
+  category: "mixed",
+  version: 1,
+  defaultParams: { emaPeriod: 20, atrPeriod: 10, multiplier: 2 },
+  reconfigParams: [{ emaPeriod: 14 }, { atrPeriod: 14 }],
+  resumeInvariantReconfig: [{ multiplier: 3 }, { multiplier: 1.5 }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    keltnerChannel(
+      candles,
+      opts as { emaPeriod?: number; atrPeriod?: number; multiplier?: number },
+    ).map((s) => s.value),
+});
+
+// StochRSI — Mixed (inline RSI accumulator + 3 windowed SMA buffers).
+// Composite output `{ stochRsi, k, d }`; stochRsi emerges first, so the
+// null predicate gates on `d` to align with `isWarmedUp`.
+describeContract<StochRsiValue, StochRsiState>({
+  name: "stochRsi",
+  create: (opts, warmUp) =>
+    createStochRsi(
+      opts as {
+        rsiPeriod?: number;
+        stochPeriod?: number;
+        kPeriod?: number;
+        dPeriod?: number;
+        source?: PriceSource;
+      },
+      warmUp,
+    ),
+  category: "mixed",
+  version: 1,
+  defaultParams: { rsiPeriod: 14, stochPeriod: 14, kPeriod: 3, dPeriod: 3, source: "close" },
+  reconfigParams: [{ rsiPeriod: 10 }, { stochPeriod: 10 }, { kPeriod: 5 }, { dPeriod: 5 }],
+  makeCandles,
+  streamLength: 120,
+  isNullishField: (v) =>
+    v === null || v === undefined || (typeof v === "object" && (v as { d: unknown }).d === null),
+  batchCompute: (opts, candles) =>
+    stochRsi(
+      candles,
+      opts as {
+        rsiPeriod?: number;
+        stochPeriod?: number;
+        kPeriod?: number;
+        dPeriod?: number;
+        source?: PriceSource;
+      },
+    ).map((s) => s.value),
+});
+
+// Connors RSI — Mixed (2 inner RSI snapshots + windowed ROC buffer +
+// streak tracker). The hand-written resume guard is replaced by the
+// mixed-category resolveResume policy. Composite output; `crsi`
+// emerges last, so the null predicate gates on it.
+describeContract<ConnorsRsiValue, ConnorsRsiState>({
+  name: "connorsRsi",
+  create: (opts, warmUp) =>
+    createConnorsRsi(
+      opts as {
+        rsiPeriod?: number;
+        streakPeriod?: number;
+        rocPeriod?: number;
+        source?: PriceSource;
+      },
+      warmUp,
+    ),
+  category: "mixed",
+  version: 1,
+  defaultParams: { rsiPeriod: 3, streakPeriod: 2, rocPeriod: 100, source: "close" },
+  reconfigParams: [{ rsiPeriod: 5 }, { streakPeriod: 3 }, { rocPeriod: 50 }, { source: "high" }],
+  makeCandles,
+  streamLength: 140,
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { crsi: unknown }).crsi === null),
+  batchCompute: (opts, candles) =>
+    connorsRsi(
+      candles,
+      opts as {
+        rsiPeriod?: number;
+        streakPeriod?: number;
+        rocPeriod?: number;
+        source?: PriceSource;
+      },
+    ).map((s) => s.value),
 });

--- a/packages/core/src/indicators/incremental/momentum/adxr.ts
+++ b/packages/core/src/indicators/incremental/momentum/adxr.ts
@@ -3,21 +3,38 @@
  *
  * ADXR = (ADX[current] + ADX[current - (period - 1)]) / 2
  * Wraps createDmi and maintains a circular buffer of ADX history.
+ *
+ * State category: **Mixed** (an inner recursive DMI snapshot plus a
+ * windowed ADX lag-lookback buffer). Resume with different params is
+ * refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import type { DmiState } from "./dmi";
 import { createDmi } from "./dmi";
 
 export type AdxrState = {
+  dmiState: IndicatorSnapshot<DmiState>;
+  adxBuffer: ReturnType<CircularBuffer<number | null>["snapshot"]>;
+  count: number;
+};
+
+export const ADXR_VERSION = 1;
+
+type AdxrParams = {
   period: number;
   dmiPeriod: number;
   adxPeriod: number;
-  dmiState: DmiState;
-  adxBuffer: ReturnType<CircularBuffer<number | null>["snapshot"]>;
-  count: number;
 };
 
 /**
@@ -34,11 +51,41 @@ export type AdxrState = {
  */
 export function createAdxr(
   options: { period?: number; dmiPeriod?: number; adxPeriod?: number } = {},
-  warmUpOptions?: WarmUpOptions<AdxrState>,
-): IncrementalIndicator<number | null, AdxrState> {
-  const period = options.period ?? 14;
-  const dmiPeriod = options.dmiPeriod ?? 14;
-  const adxPeriod = options.adxPeriod ?? 14;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<AdxrState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<AdxrState>> {
+  const { params, state } = resolveResume<AdxrParams, AdxrState>({
+    indicator: "adxr",
+    version: ADXR_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 14, dmiPeriod: 14, adxPeriod: 14 },
+  });
+
+  const period = requireParam(
+    "adxr",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const dmiPeriod = requireParam(
+    "adxr",
+    params,
+    "dmiPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const adxPeriod = requireParam(
+    "adxr",
+    params,
+    "adxPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
 
   // ADXR lookback matches TA-Lib: adx[i] + adx[i-(period-1)]
   const lookback = period - 1;
@@ -47,11 +94,10 @@ export function createAdxr(
   let adxBuffer: CircularBuffer<number | null>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    dmiInd = createDmi({ period: dmiPeriod, adxPeriod }, { fromState: s.dmiState });
-    adxBuffer = CircularBuffer.fromSnapshot(s.adxBuffer);
-    count = s.count;
+  if (state !== null) {
+    dmiInd = createDmi({ period: dmiPeriod, adxPeriod }, { fromState: state.dmiState });
+    adxBuffer = CircularBuffer.fromSnapshot(state.adxBuffer);
+    count = state.count;
   } else {
     dmiInd = createDmi({ period: dmiPeriod, adxPeriod });
     // Buffer needs to hold at least lookback+1 values to access the past ADX
@@ -70,7 +116,7 @@ export function createAdxr(
     return (currentAdx + pastAdx) / 2;
   }
 
-  const indicator: IncrementalIndicator<number | null, AdxrState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<AdxrState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const dmiResult = dmiInd.next(candle);
@@ -93,15 +139,17 @@ export function createAdxr(
       return { time: candle.time, value: (currentAdx + pastAdx) / 2 };
     },
 
-    getState(): AdxrState {
-      return {
-        period,
-        dmiPeriod,
-        adxPeriod,
-        dmiState: dmiInd.getState(),
-        adxBuffer: adxBuffer.snapshot(),
-        count,
-      };
+    getState(): IndicatorSnapshot<AdxrState> {
+      return makeSnapshot(
+        "adxr",
+        ADXR_VERSION,
+        { period, dmiPeriod, adxPeriod },
+        {
+          dmiState: dmiInd.getState(),
+          adxBuffer: adxBuffer.snapshot(),
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/cmo.ts
+++ b/packages/core/src/indicators/incremental/momentum/cmo.ts
@@ -3,21 +3,43 @@
  *
  * CMO = 100 × (AvgGain - AvgLoss) / (AvgGain + AvgLoss)
  * Uses Wilder's smoothing method (same as RSI).
+ *
+ * State category: **Recursive** (`avgUp` / `avgDown` are the recursive
+ * accumulators; `initialUps` / `initialDowns` form the warmup tally).
+ * Resume with a different `period` / `source` is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for CMO. Params (`period`, `source`) live in
+ * `meta.params` on the wire.
+ */
 export type CmoState = {
-  period: number;
-  source: PriceSource;
   prevClose: number | null;
   avgUp: number;
   avgDown: number;
   count: number;
   initialUps: number[];
   initialDowns: number[];
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const CMO_VERSION = 1;
+
+type CmoParams = {
+  period: number;
+  source: PriceSource;
 };
 
 /**
@@ -34,10 +56,28 @@ export type CmoState = {
  */
 export function createCmo(
   options: { period?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<CmoState>,
-): IncrementalIndicator<number | null, CmoState> {
-  const period = options.period ?? 14;
-  const source: PriceSource = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<CmoState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<CmoState>> {
+  const { params, state } = resolveResume<CmoParams, CmoState>({
+    indicator: "cmo",
+    version: CMO_VERSION,
+    category: "recursive",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 14, source: "close" },
+  });
+
+  const period = requireParam(
+    "cmo",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
 
   let prevClose: number | null;
   let avgUp: number;
@@ -46,14 +86,13 @@ export function createCmo(
   let initialUps: number[];
   let initialDowns: number[];
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    prevClose = s.prevClose;
-    avgUp = s.avgUp;
-    avgDown = s.avgDown;
-    count = s.count;
-    initialUps = [...s.initialUps];
-    initialDowns = [...s.initialDowns];
+  if (state !== null) {
+    prevClose = state.prevClose;
+    avgUp = state.avgUp;
+    avgDown = state.avgDown;
+    count = state.count;
+    initialUps = [...state.initialUps];
+    initialDowns = [...state.initialDowns];
   } else {
     prevClose = null;
     avgUp = 0;
@@ -68,7 +107,7 @@ export function createCmo(
     return total === 0 ? 0 : (100 * (au - ad)) / total;
   }
 
-  const indicator: IncrementalIndicator<number | null, CmoState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<CmoState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const price = getSourcePrice(candle, source);
@@ -132,17 +171,20 @@ export function createCmo(
       return { time: candle.time, value: computeCmo(peekAvgUp, peekAvgDown) };
     },
 
-    getState(): CmoState {
-      return {
-        period,
-        source,
-        prevClose,
-        avgUp,
-        avgDown,
-        count,
-        initialUps: [...initialUps],
-        initialDowns: [...initialDowns],
-      };
+    getState(): IndicatorSnapshot<CmoState> {
+      return makeSnapshot(
+        "cmo",
+        CMO_VERSION,
+        { period, source },
+        {
+          prevClose,
+          avgUp,
+          avgDown,
+          count,
+          initialUps: [...initialUps],
+          initialDowns: [...initialDowns],
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/connors-rsi.ts
+++ b/packages/core/src/indicators/incremental/momentum/connors-rsi.ts
@@ -3,16 +3,26 @@
  *
  * CRSI = (RSI(close, rsiPeriod) + RSI(streak, streakPeriod) + PercentRank(ROC(1), rocPeriod)) / 3
  *
- * State category: **Mixed/Cascaded** (two internal RSI states using
- * Wilder smoothing + a windowed ROC buffer + streak tracker). The
+ * State category: **Mixed** (two internal recursive RSI snapshots using
+ * Wilder smoothing + a windowed ROC buffer + a streak tracker). The
  * recursive RSI components permanently encode past parameters, so
  * resume requires identical `rsiPeriod`, `streakPeriod`, `rocPeriod`,
- * and `source` (or omit them and let the snapshot's params win).
+ * and `source` — enforced by the mixed-category `resolveResume` policy.
+ *
+ * Migrated to the 0.4.0 State Contract: the previous hand-written
+ * resume guard is replaced by `resolveResume`, so the refuse-on-resume
+ * behavior is now uniform with the rest of the library (§4.1).
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice, makeCandle } from "../utils";
 import type { RsiState } from "./rsi";
 import { createRsi } from "./rsi";
@@ -25,16 +35,21 @@ export type ConnorsRsiValue = {
 };
 
 export type ConnorsRsiState = {
-  rsiPeriod: number;
-  streakPeriod: number;
-  rocPeriod: number;
-  source: PriceSource;
-  priceRsiState: RsiState;
-  streakRsiState: RsiState;
+  priceRsiState: IndicatorSnapshot<RsiState>;
+  streakRsiState: IndicatorSnapshot<RsiState>;
   rocBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   prevClose: number | null;
   streak: number;
   count: number;
+};
+
+export const CONNORS_RSI_VERSION = 1;
+
+type ConnorsRsiParams = {
+  rsiPeriod: number;
+  streakPeriod: number;
+  rocPeriod: number;
+  source: PriceSource;
 };
 
 /**
@@ -56,14 +71,42 @@ export function createConnorsRsi(
     rocPeriod?: number;
     source?: PriceSource;
   } = {},
-  warmUpOptions?: WarmUpOptions<ConnorsRsiState>,
-): IncrementalIndicator<ConnorsRsiValue, ConnorsRsiState> {
-  // Resume order: explicit option > snapshot value > canonical default.
-  const fs = warmUpOptions?.fromState ?? null;
-  const rsiPeriod = options.rsiPeriod ?? fs?.rsiPeriod ?? 3;
-  const streakPeriod = options.streakPeriod ?? fs?.streakPeriod ?? 2;
-  const rocPeriod = options.rocPeriod ?? fs?.rocPeriod ?? 100;
-  const source: PriceSource = options.source ?? fs?.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<ConnorsRsiState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<ConnorsRsiValue, IndicatorSnapshot<ConnorsRsiState>> {
+  const { params, state } = resolveResume<ConnorsRsiParams, ConnorsRsiState>({
+    indicator: "connorsRsi",
+    version: CONNORS_RSI_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { rsiPeriod: 3, streakPeriod: 2, rocPeriod: 100, source: "close" },
+  });
+
+  const rsiPeriod = requireParam(
+    "connorsRsi",
+    params,
+    "rsiPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const streakPeriod = requireParam(
+    "connorsRsi",
+    params,
+    "streakPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const rocPeriod = requireParam(
+    "connorsRsi",
+    params,
+    "rocPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
 
   let priceRsi: ReturnType<typeof createRsi>;
   let streakRsi: ReturnType<typeof createRsi>;
@@ -72,26 +115,13 @@ export function createConnorsRsi(
   let streak: number;
   let count: number;
 
-  if (fs) {
-    // CRSI is Mixed/Cascaded: two internal Wilder-RSI states
-    // permanently encode past parameters. Refuse all parameter changes
-    // on resume. Pre-this-PR snapshots (no `source` field, undefined !==
-    // any string) are naturally rejected by the equality check and
-    // surface the same re-warm message.
-    if (
-      fs.rsiPeriod !== rsiPeriod ||
-      fs.streakPeriod !== streakPeriod ||
-      fs.rocPeriod !== rocPeriod ||
-      fs.source !== source
-    ) {
-      throw new Error("Connors RSI: incompatible snapshot, re-warm required");
-    }
-    priceRsi = createRsi({ period: rsiPeriod, source }, { fromState: fs.priceRsiState });
-    streakRsi = createRsi({ period: streakPeriod }, { fromState: fs.streakRsiState });
-    rocBuffer = CircularBuffer.fromSnapshot(fs.rocBuffer);
-    prevClose = fs.prevClose;
-    streak = fs.streak;
-    count = fs.count;
+  if (state !== null) {
+    priceRsi = createRsi({ period: rsiPeriod, source }, { fromState: state.priceRsiState });
+    streakRsi = createRsi({ period: streakPeriod }, { fromState: state.streakRsiState });
+    rocBuffer = CircularBuffer.fromSnapshot(state.rocBuffer);
+    prevClose = state.prevClose;
+    streak = state.streak;
+    count = state.count;
   } else {
     priceRsi = createRsi({ period: rsiPeriod, source });
     streakRsi = createRsi({ period: streakPeriod });
@@ -101,7 +131,7 @@ export function createConnorsRsi(
     count = 0;
   }
 
-  const indicator: IncrementalIndicator<ConnorsRsiValue, ConnorsRsiState> = {
+  const indicator: IncrementalIndicator<ConnorsRsiValue, IndicatorSnapshot<ConnorsRsiState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const price = getSourcePrice(candle, source);
@@ -197,19 +227,20 @@ export function createConnorsRsi(
       };
     },
 
-    getState(): ConnorsRsiState {
-      return {
-        rsiPeriod,
-        streakPeriod,
-        rocPeriod,
-        source,
-        priceRsiState: priceRsi.getState(),
-        streakRsiState: streakRsi.getState(),
-        rocBuffer: rocBuffer.snapshot(),
-        prevClose,
-        streak,
-        count,
-      };
+    getState(): IndicatorSnapshot<ConnorsRsiState> {
+      return makeSnapshot(
+        "connorsRsi",
+        CONNORS_RSI_VERSION,
+        { rsiPeriod, streakPeriod, rocPeriod, source },
+        {
+          priceRsiState: priceRsi.getState(),
+          streakRsiState: streakRsi.getState(),
+          rocBuffer: rocBuffer.snapshot(),
+          prevClose,
+          streak,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/dmi.ts
+++ b/packages/core/src/indicators/incremental/momentum/dmi.ts
@@ -3,10 +3,27 @@
  *
  * Uses Wilder's smoothing for TR, +DM, -DM and ADX computation.
  * TA-Lib compatible: TR[0]=0, first smoothed output at index=period.
+ *
+ * Note two distinct Wilder forms coexist here: the TR / +DM / -DM
+ * smoothers use the **sum form** (`prev - prev/period + current`)
+ * while the ADX smoother uses the **average form**
+ * (`(prev*(period-1) + current)/period`). Both are preserved verbatim.
+ *
+ * State category: **Recursive** (`smoothed*` and `adx` are the
+ * recursive accumulators; `initSum*` / `dxInitSum` form the warmup
+ * tallies). Resume with a different `period` / `adxPeriod` is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type DmiValue = {
   plusDi: number | null;
@@ -14,9 +31,11 @@ export type DmiValue = {
   adx: number | null;
 };
 
+/**
+ * Bare state shape for DMI. Params (`period`, `adxPeriod`) live in
+ * `meta.params` on the wire.
+ */
 export type DmiState = {
-  period: number;
-  adxPeriod: number;
   count: number;
   prevClose: number | null;
   prevHigh: number | null;
@@ -30,6 +49,14 @@ export type DmiState = {
   dxInitSum: number;
   dxValidCount: number;
   adx: number | null;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const DMI_VERSION = 1;
+
+type DmiParams = {
+  period: number;
+  adxPeriod: number;
 };
 
 /**
@@ -46,10 +73,34 @@ export type DmiState = {
  */
 export function createDmi(
   options: { period?: number; adxPeriod?: number } = {},
-  warmUpOptions?: WarmUpOptions<DmiState>,
-): IncrementalIndicator<DmiValue, DmiState> {
-  const period = options.period ?? 14;
-  const adxPeriod = options.adxPeriod ?? 14;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<DmiState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<DmiValue, IndicatorSnapshot<DmiState>> {
+  const { params, state } = resolveResume<DmiParams, DmiState>({
+    indicator: "dmi",
+    version: DMI_VERSION,
+    category: "recursive",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 14, adxPeriod: 14 },
+  });
+
+  const period = requireParam(
+    "dmi",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const adxPeriod = requireParam(
+    "dmi",
+    params,
+    "adxPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
 
   let count: number;
   let prevClose: number | null;
@@ -65,21 +116,20 @@ export function createDmi(
   let dxValidCount: number;
   let adxVal: number | null;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    count = s.count;
-    prevClose = s.prevClose;
-    prevHigh = s.prevHigh;
-    prevLow = s.prevLow;
-    initSumTr = s.initSumTr;
-    initSumPlusDm = s.initSumPlusDm;
-    initSumMinusDm = s.initSumMinusDm;
-    smoothedTr = s.smoothedTr;
-    smoothedPlusDm = s.smoothedPlusDm;
-    smoothedMinusDm = s.smoothedMinusDm;
-    dxInitSum = s.dxInitSum;
-    dxValidCount = s.dxValidCount;
-    adxVal = s.adx;
+  if (state !== null) {
+    count = state.count;
+    prevClose = state.prevClose;
+    prevHigh = state.prevHigh;
+    prevLow = state.prevLow;
+    initSumTr = state.initSumTr;
+    initSumPlusDm = state.initSumPlusDm;
+    initSumMinusDm = state.initSumMinusDm;
+    smoothedTr = state.smoothedTr;
+    smoothedPlusDm = state.smoothedPlusDm;
+    smoothedMinusDm = state.smoothedMinusDm;
+    dxInitSum = state.dxInitSum;
+    dxValidCount = state.dxValidCount;
+    adxVal = state.adx;
   } else {
     count = 0;
     prevClose = null;
@@ -202,7 +252,7 @@ export function createDmi(
     return { plusDi, minusDi, adx: currentAdx };
   }
 
-  const indicator: IncrementalIndicator<DmiValue, DmiState> = {
+  const indicator: IncrementalIndicator<DmiValue, IndicatorSnapshot<DmiState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const value = processCandle(candle);
@@ -261,24 +311,27 @@ export function createDmi(
       return { time: candle.time, value: { plusDi, minusDi, adx: currentAdx } };
     },
 
-    getState(): DmiState {
-      return {
-        period,
-        adxPeriod,
-        count,
-        prevClose,
-        prevHigh,
-        prevLow,
-        initSumTr,
-        initSumPlusDm,
-        initSumMinusDm,
-        smoothedTr,
-        smoothedPlusDm,
-        smoothedMinusDm,
-        dxInitSum,
-        dxValidCount,
-        adx: adxVal,
-      };
+    getState(): IndicatorSnapshot<DmiState> {
+      return makeSnapshot(
+        "dmi",
+        DMI_VERSION,
+        { period, adxPeriod },
+        {
+          count,
+          prevClose,
+          prevHigh,
+          prevLow,
+          initSumTr,
+          initSumPlusDm,
+          initSumMinusDm,
+          smoothedTr,
+          smoothedPlusDm,
+          smoothedMinusDm,
+          dxInitSum,
+          dxValidCount,
+          adx: adxVal,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/rsi.ts
+++ b/packages/core/src/indicators/incremental/momentum/rsi.ts
@@ -2,20 +2,48 @@
  * Incremental RSI (Relative Strength Index)
  *
  * Uses Wilder's smoothing method for consistency with batch implementation.
+ *
+ * State category: **Recursive** (`avgGain` / `avgLoss` are the recursive
+ * accumulators; `initialGains` / `initialLosses` form the warmup tally
+ * that gets baked into the averages at `count === period + 1` and is no
+ * longer consulted afterwards). Resume with a different `period` /
+ * `source` is mathematically undefined — the recursive averages are
+ * permanently conditioned on construction-time params — and is refused.
+ *
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<RsiState>` and `fromState` accepts the same.
+ * Params (`period`, `source`) now live in `meta.params`.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for RSI. Params (`period`, `source`) live in
+ * `meta.params` on the wire — they are not part of the bare state.
+ */
 export type RsiState = {
-  period: number;
   prevClose: number | null;
   avgGain: number;
   avgLoss: number;
   count: number;
   initialGains: number[];
   initialLosses: number[];
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const RSI_VERSION = 1;
+
+type RsiParams = {
+  period: number;
+  source: PriceSource;
 };
 
 /**
@@ -32,10 +60,28 @@ export type RsiState = {
  */
 export function createRsi(
   options: { period?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<RsiState>,
-): IncrementalIndicator<number | null, RsiState> {
-  const period = options.period ?? 14;
-  const source = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<RsiState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<RsiState>> {
+  const { params, state } = resolveResume<RsiParams, RsiState>({
+    indicator: "rsi",
+    version: RSI_VERSION,
+    category: "recursive",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 14, source: "close" },
+  });
+
+  const period = requireParam(
+    "rsi",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
 
   let prevClose: number | null;
   let avgGain: number;
@@ -44,14 +90,13 @@ export function createRsi(
   let initialGains: number[];
   let initialLosses: number[];
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    prevClose = s.prevClose;
-    avgGain = s.avgGain;
-    avgLoss = s.avgLoss;
-    count = s.count;
-    initialGains = [...s.initialGains];
-    initialLosses = [...s.initialLosses];
+  if (state !== null) {
+    prevClose = state.prevClose;
+    avgGain = state.avgGain;
+    avgLoss = state.avgLoss;
+    count = state.count;
+    initialGains = [...state.initialGains];
+    initialLosses = [...state.initialLosses];
   } else {
     prevClose = null;
     avgGain = 0;
@@ -68,7 +113,7 @@ export function createRsi(
     return 100 - 100 / (1 + rs);
   }
 
-  const indicator: IncrementalIndicator<number | null, RsiState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<RsiState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const price = getSourcePrice(candle, source);
@@ -142,16 +187,20 @@ export function createRsi(
       return { time: candle.time, value: computeRsi(peekAvgGain, peekAvgLoss) };
     },
 
-    getState(): RsiState {
-      return {
-        period,
-        prevClose,
-        avgGain,
-        avgLoss,
-        count,
-        initialGains: [...initialGains],
-        initialLosses: [...initialLosses],
-      };
+    getState(): IndicatorSnapshot<RsiState> {
+      return makeSnapshot(
+        "rsi",
+        RSI_VERSION,
+        { period, source },
+        {
+          prevClose,
+          avgGain,
+          avgLoss,
+          count,
+          initialGains: [...initialGains],
+          initialLosses: [...initialLosses],
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/stoch-rsi.ts
+++ b/packages/core/src/indicators/incremental/momentum/stoch-rsi.ts
@@ -8,11 +8,25 @@
  * 2. Apply Stochastic (min/max over lookback) to RSI
  * 3. Smooth with SMA for %K
  * 4. Smooth %K with SMA for %D
+ *
+ * State category: **Mixed** (an inline recursive RSI accumulator plus
+ * three windowed SMA buffers for the stochastic / %K / %D stages).
+ * Resume with different params is refused.
+ *
+ * Migrated to the 0.4.0 State Contract. The RSI stage is implemented
+ * inline (not via `createRsi`), so the bare state carries the RSI
+ * accumulators directly.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
 /**
@@ -25,13 +39,10 @@ export type StochRsiValue = {
 };
 
 /**
- * State for incremental StochRSI
+ * Bare state shape for StochRSI. Params (`rsiPeriod`, `stochPeriod`,
+ * `kPeriod`, `dPeriod`, `source`) live in `meta.params` on the wire.
  */
 export type StochRsiState = {
-  rsiPeriod: number;
-  stochPeriod: number;
-  kPeriod: number;
-  dPeriod: number;
   count: number;
   // RSI state
   prevClose: number | null;
@@ -51,6 +62,16 @@ export type StochRsiState = {
   kBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   kSum: number;
   kValidCount: number;
+};
+
+export const STOCH_RSI_VERSION = 1;
+
+type StochRsiParams = {
+  rsiPeriod: number;
+  stochPeriod: number;
+  kPeriod: number;
+  dPeriod: number;
+  source: PriceSource;
 };
 
 /**
@@ -73,13 +94,49 @@ export function createStochRsi(
     dPeriod?: number;
     source?: PriceSource;
   } = {},
-  warmUpOptions?: WarmUpOptions<StochRsiState>,
-): IncrementalIndicator<StochRsiValue, StochRsiState> {
-  const rsiPeriod = options.rsiPeriod ?? 14;
-  const stochPeriod = options.stochPeriod ?? 14;
-  const kPeriod = options.kPeriod ?? 3;
-  const dPeriod = options.dPeriod ?? 3;
-  const source: PriceSource = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<StochRsiState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<StochRsiValue, IndicatorSnapshot<StochRsiState>> {
+  const { params, state } = resolveResume<StochRsiParams, StochRsiState>({
+    indicator: "stochRsi",
+    version: STOCH_RSI_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { rsiPeriod: 14, stochPeriod: 14, kPeriod: 3, dPeriod: 3, source: "close" },
+  });
+
+  const rsiPeriod = requireParam(
+    "stochRsi",
+    params,
+    "rsiPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const stochPeriod = requireParam(
+    "stochRsi",
+    params,
+    "stochPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const kPeriod = requireParam(
+    "stochRsi",
+    params,
+    "kPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const dPeriod = requireParam(
+    "stochRsi",
+    params,
+    "dPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
 
   let count: number;
   let prevClose: number | null;
@@ -97,23 +154,22 @@ export function createStochRsi(
   let kSum: number;
   let kValidCount: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    count = s.count;
-    prevClose = s.prevClose;
-    avgGain = s.avgGain;
-    avgLoss = s.avgLoss;
-    rsiCount = s.rsiCount;
-    initialGains = [...s.initialGains];
-    initialLosses = [...s.initialLosses];
-    rsiBuffer = CircularBuffer.fromSnapshot(s.rsiBuffer);
-    rsiValidCount = s.rsiValidCount;
-    rawStochBuffer = CircularBuffer.fromSnapshot(s.rawStochBuffer);
-    rawStochSum = s.rawStochSum;
-    rawStochValidCount = s.rawStochValidCount;
-    kBuffer = CircularBuffer.fromSnapshot(s.kBuffer);
-    kSum = s.kSum;
-    kValidCount = s.kValidCount;
+  if (state !== null) {
+    count = state.count;
+    prevClose = state.prevClose;
+    avgGain = state.avgGain;
+    avgLoss = state.avgLoss;
+    rsiCount = state.rsiCount;
+    initialGains = [...state.initialGains];
+    initialLosses = [...state.initialLosses];
+    rsiBuffer = CircularBuffer.fromSnapshot(state.rsiBuffer);
+    rsiValidCount = state.rsiValidCount;
+    rawStochBuffer = CircularBuffer.fromSnapshot(state.rawStochBuffer);
+    rawStochSum = state.rawStochSum;
+    rawStochValidCount = state.rawStochValidCount;
+    kBuffer = CircularBuffer.fromSnapshot(state.kBuffer);
+    kSum = state.kSum;
+    kValidCount = state.kValidCount;
   } else {
     count = 0;
     prevClose = null;
@@ -170,6 +226,11 @@ export function createStochRsi(
       avgLoss = (avgLoss * (rsiPeriod - 1) + loss) / rsiPeriod;
     }
 
+    // Match standalone `rsi()` / `createRsi()`: a fully flat window
+    // (no gains and no losses) is neutral (50), not overbought (100).
+    // Without this branch the inline RSI diverges from batch `rsi()`
+    // — which batch `stochRsi()` consumes — on flat segments.
+    if (avgGain === 0 && avgLoss === 0) return 50;
     if (avgLoss === 0) return 100;
     const rs = avgGain / avgLoss;
     return 100 - 100 / (1 + rs);
@@ -235,7 +296,7 @@ export function createStochRsi(
     return { stochRsi: rawStoch, k: kVal, d: dVal };
   }
 
-  const indicator: IncrementalIndicator<StochRsiValue, StochRsiState> = {
+  const indicator: IncrementalIndicator<StochRsiValue, IndicatorSnapshot<StochRsiState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const rsiVal = computeRsi(getSourcePrice(candle, source));
@@ -245,51 +306,52 @@ export function createStochRsi(
 
     peek(candle: NormalizedCandle) {
       // Save state, compute, restore
-      const savedState = indicator.getState();
+      const saved = indicator.getState().state;
       const result = indicator.next(candle);
 
       // Restore state
-      count = savedState.count;
-      prevClose = savedState.prevClose;
-      avgGain = savedState.avgGain;
-      avgLoss = savedState.avgLoss;
-      rsiCount = savedState.rsiCount;
-      initialGains = [...savedState.initialGains];
-      initialLosses = [...savedState.initialLosses];
-      rsiBuffer = CircularBuffer.fromSnapshot(savedState.rsiBuffer);
-      rsiValidCount = savedState.rsiValidCount;
-      rawStochBuffer = CircularBuffer.fromSnapshot(savedState.rawStochBuffer);
-      rawStochSum = savedState.rawStochSum;
-      rawStochValidCount = savedState.rawStochValidCount;
-      kBuffer = CircularBuffer.fromSnapshot(savedState.kBuffer);
-      kSum = savedState.kSum;
-      kValidCount = savedState.kValidCount;
+      count = saved.count;
+      prevClose = saved.prevClose;
+      avgGain = saved.avgGain;
+      avgLoss = saved.avgLoss;
+      rsiCount = saved.rsiCount;
+      initialGains = [...saved.initialGains];
+      initialLosses = [...saved.initialLosses];
+      rsiBuffer = CircularBuffer.fromSnapshot(saved.rsiBuffer);
+      rsiValidCount = saved.rsiValidCount;
+      rawStochBuffer = CircularBuffer.fromSnapshot(saved.rawStochBuffer);
+      rawStochSum = saved.rawStochSum;
+      rawStochValidCount = saved.rawStochValidCount;
+      kBuffer = CircularBuffer.fromSnapshot(saved.kBuffer);
+      kSum = saved.kSum;
+      kValidCount = saved.kValidCount;
 
       return result;
     },
 
-    getState(): StochRsiState {
-      return {
-        rsiPeriod,
-        stochPeriod,
-        kPeriod,
-        dPeriod,
-        count,
-        prevClose,
-        avgGain,
-        avgLoss,
-        rsiCount,
-        initialGains: [...initialGains],
-        initialLosses: [...initialLosses],
-        rsiBuffer: rsiBuffer.snapshot(),
-        rsiValidCount,
-        rawStochBuffer: rawStochBuffer.snapshot(),
-        rawStochSum,
-        rawStochValidCount,
-        kBuffer: kBuffer.snapshot(),
-        kSum,
-        kValidCount,
-      };
+    getState(): IndicatorSnapshot<StochRsiState> {
+      return makeSnapshot(
+        "stochRsi",
+        STOCH_RSI_VERSION,
+        { rsiPeriod, stochPeriod, kPeriod, dPeriod, source },
+        {
+          count,
+          prevClose,
+          avgGain,
+          avgLoss,
+          rsiCount,
+          initialGains: [...initialGains],
+          initialLosses: [...initialLosses],
+          rsiBuffer: rsiBuffer.snapshot(),
+          rsiValidCount,
+          rawStochBuffer: rawStochBuffer.snapshot(),
+          rawStochSum,
+          rawStochValidCount,
+          kBuffer: kBuffer.snapshot(),
+          kSum,
+          kValidCount,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/price/zigzag.ts
+++ b/packages/core/src/indicators/incremental/price/zigzag.ts
@@ -12,6 +12,7 @@
  */
 
 import type { NormalizedCandle } from "../../../types";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import type { AtrState } from "../volatility/atr";
 import { createAtr } from "../volatility/atr";
@@ -37,7 +38,7 @@ export type ZigzagState = {
   firstLow: number;
   count: number;
   maxInitBars: number;
-  atrState: AtrState | null;
+  atrState: IndicatorSnapshot<AtrState> | null;
 };
 
 const nullValue: ZigzagValue = { point: null, price: null, changePercent: null };
@@ -83,7 +84,7 @@ export function createZigzag(
   let firstHigh: number;
   let firstLow: number;
   let count: number;
-  let atr: IncrementalIndicator<number | null, AtrState> | null;
+  let atr: IncrementalIndicator<number | null, IndicatorSnapshot<AtrState>> | null;
 
   if (warmUpOptions?.fromState) {
     const s = warmUpOptions.fromState;

--- a/packages/core/src/indicators/incremental/state-contract.ts
+++ b/packages/core/src/indicators/incremental/state-contract.ts
@@ -98,6 +98,22 @@ export type ResolveResumeOptions<TParams extends Record<string, unknown>, TState
    * `options` or `fromState`, and throw otherwise.
    */
   defaults: Partial<TParams>;
+  /**
+   * Params that only affect the state→output projection, never the
+   * state itself — e.g., a band-width `multiplier` in
+   * `EMA ± multiplier × ATR`. Changing one of these on resume is
+   * mathematically safe: the saved recursive / windowed state is
+   * reused verbatim and the new value takes effect immediately.
+   *
+   * This is the **param-role axis**, orthogonal to `category` (the
+   * state-structure axis): a `mixed` indicator can still have
+   * resume-invariant params. See STATE_CONTRACT.md §2.4.
+   *
+   * `source` is never eligible — it changes the input series, so the
+   * saved state corresponds to different data — and is refused even
+   * if mistakenly listed here.
+   */
+  resumeInvariantParams?: (keyof TParams & string)[];
 };
 
 /**
@@ -129,7 +145,8 @@ export type ResolveResumeOptions<TParams extends Record<string, unknown>, TState
 export function resolveResume<TParams extends Record<string, unknown>, TState>(
   opts: ResolveResumeOptions<TParams, TState>,
 ): ResolveResumeResult<TParams, TState> {
-  const { indicator, version, category, options, fromState, defaults } = opts;
+  const { indicator, version, category, options, fromState, defaults, resumeInvariantParams } =
+    opts;
 
   // Fresh start: just merge defaults + options. No snapshot to consult.
   if (!fromState) {
@@ -189,20 +206,35 @@ export function resolveResume<TParams extends Record<string, unknown>, TState>(
   // Source change is always a refuse — the input series differs, so
   // the snapshot's accumulated data (whether buffer or recursive
   // value) corresponds to a different input than the new run will see.
+  // Checked before the resume-invariant filter so `source` can never
+  // be waved through even if mistakenly listed there.
   if (changedKeys.includes("source")) {
     throw new Error(
       `${indicator}: incompatible snapshot, re-warm required (source mismatch — different source means different input series)`,
     );
   }
 
+  // Resume-invariant params (the param-role axis) only scale the
+  // state→output projection — changing them never invalidates the
+  // saved state. Drop them from the change set; the merged `params`
+  // already carries their new values.
+  const invariantSet = new Set<string>(resumeInvariantParams ?? []);
+  const stateShapingChanges = changedKeys.filter((k) => !invariantSet.has(k));
+
+  if (stateShapingChanges.length === 0) {
+    // Only resume-invariant params changed — resume the saved state
+    // verbatim, no buffer rebuild needed.
+    return { params, state: fromState.state, reconfigured: false };
+  }
+
   if (category === "windowed" || category === "event") {
     return { params, state: fromState.state, reconfigured: true };
   }
 
-  // recursive / mixed / cascaded: any param change permanently
-  // poisons the recursive accumulator(s).
+  // recursive / mixed / cascaded: any state-shaping param change
+  // permanently poisons the recursive accumulator(s).
   throw new Error(
-    `${indicator}: incompatible snapshot, re-warm required (${category} indicators cannot be reconfigured on resume; changed: ${changedKeys.join(", ")})`,
+    `${indicator}: incompatible snapshot, re-warm required (${category} indicators cannot be reconfigured on resume; changed: ${stateShapingChanges.join(", ")})`,
   );
 }
 

--- a/packages/core/src/indicators/incremental/trend/supertrend.ts
+++ b/packages/core/src/indicators/incremental/trend/supertrend.ts
@@ -5,6 +5,7 @@
  */
 
 import type { NormalizedCandle } from "../../../types";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import type { AtrState } from "../volatility/atr";
 import { createAtr } from "../volatility/atr";
@@ -19,7 +20,7 @@ export type SupertrendValue = {
 export type SupertrendState = {
   period: number;
   multiplier: number;
-  atrState: AtrState;
+  atrState: IndicatorSnapshot<AtrState>;
   prevFinalUpper: number | null;
   prevFinalLower: number | null;
   prevClose: number | null;

--- a/packages/core/src/indicators/incremental/volatility/atr-stops.ts
+++ b/packages/core/src/indicators/incremental/volatility/atr-stops.ts
@@ -6,11 +6,12 @@
  */
 
 import type { AtrStopsValue, NormalizedCandle } from "../../../types";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import { type AtrState, createAtr } from "./atr";
 
 export type AtrStopsState = {
-  atrState: AtrState;
+  atrState: IndicatorSnapshot<AtrState>;
   period: number;
   stopMultiplier: number;
   takeProfitMultiplier: number;
@@ -53,7 +54,7 @@ export function createAtrStops(
   const takeProfitMultiplier = options.takeProfitMultiplier ?? 3.0;
 
   let count: number;
-  let atr: IncrementalIndicator<number | null, AtrState>;
+  let atr: IncrementalIndicator<number | null, IndicatorSnapshot<AtrState>>;
 
   if (warmUpOptions?.fromState) {
     const s = warmUpOptions.fromState;

--- a/packages/core/src/indicators/incremental/volatility/atr.ts
+++ b/packages/core/src/indicators/incremental/volatility/atr.ts
@@ -2,17 +2,40 @@
  * Incremental ATR (Average True Range)
  *
  * Uses Wilder's smoothing method for consistency with batch implementation.
+ *
+ * State category: **Recursive** (`atr` is the recursive accumulator;
+ * `trSum` is the warmup tally baked into the first ATR at
+ * `count === period + 1`). Resume with a different `period` is
+ * mathematically undefined and refused.
+ *
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<AtrState>` and `fromState` accepts the same.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
+/**
+ * Bare state shape for ATR. Param (`period`) lives in `meta.params`.
+ */
 export type AtrState = {
-  period: number;
   prevClose: number | null;
   atr: number | null;
   trSum: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const ATR_VERSION = 1;
+
+type AtrParams = {
+  period: number;
 };
 
 /**
@@ -29,21 +52,38 @@ export type AtrState = {
  */
 export function createAtr(
   options: { period?: number } = {},
-  warmUpOptions?: WarmUpOptions<AtrState>,
-): IncrementalIndicator<number | null, AtrState> {
-  const period = options.period ?? 14;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<AtrState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<AtrState>> {
+  const { params, state } = resolveResume<AtrParams, AtrState>({
+    indicator: "atr",
+    version: ATR_VERSION,
+    category: "recursive",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 14 },
+  });
+
+  const period = requireParam(
+    "atr",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
 
   let prevClose: number | null;
   let atrValue: number | null;
   let trSum: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    prevClose = s.prevClose;
-    atrValue = s.atr;
-    trSum = s.trSum;
-    count = s.count;
+  if (state !== null) {
+    prevClose = state.prevClose;
+    atrValue = state.atr;
+    trSum = state.trSum;
+    count = state.count;
   } else {
     prevClose = null;
     atrValue = null;
@@ -59,7 +99,7 @@ export function createAtr(
     );
   }
 
-  const indicator: IncrementalIndicator<number | null, AtrState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<AtrState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -107,8 +147,13 @@ export function createAtr(
       return { time: candle.time, value: peekAtr };
     },
 
-    getState(): AtrState {
-      return { period, prevClose, atr: atrValue, trSum, count };
+    getState(): IndicatorSnapshot<AtrState> {
+      return makeSnapshot(
+        "atr",
+        ATR_VERSION,
+        { period },
+        { prevClose, atr: atrValue, trSum, count },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/volatility/chandelier-exit.ts
+++ b/packages/core/src/indicators/incremental/volatility/chandelier-exit.ts
@@ -7,6 +7,7 @@
 
 import type { ChandelierExitValue, NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
+import type { IndicatorSnapshot } from "../state-contract";
 import type { IncrementalIndicator, WarmUpOptions } from "../types";
 import type { AtrState } from "./atr";
 import { createAtr } from "./atr";
@@ -15,7 +16,7 @@ export type ChandelierExitState = {
   period: number;
   multiplier: number;
   hlLookback: number;
-  atrState: AtrState;
+  atrState: IndicatorSnapshot<AtrState>;
   highBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   lowBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   prevDirection: 1 | -1 | 0;

--- a/packages/core/src/indicators/incremental/volatility/keltner-channel.ts
+++ b/packages/core/src/indicators/incremental/volatility/keltner-channel.ts
@@ -5,12 +5,28 @@
  * Middle Band = EMA(close)
  * Upper Band = EMA + multiplier × ATR
  * Lower Band = EMA - multiplier × ATR
+ *
+ * State category: **Mixed** (an inner recursive EMA snapshot and an
+ * inner recursive ATR snapshot, composed in parallel). Resume with a
+ * different `emaPeriod` / `atrPeriod` is refused.
+ *
+ * `multiplier` is a **resume-invariant param**: it only scales the
+ * final `EMA ± multiplier × ATR` band width and never touches the
+ * inner EMA / ATR state. Changing it on resume is mathematically safe
+ * and stays supported (parity with 0.3.x). See STATE_CONTRACT.md §2.4.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { createEma, type EmaState } from "../moving-average/ema";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { type AtrState, createAtr } from "../volatility/atr";
 
 /**
@@ -23,15 +39,21 @@ export type KeltnerChannelValue = {
 };
 
 /**
- * State for incremental Keltner Channel
+ * Bare state shape for Keltner Channel. Params (`emaPeriod`,
+ * `atrPeriod`, `multiplier`) live in `meta.params` on the wire.
  */
 export type KeltnerChannelState = {
+  emaState: IndicatorSnapshot<EmaState>;
+  atrState: IndicatorSnapshot<AtrState>;
+  count: number;
+};
+
+export const KELTNER_CHANNEL_VERSION = 1;
+
+type KeltnerChannelParams = {
   emaPeriod: number;
   atrPeriod: number;
   multiplier: number;
-  emaState: IndicatorSnapshot<EmaState>;
-  atrState: AtrState;
-  count: number;
 };
 
 /**
@@ -48,21 +70,51 @@ export type KeltnerChannelState = {
  */
 export function createKeltnerChannel(
   options: { emaPeriod?: number; atrPeriod?: number; multiplier?: number } = {},
-  warmUpOptions?: WarmUpOptions<KeltnerChannelState>,
-): IncrementalIndicator<KeltnerChannelValue, KeltnerChannelState> {
-  const emaPeriod = options.emaPeriod ?? 20;
-  const atrPeriod = options.atrPeriod ?? 10;
-  const multiplier = options.multiplier ?? 2;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<KeltnerChannelState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<KeltnerChannelValue, IndicatorSnapshot<KeltnerChannelState>> {
+  const { params, state } = resolveResume<KeltnerChannelParams, KeltnerChannelState>({
+    indicator: "keltnerChannel",
+    version: KELTNER_CHANNEL_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { emaPeriod: 20, atrPeriod: 10, multiplier: 2 },
+    resumeInvariantParams: ["multiplier"],
+  });
+
+  const emaPeriod = requireParam(
+    "keltnerChannel",
+    params,
+    "emaPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const atrPeriod = requireParam(
+    "keltnerChannel",
+    params,
+    "atrPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const multiplier = requireParam(
+    "keltnerChannel",
+    params,
+    "multiplier",
+    (v): v is number => typeof v === "number" && Number.isFinite(v) && v > 0,
+    "must be a positive number",
+  );
 
   let emaInd: IncrementalIndicator<number | null, IndicatorSnapshot<EmaState>>;
-  let atrInd: IncrementalIndicator<number | null, AtrState>;
+  let atrInd: IncrementalIndicator<number | null, IndicatorSnapshot<AtrState>>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    emaInd = createEma({ period: emaPeriod, source: "close" }, { fromState: s.emaState });
-    atrInd = createAtr({ period: atrPeriod }, { fromState: s.atrState });
-    count = s.count;
+  if (state !== null) {
+    emaInd = createEma({ period: emaPeriod, source: "close" }, { fromState: state.emaState });
+    atrInd = createAtr({ period: atrPeriod }, { fromState: state.atrState });
+    count = state.count;
   } else {
     emaInd = createEma({ period: emaPeriod, source: "close" });
     atrInd = createAtr({ period: atrPeriod });
@@ -81,7 +133,10 @@ export function createKeltnerChannel(
     };
   }
 
-  const indicator: IncrementalIndicator<KeltnerChannelValue, KeltnerChannelState> = {
+  const indicator: IncrementalIndicator<
+    KeltnerChannelValue,
+    IndicatorSnapshot<KeltnerChannelState>
+  > = {
     next(candle: NormalizedCandle) {
       count++;
       const emaResult = emaInd.next(candle);
@@ -97,15 +152,17 @@ export function createKeltnerChannel(
       return { time: candle.time, value };
     },
 
-    getState(): KeltnerChannelState {
-      return {
-        emaPeriod,
-        atrPeriod,
-        multiplier,
-        emaState: emaInd.getState(),
-        atrState: atrInd.getState(),
-        count,
-      };
+    getState(): IndicatorSnapshot<KeltnerChannelState> {
+      return makeSnapshot(
+        "keltnerChannel",
+        KELTNER_CHANNEL_VERSION,
+        { emaPeriod, atrPeriod, multiplier },
+        {
+          emaState: emaInd.getState(),
+          atrState: atrInd.getState(),
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/volatility/regime.ts
+++ b/packages/core/src/indicators/incremental/volatility/regime.ts
@@ -36,9 +36,9 @@ export type RegimeState = {
   bbPeriod: number;
   dmiPeriod: number;
   lookback: number;
-  atrState: AtrState;
+  atrState: IndicatorSnapshot<AtrState>;
   bbState: BollingerBandsState;
-  dmiState: DmiState;
+  dmiState: IndicatorSnapshot<DmiState>;
   smaState: IndicatorSnapshot<SmaState>;
   atrBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   bwBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
@@ -98,7 +98,7 @@ export function createRegime(
   const dmiPeriod = options.dmiPeriod ?? 14;
   const lookback = options.lookback ?? 100;
 
-  let atrInd: IncrementalIndicator<number | null, AtrState>;
+  let atrInd: IncrementalIndicator<number | null, IndicatorSnapshot<AtrState>>;
   let bbInd: IncrementalIndicator<
     {
       upper: number | null;

--- a/packages/core/src/indicators/incremental/wyckoff/vsa.ts
+++ b/packages/core/src/indicators/incremental/wyckoff/vsa.ts
@@ -54,7 +54,7 @@ type CandleEntry = {
 };
 
 export type VsaState = {
-  atrState: AtrState;
+  atrState: IndicatorSnapshot<AtrState>;
   volumeSmaState: IndicatorSnapshot<SmaState>;
   candleBuffer: ReturnType<CircularBuffer<CandleEntry>["snapshot"]>;
   volumeMaPeriod: number;


### PR DESCRIPTION
## Summary

Wave 3 Bundle J migrates the Wilder smoother cluster to the 0.4.0 State Contract and introduces the **param-role axis**.

### Migrated (8)

- **Recursive**: RSI, ATR, DMI, CMO — Wilder accumulators + warmup tally.
- **Mixed**: ADXR, Keltner Channel, StochRSI, Connors RSI — compose the above.

No standalone Wilder helper is extracted: the smoothing is a one-line expression and the seed phases / state shapes differ per indicator (DMI alone mixes the sum-form Wilder smoother for TR/DM and the average-form for ADX). Connors RSI's hand-written resume guard is replaced by the mixed-category `resolveResume` policy.

### Type cascade (6, opaque pass-through)

`supertrend`, `atrStops`, `chandelierExit`, `zigzag`, `regime`, `vsa` embed ATR/DMI state — their nested fields get the `IndicatorSnapshot<...>` type. No behavioral change; they migrate fully in Bundle L.

### Param-role axis (new)

`resolveResume` gains `resumeInvariantParams` — a second classification axis orthogonal to the five state-structure categories. Params that scale only the state→output projection (e.g. Keltner's band-width `multiplier` in `EMA ± multiplier × ATR`) never touch state, so changing them on resume is mathematically safe even for `mixed` indicators. This restores 0.3.x parity for multiplier-only Keltner resumes. Documented in STATE_CONTRACT.md §2.4; verified by the new contract DSL invariant [9].

## Intended breaking — pre-0.4.0 nested snapshots

Resuming a pre-0.4.0 snapshot of the 6 parents above now throws a leaf-scoped `incompatible snapshot` error from the inner ATR/DMI. This is the **intended behavior** documented in STATE_CONTRACT.md §5.4 (legacy nested snapshots) and §5.3 — per-wrapper legacy guards are deliberately not added (§4.1). When the parents migrate in Bundle L, the throw moves to parent scope. The error is a loud throw; there is no silent corruption.

## Latent drift fixed

Invariant [8] (batch/incremental parity) surfaced one drift: StochRSI's inline RSI returned 100 for a fully flat window, where standalone `rsi()` — which batch `stochRsi()` consumes — returns the neutral 50. Aligned with a one-line branch and pinned by the parity gate.

## Test plan

- [x] `pnpm test` — 5513 passing (invariant [9] included)
- [x] `pnpm lint` — clean
- [x] `pnpm build` — success
- [x] `tsc --noEmit --ignoreDeprecations 6.0` — pre-existing errors only, 0 new