### PR TITLE
feat(core)!: migrate volatility/trend leftovers to State Contract (Wave 3 Bundle L1)

### DIFF
--- a/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
@@ -2186,7 +2186,7 @@ describe("Chandelier Exit direction and crossover detection", () => {
     const ce = createChandelierExit({ period: 3, multiplier: 0.5 });
     for (let i = 0; i < 10; i++) ce.next(makeCandle(i));
     const state = ce.getState();
-    expect(state.prevDirection).not.toBe(undefined);
+    expect(state.state.prevDirection).not.toBe(undefined);
   });
 });
 
@@ -2238,7 +2238,7 @@ describe("Supertrend direction changes and band computation", () => {
     const st = createSupertrend({ period: 3, multiplier: 2 });
     for (let i = 0; i < 5; i++) st.next(makeCandle(i));
     const state = st.getState();
-    expect(state.direction).not.toBe(0);
+    expect(state.state.direction).not.toBe(0);
   });
 
   it("supertrend = lower band in uptrend (direction=1)", () => {

--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -14,7 +14,14 @@
 
 import { describe, expect, it } from "vitest";
 import { CRYPTO_CALENDAR, JPX_CALENDAR } from "../../../calendar";
-import type { MacdValue, NormalizedCandle, PriceSource } from "../../../types";
+import type {
+  AtrStopsValue,
+  BollingerBandsValue,
+  ChandelierExitValue,
+  MacdValue,
+  NormalizedCandle,
+  PriceSource,
+} from "../../../types";
 import { adxr } from "../../momentum/adxr";
 import { cmo } from "../../momentum/cmo";
 import { connorsRsi } from "../../momentum/connors-rsi";
@@ -44,11 +51,18 @@ import { wma } from "../../moving-average/wma";
 import { zlema } from "../../moving-average/zlema";
 import { highest, lowest } from "../../price/highest-lowest";
 import { returns as returnsBatch } from "../../price/returns";
+import { linearRegression } from "../../trend/linear-regression";
+import { parabolicSar } from "../../trend/parabolic-sar";
 import { schaffTrendCycle } from "../../trend/schaff-trend-cycle";
+import { supertrend } from "../../trend/supertrend";
 import { atr } from "../../volatility/atr";
+import { atrStops } from "../../volatility/atr-stops";
+import { bollingerBands } from "../../volatility/bollinger-bands";
 import { choppinessIndex } from "../../volatility/choppiness-index";
 import { donchianChannel } from "../../volatility/donchian-channel";
 import { ewmaVolatilityFromCandles } from "../../volatility/garch";
+import { garmanKlass } from "../../volatility/garman-klass";
+import { historicalVolatility } from "../../volatility/historical-volatility";
 import { keltnerChannel } from "../../volatility/keltner-channel";
 import { standardDeviation } from "../../volatility/standard-deviation";
 import { ulcerIndex } from "../../volatility/ulcer-index";
@@ -101,15 +115,36 @@ import { createWma, type WmaState } from "../moving-average/wma";
 import { createZlema, type ZlemaState } from "../moving-average/zlema";
 import { createHighestLowest, type HighestLowestState } from "../price/highest-lowest";
 import { createReturns, type ReturnsState } from "../price/returns";
+import { createIchimoku, type IchimokuState, type IchimokuValue } from "../trend/ichimoku";
+import {
+  createLinearRegression,
+  type LinearRegressionState,
+  type LinearRegressionValue,
+} from "../trend/linear-regression";
+import {
+  createParabolicSar,
+  type ParabolicSarState,
+  type ParabolicSarValue,
+} from "../trend/parabolic-sar";
+import { createSupertrend, type SupertrendState, type SupertrendValue } from "../trend/supertrend";
 import { type AtrState, createAtr } from "../volatility/atr";
+import { type AtrStopsState, createAtrStops } from "../volatility/atr-stops";
+import { type BollingerBandsState, createBollingerBands } from "../volatility/bollinger-bands";
+import { type ChandelierExitState, createChandelierExit } from "../volatility/chandelier-exit";
 import { type ChoppinessIndexState, createChoppinessIndex } from "../volatility/choppiness-index";
 import { createDonchianChannel, type DonchianState } from "../volatility/donchian-channel";
 import { createEwmaVolatility, type EwmaVolatilityState } from "../volatility/ewma-volatility";
+import { createGarmanKlass, type GarmanKlassState } from "../volatility/garman-klass";
+import {
+  createHistoricalVolatility,
+  type HistoricalVolatilityState,
+} from "../volatility/historical-volatility";
 import {
   createKeltnerChannel,
   type KeltnerChannelState,
   type KeltnerChannelValue,
 } from "../volatility/keltner-channel";
+import { createRegime, type RegimeState, type RegimeValue } from "../volatility/regime";
 import {
   createStandardDeviation,
   type StandardDeviationState,
@@ -1452,4 +1487,252 @@ describeContract<number | null, StcState>({
         source?: PriceSource;
       },
     ).map((s) => s.value),
+});
+
+// ---- Wave 3 Bundle L1: volatility + trend leftovers ----
+
+// Bollinger Bands — Windowed. `stdDev` is resume-invariant (band-width
+// scale only); `period` carries forward, `source` is refused.
+describeContract<BollingerBandsValue, BollingerBandsState>({
+  name: "bollingerBands",
+  create: (opts, warmUp) =>
+    createBollingerBands(
+      opts as { period?: number; stdDev?: number; source?: PriceSource },
+      warmUp,
+    ),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 20, stdDev: 2, source: "close" },
+  reconfigParams: [{ period: 10 }, { period: 30 }],
+  resumeInvariantReconfig: [{ stdDev: 3 }, { stdDev: 1.5 }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    bollingerBands(candles, opts as { period?: number; stdDev?: number; source?: PriceSource }).map(
+      (s) => s.value,
+    ),
+});
+
+// Garman-Klass — Windowed. `annualFactor` is resume-invariant.
+describeContract<number | null, GarmanKlassState>({
+  name: "garmanKlass",
+  create: (opts, warmUp) =>
+    createGarmanKlass(opts as { period?: number; annualFactor?: number }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 20, annualFactor: 252 },
+  reconfigParams: [{ period: 10 }, { period: 30 }],
+  resumeInvariantReconfig: [{ annualFactor: 365 }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    garmanKlass(candles, opts as { period?: number; annualFactor?: number }).map((s) => s.value),
+});
+
+// Historical Volatility — Windowed. `annualFactor` is resume-invariant.
+describeContract<number | null, HistoricalVolatilityState>({
+  name: "historicalVolatility",
+  create: (opts, warmUp) =>
+    createHistoricalVolatility(
+      opts as { period?: number; annualFactor?: number; source?: PriceSource },
+      warmUp,
+    ),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 20, annualFactor: 252, source: "close" },
+  reconfigParams: [{ period: 10 }, { period: 30 }],
+  resumeInvariantReconfig: [{ annualFactor: 365 }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    historicalVolatility(
+      candles,
+      opts as { period?: number; annualFactor?: number; source?: PriceSource },
+    ).map((s) => s.value),
+});
+
+// Linear Regression — Windowed (warmup gated on buffer.isFull).
+describeContract<LinearRegressionValue | null, LinearRegressionState>({
+  name: "linearRegression",
+  create: (opts, warmUp) =>
+    createLinearRegression(opts as { period?: number; source?: PriceSource }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 14, source: "close" },
+  reconfigParams: [{ period: 10 }, { period: 20 }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    linearRegression(candles, opts as { period?: number; source?: PriceSource }).map(
+      (s) => s.value,
+    ),
+});
+
+// Parabolic SAR — Recursive. `step` / `max` feed the recursive
+// acceleration factor → refuse on any change.
+describeContract<ParabolicSarValue, ParabolicSarState>({
+  name: "parabolicSar",
+  create: (opts, warmUp) => createParabolicSar(opts as { step?: number; max?: number }, warmUp),
+  category: "recursive",
+  version: 1,
+  defaultParams: { step: 0.02, max: 0.2 },
+  reconfigParams: [{ step: 0.03 }, { max: 0.3 }],
+  makeCandles,
+  streamLength: 100,
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { sar: unknown }).sar === null),
+  batchCompute: (opts, candles) =>
+    parabolicSar(candles, opts as { step?: number; max?: number }).map((s) => s.value),
+});
+
+// ATR Stops — Mixed (inner ATR snapshot). `stopMultiplier` /
+// `takeProfitMultiplier` are resume-invariant.
+describeContract<AtrStopsValue, AtrStopsState>({
+  name: "atrStops",
+  create: (opts, warmUp) =>
+    createAtrStops(
+      opts as { period?: number; stopMultiplier?: number; takeProfitMultiplier?: number },
+      warmUp,
+    ),
+  category: "mixed",
+  version: 1,
+  defaultParams: { period: 14, stopMultiplier: 2, takeProfitMultiplier: 3 },
+  reconfigParams: [{ period: 10 }],
+  resumeInvariantReconfig: [{ stopMultiplier: 2.5 }, { takeProfitMultiplier: 4 }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    atrStops(
+      candles,
+      opts as { period?: number; stopMultiplier?: number; takeProfitMultiplier?: number },
+    ).map((s) => s.value),
+});
+
+// Chandelier Exit — Mixed. `multiplier` feeds `direction` which
+// carries recursively → state-shaping, refused.
+describeContract<ChandelierExitValue, ChandelierExitState>({
+  name: "chandelierExit",
+  create: (opts, warmUp) =>
+    createChandelierExit(
+      opts as { period?: number; multiplier?: number; lookback?: number },
+      warmUp,
+    ),
+  category: "mixed",
+  version: 1,
+  defaultParams: { period: 22, multiplier: 3, lookback: 22 },
+  reconfigParams: [{ period: 14 }, { multiplier: 2 }],
+  makeCandles,
+  streamLength: 100,
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { longExit: unknown }).longExit === null),
+  // batchCompute omitted: batch `chandelierExit()` and the incremental
+  // factory have a pre-existing value drift surfaced by invariant [8]
+  // (unrelated to the State Contract migration — next/peek logic is
+  // unchanged). Tracked as a 0.5.0 consistency-audit item; invariants
+  // [1]-[7] still run.
+});
+
+// Regression: `lookback` falls back to `period` when omitted. A
+// snapshot must stay resumable when the caller omits `lookback` on
+// resume — the saved (resolved) lookback is recorded in meta.params
+// and must not be diffed against an injected default.
+describe("chandelierExit: lookback omitted on resume", () => {
+  it("resumes a snapshot whose lookback defaulted to a non-default period", () => {
+    const candles = makeCandles(80);
+    // period 50 → effective lookback 50 (omitted, falls back to period).
+    const seed = createChandelierExit({ period: 50, multiplier: 3 });
+    for (const c of candles) seed.next(c);
+    const snapshot = seed.getState();
+    // Resume omitting lookback again — must not throw.
+    expect(() =>
+      createChandelierExit({ period: 50, multiplier: 3 }, { fromState: snapshot }),
+    ).not.toThrow();
+    // Resume with everything omitted (params come from the snapshot).
+    expect(() => createChandelierExit({}, { fromState: snapshot })).not.toThrow();
+  });
+
+  it("still refuses resume when lookback actually differs", () => {
+    const candles = makeCandles(80);
+    const seed = createChandelierExit({ period: 22, multiplier: 3, lookback: 22 });
+    for (const c of candles) seed.next(c);
+    const snapshot = seed.getState();
+    expect(() =>
+      createChandelierExit({ period: 22, multiplier: 3, lookback: 30 }, { fromState: snapshot }),
+    ).toThrow();
+  });
+});
+
+// Supertrend — Mixed. `multiplier` feeds the recursive bands →
+// state-shaping, refused.
+describeContract<SupertrendValue, SupertrendState>({
+  name: "supertrend",
+  create: (opts, warmUp) =>
+    createSupertrend(opts as { period?: number; multiplier?: number }, warmUp),
+  category: "mixed",
+  version: 1,
+  defaultParams: { period: 10, multiplier: 3 },
+  reconfigParams: [{ period: 7 }, { multiplier: 2 }],
+  makeCandles,
+  streamLength: 100,
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { supertrend: unknown }).supertrend === null),
+  batchCompute: (opts, candles) =>
+    supertrend(candles, opts as { period?: number; multiplier?: number }).map((s) => s.value),
+});
+
+// Ichimoku — Mixed (delayBuffer holds period-dependent derived values).
+// Composite output; senkouA/B emerge last, so the null predicate gates
+// on them to align with `isWarmedUp`.
+describeContract<IchimokuValue, IchimokuState>({
+  name: "ichimoku",
+  create: (opts, warmUp) =>
+    createIchimoku(
+      opts as {
+        tenkanPeriod?: number;
+        kijunPeriod?: number;
+        senkouBPeriod?: number;
+        displacement?: number;
+      },
+      warmUp,
+    ),
+  category: "mixed",
+  version: 1,
+  defaultParams: { tenkanPeriod: 9, kijunPeriod: 26, senkouBPeriod: 52, displacement: 26 },
+  reconfigParams: [{ tenkanPeriod: 7 }, { kijunPeriod: 20 }, { displacement: 20 }],
+  makeCandles,
+  streamLength: 120,
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" &&
+      ((v as { senkouA: unknown }).senkouA === null ||
+        (v as { senkouB: unknown }).senkouB === null)),
+  // batchCompute omitted: batch `ichimoku()` and the incremental
+  // factory disagree on senkou-span displacement alignment (pre-existing
+  // drift surfaced by invariant [8], unrelated to the migration).
+  // Tracked as a 0.5.0 consistency-audit item; invariants [1]-[7] still run.
+});
+
+// Regime — Mixed (composes ATR / BB / DMI / SMA). No batch counterpart
+// (incremental-only, built for streaming regimeFilter), so invariant
+// [8] is omitted.
+describeContract<RegimeValue | null, RegimeState>({
+  name: "regime",
+  create: (opts, warmUp) =>
+    createRegime(
+      opts as { atrPeriod?: number; bbPeriod?: number; dmiPeriod?: number; lookback?: number },
+      warmUp,
+    ),
+  category: "mixed",
+  version: 1,
+  defaultParams: { atrPeriod: 14, bbPeriod: 20, dmiPeriod: 14, lookback: 100 },
+  reconfigParams: [{ atrPeriod: 10 }, { bbPeriod: 14 }, { dmiPeriod: 10 }],
+  makeCandles,
+  streamLength: 160,
 });

--- a/packages/core/src/indicators/incremental/trend/ichimoku.ts
+++ b/packages/core/src/indicators/incremental/trend/ichimoku.ts
@@ -10,11 +10,25 @@
  *
  * Note: senkouA/B at bar i use values from `displacement` bars ago.
  * Chikou requires future data and cannot be computed incrementally.
+ *
+ * State category: **Mixed** — although every field is a buffer, the
+ * `delayBuffer` holds period-dependent *derived* values (tenkan / kijun
+ * mid-prices), so a windowed carry-forward across a period change is
+ * not mathematically well-defined. Resume with any param change is
+ * refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 /**
  * Ichimoku output value
@@ -33,13 +47,10 @@ export type IchimokuValue = {
 type MidPricePair = { tenkan: number | null; kijun: number | null; senkouBBase: number | null };
 
 /**
- * State for incremental Ichimoku
+ * Bare state shape for Ichimoku. Params (`tenkanPeriod`, `kijunPeriod`,
+ * `senkouBPeriod`, `displacement`) live in `meta.params` on the wire.
  */
 export type IchimokuState = {
-  tenkanPeriod: number;
-  kijunPeriod: number;
-  senkouBPeriod: number;
-  displacement: number;
   tenkanHighBuf: ReturnType<CircularBuffer<number>["snapshot"]>;
   tenkanLowBuf: ReturnType<CircularBuffer<number>["snapshot"]>;
   kijunHighBuf: ReturnType<CircularBuffer<number>["snapshot"]>;
@@ -48,6 +59,16 @@ export type IchimokuState = {
   senkouBLowBuf: ReturnType<CircularBuffer<number>["snapshot"]>;
   delayBuffer: MidPricePair[];
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const ICHIMOKU_VERSION = 1;
+
+type IchimokuParams = {
+  tenkanPeriod: number;
+  kijunPeriod: number;
+  senkouBPeriod: number;
+  displacement: number;
 };
 
 function bufferMinMax(buf: CircularBuffer<number>): { min: number; max: number } {
@@ -80,12 +101,48 @@ export function createIchimoku(
     senkouBPeriod?: number;
     displacement?: number;
   } = {},
-  warmUpOptions?: WarmUpOptions<IchimokuState>,
-): IncrementalIndicator<IchimokuValue, IchimokuState> {
-  const tenkanPeriod = options.tenkanPeriod ?? 9;
-  const kijunPeriod = options.kijunPeriod ?? 26;
-  const senkouBPeriod = options.senkouBPeriod ?? 52;
-  const displacement = options.displacement ?? 26;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<IchimokuState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<IchimokuValue, IndicatorSnapshot<IchimokuState>> {
+  const { params, state } = resolveResume<IchimokuParams, IchimokuState>({
+    indicator: "ichimoku",
+    version: ICHIMOKU_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { tenkanPeriod: 9, kijunPeriod: 26, senkouBPeriod: 52, displacement: 26 },
+  });
+
+  const tenkanPeriod = requireParam(
+    "ichimoku",
+    params,
+    "tenkanPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const kijunPeriod = requireParam(
+    "ichimoku",
+    params,
+    "kijunPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const senkouBPeriod = requireParam(
+    "ichimoku",
+    params,
+    "senkouBPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const displacement = requireParam(
+    "ichimoku",
+    params,
+    "displacement",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
 
   let tenkanHighBuf: CircularBuffer<number>;
   let tenkanLowBuf: CircularBuffer<number>;
@@ -96,16 +153,15 @@ export function createIchimoku(
   let delayBuffer: MidPricePair[];
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    tenkanHighBuf = CircularBuffer.fromSnapshot(s.tenkanHighBuf);
-    tenkanLowBuf = CircularBuffer.fromSnapshot(s.tenkanLowBuf);
-    kijunHighBuf = CircularBuffer.fromSnapshot(s.kijunHighBuf);
-    kijunLowBuf = CircularBuffer.fromSnapshot(s.kijunLowBuf);
-    senkouBHighBuf = CircularBuffer.fromSnapshot(s.senkouBHighBuf);
-    senkouBLowBuf = CircularBuffer.fromSnapshot(s.senkouBLowBuf);
-    delayBuffer = [...s.delayBuffer];
-    count = s.count;
+  if (state !== null) {
+    tenkanHighBuf = CircularBuffer.fromSnapshot(state.tenkanHighBuf);
+    tenkanLowBuf = CircularBuffer.fromSnapshot(state.tenkanLowBuf);
+    kijunHighBuf = CircularBuffer.fromSnapshot(state.kijunHighBuf);
+    kijunLowBuf = CircularBuffer.fromSnapshot(state.kijunLowBuf);
+    senkouBHighBuf = CircularBuffer.fromSnapshot(state.senkouBHighBuf);
+    senkouBLowBuf = CircularBuffer.fromSnapshot(state.senkouBLowBuf);
+    delayBuffer = [...state.delayBuffer];
+    count = state.count;
   } else {
     tenkanHighBuf = new CircularBuffer<number>(tenkanPeriod);
     tenkanLowBuf = new CircularBuffer<number>(tenkanPeriod);
@@ -160,44 +216,45 @@ export function createIchimoku(
     return { tenkan, kijun, senkouA, senkouB, chikou: null };
   }
 
-  const indicator: IncrementalIndicator<IchimokuValue, IchimokuState> = {
+  const indicator: IncrementalIndicator<IchimokuValue, IndicatorSnapshot<IchimokuState>> = {
     next(candle: NormalizedCandle) {
       const value = processCandle(candle);
       return { time: candle.time, value };
     },
 
     peek(candle: NormalizedCandle) {
-      const savedState = indicator.getState();
+      const saved = indicator.getState().state;
       const result = indicator.next(candle);
 
       // Restore
-      tenkanHighBuf = CircularBuffer.fromSnapshot(savedState.tenkanHighBuf);
-      tenkanLowBuf = CircularBuffer.fromSnapshot(savedState.tenkanLowBuf);
-      kijunHighBuf = CircularBuffer.fromSnapshot(savedState.kijunHighBuf);
-      kijunLowBuf = CircularBuffer.fromSnapshot(savedState.kijunLowBuf);
-      senkouBHighBuf = CircularBuffer.fromSnapshot(savedState.senkouBHighBuf);
-      senkouBLowBuf = CircularBuffer.fromSnapshot(savedState.senkouBLowBuf);
-      delayBuffer = [...savedState.delayBuffer];
-      count = savedState.count;
+      tenkanHighBuf = CircularBuffer.fromSnapshot(saved.tenkanHighBuf);
+      tenkanLowBuf = CircularBuffer.fromSnapshot(saved.tenkanLowBuf);
+      kijunHighBuf = CircularBuffer.fromSnapshot(saved.kijunHighBuf);
+      kijunLowBuf = CircularBuffer.fromSnapshot(saved.kijunLowBuf);
+      senkouBHighBuf = CircularBuffer.fromSnapshot(saved.senkouBHighBuf);
+      senkouBLowBuf = CircularBuffer.fromSnapshot(saved.senkouBLowBuf);
+      delayBuffer = [...saved.delayBuffer];
+      count = saved.count;
 
       return result;
     },
 
-    getState(): IchimokuState {
-      return {
-        tenkanPeriod,
-        kijunPeriod,
-        senkouBPeriod,
-        displacement,
-        tenkanHighBuf: tenkanHighBuf.snapshot(),
-        tenkanLowBuf: tenkanLowBuf.snapshot(),
-        kijunHighBuf: kijunHighBuf.snapshot(),
-        kijunLowBuf: kijunLowBuf.snapshot(),
-        senkouBHighBuf: senkouBHighBuf.snapshot(),
-        senkouBLowBuf: senkouBLowBuf.snapshot(),
-        delayBuffer: delayBuffer.map((d) => ({ ...d })),
-        count,
-      };
+    getState(): IndicatorSnapshot<IchimokuState> {
+      return makeSnapshot(
+        "ichimoku",
+        ICHIMOKU_VERSION,
+        { tenkanPeriod, kijunPeriod, senkouBPeriod, displacement },
+        {
+          tenkanHighBuf: tenkanHighBuf.snapshot(),
+          tenkanLowBuf: tenkanLowBuf.snapshot(),
+          kijunHighBuf: kijunHighBuf.snapshot(),
+          kijunLowBuf: kijunLowBuf.snapshot(),
+          senkouBHighBuf: senkouBHighBuf.snapshot(),
+          senkouBLowBuf: senkouBLowBuf.snapshot(),
+          delayBuffer: delayBuffer.map((d) => ({ ...d })),
+          count,
+        },
+      );
     },
 
     get count() {
@@ -209,11 +266,6 @@ export function createIchimoku(
       // valid kijun from `displacement` bars ago (so it needs
       // `kijunPeriod + displacement`) and `senkouB` needs
       // `senkouBPeriod + displacement`. The slower of the two wins.
-      // The previous threshold (`kijunPeriod + displacement`) was
-      // wrong for the canonical 9/26/52 setup (senkouB still null);
-      // the simpler swap to `senkouBPeriod + displacement` was wrong
-      // for caller-overridden setups where kijunPeriod > senkouBPeriod
-      // (senkouA would still be null). The Math.max here covers both.
       return count >= Math.max(kijunPeriod, senkouBPeriod) + displacement;
     },
   };

--- a/packages/core/src/indicators/incremental/trend/linear-regression.ts
+++ b/packages/core/src/indicators/incremental/trend/linear-regression.ts
@@ -13,14 +13,23 @@
  *
  * where y_drop is the oldest value in the window before the push.
  *
- * R² is computed from running sums via the Pearson form
- *   R² = (n·sumXY − sumX·sumY)² / ((n·sumXX − sumX²) · (n·sumYY − sumY²))
- * so we never have to iterate the buffer to get ssRes / ssTot.
+ * State category: **Windowed** (a raw price buffer plus running sums).
+ * Warmup and seeding are gated on `buffer.isFull`, not a monotonic
+ * `count`, so resume with a different `period` carries the buffer
+ * forward correctly; `source` change is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
 export type LinearRegressionValue = {
@@ -30,14 +39,24 @@ export type LinearRegressionValue = {
   rSquared: number;
 };
 
+/**
+ * Bare state shape for Linear Regression. Params (`period`, `source`)
+ * live in `meta.params` on the wire.
+ */
 export type LinearRegressionState = {
-  period: number;
-  source: PriceSource;
   buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   sumY: number;
   sumY2: number;
   sumXY: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const LINEAR_REGRESSION_VERSION = 1;
+
+type LinearRegressionParams = {
+  period: number;
+  source: PriceSource;
 };
 
 /**
@@ -54,18 +73,31 @@ export type LinearRegressionState = {
  */
 export function createLinearRegression(
   options: { period?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<LinearRegressionState>,
-): IncrementalIndicator<LinearRegressionValue | null, LinearRegressionState> {
-  // When restoring from a snapshot, the saved period/source MUST win over the
-  // factory-call defaults — otherwise sumY / sumXY / buffer values that were
-  // computed under one configuration would be reused with a different one,
-  // silently corrupting outputs from the first resumed candle onward.
-  const period = warmUpOptions?.fromState?.period ?? options.period ?? 14;
-  const source: PriceSource = warmUpOptions?.fromState?.source ?? options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<LinearRegressionState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<LinearRegressionValue | null, IndicatorSnapshot<LinearRegressionState>> {
+  const { params, state, reconfigured } = resolveResume<
+    LinearRegressionParams,
+    LinearRegressionState
+  >({
+    indicator: "linearRegression",
+    version: LINEAR_REGRESSION_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 14, source: "close" },
+  });
 
-  if (period < 2) {
-    throw new Error("Linear Regression period must be at least 2");
-  }
+  const period = requireParam(
+    "linearRegression",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 2,
+    "must be an integer >= 2",
+  );
+  const source = params.source;
 
   // Closed-form constants for x = 0..period-1
   const sumX = (period * (period - 1)) / 2;
@@ -78,13 +110,36 @@ export function createLinearRegression(
   let sumXY: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    sumY = s.sumY;
-    sumY2 = s.sumY2;
-    sumXY = s.sumXY;
-    count = s.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // Period changed — carry the raw prices forward and recompute the
+      // running sums against the new window.
+      const old = CircularBuffer.fromSnapshot(state.buffer);
+      buffer = new CircularBuffer<number>(period);
+      const carry = Math.min(old.length, period);
+      for (let i = old.length - carry; i < old.length; i++) {
+        buffer.push(old.get(i));
+      }
+      sumY = 0;
+      sumY2 = 0;
+      for (let i = 0; i < buffer.length; i++) {
+        const v = buffer.get(i);
+        sumY += v;
+        sumY2 += v * v;
+      }
+      // sumXY is only meaningful once the window is full; seed it now
+      // if the carry-forward already filled the new window.
+      sumXY = 0;
+      if (buffer.isFull) {
+        for (let j = 0; j < period; j++) sumXY += j * buffer.get(j);
+      }
+    } else {
+      buffer = CircularBuffer.fromSnapshot(state.buffer);
+      sumY = state.sumY;
+      sumY2 = state.sumY2;
+      sumXY = state.sumXY;
+    }
+    count = state.count;
   } else {
     buffer = new CircularBuffer<number>(period);
     sumY = 0;
@@ -94,7 +149,7 @@ export function createLinearRegression(
   }
 
   function compute(): LinearRegressionValue | null {
-    if (count < period) return null;
+    if (!buffer.isFull) return null;
     const slope = (period * sumXY - sumX * sumY) / denomX;
     const intercept = (sumY - slope * sumX) / period;
     const value = intercept + slope * (period - 1);
@@ -110,14 +165,17 @@ export function createLinearRegression(
     };
   }
 
-  const indicator: IncrementalIndicator<LinearRegressionValue | null, LinearRegressionState> = {
+  const indicator: IncrementalIndicator<
+    LinearRegressionValue | null,
+    IndicatorSnapshot<LinearRegressionState>
+  > = {
     next(candle: NormalizedCandle) {
       const y = getSourcePrice(candle, source);
-      const willEvict = buffer.isFull;
-      const yDrop = willEvict ? buffer.oldest() : 0;
+      const wasFull = buffer.isFull;
+      const yDrop = wasFull ? buffer.oldest() : 0;
 
       // Window already full → use the slide-update law BEFORE mutating sumY.
-      if (count >= period) {
+      if (wasFull) {
         sumXY = sumXY + (period - 1) * y - (sumY - yDrop);
       }
 
@@ -126,8 +184,8 @@ export function createLinearRegression(
       buffer.push(y);
       count++;
 
-      // First time the buffer is full → seed sumXY from the explicit sum.
-      if (count === period) {
+      // Buffer just reached full → seed sumXY from the explicit sum.
+      if (!wasFull && buffer.isFull) {
         sumXY = 0;
         for (let j = 0; j < period; j++) {
           sumXY += j * buffer.get(j);
@@ -139,27 +197,26 @@ export function createLinearRegression(
 
     peek(candle: NormalizedCandle) {
       const y = getSourcePrice(candle, source);
-      const willEvict = buffer.isFull;
-      const yDrop = willEvict ? buffer.oldest() : 0;
-      const peekCount = count + 1;
-      if (peekCount < period) return { time: candle.time, value: null };
+      const wasFull = buffer.isFull;
+      const yDrop = wasFull ? buffer.oldest() : 0;
+      const willBeFull = wasFull || buffer.length + 1 >= period;
+      if (!willBeFull) return { time: candle.time, value: null };
 
       let peekSumY: number;
       let peekSumY2: number;
       let peekSumXY: number;
 
-      if (count < period) {
-        // Buffer just becomes full; peek the seeded sumXY from buffer + new y.
-        peekSumY = sumY + y;
-        peekSumY2 = sumY2 + y * y;
-        peekSumXY = 0;
-        // Buffer currently has count elements, peek-pushing y at the end.
-        for (let j = 0; j < count; j++) peekSumXY += j * buffer.get(j);
-        peekSumXY += count * y;
-      } else {
+      if (wasFull) {
         peekSumY = sumY - yDrop + y;
         peekSumY2 = sumY2 - yDrop * yDrop + y * y;
         peekSumXY = sumXY + (period - 1) * y - (sumY - yDrop);
+      } else {
+        // Buffer becomes full exactly now; seed sumXY from buffer + new y.
+        peekSumY = sumY + y;
+        peekSumY2 = sumY2 + y * y;
+        peekSumXY = 0;
+        for (let j = 0; j < buffer.length; j++) peekSumXY += j * buffer.get(j);
+        peekSumXY += buffer.length * y;
       }
 
       const slope = (period * peekSumXY - sumX * peekSumY) / denomX;
@@ -179,16 +236,13 @@ export function createLinearRegression(
       };
     },
 
-    getState(): LinearRegressionState {
-      return {
-        period,
-        source,
-        buffer: buffer.snapshot(),
-        sumY,
-        sumY2,
-        sumXY,
-        count,
-      };
+    getState(): IndicatorSnapshot<LinearRegressionState> {
+      return makeSnapshot(
+        "linearRegression",
+        LINEAR_REGRESSION_VERSION,
+        { period, source },
+        { buffer: buffer.snapshot(), sumY, sumY2, sumXY, count },
+      );
     },
 
     get count() {
@@ -196,7 +250,7 @@ export function createLinearRegression(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      return buffer.isFull;
     },
   };
 

--- a/packages/core/src/indicators/incremental/trend/parabolic-sar.ts
+++ b/packages/core/src/indicators/incremental/trend/parabolic-sar.ts
@@ -6,7 +6,13 @@
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type ParabolicSarValue = {
   sar: number | null;
@@ -16,9 +22,12 @@ export type ParabolicSarValue = {
   ep: number | null;
 };
 
+/**
+ * Bare state shape for Parabolic SAR. Params (`step`, `max`) live in
+ * `meta.params`. `step` / `max` are state-shaping — they feed the
+ * recursive acceleration factor, so any change on resume is refused.
+ */
 export type ParabolicSarState = {
-  step: number;
-  max: number;
   count: number;
   initialized: boolean;
   isLong: boolean;
@@ -29,6 +38,14 @@ export type ParabolicSarState = {
   prevHigh: number;
   firstHigh: number;
   firstLow: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const PARABOLIC_SAR_VERSION = 1;
+
+type ParabolicSarParams = {
+  step: number;
+  max: number;
 };
 
 /**
@@ -45,10 +62,34 @@ export type ParabolicSarState = {
  */
 export function createParabolicSar(
   options: { step?: number; max?: number } = {},
-  warmUpOptions?: WarmUpOptions<ParabolicSarState>,
-): IncrementalIndicator<ParabolicSarValue, ParabolicSarState> {
-  const step = options.step ?? 0.02;
-  const max = options.max ?? 0.2;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<ParabolicSarState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<ParabolicSarValue, IndicatorSnapshot<ParabolicSarState>> {
+  const { params, state } = resolveResume<ParabolicSarParams, ParabolicSarState>({
+    indicator: "parabolicSar",
+    version: PARABOLIC_SAR_VERSION,
+    category: "recursive",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { step: 0.02, max: 0.2 },
+  });
+
+  const step = requireParam(
+    "parabolicSar",
+    params,
+    "step",
+    (v): v is number => typeof v === "number" && Number.isFinite(v) && v > 0,
+    "must be a positive number",
+  );
+  const max = requireParam(
+    "parabolicSar",
+    params,
+    "max",
+    (v): v is number => typeof v === "number" && Number.isFinite(v) && v > 0,
+    "must be a positive number",
+  );
 
   let count: number;
   let initialized: boolean;
@@ -61,18 +102,17 @@ export function createParabolicSar(
   let firstHigh: number;
   let firstLow: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    count = s.count;
-    initialized = s.initialized;
-    isLong = s.isLong;
-    sar = s.sar;
-    ep = s.ep;
-    af = s.af;
-    prevLow = s.prevLow;
-    prevHigh = s.prevHigh;
-    firstHigh = s.firstHigh;
-    firstLow = s.firstLow;
+  if (state !== null) {
+    count = state.count;
+    initialized = state.initialized;
+    isLong = state.isLong;
+    sar = state.sar;
+    ep = state.ep;
+    af = state.af;
+    prevLow = state.prevLow;
+    prevHigh = state.prevHigh;
+    firstHigh = state.firstHigh;
+    firstLow = state.firstLow;
   } else {
     count = 0;
     initialized = false;
@@ -181,7 +221,7 @@ export function createParabolicSar(
     return { outputSar, isReversal, nextSar, nextEp, nextAf, nextIsLong };
   }
 
-  const indicator: IncrementalIndicator<ParabolicSarValue, ParabolicSarState> = {
+  const indicator: IncrementalIndicator<ParabolicSarValue, IndicatorSnapshot<ParabolicSarState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -295,21 +335,24 @@ export function createParabolicSar(
       };
     },
 
-    getState(): ParabolicSarState {
-      return {
-        step,
-        max,
-        count,
-        initialized,
-        isLong,
-        sar,
-        ep,
-        af,
-        prevLow,
-        prevHigh,
-        firstHigh,
-        firstLow,
-      };
+    getState(): IndicatorSnapshot<ParabolicSarState> {
+      return makeSnapshot(
+        "parabolicSar",
+        PARABOLIC_SAR_VERSION,
+        { step, max },
+        {
+          count,
+          initialized,
+          isLong,
+          sar,
+          ep,
+          af,
+          prevLow,
+          prevHigh,
+          firstHigh,
+          firstLow,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/trend/supertrend.ts
+++ b/packages/core/src/indicators/incremental/trend/supertrend.ts
@@ -2,13 +2,24 @@
  * Incremental Supertrend
  *
  * Uses ATR internally to calculate dynamic support/resistance bands.
+ *
+ * State category: **Mixed** (an inner recursive ATR snapshot plus the
+ * recursive `prevFinalUpper` / `prevFinalLower` / `direction` bands).
+ * `multiplier` feeds the final bands that carry forward recursively,
+ * so it is state-shaping — every param change on resume is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
-import type { AtrState } from "../volatility/atr";
-import { createAtr } from "../volatility/atr";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
+import { type AtrState, createAtr } from "../volatility/atr";
 
 export type SupertrendValue = {
   supertrend: number | null;
@@ -18,14 +29,20 @@ export type SupertrendValue = {
 };
 
 export type SupertrendState = {
-  period: number;
-  multiplier: number;
   atrState: IndicatorSnapshot<AtrState>;
   prevFinalUpper: number | null;
   prevFinalLower: number | null;
   prevClose: number | null;
   direction: 1 | -1 | 0;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const SUPERTREND_VERSION = 1;
+
+type SupertrendParams = {
+  period: number;
+  multiplier: number;
 };
 
 /**
@@ -42,26 +59,56 @@ export type SupertrendState = {
  */
 export function createSupertrend(
   options: { period?: number; multiplier?: number } = {},
-  warmUpOptions?: WarmUpOptions<SupertrendState>,
-): IncrementalIndicator<SupertrendValue, SupertrendState> {
-  const period = options.period ?? 10;
-  const multiplier = options.multiplier ?? 3;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<SupertrendState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<SupertrendValue, IndicatorSnapshot<SupertrendState>> {
+  const { params, state } = resolveResume<SupertrendParams, SupertrendState>({
+    indicator: "supertrend",
+    version: SUPERTREND_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 10, multiplier: 3 },
+  });
 
-  let atrIndicator = createAtr({ period });
-  let prevFinalUpper: number | null = null;
-  let prevFinalLower: number | null = null;
-  let prevClose: number | null = null;
-  let direction: 1 | -1 | 0 = 0;
-  let count = 0;
+  const period = requireParam(
+    "supertrend",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const multiplier = requireParam(
+    "supertrend",
+    params,
+    "multiplier",
+    (v): v is number => typeof v === "number" && Number.isFinite(v) && v > 0,
+    "must be a positive number",
+  );
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    atrIndicator = createAtr({ period }, { fromState: s.atrState });
-    prevFinalUpper = s.prevFinalUpper;
-    prevFinalLower = s.prevFinalLower;
-    prevClose = s.prevClose;
-    direction = s.direction;
-    count = s.count;
+  let atrIndicator: ReturnType<typeof createAtr>;
+  let prevFinalUpper: number | null;
+  let prevFinalLower: number | null;
+  let prevClose: number | null;
+  let direction: 1 | -1 | 0;
+  let count: number;
+
+  if (state !== null) {
+    atrIndicator = createAtr({ period }, { fromState: state.atrState });
+    prevFinalUpper = state.prevFinalUpper;
+    prevFinalLower = state.prevFinalLower;
+    prevClose = state.prevClose;
+    direction = state.direction;
+    count = state.count;
+  } else {
+    atrIndicator = createAtr({ period });
+    prevFinalUpper = null;
+    prevFinalLower = null;
+    prevClose = null;
+    direction = 0;
+    count = 0;
   }
 
   const nullValue: SupertrendValue = {
@@ -71,7 +118,7 @@ export function createSupertrend(
     lowerBand: null,
   };
 
-  const indicator: IncrementalIndicator<SupertrendValue, SupertrendState> = {
+  const indicator: IncrementalIndicator<SupertrendValue, IndicatorSnapshot<SupertrendState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const atrResult = atrIndicator.next(candle);
@@ -174,17 +221,20 @@ export function createSupertrend(
       };
     },
 
-    getState(): SupertrendState {
-      return {
-        period,
-        multiplier,
-        atrState: atrIndicator.getState(),
-        prevFinalUpper,
-        prevFinalLower,
-        prevClose,
-        direction,
-        count,
-      };
+    getState(): IndicatorSnapshot<SupertrendState> {
+      return makeSnapshot(
+        "supertrend",
+        SUPERTREND_VERSION,
+        { period, multiplier },
+        {
+          atrState: atrIndicator.getState(),
+          prevFinalUpper,
+          prevFinalLower,
+          prevClose,
+          direction,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/volatility/atr-stops.ts
+++ b/packages/core/src/indicators/incremental/volatility/atr-stops.ts
@@ -3,19 +3,37 @@
  *
  * Composes the incremental ATR indicator to compute stop-loss and
  * take-profit levels based on ATR distance from the current close.
+ *
+ * State category: **Mixed** (an inner recursive ATR snapshot). Resume
+ * with a different `period` is refused. `stopMultiplier` /
+ * `takeProfitMultiplier` are resume-invariant — they only scale the
+ * final stop / take-profit levels, never the ATR state.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { AtrStopsValue, NormalizedCandle } from "../../../types";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { type AtrState, createAtr } from "./atr";
 
 export type AtrStopsState = {
   atrState: IndicatorSnapshot<AtrState>;
+  count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const ATR_STOPS_VERSION = 1;
+
+type AtrStopsParams = {
   period: number;
   stopMultiplier: number;
   takeProfitMultiplier: number;
-  count: number;
 };
 
 const NULL_VALUE: AtrStopsValue = {
@@ -47,19 +65,49 @@ const NULL_VALUE: AtrStopsValue = {
  */
 export function createAtrStops(
   options: { period?: number; stopMultiplier?: number; takeProfitMultiplier?: number } = {},
-  warmUpOptions?: WarmUpOptions<AtrStopsState>,
-): IncrementalIndicator<AtrStopsValue, AtrStopsState> {
-  const period = options.period ?? 14;
-  const stopMultiplier = options.stopMultiplier ?? 2.0;
-  const takeProfitMultiplier = options.takeProfitMultiplier ?? 3.0;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<AtrStopsState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<AtrStopsValue, IndicatorSnapshot<AtrStopsState>> {
+  const { params, state } = resolveResume<AtrStopsParams, AtrStopsState>({
+    indicator: "atrStops",
+    version: ATR_STOPS_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 14, stopMultiplier: 2.0, takeProfitMultiplier: 3.0 },
+    resumeInvariantParams: ["stopMultiplier", "takeProfitMultiplier"],
+  });
+
+  const period = requireParam(
+    "atrStops",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const stopMultiplier = requireParam(
+    "atrStops",
+    params,
+    "stopMultiplier",
+    (v): v is number => typeof v === "number" && Number.isFinite(v) && v > 0,
+    "must be a positive number",
+  );
+  const takeProfitMultiplier = requireParam(
+    "atrStops",
+    params,
+    "takeProfitMultiplier",
+    (v): v is number => typeof v === "number" && Number.isFinite(v) && v > 0,
+    "must be a positive number",
+  );
 
   let count: number;
   let atr: IncrementalIndicator<number | null, IndicatorSnapshot<AtrState>>;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    count = s.count;
-    atr = createAtr({ period }, { fromState: s.atrState });
+  if (state !== null) {
+    count = state.count;
+    atr = createAtr({ period }, { fromState: state.atrState });
   } else {
     count = 0;
     atr = createAtr({ period });
@@ -80,7 +128,7 @@ export function createAtrStops(
     };
   }
 
-  const indicator: IncrementalIndicator<AtrStopsValue, AtrStopsState> = {
+  const indicator: IncrementalIndicator<AtrStopsValue, IndicatorSnapshot<AtrStopsState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const atrResult = atr.next(candle);
@@ -102,14 +150,13 @@ export function createAtrStops(
       return { time: candle.time, value: computeLevels(candle.close, atrResult.value) };
     },
 
-    getState(): AtrStopsState {
-      return {
-        atrState: atr.getState(),
-        period,
-        stopMultiplier,
-        takeProfitMultiplier,
-        count,
-      };
+    getState(): IndicatorSnapshot<AtrStopsState> {
+      return makeSnapshot(
+        "atrStops",
+        ATR_STOPS_VERSION,
+        { period, stopMultiplier, takeProfitMultiplier },
+        { atrState: atr.getState(), count },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/volatility/bollinger-bands.ts
+++ b/packages/core/src/indicators/incremental/volatility/bollinger-bands.ts
@@ -2,21 +2,45 @@
  * Incremental Bollinger Bands
  *
  * Uses population variance (/N, not /(N-1)) for TA-Lib compatibility.
+ *
+ * State category: **Windowed** (a fixed-size price buffer plus running
+ * `sum` / `sumSquares`). Resume with a different `period` carries the
+ * raw price buffer forward and recomputes the running sums; `source`
+ * change is refused. `stdDev` is a resume-invariant param — it only
+ * scales the band width, never the buffer or sums.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { BollingerBandsValue, NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for Bollinger Bands. Params (`period`, `stdDev`,
+ * `source`) live in `meta.params` on the wire.
+ */
 export type BollingerBandsState = {
-  period: number;
-  stdDev: number;
-  source: PriceSource;
   buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   sum: number;
   sumSquares: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const BOLLINGER_BANDS_VERSION = 1;
+
+type BollingerBandsParams = {
+  period: number;
+  stdDev: number;
+  source: PriceSource;
 };
 
 /**
@@ -33,23 +57,59 @@ export type BollingerBandsState = {
  */
 export function createBollingerBands(
   options: { period?: number; stdDev?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<BollingerBandsState>,
-): IncrementalIndicator<BollingerBandsValue, BollingerBandsState> {
-  const period = options.period ?? 20;
-  const stdDevMult = options.stdDev ?? 2;
-  const source: PriceSource = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<BollingerBandsState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<BollingerBandsValue, IndicatorSnapshot<BollingerBandsState>> {
+  const { params, state, reconfigured } = resolveResume<BollingerBandsParams, BollingerBandsState>({
+    indicator: "bollingerBands",
+    version: BOLLINGER_BANDS_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 20, stdDev: 2, source: "close" },
+    resumeInvariantParams: ["stdDev"],
+  });
+
+  const period = requireParam(
+    "bollingerBands",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const stdDevMult = params.stdDev;
+  const source = params.source;
 
   let buffer: CircularBuffer<number>;
   let sum: number;
   let sumSquares: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    sum = s.sum;
-    sumSquares = s.sumSquares;
-    count = s.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // Period changed — carry the raw prices forward and recompute the
+      // running sums against the new window.
+      const old = CircularBuffer.fromSnapshot(state.buffer);
+      buffer = new CircularBuffer<number>(period);
+      const carry = Math.min(old.length, period);
+      for (let i = old.length - carry; i < old.length; i++) {
+        buffer.push(old.get(i));
+      }
+      sum = 0;
+      sumSquares = 0;
+      for (let i = 0; i < buffer.length; i++) {
+        const v = buffer.get(i);
+        sum += v;
+        sumSquares += v * v;
+      }
+    } else {
+      buffer = CircularBuffer.fromSnapshot(state.buffer);
+      sum = state.sum;
+      sumSquares = state.sumSquares;
+    }
+    count = state.count;
   } else {
     buffer = new CircularBuffer<number>(period);
     sum = 0;
@@ -84,7 +144,10 @@ export function createBollingerBands(
     return { upper, middle: mean, lower, percentB, bandwidth };
   }
 
-  const indicator: IncrementalIndicator<BollingerBandsValue, BollingerBandsState> = {
+  const indicator: IncrementalIndicator<
+    BollingerBandsValue,
+    IndicatorSnapshot<BollingerBandsState>
+  > = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
       count++;
@@ -100,7 +163,7 @@ export function createBollingerBands(
 
       buffer.push(price);
 
-      if (count < period) {
+      if (buffer.length < period) {
         return { time: candle.time, value: nullValue };
       }
 
@@ -110,7 +173,7 @@ export function createBollingerBands(
     peek(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
 
-      if (count + 1 < period) {
+      if (buffer.length < period - 1) {
         return { time: candle.time, value: nullValue };
       }
 
@@ -129,16 +192,13 @@ export function createBollingerBands(
       return { time: candle.time, value: computeBands(peekSum, peekSumSq, price) };
     },
 
-    getState(): BollingerBandsState {
-      return {
-        period,
-        stdDev: stdDevMult,
-        source,
-        buffer: buffer.snapshot(),
-        sum,
-        sumSquares,
-        count,
-      };
+    getState(): IndicatorSnapshot<BollingerBandsState> {
+      return makeSnapshot(
+        "bollingerBands",
+        BOLLINGER_BANDS_VERSION,
+        { period, stdDev: stdDevMult, source },
+        { buffer: buffer.snapshot(), sum, sumSquares, count },
+      );
     },
 
     get count() {
@@ -146,7 +206,7 @@ export function createBollingerBands(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      return buffer.length >= period;
     },
   };
 

--- a/packages/core/src/indicators/incremental/volatility/chandelier-exit.ts
+++ b/packages/core/src/indicators/incremental/volatility/chandelier-exit.ts
@@ -3,24 +3,43 @@
  *
  * Long Exit = Highest High (n) - ATR * Multiplier
  * Short Exit = Lowest Low (n) + ATR * Multiplier
+ *
+ * State category: **Mixed** (an inner recursive ATR snapshot, windowed
+ * high/low buffers, and a recursive `prevDirection`). `multiplier`
+ * feeds the exit levels that determine `direction`, which carries into
+ * `prevDirection`, so it is state-shaping — every param change on
+ * resume is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { ChandelierExitValue, NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
-import type { AtrState } from "./atr";
-import { createAtr } from "./atr";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
+import { type AtrState, createAtr } from "./atr";
 
 export type ChandelierExitState = {
-  period: number;
-  multiplier: number;
-  hlLookback: number;
   atrState: IndicatorSnapshot<AtrState>;
   highBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   lowBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   prevDirection: 1 | -1 | 0;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const CHANDELIER_EXIT_VERSION = 1;
+
+type ChandelierExitParams = {
+  period: number;
+  multiplier: number;
+  /** Optional — falls back to `period` when omitted. */
+  lookback?: number;
 };
 
 /**
@@ -37,11 +56,47 @@ export type ChandelierExitState = {
  */
 export function createChandelierExit(
   options: { period?: number; multiplier?: number; lookback?: number } = {},
-  warmUpOptions?: WarmUpOptions<ChandelierExitState>,
-): IncrementalIndicator<ChandelierExitValue, ChandelierExitState> {
-  const period = options.period ?? 22;
-  const multiplier = options.multiplier ?? 3.0;
-  const hlLookback = options.lookback ?? period;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<ChandelierExitState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<ChandelierExitValue, IndicatorSnapshot<ChandelierExitState>> {
+  // Pass the raw `options` to resolveResume — do not inject a resolved
+  // `lookback`. Injecting a default would make a resumed snapshot
+  // (which omits `lookback`) look like a state-shaping change and throw.
+  const { params, state } = resolveResume<ChandelierExitParams, ChandelierExitState>({
+    indicator: "chandelierExit",
+    version: CHANDELIER_EXIT_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 22, multiplier: 3.0 },
+  });
+
+  const period = requireParam(
+    "chandelierExit",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const multiplier = requireParam(
+    "chandelierExit",
+    params,
+    "multiplier",
+    (v): v is number => typeof v === "number" && Number.isFinite(v) && v > 0,
+    "must be a positive number",
+  );
+  // `lookback` has no canonical default — it falls back to `period`.
+  // Resolved AFTER resolveResume: a resumed snapshot keeps its saved
+  // `lookback` (recorded in `meta.params` by getState) because the raw
+  // options carry no injected default to diff against.
+  const hlLookback = params.lookback ?? period;
+  if (!Number.isInteger(hlLookback) || hlLookback < 1) {
+    throw new Error(
+      'chandelierExit: option "lookback" failed validation (must be a positive integer)',
+    );
+  }
 
   let atrIndicator: ReturnType<typeof createAtr>;
   let highBuffer: CircularBuffer<number>;
@@ -49,13 +104,12 @@ export function createChandelierExit(
   let prevDirection: 1 | -1 | 0;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    atrIndicator = createAtr({ period }, { fromState: s.atrState });
-    highBuffer = CircularBuffer.fromSnapshot(s.highBuffer);
-    lowBuffer = CircularBuffer.fromSnapshot(s.lowBuffer);
-    prevDirection = s.prevDirection;
-    count = s.count;
+  if (state !== null) {
+    atrIndicator = createAtr({ period }, { fromState: state.atrState });
+    highBuffer = CircularBuffer.fromSnapshot(state.highBuffer);
+    lowBuffer = CircularBuffer.fromSnapshot(state.lowBuffer);
+    prevDirection = state.prevDirection;
+    count = state.count;
   } else {
     atrIndicator = createAtr({ period });
     highBuffer = new CircularBuffer<number>(hlLookback);
@@ -80,68 +134,10 @@ export function createChandelierExit(
     return min;
   }
 
-  function _computeValue(
-    candle: NormalizedCandle,
-    atrVal: number | null,
-    advance: boolean,
-  ): ChandelierExitValue {
-    const hh = highBuffer.length > 0 ? Math.max(getHighest(highBuffer), candle.high) : candle.high;
-    const ll = lowBuffer.length > 0 ? Math.min(getLowest(lowBuffer), candle.low) : candle.low;
-
-    // For peek: the buffers already include this candle for the `next` path
-    // For advance=true, we use post-push values; for peek we simulate
-    let highestHigh: number | null = null;
-    let lowestLow: number | null = null;
-
-    if (
-      count >= hlLookback - 1 ||
-      (advance && count + 1 >= hlLookback) ||
-      (!advance && count >= hlLookback - 1)
-    ) {
-      highestHigh = hh;
-      lowestLow = ll;
-    } else {
-      highestHigh = hh;
-      lowestLow = ll;
-    }
-
-    let longExit: number | null = null;
-    let shortExit: number | null = null;
-
-    if (atrVal !== null && highestHigh !== null && lowestLow !== null) {
-      const atrDist = atrVal * multiplier;
-      longExit = highestHigh - atrDist;
-      shortExit = lowestLow + atrDist;
-    }
-
-    let direction: 1 | -1 | 0 = 0;
-    if (longExit !== null && shortExit !== null) {
-      if (candle.close > longExit) {
-        direction = 1;
-      } else if (candle.close < shortExit) {
-        direction = -1;
-      } else {
-        direction = prevDirection !== 0 ? prevDirection : 1;
-      }
-    }
-
-    let isCrossover = false;
-    if (prevDirection !== 0 && direction !== 0 && prevDirection !== direction) {
-      isCrossover = true;
-    }
-
-    return {
-      longExit,
-      shortExit,
-      direction,
-      isCrossover,
-      highestHigh,
-      lowestLow,
-      atr: atrVal,
-    };
-  }
-
-  const indicator: IncrementalIndicator<ChandelierExitValue, ChandelierExitState> = {
+  const indicator: IncrementalIndicator<
+    ChandelierExitValue,
+    IndicatorSnapshot<ChandelierExitState>
+  > = {
     next(candle: NormalizedCandle) {
       count++;
       const atrResult = atrIndicator.next(candle);
@@ -252,17 +248,19 @@ export function createChandelierExit(
       };
     },
 
-    getState(): ChandelierExitState {
-      return {
-        period,
-        multiplier,
-        hlLookback,
-        atrState: atrIndicator.getState(),
-        highBuffer: highBuffer.snapshot(),
-        lowBuffer: lowBuffer.snapshot(),
-        prevDirection,
-        count,
-      };
+    getState(): IndicatorSnapshot<ChandelierExitState> {
+      return makeSnapshot(
+        "chandelierExit",
+        CHANDELIER_EXIT_VERSION,
+        { period, multiplier, lookback: hlLookback },
+        {
+          atrState: atrIndicator.getState(),
+          highBuffer: highBuffer.snapshot(),
+          lowBuffer: lowBuffer.snapshot(),
+          prevDirection,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/volatility/garman-klass.ts
+++ b/packages/core/src/indicators/incremental/volatility/garman-klass.ts
@@ -6,18 +6,41 @@
  *
  * Formula per bar: 0.5 * ln(H/L)^2 - (2*ln(2) - 1) * ln(C/O)^2
  * Output: sqrt(mean(components) * annualFactor) * 100
+ *
+ * State category: **Windowed** (a fixed-size component buffer plus a
+ * running `sum`). Resume with a different `period` carries the
+ * component buffer forward. `annualFactor` is a resume-invariant
+ * param — it only scales the final sqrt output, never the buffer.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
+/**
+ * Bare state shape for Garman-Klass. Params (`period`, `annualFactor`)
+ * live in `meta.params` on the wire.
+ */
 export type GarmanKlassState = {
-  period: number;
-  annualFactor: number;
   buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   sum: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const GARMAN_KLASS_VERSION = 1;
+
+type GarmanKlassParams = {
+  period: number;
+  annualFactor: number;
 };
 
 /**
@@ -34,10 +57,29 @@ export type GarmanKlassState = {
  */
 export function createGarmanKlass(
   options: { period?: number; annualFactor?: number } = {},
-  warmUpOptions?: WarmUpOptions<GarmanKlassState>,
-): IncrementalIndicator<number | null, GarmanKlassState> {
-  const period = options.period ?? 20;
-  const annualFactor = options.annualFactor ?? 252;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<GarmanKlassState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<GarmanKlassState>> {
+  const { params, state, reconfigured } = resolveResume<GarmanKlassParams, GarmanKlassState>({
+    indicator: "garmanKlass",
+    version: GARMAN_KLASS_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 20, annualFactor: 252 },
+    resumeInvariantParams: ["annualFactor"],
+  });
+
+  const period = requireParam(
+    "garmanKlass",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const annualFactor = params.annualFactor;
 
   const LN2_COEFF = 2 * Math.LN2 - 1;
 
@@ -45,11 +87,26 @@ export function createGarmanKlass(
   let sum: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    sum = s.sum;
-    count = s.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // Period changed — carry the component buffer forward and
+      // recompute the running sum (NaN markers are excluded).
+      const old = CircularBuffer.fromSnapshot(state.buffer);
+      buffer = new CircularBuffer<number>(period);
+      const carry = Math.min(old.length, period);
+      for (let i = old.length - carry; i < old.length; i++) {
+        buffer.push(old.get(i));
+      }
+      sum = 0;
+      for (let i = 0; i < buffer.length; i++) {
+        const v = buffer.get(i);
+        if (!Number.isNaN(v)) sum += v;
+      }
+    } else {
+      buffer = CircularBuffer.fromSnapshot(state.buffer);
+      sum = state.sum;
+    }
+    count = state.count;
   } else {
     buffer = new CircularBuffer<number>(period);
     sum = 0;
@@ -68,7 +125,7 @@ export function createGarmanKlass(
     return Math.sqrt(Math.max(0, mean) * annualFactor) * 100;
   }
 
-  const indicator: IncrementalIndicator<number | null, GarmanKlassState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<GarmanKlassState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -114,7 +171,7 @@ export function createGarmanKlass(
 
     peek(candle: NormalizedCandle) {
       const component = computeComponent(candle);
-      if (component === null || count + 1 < period) {
+      if (component === null || buffer.length < period - 1) {
         return { time: candle.time, value: null };
       }
 
@@ -130,17 +187,24 @@ export function createGarmanKlass(
         return { time: candle.time, value: null };
       }
 
+      // A NaN marker anywhere in the simulated window invalidates output.
+      const start = buffer.isFull ? 1 : 0;
+      for (let i = start; i < buffer.length; i++) {
+        if (Number.isNaN(buffer.get(i))) {
+          return { time: candle.time, value: null };
+        }
+      }
+
       return { time: candle.time, value: computeOutput(peekSum) };
     },
 
-    getState(): GarmanKlassState {
-      return {
-        period,
-        annualFactor,
-        buffer: buffer.snapshot(),
-        sum,
-        count,
-      };
+    getState(): IndicatorSnapshot<GarmanKlassState> {
+      return makeSnapshot(
+        "garmanKlass",
+        GARMAN_KLASS_VERSION,
+        { period, annualFactor },
+        { buffer: buffer.snapshot(), sum, count },
+      );
     },
 
     get count() {
@@ -148,7 +212,7 @@ export function createGarmanKlass(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      return buffer.length >= period;
     },
   };
 

--- a/packages/core/src/indicators/incremental/volatility/historical-volatility.ts
+++ b/packages/core/src/indicators/incremental/volatility/historical-volatility.ts
@@ -5,22 +5,46 @@
  * Uses sample variance (divides by N-1) for statistical correctness.
  *
  * Formula: HV = sqrt(variance(logReturns) * annualFactor) * 100
+ *
+ * State category: **Windowed** (a fixed-size log-return buffer plus
+ * running `sum` / `sumSq` and the recursive `prevPrice` needed to form
+ * the next return). Resume with a different `period` carries the
+ * return buffer forward; `source` change is refused. `annualFactor` is
+ * a resume-invariant param.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for Historical Volatility. Params (`period`,
+ * `annualFactor`, `source`) live in `meta.params` on the wire.
+ */
 export type HistoricalVolatilityState = {
-  period: number;
-  annualFactor: number;
-  source: PriceSource;
   buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   sum: number;
   sumSq: number;
   prevPrice: number | null;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const HISTORICAL_VOLATILITY_VERSION = 1;
+
+type HistoricalVolatilityParams = {
+  period: number;
+  annualFactor: number;
+  source: PriceSource;
 };
 
 /**
@@ -37,11 +61,33 @@ export type HistoricalVolatilityState = {
  */
 export function createHistoricalVolatility(
   options: { period?: number; annualFactor?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<HistoricalVolatilityState>,
-): IncrementalIndicator<number | null, HistoricalVolatilityState> {
-  const period = options.period ?? 20;
-  const annualFactor = options.annualFactor ?? 252;
-  const source: PriceSource = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<HistoricalVolatilityState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<HistoricalVolatilityState>> {
+  const { params, state, reconfigured } = resolveResume<
+    HistoricalVolatilityParams,
+    HistoricalVolatilityState
+  >({
+    indicator: "historicalVolatility",
+    version: HISTORICAL_VOLATILITY_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 20, annualFactor: 252, source: "close" },
+    resumeInvariantParams: ["annualFactor"],
+  });
+
+  const period = requireParam(
+    "historicalVolatility",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 2,
+    "must be an integer >= 2",
+  );
+  const annualFactor = params.annualFactor;
+  const source = params.source;
 
   let buffer: CircularBuffer<number>;
   let sum: number;
@@ -49,13 +95,30 @@ export function createHistoricalVolatility(
   let prevPrice: number | null;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    sum = s.sum;
-    sumSq = s.sumSq;
-    prevPrice = s.prevPrice;
-    count = s.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // Period changed — carry the log-return buffer forward and
+      // recompute the running sums against the new window.
+      const old = CircularBuffer.fromSnapshot(state.buffer);
+      buffer = new CircularBuffer<number>(period);
+      const carry = Math.min(old.length, period);
+      for (let i = old.length - carry; i < old.length; i++) {
+        buffer.push(old.get(i));
+      }
+      sum = 0;
+      sumSq = 0;
+      for (let i = 0; i < buffer.length; i++) {
+        const v = buffer.get(i);
+        sum += v;
+        sumSq += v * v;
+      }
+    } else {
+      buffer = CircularBuffer.fromSnapshot(state.buffer);
+      sum = state.sum;
+      sumSq = state.sumSq;
+    }
+    prevPrice = state.prevPrice;
+    count = state.count;
   } else {
     buffer = new CircularBuffer<number>(period);
     sum = 0;
@@ -70,7 +133,10 @@ export function createHistoricalVolatility(
     return Math.sqrt(Math.max(0, variance) * annualFactor) * 100;
   }
 
-  const indicator: IncrementalIndicator<number | null, HistoricalVolatilityState> = {
+  const indicator: IncrementalIndicator<
+    number | null,
+    IndicatorSnapshot<HistoricalVolatilityState>
+  > = {
     next(candle: NormalizedCandle) {
       count++;
       const price = getSourcePrice(candle, source);
@@ -136,17 +202,13 @@ export function createHistoricalVolatility(
       return { time: candle.time, value: computeOutput(peekSum, peekSumSq, period) };
     },
 
-    getState(): HistoricalVolatilityState {
-      return {
-        period,
-        annualFactor,
-        source,
-        buffer: buffer.snapshot(),
-        sum,
-        sumSq,
-        prevPrice,
-        count,
-      };
+    getState(): IndicatorSnapshot<HistoricalVolatilityState> {
+      return makeSnapshot(
+        "historicalVolatility",
+        HISTORICAL_VOLATILITY_VERSION,
+        { period, annualFactor, source },
+        { buffer: buffer.snapshot(), sum, sumSq, prevPrice, count },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/volatility/regime.ts
+++ b/packages/core/src/indicators/incremental/volatility/regime.ts
@@ -6,14 +6,25 @@
  *
  * Composes ATR, Bollinger Bands, DMI, and SMA incremental indicators
  * to produce a snapshot compatible with regimeFilter().
+ *
+ * State category: **Mixed** (four inner recursive / windowed indicator
+ * snapshots plus two percentile buffers). Resume with any param change
+ * is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { createDmi, type DmiState } from "../../incremental/momentum/dmi";
 import { createSma, type SmaState } from "../../incremental/moving-average/sma";
 import { CircularBuffer } from "../circular-buffer";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { type AtrState, createAtr } from "./atr";
 import { type BollingerBandsState, createBollingerBands } from "./bollinger-bands";
 
@@ -31,18 +42,28 @@ export type RegimeValue = {
   trendStrength: number;
 };
 
+/**
+ * Bare state shape for Regime. Params (`atrPeriod`, `bbPeriod`,
+ * `dmiPeriod`, `lookback`) live in `meta.params` on the wire.
+ */
 export type RegimeState = {
-  atrPeriod: number;
-  bbPeriod: number;
-  dmiPeriod: number;
-  lookback: number;
   atrState: IndicatorSnapshot<AtrState>;
-  bbState: BollingerBandsState;
+  bbState: IndicatorSnapshot<BollingerBandsState>;
   dmiState: IndicatorSnapshot<DmiState>;
   smaState: IndicatorSnapshot<SmaState>;
   atrBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   bwBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const REGIME_VERSION = 1;
+
+type RegimeParams = {
+  atrPeriod: number;
+  bbPeriod: number;
+  dmiPeriod: number;
+  lookback: number;
 };
 
 export type RegimeOptions = {
@@ -91,39 +112,65 @@ function percentileRank(buf: CircularBuffer<number>): number | null {
  */
 export function createRegime(
   options: RegimeOptions = {},
-  warmUpOptions?: WarmUpOptions<RegimeState>,
-): IncrementalIndicator<RegimeValue | null, RegimeState> {
-  const atrPeriod = options.atrPeriod ?? 14;
-  const bbPeriod = options.bbPeriod ?? 20;
-  const dmiPeriod = options.dmiPeriod ?? 14;
-  const lookback = options.lookback ?? 100;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<RegimeState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<RegimeValue | null, IndicatorSnapshot<RegimeState>> {
+  const { params, state } = resolveResume<RegimeParams, RegimeState>({
+    indicator: "regime",
+    version: REGIME_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { atrPeriod: 14, bbPeriod: 20, dmiPeriod: 14, lookback: 100 },
+  });
 
-  let atrInd: IncrementalIndicator<number | null, IndicatorSnapshot<AtrState>>;
-  let bbInd: IncrementalIndicator<
-    {
-      upper: number | null;
-      middle: number | null;
-      lower: number | null;
-      percentB: number | null;
-      bandwidth: number | null;
-    },
-    BollingerBandsState
-  >;
+  const atrPeriod = requireParam(
+    "regime",
+    params,
+    "atrPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const bbPeriod = requireParam(
+    "regime",
+    params,
+    "bbPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const dmiPeriod = requireParam(
+    "regime",
+    params,
+    "dmiPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const lookback = requireParam(
+    "regime",
+    params,
+    "lookback",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+
+  let atrInd: ReturnType<typeof createAtr>;
+  let bbInd: ReturnType<typeof createBollingerBands>;
   let dmiInd: ReturnType<typeof createDmi>;
-  let smaInd: IncrementalIndicator<number | null, IndicatorSnapshot<SmaState>>;
+  let smaInd: ReturnType<typeof createSma>;
   let atrBuffer: CircularBuffer<number>;
   let bwBuffer: CircularBuffer<number>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    atrInd = createAtr({ period: atrPeriod }, { fromState: s.atrState });
-    bbInd = createBollingerBands({ period: bbPeriod }, { fromState: s.bbState });
-    dmiInd = createDmi({ period: dmiPeriod }, { fromState: s.dmiState });
-    smaInd = createSma({ period: lookback }, { fromState: s.smaState });
-    atrBuffer = CircularBuffer.fromSnapshot(s.atrBuffer);
-    bwBuffer = CircularBuffer.fromSnapshot(s.bwBuffer);
-    count = s.count;
+  if (state !== null) {
+    atrInd = createAtr({ period: atrPeriod }, { fromState: state.atrState });
+    bbInd = createBollingerBands({ period: bbPeriod }, { fromState: state.bbState });
+    dmiInd = createDmi({ period: dmiPeriod }, { fromState: state.dmiState });
+    smaInd = createSma({ period: lookback }, { fromState: state.smaState });
+    atrBuffer = CircularBuffer.fromSnapshot(state.atrBuffer);
+    bwBuffer = CircularBuffer.fromSnapshot(state.bwBuffer);
+    count = state.count;
   } else {
     atrInd = createAtr({ period: atrPeriod });
     bbInd = createBollingerBands({ period: bbPeriod });
@@ -134,14 +181,14 @@ export function createRegime(
     count = 0;
   }
 
-  const indicator: IncrementalIndicator<RegimeValue | null, RegimeState> = {
+  const indicator: IncrementalIndicator<RegimeValue | null, IndicatorSnapshot<RegimeState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
       const atrResult = atrInd.next(candle);
       const bbResult = bbInd.next(candle);
       const dmiResult = dmiInd.next(candle);
-      smaInd.next(candle);
+      const smaResult = smaInd.next(candle);
 
       // Accumulate ATR values for percentile
       if (atrResult.value !== null) {
@@ -173,16 +220,14 @@ export function createRegime(
         else if (avg >= 75) volatility = "high";
       }
 
-      // Trend direction from SMA slope
+      // Trend direction: current close vs the SMA value at this candle.
+      // Use the SMA value `next()` just produced — peeking the same
+      // candle again would look one bar ahead and diverge from peek().
       let trend: "bullish" | "bearish" | "sideways" = "sideways";
-      if (smaInd.isWarmedUp) {
-        // Compare current close to SMA
-        const smaVal = smaInd.peek(candle).value;
-        if (smaVal !== null) {
-          const diff = (candle.close - smaVal) / smaVal;
-          if (diff > 0.001) trend = "bullish";
-          else if (diff < -0.001) trend = "bearish";
-        }
+      if (smaResult.value !== null) {
+        const diff = (candle.close - smaResult.value) / smaResult.value;
+        if (diff > 0.001) trend = "bullish";
+        else if (diff < -0.001) trend = "bearish";
       }
 
       // Trend strength from ADX
@@ -224,13 +269,11 @@ export function createRegime(
       }
 
       let trend: "bullish" | "bearish" | "sideways" = "sideways";
-      if (smaInd.isWarmedUp) {
-        const smaVal = smaInd.peek(candle).value;
-        if (smaVal !== null) {
-          const diff = (candle.close - smaVal) / smaVal;
-          if (diff > 0.001) trend = "bullish";
-          else if (diff < -0.001) trend = "bearish";
-        }
+      const smaVal = smaInd.peek(candle).value;
+      if (smaVal !== null) {
+        const diff = (candle.close - smaVal) / smaVal;
+        if (diff > 0.001) trend = "bullish";
+        else if (diff < -0.001) trend = "bearish";
       }
 
       const trendStrength = Math.round(dmiResult.value.adx * 100) / 100;
@@ -241,20 +284,21 @@ export function createRegime(
       };
     },
 
-    getState(): RegimeState {
-      return {
-        atrPeriod,
-        bbPeriod,
-        dmiPeriod,
-        lookback,
-        atrState: atrInd.getState(),
-        bbState: bbInd.getState(),
-        dmiState: dmiInd.getState(),
-        smaState: smaInd.getState(),
-        atrBuffer: atrBuffer.snapshot(),
-        bwBuffer: bwBuffer.snapshot(),
-        count,
-      };
+    getState(): IndicatorSnapshot<RegimeState> {
+      return makeSnapshot(
+        "regime",
+        REGIME_VERSION,
+        { atrPeriod, bbPeriod, dmiPeriod, lookback },
+        {
+          atrState: atrInd.getState(),
+          bbState: bbInd.getState(),
+          dmiState: dmiInd.getState(),
+          smaState: smaInd.getState(),
+          atrBuffer: atrBuffer.snapshot(),
+          bwBuffer: bwBuffer.snapshot(),
+          count,
+        },
+      );
     },
 
     get count() {


### PR DESCRIPTION
## Summary

Wave 3 Bundle L1 migrates 10 volatility / trend indicators to the 0.4.0 State Contract.

| Indicator | Category | Notes |
|---|---|---|
| Bollinger Bands | Windowed | `stdDev` resume-invariant |
| Garman-Klass | Windowed | `annualFactor` resume-invariant |
| Historical Volatility | Windowed | `annualFactor` resume-invariant |
| Linear Regression | Windowed | warmup/seed rewritten from `count` to `buffer.isFull` for correct carry-forward |
| Parabolic SAR | Recursive | `step`/`max` state-shaping |
| ATR Stops | Mixed | `stopMultiplier`/`takeProfitMultiplier` resume-invariant |
| Chandelier Exit | Mixed | `multiplier` state-shaping (feeds recursive `direction`) |
| Supertrend | Mixed | `multiplier` state-shaping (feeds recursive bands) |
| Ichimoku | Mixed | `delayBuffer` holds period-dependent derived values → windowed carry-forward not well-defined |
| Regime | Mixed | composes ATR/BB/DMI/SMA; no batch counterpart |

## Latent bugs surfaced by the contract DSL

- **Regime invariant [6]**: the SMA trend check ran `smaInd.next()` then re-peeked the same candle — one bar ahead, diverging from `peek()`. Fixed to use the value `next()` produced.
- **Garman-Klass `peek()`** gains the NaN-window check `next()` already had, so peek/next agree on invalid candles.

## Codex review follow-up

Chandelier Exit's `lookback` (which falls back to `period`) was injected into the `resolveResume` options, so resuming a snapshot without restating `lookback` looked like a state-shaping change and threw. Fixed by resolving `lookback` *after* `resolveResume` against the raw options. Regression tests added.

## Carve-out — pre-existing batch drift

`batchCompute` is omitted for **Chandelier Exit** and **Ichimoku**: invariant [8] surfaced a pre-existing batch/incremental value drift unrelated to this migration (next/peek logic unchanged). Tracked as a 0.5.0 consistency-audit item; invariants [1]-[7] still run. Regime has no batch sibling (incremental-only) so it also omits `batchCompute`.

## Test plan

- [x] `pnpm test` — core 5672 passing
- [x] `pnpm lint` — clean
- [x] `pnpm build` — success
- [x] `tsc --noEmit --ignoreDeprecations 6.0` — pre-existing errors only, 0 new