### PR TITLE
feat(core)!: migrate Mixed / own-EMA indicators to State Contract (Wave 3 Bundle K)

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
@@ -445,8 +445,8 @@ describe("HMA (Hull Moving Average)", () => {
     const state = hma1.getState();
 
     const hma2 = createHma({}, { fromState: state });
-    expect(hma2.getState().period).toBe(16);
-    expect(hma2.getState().source).toBe("high");
+    expect(hma2.getState().meta.params.period).toBe(16);
+    expect(hma2.getState().meta.params.source).toBe("high");
   });
 
   it("refuses resume with a different period", () => {
@@ -1235,16 +1235,16 @@ describe("KAMA adapts smoothing constant based on price efficiency", () => {
   // Resume contract: KAMA is Mixed (price buffer + recursive prevKama).
   // The recursive component permanently encodes past parameters so
   // reconfiguring on resume is refused.
-  it("fromState restores period / source / fastSC / slowSC when options are omitted", () => {
+  it("fromState restores period / fastPeriod / slowPeriod / source when options are omitted", () => {
     const k1 = createKama({ period: 10, fastPeriod: 2, slowPeriod: 30, source: "high" });
     for (let i = 0; i < 15; i++) k1.next(makeCandle(i));
     const state = k1.getState();
 
     const k2 = createKama({}, { fromState: state });
-    expect(k2.getState().period).toBe(10);
-    expect(k2.getState().source).toBe("high");
-    expect(k2.getState().fastSC).toBe(2 / 3);
-    expect(k2.getState().slowSC).toBe(2 / 31);
+    expect(k2.getState().meta.params.period).toBe(10);
+    expect(k2.getState().meta.params.source).toBe("high");
+    expect(k2.getState().meta.params.fastPeriod).toBe(2);
+    expect(k2.getState().meta.params.slowPeriod).toBe(30);
   });
 
   it("refuses resume with a different period", () => {

--- a/packages/core/src/indicators/incremental/__tests__/momentum-indicators.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/momentum-indicators.test.ts
@@ -385,11 +385,11 @@ describe("STC incremental", () => {
     const state = s1.getState();
 
     const s2 = createStc({}, { fromState: state });
-    expect(s2.getState().fastPeriod).toBe(12);
-    expect(s2.getState().slowPeriod).toBe(26);
-    expect(s2.getState().cyclePeriod).toBe(7);
-    expect(s2.getState().factor).toBe(0.4);
-    expect(s2.getState().source).toBe("high");
+    expect(s2.getState().meta.params.fastPeriod).toBe(12);
+    expect(s2.getState().meta.params.slowPeriod).toBe(26);
+    expect(s2.getState().meta.params.cyclePeriod).toBe(7);
+    expect(s2.getState().meta.params.factor).toBe(0.4);
+    expect(s2.getState().meta.params.source).toBe("high");
   });
 
   it("refuses resume with a different fastPeriod", () => {
@@ -440,15 +440,15 @@ describe("STC incremental", () => {
 
   // Validation must match the batch indicator's so the same options
   // object behaves identically across both APIs.
-  it("rejects invalid factor (<=0 or >1) just like the batch indicator", () => {
-    expect(() => createStc({ factor: 0 })).toThrow(/factor must be in/);
-    expect(() => createStc({ factor: -0.1 })).toThrow(/factor must be in/);
-    expect(() => createStc({ factor: 1.5 })).toThrow(/factor must be in/);
+  it("rejects invalid factor (<=0 or >1) via the State Contract requireParam check", () => {
+    expect(() => createStc({ factor: 0 })).toThrow(/"factor" failed validation/);
+    expect(() => createStc({ factor: -0.1 })).toThrow(/"factor" failed validation/);
+    expect(() => createStc({ factor: 1.5 })).toThrow(/"factor" failed validation/);
   });
 
-  it("rejects invalid periods (<1) just like the batch indicator", () => {
-    expect(() => createStc({ fastPeriod: 0 })).toThrow(/periods must be at least 1/);
-    expect(() => createStc({ slowPeriod: 0 })).toThrow(/periods must be at least 1/);
-    expect(() => createStc({ cyclePeriod: 0 })).toThrow(/periods must be at least 1/);
+  it("rejects invalid periods (<1) via the State Contract requireParam check", () => {
+    expect(() => createStc({ fastPeriod: 0 })).toThrow(/"fastPeriod" failed validation/);
+    expect(() => createStc({ slowPeriod: 0 })).toThrow(/"slowPeriod" failed validation/);
+    expect(() => createStc({ cyclePeriod: 0 })).toThrow(/"cyclePeriod" failed validation/);
   });
 });

--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -14,12 +14,16 @@
 
 import { describe, expect, it } from "vitest";
 import { CRYPTO_CALENDAR, JPX_CALENDAR } from "../../../calendar";
-import type { NormalizedCandle, PriceSource } from "../../../types";
+import type { MacdValue, NormalizedCandle, PriceSource } from "../../../types";
 import { adxr } from "../../momentum/adxr";
 import { cmo } from "../../momentum/cmo";
 import { connorsRsi } from "../../momentum/connors-rsi";
+import { coppockCurve } from "../../momentum/coppock-curve";
 import { dmi } from "../../momentum/dmi";
+import { macd } from "../../momentum/macd";
 import { massIndex } from "../../momentum/mass-index";
+import { ppo } from "../../momentum/ppo";
+import { roc } from "../../momentum/roc";
 import { rsi } from "../../momentum/rsi";
 import { stochRsi } from "../../momentum/stoch-rsi";
 import { trix } from "../../momentum/trix";
@@ -28,6 +32,9 @@ import { alma } from "../../moving-average/alma";
 import { dema } from "../../moving-average/dema";
 import { ema } from "../../moving-average/ema";
 import { emaRibbon } from "../../moving-average/ema-ribbon";
+import { frama } from "../../moving-average/frama";
+import { hma } from "../../moving-average/hma";
+import { kama } from "../../moving-average/kama";
 import { mcginleyDynamic } from "../../moving-average/mcginley-dynamic";
 import { sma } from "../../moving-average/sma";
 import { t3 } from "../../moving-average/t3";
@@ -37,6 +44,7 @@ import { wma } from "../../moving-average/wma";
 import { zlema } from "../../moving-average/zlema";
 import { highest, lowest } from "../../price/highest-lowest";
 import { returns as returnsBatch } from "../../price/returns";
+import { schaffTrendCycle } from "../../trend/schaff-trend-cycle";
 import { atr } from "../../volatility/atr";
 import { choppinessIndex } from "../../volatility/choppiness-index";
 import { donchianChannel } from "../../volatility/donchian-channel";
@@ -59,9 +67,14 @@ import {
   type ConnorsRsiValue,
   createConnorsRsi,
 } from "../momentum/connors-rsi";
+import { type CoppockCurveState, createCoppockCurve } from "../momentum/coppock-curve";
 import { createDmi, type DmiState, type DmiValue } from "../momentum/dmi";
+import { createMacd, type MacdState } from "../momentum/macd";
 import { createMassIndex, type MassIndexState } from "../momentum/mass-index";
+import { createPpo, type PpoState, type PpoValue } from "../momentum/ppo";
+import { createRoc, type RocState } from "../momentum/roc";
 import { createRsi, type RsiState } from "../momentum/rsi";
+import { createStc, type StcState } from "../momentum/schaff-trend-cycle";
 import { createStochRsi, type StochRsiState, type StochRsiValue } from "../momentum/stoch-rsi";
 import { createTrix, type TrixState, type TrixValue } from "../momentum/trix";
 import { createTsi, type TsiState, type TsiValue } from "../momentum/tsi";
@@ -73,6 +86,9 @@ import {
   type EmaRibbonState,
   type EmaRibbonValue,
 } from "../moving-average/ema-ribbon";
+import { createFrama, type FramaState } from "../moving-average/frama";
+import { createHma, type HmaState } from "../moving-average/hma";
+import { createKama, type KamaState } from "../moving-average/kama";
 import {
   createMcGinleyDynamic,
   type McGinleyDynamicState,
@@ -1216,6 +1232,223 @@ describeContract<ConnorsRsiValue, ConnorsRsiState>({
         rsiPeriod?: number;
         streakPeriod?: number;
         rocPeriod?: number;
+        source?: PriceSource;
+      },
+    ).map((s) => s.value),
+});
+
+// ---- Wave 3 Bundle K: Mixed + own-EMA indicators ----
+//
+// ROC is Windowed (price buffer carry-forward). FRAMA / KAMA are Mixed,
+// HMA / Coppock Curve / MACD / PPO / Schaff Trend Cycle are Cascaded.
+// MACD / PPO / STC keep their own inline EMA logic (no createEma) with
+// derived multipliers dropped from bare state. `batchCompute` pins
+// invariant [8].
+
+// ROC — Windowed (period+1 price buffer; carry-forward on reconfig).
+describeContract<number | null, RocState>({
+  name: "roc",
+  create: (opts, warmUp) => createRoc(opts as { period?: number; source?: PriceSource }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 12, source: "close" },
+  reconfigParams: [{ period: 8 }, { period: 20 }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    roc(candles, opts as { period?: number; source?: PriceSource }).map((s) => s.value),
+});
+
+// FRAMA — Mixed (high/low buffers for fractal dimension + recursive
+// prevFrama). Resume with a different period/source is refused.
+describeContract<number | null, FramaState>({
+  name: "frama",
+  create: (opts, warmUp) => createFrama(opts as { period?: number; source?: PriceSource }, warmUp),
+  category: "mixed",
+  version: 1,
+  defaultParams: { period: 16, source: "close" },
+  reconfigParams: [{ period: 10 }, { period: 20 }, { source: "high" }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    frama(candles, opts as { period?: number; source?: PriceSource }).map((s) => s.value),
+});
+
+// KAMA — Mixed (price buffer for ER + recursive prevKama). fastSC /
+// slowSC are derived from fastPeriod / slowPeriod.
+describeContract<number | null, KamaState>({
+  name: "kama",
+  create: (opts, warmUp) =>
+    createKama(
+      opts as { period?: number; fastPeriod?: number; slowPeriod?: number; source?: PriceSource },
+      warmUp,
+    ),
+  category: "mixed",
+  version: 1,
+  defaultParams: { period: 10, fastPeriod: 2, slowPeriod: 30, source: "close" },
+  reconfigParams: [{ period: 8 }, { fastPeriod: 3 }, { slowPeriod: 20 }, { source: "high" }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    kama(
+      candles,
+      opts as { period?: number; fastPeriod?: number; slowPeriod?: number; source?: PriceSource },
+    ).map((s) => s.value),
+});
+
+// HMA — Cascaded (3 stacked WMAs).
+describeContract<number | null, HmaState>({
+  name: "hma",
+  create: (opts, warmUp) => createHma(opts as { period?: number; source?: PriceSource }, warmUp),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { period: 9, source: "close" },
+  reconfigParams: [{ period: 16 }, { period: 25 }, { source: "high" }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    hma(candles, opts as { period?: number; source?: PriceSource }).map((s) => s.value),
+});
+
+// Coppock Curve — Cascaded (2 ROC stages → WMA).
+describeContract<number | null, CoppockCurveState>({
+  name: "coppockCurve",
+  create: (opts, warmUp) =>
+    createCoppockCurve(
+      opts as {
+        wmaPeriod?: number;
+        longRocPeriod?: number;
+        shortRocPeriod?: number;
+        source?: PriceSource;
+      },
+      warmUp,
+    ),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { wmaPeriod: 10, longRocPeriod: 14, shortRocPeriod: 11, source: "close" },
+  reconfigParams: [{ wmaPeriod: 8 }, { longRocPeriod: 10 }, { shortRocPeriod: 8 }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    coppockCurve(
+      candles,
+      opts as {
+        wmaPeriod?: number;
+        longRocPeriod?: number;
+        shortRocPeriod?: number;
+        source?: PriceSource;
+      },
+    ).map((s) => s.value),
+});
+
+// MACD — Cascaded (own inline EMA logic). Composite `{ macd, signal,
+// histogram }`; macd emerges before signal, so the null predicate
+// gates on `signal` to align with `isWarmedUp`.
+describeContract<MacdValue, MacdState>({
+  name: "macd",
+  create: (opts, warmUp) =>
+    createMacd(
+      opts as {
+        fastPeriod?: number;
+        slowPeriod?: number;
+        signalPeriod?: number;
+        source?: PriceSource;
+      },
+      warmUp,
+    ),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { fastPeriod: 12, slowPeriod: 26, signalPeriod: 9, source: "close" },
+  reconfigParams: [{ fastPeriod: 10 }, { slowPeriod: 20 }, { signalPeriod: 5 }],
+  makeCandles,
+  streamLength: 120,
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { signal: unknown }).signal === null),
+  batchCompute: (opts, candles) =>
+    macd(
+      candles,
+      opts as {
+        fastPeriod?: number;
+        slowPeriod?: number;
+        signalPeriod?: number;
+        source?: PriceSource;
+      },
+    ).map((s) => s.value),
+});
+
+// PPO — Cascaded (own inline EMA logic). Composite `{ ppo, signal,
+// histogram } | null`; gates on `signal` like MACD.
+describeContract<PpoValue | null, PpoState>({
+  name: "ppo",
+  create: (opts, warmUp) =>
+    createPpo(
+      opts as {
+        fastPeriod?: number;
+        slowPeriod?: number;
+        signalPeriod?: number;
+        source?: PriceSource;
+      },
+      warmUp,
+    ),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { fastPeriod: 12, slowPeriod: 26, signalPeriod: 9, source: "close" },
+  reconfigParams: [{ fastPeriod: 10 }, { slowPeriod: 20 }, { signalPeriod: 5 }],
+  makeCandles,
+  streamLength: 120,
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { signal: unknown }).signal === null),
+  batchCompute: (opts, candles) =>
+    ppo(
+      candles,
+      opts as {
+        fastPeriod?: number;
+        slowPeriod?: number;
+        signalPeriod?: number;
+        source?: PriceSource;
+      },
+    ).map((s) => s.value),
+});
+
+// Schaff Trend Cycle — Cascaded (2 inline EMAs + 2 recursive stochastic
+// smoothings + 2 windowed buffers).
+describeContract<number | null, StcState>({
+  name: "stc",
+  create: (opts, warmUp) =>
+    createStc(
+      opts as {
+        fastPeriod?: number;
+        slowPeriod?: number;
+        cyclePeriod?: number;
+        factor?: number;
+        source?: PriceSource;
+      },
+      warmUp,
+    ),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { fastPeriod: 23, slowPeriod: 50, cyclePeriod: 10, factor: 0.5, source: "close" },
+  reconfigParams: [
+    { fastPeriod: 12 },
+    { slowPeriod: 30 },
+    { cyclePeriod: 7 },
+    { factor: 0.4 },
+    { source: "high" },
+  ],
+  makeCandles,
+  streamLength: 160,
+  batchCompute: (opts, candles) =>
+    schaffTrendCycle(
+      candles,
+      opts as {
+        fastPeriod?: number;
+        slowPeriod?: number;
+        cyclePeriod?: number;
+        factor?: number;
         source?: PriceSource;
       },
     ).map((s) => s.value),

--- a/packages/core/src/indicators/incremental/momentum/coppock-curve.ts
+++ b/packages/core/src/indicators/incremental/momentum/coppock-curve.ts
@@ -6,30 +6,42 @@
  * A momentum indicator originally designed for long-term monthly charts.
  * Buy signals occur when the Coppock Curve turns up from below zero.
  *
- * Composes: 2x ROC (long + short) + 1x WMA
+ * State category: **Cascaded** (two ROC stages feeding a WMA). Resume
+ * with a different `wmaPeriod` / `longRocPeriod` / `shortRocPeriod` /
+ * `source` is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import type { WmaState } from "../moving-average/wma";
 import { createWma } from "../moving-average/wma";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { makeCandle } from "../utils";
 import type { RocState } from "./roc";
 import { createRoc } from "./roc";
 
-/**
- * State for incremental Coppock Curve
- */
 export type CoppockCurveState = {
+  longRocState: IndicatorSnapshot<RocState>;
+  shortRocState: IndicatorSnapshot<RocState>;
+  wmaState: IndicatorSnapshot<WmaState>;
+  count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const COPPOCK_CURVE_VERSION = 1;
+
+type CoppockCurveParams = {
   wmaPeriod: number;
   longRocPeriod: number;
   shortRocPeriod: number;
   source: PriceSource;
-  longRocState: RocState;
-  shortRocState: RocState;
-  wmaState: IndicatorSnapshot<WmaState>;
-  count: number;
 };
 
 /**
@@ -51,24 +63,53 @@ export function createCoppockCurve(
     shortRocPeriod?: number;
     source?: PriceSource;
   } = {},
-  warmUpOptions?: WarmUpOptions<CoppockCurveState>,
-): IncrementalIndicator<number | null, CoppockCurveState> {
-  const wmaPeriod = options.wmaPeriod ?? 10;
-  const longRocPeriod = options.longRocPeriod ?? 14;
-  const shortRocPeriod = options.shortRocPeriod ?? 11;
-  const source: PriceSource = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<CoppockCurveState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<CoppockCurveState>> {
+  const { params, state } = resolveResume<CoppockCurveParams, CoppockCurveState>({
+    indicator: "coppockCurve",
+    version: COPPOCK_CURVE_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { wmaPeriod: 10, longRocPeriod: 14, shortRocPeriod: 11, source: "close" },
+  });
+
+  const wmaPeriod = requireParam(
+    "coppockCurve",
+    params,
+    "wmaPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const longRocPeriod = requireParam(
+    "coppockCurve",
+    params,
+    "longRocPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const shortRocPeriod = requireParam(
+    "coppockCurve",
+    params,
+    "shortRocPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
 
   let longRoc: ReturnType<typeof createRoc>;
   let shortRoc: ReturnType<typeof createRoc>;
   let wma: ReturnType<typeof createWma>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    longRoc = createRoc({ period: longRocPeriod, source }, { fromState: s.longRocState });
-    shortRoc = createRoc({ period: shortRocPeriod, source }, { fromState: s.shortRocState });
-    wma = createWma({ period: wmaPeriod }, { fromState: s.wmaState });
-    count = s.count;
+  if (state !== null) {
+    longRoc = createRoc({ period: longRocPeriod, source }, { fromState: state.longRocState });
+    shortRoc = createRoc({ period: shortRocPeriod, source }, { fromState: state.shortRocState });
+    wma = createWma({ period: wmaPeriod }, { fromState: state.wmaState });
+    count = state.count;
   } else {
     longRoc = createRoc({ period: longRocPeriod, source });
     shortRoc = createRoc({ period: shortRocPeriod, source });
@@ -76,7 +117,7 @@ export function createCoppockCurve(
     count = 0;
   }
 
-  const indicator: IncrementalIndicator<number | null, CoppockCurveState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<CoppockCurveState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -105,17 +146,18 @@ export function createCoppockCurve(
       return { time: candle.time, value: null };
     },
 
-    getState(): CoppockCurveState {
-      return {
-        wmaPeriod,
-        longRocPeriod,
-        shortRocPeriod,
-        source,
-        longRocState: longRoc.getState(),
-        shortRocState: shortRoc.getState(),
-        wmaState: wma.getState(),
-        count,
-      };
+    getState(): IndicatorSnapshot<CoppockCurveState> {
+      return makeSnapshot(
+        "coppockCurve",
+        COPPOCK_CURVE_VERSION,
+        { wmaPeriod, longRocPeriod, shortRocPeriod, source },
+        {
+          longRocState: longRoc.getState(),
+          shortRocState: shortRoc.getState(),
+          wmaState: wma.getState(),
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/kst.ts
+++ b/packages/core/src/indicators/incremental/momentum/kst.ts
@@ -23,7 +23,12 @@ export type KstValue = {
 };
 
 export type KstState = {
-  rocStates: [RocState, RocState, RocState, RocState];
+  rocStates: [
+    IndicatorSnapshot<RocState>,
+    IndicatorSnapshot<RocState>,
+    IndicatorSnapshot<RocState>,
+    IndicatorSnapshot<RocState>,
+  ];
   smaStates: [
     IndicatorSnapshot<SmaState>,
     IndicatorSnapshot<SmaState>,
@@ -174,7 +179,12 @@ export function createKst(
 
     getState(): KstState {
       return {
-        rocStates: rocs.map((r) => r.getState()) as [RocState, RocState, RocState, RocState],
+        rocStates: rocs.map((r) => r.getState()) as [
+          IndicatorSnapshot<RocState>,
+          IndicatorSnapshot<RocState>,
+          IndicatorSnapshot<RocState>,
+          IndicatorSnapshot<RocState>,
+        ],
         smaStates: smas.map((s) => s.getState()) as [
           IndicatorSnapshot<SmaState>,
           IndicatorSnapshot<SmaState>,

--- a/packages/core/src/indicators/incremental/momentum/macd.ts
+++ b/packages/core/src/indicators/incremental/momentum/macd.ts
@@ -2,27 +2,52 @@
  * Incremental MACD (Moving Average Convergence Divergence)
  *
  * Composite indicator using three EMA layers: fast, slow, signal.
+ *
+ * State category: **Cascaded** (three recursive EMA layers). MACD
+ * keeps its own inline EMA logic — it does not compose `createEma` —
+ * so the bare state carries the EMA accumulators directly. Resume
+ * with a different `fastPeriod` / `slowPeriod` / `signalPeriod` /
+ * `source` is refused.
+ *
+ * Migrated to the 0.4.0 State Contract. The EMA multipliers
+ * (`fastMult` / `slowMult` / `signalMult`) are derived from the
+ * periods in the factory closure and not persisted.
  */
 
 import type { MacdValue, NormalizedCandle, PriceSource } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for MACD. Params (`fastPeriod`, `slowPeriod`,
+ * `signalPeriod`, `source`) live in `meta.params`; the EMA multipliers
+ * are derived from the periods.
+ */
 export type MacdState = {
-  fastPeriod: number;
-  slowPeriod: number;
-  signalPeriod: number;
   fastEma: number | null;
   slowEma: number | null;
   signalEma: number | null;
   fastSum: number;
   slowSum: number;
   signalSum: number;
-  fastMult: number;
-  slowMult: number;
-  signalMult: number;
   count: number;
   validMacdCount: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const MACD_VERSION = 1;
+
+type MacdParams = {
+  fastPeriod: number;
+  slowPeriod: number;
+  signalPeriod: number;
+  source: PriceSource;
 };
 
 /**
@@ -44,12 +69,42 @@ export function createMacd(
     signalPeriod?: number;
     source?: PriceSource;
   } = {},
-  warmUpOptions?: WarmUpOptions<MacdState>,
-): IncrementalIndicator<MacdValue, MacdState> {
-  const fastPeriod = options.fastPeriod ?? 12;
-  const slowPeriod = options.slowPeriod ?? 26;
-  const signalPeriod = options.signalPeriod ?? 9;
-  const source = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<MacdState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<MacdValue, IndicatorSnapshot<MacdState>> {
+  const { params, state } = resolveResume<MacdParams, MacdState>({
+    indicator: "macd",
+    version: MACD_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { fastPeriod: 12, slowPeriod: 26, signalPeriod: 9, source: "close" },
+  });
+
+  const fastPeriod = requireParam(
+    "macd",
+    params,
+    "fastPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const slowPeriod = requireParam(
+    "macd",
+    params,
+    "slowPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const signalPeriod = requireParam(
+    "macd",
+    params,
+    "signalPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
   const fastMult = 2 / (fastPeriod + 1);
   const slowMult = 2 / (slowPeriod + 1);
   const signalMult = 2 / (signalPeriod + 1);
@@ -63,16 +118,15 @@ export function createMacd(
   let count: number;
   let validMacdCount: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    fastEma = s.fastEma;
-    slowEma = s.slowEma;
-    signalEma = s.signalEma;
-    fastSum = s.fastSum;
-    slowSum = s.slowSum;
-    signalSum = s.signalSum;
-    count = s.count;
-    validMacdCount = s.validMacdCount;
+  if (state !== null) {
+    fastEma = state.fastEma;
+    slowEma = state.slowEma;
+    signalEma = state.signalEma;
+    fastSum = state.fastSum;
+    slowSum = state.slowSum;
+    signalSum = state.signalSum;
+    count = state.count;
+    validMacdCount = state.validMacdCount;
   } else {
     fastEma = null;
     slowEma = null;
@@ -104,7 +158,7 @@ export function createMacd(
     return { ema: price * mult + (prevEma ?? 0) * (1 - mult), sum };
   }
 
-  const indicator: IncrementalIndicator<MacdValue, MacdState> = {
+  const indicator: IncrementalIndicator<MacdValue, IndicatorSnapshot<MacdState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const price = getSourcePrice(candle, source);
@@ -186,23 +240,22 @@ export function createMacd(
       };
     },
 
-    getState(): MacdState {
-      return {
-        fastPeriod,
-        slowPeriod,
-        signalPeriod,
-        fastEma,
-        slowEma,
-        signalEma,
-        fastSum,
-        slowSum,
-        signalSum,
-        fastMult,
-        slowMult,
-        signalMult,
-        count,
-        validMacdCount,
-      };
+    getState(): IndicatorSnapshot<MacdState> {
+      return makeSnapshot(
+        "macd",
+        MACD_VERSION,
+        { fastPeriod, slowPeriod, signalPeriod, source },
+        {
+          fastEma,
+          slowEma,
+          signalEma,
+          fastSum,
+          slowSum,
+          signalSum,
+          count,
+          validMacdCount,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/ppo.ts
+++ b/packages/core/src/indicators/incremental/momentum/ppo.ts
@@ -6,10 +6,25 @@
  * Histogram = PPO - Signal
  *
  * Similar to MACD but expressed as a percentage, making it comparable across instruments.
+ *
+ * State category: **Cascaded** (three recursive EMA layers). PPO keeps
+ * its own inline EMA logic — it does not compose `createEma` — so the
+ * bare state carries the EMA accumulators directly. Resume with a
+ * different `fastPeriod` / `slowPeriod` / `signalPeriod` / `source` is
+ * refused.
+ *
+ * Migrated to the 0.4.0 State Contract. The EMA multipliers are
+ * derived from the periods in the factory closure and not persisted.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
 export type PpoValue = {
@@ -18,22 +33,30 @@ export type PpoValue = {
   histogram: number | null;
 };
 
+/**
+ * Bare state shape for PPO. Params (`fastPeriod`, `slowPeriod`,
+ * `signalPeriod`, `source`) live in `meta.params`; the EMA multipliers
+ * are derived from the periods.
+ */
 export type PpoState = {
-  fastPeriod: number;
-  slowPeriod: number;
-  signalPeriod: number;
-  source: PriceSource;
   fastEma: number | null;
   slowEma: number | null;
   signalEma: number | null;
   fastSum: number;
   slowSum: number;
   signalSum: number;
-  fastMult: number;
-  slowMult: number;
-  signalMult: number;
   count: number;
   validPpoCount: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const PPO_VERSION = 1;
+
+type PpoParams = {
+  fastPeriod: number;
+  slowPeriod: number;
+  signalPeriod: number;
+  source: PriceSource;
 };
 
 /**
@@ -57,12 +80,42 @@ export function createPpo(
     signalPeriod?: number;
     source?: PriceSource;
   } = {},
-  warmUpOptions?: WarmUpOptions<PpoState>,
-): IncrementalIndicator<PpoValue | null, PpoState> {
-  const fastPeriod = options.fastPeriod ?? 12;
-  const slowPeriod = options.slowPeriod ?? 26;
-  const signalPeriod = options.signalPeriod ?? 9;
-  const source: PriceSource = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<PpoState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<PpoValue | null, IndicatorSnapshot<PpoState>> {
+  const { params, state } = resolveResume<PpoParams, PpoState>({
+    indicator: "ppo",
+    version: PPO_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { fastPeriod: 12, slowPeriod: 26, signalPeriod: 9, source: "close" },
+  });
+
+  const fastPeriod = requireParam(
+    "ppo",
+    params,
+    "fastPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const slowPeriod = requireParam(
+    "ppo",
+    params,
+    "slowPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const signalPeriod = requireParam(
+    "ppo",
+    params,
+    "signalPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
   const fastMult = 2 / (fastPeriod + 1);
   const slowMult = 2 / (slowPeriod + 1);
   const signalMult = 2 / (signalPeriod + 1);
@@ -76,16 +129,15 @@ export function createPpo(
   let count: number;
   let validPpoCount: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    fastEma = s.fastEma;
-    slowEma = s.slowEma;
-    signalEma = s.signalEma;
-    fastSum = s.fastSum;
-    slowSum = s.slowSum;
-    signalSum = s.signalSum;
-    count = s.count;
-    validPpoCount = s.validPpoCount;
+  if (state !== null) {
+    fastEma = state.fastEma;
+    slowEma = state.slowEma;
+    signalEma = state.signalEma;
+    fastSum = state.fastSum;
+    slowSum = state.slowSum;
+    signalSum = state.signalSum;
+    count = state.count;
+    validPpoCount = state.validPpoCount;
   } else {
     fastEma = null;
     slowEma = null;
@@ -117,7 +169,7 @@ export function createPpo(
     return { ema: price * mult + (prevEma ?? 0) * (1 - mult), sum };
   }
 
-  const indicator: IncrementalIndicator<PpoValue | null, PpoState> = {
+  const indicator: IncrementalIndicator<PpoValue | null, IndicatorSnapshot<PpoState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const price = getSourcePrice(candle, source);
@@ -199,24 +251,22 @@ export function createPpo(
       };
     },
 
-    getState(): PpoState {
-      return {
-        fastPeriod,
-        slowPeriod,
-        signalPeriod,
-        source,
-        fastEma,
-        slowEma,
-        signalEma,
-        fastSum,
-        slowSum,
-        signalSum,
-        fastMult,
-        slowMult,
-        signalMult,
-        count,
-        validPpoCount,
-      };
+    getState(): IndicatorSnapshot<PpoState> {
+      return makeSnapshot(
+        "ppo",
+        PPO_VERSION,
+        { fastPeriod, slowPeriod, signalPeriod, source },
+        {
+          fastEma,
+          slowEma,
+          signalEma,
+          fastSum,
+          slowSum,
+          signalSum,
+          count,
+          validPpoCount,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/roc.ts
+++ b/packages/core/src/indicators/incremental/momentum/roc.ts
@@ -3,22 +3,40 @@
  *
  * ROC = ((Current Price - Price N periods ago) / Price N periods ago) × 100
  *
- * Uses CircularBuffer to store lookback prices.
+ * State category: **Windowed** (a fixed-size price buffer; no
+ * recursive accumulator). Resume with a different `period` carries the
+ * raw price buffer forward; `source` change is refused.
+ *
+ * Migrated to the 0.4.0 State Contract: `getState()` returns
+ * `IndicatorSnapshot<RocState>` and `fromState` accepts the same.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
 /**
- * State for incremental ROC
+ * Bare state shape for ROC. Params (`period`, `source`) live in
+ * `meta.params` on the wire.
  */
 export type RocState = {
-  period: number;
-  source: PriceSource;
   buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const ROC_VERSION = 1;
+
+type RocParams = {
+  period: number;
+  source: PriceSource;
 };
 
 /**
@@ -34,32 +52,60 @@ export type RocState = {
  * ```
  */
 export function createRoc(
-  options: { period: number; source?: PriceSource },
-  warmUpOptions?: WarmUpOptions<RocState>,
-): IncrementalIndicator<number | null, RocState> {
-  const period = options.period;
-  const source: PriceSource = options.source ?? "close";
+  options: { period?: number; source?: PriceSource },
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<RocState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<RocState>> {
+  const { params, state, reconfigured } = resolveResume<RocParams, RocState>({
+    indicator: "roc",
+    version: ROC_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { source: "close" },
+  });
 
+  const period = requireParam(
+    "roc",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
+
+  // Need period + 1 slots: period historical values + current.
   let buffer: CircularBuffer<number>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    count = s.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // Period changed — carry the raw prices forward into a buffer
+      // resized to the new capacity (windowed carry-forward).
+      const old = CircularBuffer.fromSnapshot(state.buffer);
+      buffer = new CircularBuffer<number>(period + 1);
+      const carry = Math.min(old.length, period + 1);
+      for (let i = old.length - carry; i < old.length; i++) {
+        buffer.push(old.get(i));
+      }
+    } else {
+      buffer = CircularBuffer.fromSnapshot(state.buffer);
+    }
+    count = state.count;
   } else {
-    // Need period + 1 slots: period historical values + current
     buffer = new CircularBuffer<number>(period + 1);
     count = 0;
   }
 
-  const indicator: IncrementalIndicator<number | null, RocState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<RocState>> = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
       buffer.push(price);
       count++;
 
-      if (count <= period) {
+      if (buffer.length <= period) {
         return { time: candle.time, value: null };
       }
 
@@ -71,9 +117,8 @@ export function createRoc(
 
     peek(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
-      const newCount = count + 1;
 
-      if (newCount <= period) {
+      if (buffer.length < period) {
         return { time: candle.time, value: null };
       }
 
@@ -90,8 +135,13 @@ export function createRoc(
       return { time: candle.time, value };
     },
 
-    getState(): RocState {
-      return { period, source, buffer: buffer.snapshot(), count };
+    getState(): IndicatorSnapshot<RocState> {
+      return makeSnapshot(
+        "roc",
+        ROC_VERSION,
+        { period, source },
+        { buffer: buffer.snapshot(), count },
+      );
     },
 
     get count() {
@@ -99,7 +149,7 @@ export function createRoc(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      return buffer.length > period;
     },
   };
 

--- a/packages/core/src/indicators/incremental/momentum/schaff-trend-cycle.ts
+++ b/packages/core/src/indicators/incremental/momentum/schaff-trend-cycle.ts
@@ -9,28 +9,35 @@
  *
  * State category: **Cascaded** (two recursive EMAs + two recursive
  * stochastic smoothings + two windowed buffers). The recursive
- * components permanently encode past parameters, so resume requires
- * identical `fastPeriod`, `slowPeriod`, `cyclePeriod`, `factor`, and
- * `source` (or omit them and let the snapshot's params win).
+ * components permanently encode past parameters, so resume with a
+ * different `fastPeriod` / `slowPeriod` / `cyclePeriod` / `factor` /
+ * `source` is refused.
+ *
+ * Migrated to the 0.4.0 State Contract. The EMA multipliers are
+ * derived from the periods in the factory closure and not persisted.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for STC. Params (`fastPeriod`, `slowPeriod`,
+ * `cyclePeriod`, `factor`, `source`) live in `meta.params`; the EMA
+ * multipliers are derived from the periods.
+ */
 export type StcState = {
-  fastPeriod: number;
-  slowPeriod: number;
-  cyclePeriod: number;
-  factor: number;
-  source: PriceSource;
   fastEma: number | null;
   slowEma: number | null;
   fastSum: number;
   slowSum: number;
-  fastMult: number;
-  slowMult: number;
   macdBuffer: { data: (number | null)[]; head: number; length: number; capacity: number };
   prevPf: number;
   pfBuffer: { data: (number | null)[]; head: number; length: number; capacity: number };
@@ -38,6 +45,17 @@ export type StcState = {
   firstPfDone: boolean;
   firstStcDone: boolean;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const STC_VERSION = 1;
+
+type StcParams = {
+  fastPeriod: number;
+  slowPeriod: number;
+  cyclePeriod: number;
+  factor: number;
+  source: PriceSource;
 };
 
 /**
@@ -60,24 +78,49 @@ export function createStc(
     factor?: number;
     source?: PriceSource;
   } = {},
-  warmUpOptions?: WarmUpOptions<StcState>,
-): IncrementalIndicator<number | null, StcState> {
-  // Resume order: explicit option > snapshot value > canonical default.
-  const fs = warmUpOptions?.fromState ?? null;
-  const fastPeriod = options.fastPeriod ?? fs?.fastPeriod ?? 23;
-  const slowPeriod = options.slowPeriod ?? fs?.slowPeriod ?? 50;
-  const cyclePeriod = options.cyclePeriod ?? fs?.cyclePeriod ?? 10;
-  const factor = options.factor ?? fs?.factor ?? 0.5;
-  const source: PriceSource = options.source ?? fs?.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<StcState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<StcState>> {
+  const { params, state } = resolveResume<StcParams, StcState>({
+    indicator: "stc",
+    version: STC_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { fastPeriod: 23, slowPeriod: 50, cyclePeriod: 10, factor: 0.5, source: "close" },
+  });
 
-  // Validate parameters identically to the batch indicator so the same
-  // options object behaves the same in both APIs.
-  if (fastPeriod < 1 || slowPeriod < 1 || cyclePeriod < 1) {
-    throw new Error("Schaff Trend Cycle periods must be at least 1");
-  }
-  if (factor <= 0 || factor > 1) {
-    throw new Error("Schaff Trend Cycle factor must be in (0, 1]");
-  }
+  const fastPeriod = requireParam(
+    "stc",
+    params,
+    "fastPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const slowPeriod = requireParam(
+    "stc",
+    params,
+    "slowPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const cyclePeriod = requireParam(
+    "stc",
+    params,
+    "cyclePeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const factor = requireParam(
+    "stc",
+    params,
+    "factor",
+    (v): v is number => typeof v === "number" && v > 0 && v <= 1,
+    "must be in (0, 1]",
+  );
+  const source = params.source;
 
   const fastMult = 2 / (fastPeriod + 1);
   const slowMult = 2 / (slowPeriod + 1);
@@ -94,30 +137,18 @@ export function createStc(
   let firstStcDone: boolean;
   let count: number;
 
-  if (fs) {
-    // Cascaded: two recursive EMAs + two recursive stochastic
-    // smoothings permanently encode past parameters, so reconfiguring
-    // on resume produces a hybrid series.
-    if (
-      fs.fastPeriod !== fastPeriod ||
-      fs.slowPeriod !== slowPeriod ||
-      fs.cyclePeriod !== cyclePeriod ||
-      fs.factor !== factor ||
-      fs.source !== source
-    ) {
-      throw new Error("Schaff Trend Cycle: incompatible snapshot, re-warm required");
-    }
-    fastEma = fs.fastEma;
-    slowEma = fs.slowEma;
-    fastSum = fs.fastSum;
-    slowSum = fs.slowSum;
-    macdBuffer = CircularBuffer.fromSnapshot(fs.macdBuffer);
-    prevPf = fs.prevPf;
-    pfBuffer = CircularBuffer.fromSnapshot(fs.pfBuffer);
-    prevStc = fs.prevStc;
-    firstPfDone = fs.firstPfDone;
-    firstStcDone = fs.firstStcDone;
-    count = fs.count;
+  if (state !== null) {
+    fastEma = state.fastEma;
+    slowEma = state.slowEma;
+    fastSum = state.fastSum;
+    slowSum = state.slowSum;
+    macdBuffer = CircularBuffer.fromSnapshot(state.macdBuffer);
+    prevPf = state.prevPf;
+    pfBuffer = CircularBuffer.fromSnapshot(state.pfBuffer);
+    prevStc = state.prevStc;
+    firstPfDone = state.firstPfDone;
+    firstStcDone = state.firstStcDone;
+    count = state.count;
   } else {
     fastEma = null;
     slowEma = null;
@@ -183,7 +214,7 @@ export function createStc(
     return { min, max };
   }
 
-  const indicator: IncrementalIndicator<number | null, StcState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<StcState>> = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
       count++;
@@ -260,27 +291,25 @@ export function createStc(
       return { time: candle.time, value: peekStc };
     },
 
-    getState(): StcState {
-      return {
-        fastPeriod,
-        slowPeriod,
-        cyclePeriod,
-        factor,
-        source,
-        fastEma,
-        slowEma,
-        fastSum,
-        slowSum,
-        fastMult,
-        slowMult,
-        macdBuffer: macdBuffer.snapshot() as StcState["macdBuffer"],
-        prevPf,
-        pfBuffer: pfBuffer.snapshot() as StcState["pfBuffer"],
-        prevStc,
-        firstPfDone,
-        firstStcDone,
-        count,
-      };
+    getState(): IndicatorSnapshot<StcState> {
+      return makeSnapshot(
+        "stc",
+        STC_VERSION,
+        { fastPeriod, slowPeriod, cyclePeriod, factor, source },
+        {
+          fastEma,
+          slowEma,
+          fastSum,
+          slowSum,
+          macdBuffer: macdBuffer.snapshot() as StcState["macdBuffer"],
+          prevPf,
+          pfBuffer: pfBuffer.snapshot() as StcState["pfBuffer"],
+          prevStc,
+          firstPfDone,
+          firstStcDone,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/moving-average/frama.ts
+++ b/packages/core/src/indicators/incremental/moving-average/frama.ts
@@ -15,18 +15,33 @@
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for FRAMA. Params (`period`, `source`) live in
+ * `meta.params`; `effectivePeriod` / `halfPeriod` are derived from
+ * `period` in the factory closure and intentionally not persisted.
+ */
 export type FramaState = {
-  period: number;
-  effectivePeriod: number;
-  halfPeriod: number;
-  source: PriceSource;
   prevFrama: number | null;
   highBuffer: { data: number[]; head: number; length: number; capacity: number };
   lowBuffer: { data: number[]; head: number; length: number; capacity: number };
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const FRAMA_VERSION = 1;
+
+type FramaParams = {
+  period: number;
+  source: PriceSource;
 };
 
 /**
@@ -43,22 +58,32 @@ export type FramaState = {
  */
 export function createFrama(
   options: { period?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<FramaState>,
-): IncrementalIndicator<number | null, FramaState> {
-  // Resume contract: a snapshot can only be resumed with the SAME
-  // period and source it was created under. FRAMA is fundamentally
-  // recursive (`prevFrama` carries the smoothed history forward forever),
-  // so changing either of those mid-stream produces a series that
-  // doesn't match what `createFrama(newOptions)` would compute over the
-  // same candle history. We refuse the reconfiguration explicitly rather
-  // than silently producing a hybrid output.
-  //
-  // If options are omitted on resume, snapshot values are restored.
-  // If options are provided, they must match the snapshot or be the
-  // first time the indicator is created (no fromState).
-  const fs = warmUpOptions?.fromState ?? null;
-  const period = options.period ?? fs?.period ?? 16;
-  const source: PriceSource = options.source ?? fs?.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<FramaState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<FramaState>> {
+  // FRAMA is Mixed: the recursive `prevFrama` carries smoothed history
+  // forward forever, so changing `period` / `source` mid-stream
+  // produces a hybrid series. The mixed-category `resolveResume`
+  // policy refuses any param change on resume.
+  const { params, state } = resolveResume<FramaParams, FramaState>({
+    indicator: "frama",
+    version: FRAMA_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 16, source: "close" },
+  });
+
+  const period = requireParam(
+    "frama",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
   const effectivePeriod = period % 2 === 0 ? period : period + 1;
   const halfPeriod = effectivePeriod / 2;
 
@@ -67,23 +92,11 @@ export function createFrama(
   let prevFrama: number | null;
   let count: number;
 
-  if (fs) {
-    // Resume contract: same period and source as the snapshot, or omit
-    // both. FRAMA's recursive `prevFrama` makes mid-stream reconfig
-    // mathematically undefined, and pre-canonical snapshots (close-only
-    // buffer, no wick range) cannot be migrated cleanly — re-warm.
-    if (
-      fs.effectivePeriod !== effectivePeriod ||
-      fs.source !== source ||
-      !fs.highBuffer ||
-      !fs.lowBuffer
-    ) {
-      throw new Error("FRAMA: incompatible snapshot, re-warm required");
-    }
-    highBuffer = CircularBuffer.fromSnapshot(fs.highBuffer);
-    lowBuffer = CircularBuffer.fromSnapshot(fs.lowBuffer);
-    prevFrama = fs.prevFrama;
-    count = fs.count;
+  if (state !== null) {
+    highBuffer = CircularBuffer.fromSnapshot(state.highBuffer);
+    lowBuffer = CircularBuffer.fromSnapshot(state.lowBuffer);
+    prevFrama = state.prevFrama;
+    count = state.count;
   } else {
     highBuffer = new CircularBuffer<number>(effectivePeriod);
     lowBuffer = new CircularBuffer<number>(effectivePeriod);
@@ -127,7 +140,7 @@ export function createFrama(
     return 0.01;
   }
 
-  const indicator: IncrementalIndicator<number | null, FramaState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<FramaState>> = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
       count++;
@@ -154,13 +167,12 @@ export function createFrama(
     peek(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
 
-      // Gate on the *existing* buffer being full (not the simulated +1
-      // length). Otherwise the loop below would call
-      // `highBuffer.get(j+1)` for j up to effectivePeriod-2 — which
-      // requires length >= effectivePeriod. After a period-growing
-      // resume the buffer is partially refilled and we must report null
-      // until next() finishes warming.
-      if (highBuffer.length < effectivePeriod) {
+      // Mirror next(): it pushes first, then gates on
+      // `buffer.length >= effectivePeriod`. After a simulated push the
+      // window holds min(length + 1, capacity) entries, so peek must
+      // gate on `length + 1 >= effectivePeriod` to agree with next on
+      // the warmup boundary.
+      if (highBuffer.length + 1 < effectivePeriod) {
         return { time: candle.time, value: null };
       }
 
@@ -168,7 +180,11 @@ export function createFrama(
         return { time: candle.time, value: price };
       }
 
-      // Simulate buffer with new candle's high/low.
+      // Simulate the post-push window: the most recent
+      // (effectivePeriod - 1) buffer entries plus the new candle.
+      // `startIdx` is 1 when the buffer is full (the push evicts the
+      // oldest entry) and 0 when it holds exactly effectivePeriod - 1.
+      const startIdx = highBuffer.length - (effectivePeriod - 1);
       let h1High = Number.NEGATIVE_INFINITY;
       let h1Low = Number.POSITIVE_INFINITY;
       let h2High = Number.NEGATIVE_INFINITY;
@@ -177,8 +193,8 @@ export function createFrama(
       let fLow = Number.POSITIVE_INFINITY;
 
       for (let j = 0; j < effectivePeriod; j++) {
-        const high = j < effectivePeriod - 1 ? highBuffer.get(j + 1) : candle.high;
-        const low = j < effectivePeriod - 1 ? lowBuffer.get(j + 1) : candle.low;
+        const high = j < effectivePeriod - 1 ? highBuffer.get(startIdx + j) : candle.high;
+        const low = j < effectivePeriod - 1 ? lowBuffer.get(startIdx + j) : candle.low;
 
         if (j < halfPeriod) {
           if (high > h1High) h1High = high;
@@ -207,17 +223,18 @@ export function createFrama(
       return { time: candle.time, value: alpha * price + (1 - alpha) * prevFrama };
     },
 
-    getState(): FramaState {
-      return {
-        period,
-        effectivePeriod,
-        halfPeriod,
-        source,
-        prevFrama,
-        highBuffer: highBuffer.snapshot(),
-        lowBuffer: lowBuffer.snapshot(),
-        count,
-      };
+    getState(): IndicatorSnapshot<FramaState> {
+      return makeSnapshot(
+        "frama",
+        FRAMA_VERSION,
+        { period, source },
+        {
+          prevFrama,
+          highBuffer: highBuffer.snapshot(),
+          lowBuffer: lowBuffer.snapshot(),
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/moving-average/hma.ts
+++ b/packages/core/src/indicators/incremental/moving-average/hma.ts
@@ -7,24 +7,37 @@
  * WMAs hold raw price buffers, but the outer `finalWma` holds
  * intermediate `2*WMA(n/2) - WMA(n)` values whose meaning depends on
  * `period`. Reconfiguring `period` mid-stream invalidates that
- * intermediate buffer, so resume requires identical `period` and
- * `source` (or omit them and let the snapshot's params win).
+ * intermediate buffer, so the cascaded-category policy refuses any
+ * `period` / `source` change on resume.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { makeCandle } from "../utils";
 import type { WmaState } from "./wma";
 import { createWma } from "./wma";
 
 export type HmaState = {
-  period: number;
-  source: PriceSource;
   halfWmaState: IndicatorSnapshot<WmaState>;
   fullWmaState: IndicatorSnapshot<WmaState>;
   finalWmaState: IndicatorSnapshot<WmaState>;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const HMA_VERSION = 1;
+
+type HmaParams = {
+  period: number;
+  source: PriceSource;
 };
 
 /**
@@ -41,12 +54,28 @@ export type HmaState = {
  */
 export function createHma(
   options: { period?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<HmaState>,
-): IncrementalIndicator<number | null, HmaState> {
-  // Resume order: explicit option > snapshot value > canonical default.
-  const fs = warmUpOptions?.fromState ?? null;
-  const period = options.period ?? fs?.period ?? 9;
-  const source: PriceSource = options.source ?? fs?.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<HmaState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<HmaState>> {
+  const { params, state } = resolveResume<HmaParams, HmaState>({
+    indicator: "hma",
+    version: HMA_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 9, source: "close" },
+  });
+
+  const period = requireParam(
+    "hma",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
   const halfPeriod = Math.floor(period / 2);
   const sqrtPeriod = Math.floor(Math.sqrt(period));
 
@@ -55,18 +84,11 @@ export function createHma(
   let finalWma: ReturnType<typeof createWma>;
   let count: number;
 
-  if (fs) {
-    // HMA is a cascade: the outer `finalWma` carries intermediate
-    // `2*WMA(n/2) - WMA(n)` values whose semantics depend on `period`.
-    // Reconfiguring `period` invalidates those intermediates, so
-    // resume requires identical params.
-    if (fs.period !== period || fs.source !== source) {
-      throw new Error("HMA: incompatible snapshot, re-warm required");
-    }
-    halfWma = createWma({ period: halfPeriod, source }, { fromState: fs.halfWmaState });
-    fullWma = createWma({ period, source }, { fromState: fs.fullWmaState });
-    finalWma = createWma({ period: sqrtPeriod }, { fromState: fs.finalWmaState });
-    count = fs.count;
+  if (state !== null) {
+    halfWma = createWma({ period: halfPeriod, source }, { fromState: state.halfWmaState });
+    fullWma = createWma({ period, source }, { fromState: state.fullWmaState });
+    finalWma = createWma({ period: sqrtPeriod }, { fromState: state.finalWmaState });
+    count = state.count;
   } else {
     halfWma = createWma({ period: halfPeriod, source });
     fullWma = createWma({ period, source });
@@ -74,7 +96,7 @@ export function createHma(
     count = 0;
   }
 
-  const indicator: IncrementalIndicator<number | null, HmaState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<HmaState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -102,15 +124,18 @@ export function createHma(
       return { time: candle.time, value: finalWma.peek(makeCandle(candle.time, diff)).value };
     },
 
-    getState(): HmaState {
-      return {
-        period,
-        source,
-        halfWmaState: halfWma.getState(),
-        fullWmaState: fullWma.getState(),
-        finalWmaState: finalWma.getState(),
-        count,
-      };
+    getState(): IndicatorSnapshot<HmaState> {
+      return makeSnapshot(
+        "hma",
+        HMA_VERSION,
+        { period, source },
+        {
+          halfWmaState: halfWma.getState(),
+          fullWmaState: fullWma.getState(),
+          finalWmaState: finalWma.getState(),
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/moving-average/kama.ts
+++ b/packages/core/src/indicators/incremental/moving-average/kama.ts
@@ -5,23 +5,44 @@
  *
  * State category: **Mixed** (price buffer for ER + recursive
  * `prevKama`). The recursive component permanently carries past
- * parameters, so resume requires identical period, fastSC, slowSC,
- * and source (or omit them and let the snapshot's params win).
+ * parameters, so resume with a different `period` / `fastPeriod` /
+ * `slowPeriod` / `source` is refused by the mixed-category policy.
+ *
+ * Migrated to the 0.4.0 State Contract. The smoothing constants
+ * `fastSC` / `slowSC` are derived from `fastPeriod` / `slowPeriod` in
+ * the factory closure and not persisted — `meta.params` carries the
+ * periods themselves.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for KAMA. Params (`period`, `fastPeriod`,
+ * `slowPeriod`, `source`) live in `meta.params`.
+ */
 export type KamaState = {
-  period: number;
-  source: PriceSource;
-  fastSC: number;
-  slowSC: number;
   priceBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   prevKama: number | null;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const KAMA_VERSION = 1;
+
+type KamaParams = {
+  period: number;
+  fastPeriod: number;
+  slowPeriod: number;
+  source: PriceSource;
 };
 
 /**
@@ -38,46 +59,61 @@ export type KamaState = {
  */
 export function createKama(
   options: { period?: number; fastPeriod?: number; slowPeriod?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<KamaState>,
-): IncrementalIndicator<number | null, KamaState> {
-  // Resume order: explicit option > snapshot value > canonical default.
-  // fastPeriod/slowPeriod aren't stored on state directly — fastSC and
-  // slowSC are. When the caller omits the period option, restore the
-  // SC from the snapshot; otherwise re-derive from the new period.
-  const fs = warmUpOptions?.fromState ?? null;
-  const period = options.period ?? fs?.period ?? 10;
-  const source: PriceSource = options.source ?? fs?.source ?? "close";
-  const fastSC =
-    options.fastPeriod !== undefined ? 2 / (options.fastPeriod + 1) : (fs?.fastSC ?? 2 / 3);
-  const slowSC =
-    options.slowPeriod !== undefined ? 2 / (options.slowPeriod + 1) : (fs?.slowSC ?? 2 / 31);
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<KamaState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<KamaState>> {
+  const { params, state } = resolveResume<KamaParams, KamaState>({
+    indicator: "kama",
+    version: KAMA_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 10, fastPeriod: 2, slowPeriod: 30, source: "close" },
+  });
+
+  const period = requireParam(
+    "kama",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const fastPeriod = requireParam(
+    "kama",
+    params,
+    "fastPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const slowPeriod = requireParam(
+    "kama",
+    params,
+    "slowPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
+  const fastSC = 2 / (fastPeriod + 1);
+  const slowSC = 2 / (slowPeriod + 1);
 
   // Need period+1 prices to compute direction and volatility
   let priceBuffer: CircularBuffer<number>;
   let prevKama: number | null;
   let count: number;
 
-  if (fs) {
-    // KAMA is Mixed-recursive: `prevKama` carries past parameters
-    // forever, so reconfiguring mid-stream yields a hybrid series.
-    if (
-      fs.period !== period ||
-      fs.source !== source ||
-      fs.fastSC !== fastSC ||
-      fs.slowSC !== slowSC
-    ) {
-      throw new Error("KAMA: incompatible snapshot, re-warm required");
-    }
-    priceBuffer = CircularBuffer.fromSnapshot(fs.priceBuffer);
-    prevKama = fs.prevKama;
-    count = fs.count;
+  if (state !== null) {
+    priceBuffer = CircularBuffer.fromSnapshot(state.priceBuffer);
+    prevKama = state.prevKama;
+    count = state.count;
   } else {
     priceBuffer = new CircularBuffer<number>(period + 1);
     prevKama = null;
     count = 0;
   }
 
-  const indicator: IncrementalIndicator<number | null, KamaState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<KamaState>> = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
       count++;
@@ -142,16 +178,17 @@ export function createKama(
       return { time: candle.time, value: prev + sc * (price - prev) };
     },
 
-    getState(): KamaState {
-      return {
-        period,
-        source,
-        fastSC,
-        slowSC,
-        priceBuffer: priceBuffer.snapshot(),
-        prevKama,
-        count,
-      };
+    getState(): IndicatorSnapshot<KamaState> {
+      return makeSnapshot(
+        "kama",
+        KAMA_VERSION,
+        { period, fastPeriod, slowPeriod, source },
+        {
+          priceBuffer: priceBuffer.snapshot(),
+          prevKama,
+          count,
+        },
+      );
     },
 
     get count() {


### PR DESCRIPTION
## Summary

Wave 3 Bundle K migrates 8 indicators to the 0.4.0 State Contract.

| Indicator | Category | Notes |
|---|---|---|
| ROC | Windowed | period change carries the price buffer forward |
| FRAMA | Mixed | hand-written resume guard → `resolveResume` |
| KAMA | Mixed | `fastSC`/`slowSC` derived from periods, dropped from state |
| HMA | Cascaded | 3 stacked WMAs; resume guard → `resolveResume` |
| Coppock Curve | Cascaded | 2 ROC stages → WMA |
| MACD | Cascaded | own inline EMA logic; multipliers derived |
| PPO | Cascaded | own inline EMA logic; multipliers derived |
| Schaff Trend Cycle | Cascaded | resume guard → `resolveResume`; param validation → `requireParam` |

FRAMA / KAMA / HMA / Schaff Trend Cycle drop their hand-written resume guards in favor of the category-uniform `resolveResume` policy (§4.1). MACD / PPO / Schaff keep their own inline EMA logic — the derived multipliers are no longer persisted.

## Type cascade (1, opaque pass-through)

`kst` gets the `IndicatorSnapshot<RocState>` type on its nested `rocStates` field. KST itself migrates in Bundle L.

## Intended breaking — pre-0.4.0 nested snapshots

Resuming a pre-0.4.0 KST snapshot now throws a leaf-scoped `incompatible snapshot` error from the inner ROC. This is the **intended behavior** documented in STATE_CONTRACT.md §5.4 (legacy nested snapshots); per-wrapper migration shims are deliberately not added (§4.1). When KST is migrated in Bundle L, the throw moves to KST scope. The error is a loud throw — no silent corruption.

## Latent bug fixed

invariant [7] (warmup gate) surfaced a FRAMA `peek()` off-by-one: `peek` gated warmup on the current (pre-push) buffer length, one bar behind `next()` (which gates after pushing). `peek` now mirrors the post-push window so its null boundary aligns with `next`.

## Test plan

- [x] `pnpm test` — core 5585 passing
- [x] `pnpm lint` — clean
- [x] `pnpm build` — success
- [x] `tsc --noEmit --ignoreDeprecations 6.0` — pre-existing errors only, 0 new