### PR TITLE
feat(core)!: migrate remaining 39 incremental indicators to State Contract (Wave 3 Bundle L2-L5)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,67 @@
 
 ## Unreleased
 
+### Breaking — Indicator State Contract (`getState` / `fromState` wire format)
+
+Every incremental indicator (`createSma`, `createEma`, `createMacd`,
+… — all ~94 of them) now exchanges state through a versioned
+envelope instead of a bare state object:
+
+```ts
+type IndicatorSnapshot<TState> = {
+  meta: {
+    version: number;                  // per-indicator schema version
+    indicator: string;                // "sma" | "ema" | … runtime guard
+    params: Record<string, unknown>;  // params captured at snapshot time
+  };
+  state: TState;                       // indicator-specific state
+};
+```
+
+- `getState()` now returns `IndicatorSnapshot<TState>` (previously
+  the bare `TState`).
+- `createXxx(options, { fromState })` now expects an
+  `IndicatorSnapshot<TState>` for `fromState` (previously the bare
+  `TState`).
+
+**Pre-0.4.0 snapshots cannot be resumed.** They have no `meta`
+field; `fromState` detects this and throws
+`<indicator>: incompatible snapshot, re-warm required`. The fix is
+to re-warm the indicator from candle history (replay candles through
+`next()`), or fall back to a fresh instance. There is no automatic
+migration in 0.4.0 — `throw + re-warm` is the policy.
+
+Resume behaviour is now defined per **state category**:
+
+- **Windowed** (SMA, WMA, ALMA, Donchian, Highest/Lowest, …) —
+  carry-forward: resuming with a different `period` reuses the
+  saved buffer and re-warms only the shortfall. A `source` change
+  still throws.
+- **Recursive / Mixed / Cascaded** (EMA, ZLEMA, FRAMA, KAMA, MACD,
+  DEMA, TEMA, HMA, …) — any state-shaping param change on resume
+  throws; the recursive accumulator encodes past params and cannot
+  be reconfigured mid-stream.
+- **Event log** (BOS, FVG, Liquidity Sweep, Pivot Points, Order
+  Block, Swing Points, …) — append-only: a params change keeps the
+  recorded events and continues appending.
+
+A new orthogonal **param-role** axis lets *resume-invariant* params
+change freely on resume regardless of category. These params (e.g.
+a band-width `multiplier` that only scales the state→output
+projection, never the state itself) are exempt from the resume
+compatibility check — the saved state is reused verbatim and the new
+value takes effect immediately. `source` is never eligible.
+
+Streaming sessions (`createLiveCandle` / `createPipeline` /
+`createSession`) persist per-indicator `getState()` output, so
+**0.3.x streaming session snapshots cannot be resumed in 0.4.0** —
+re-warm from candle history. Strategy JSON
+(`serializeStrategy` / `parseStrategy`) describes configurations,
+not runtime state, and is unaffected.
+
+See `docs/STATE_CONTRACT.md` (full design) and
+`docs/migration-0.3-to-0.4.md` (5-minute upgrade guide).
+
 ### Breaking — Elder's Force Index returns `{ short, long }`
 
 `elderForceIndex` and the incremental `createElderForceIndex` now

--- a/packages/core/docs/STATE_CONTRACT.md
+++ b/packages/core/docs/STATE_CONTRACT.md
@@ -1,10 +1,12 @@
 # Indicator State Contract (target: trendcraft 0.4.0)
 
-> **Status**: Phase 0 design document. The contract is being introduced
-> in the `epic/state-contract` branch and will land in trendcraft
-> 0.4.0 as a breaking change. 1.0 is still ahead; the 0.x line
-> continues to allow breaking changes per the project's release
-> practice.
+> **Status**: Complete. The contract is fully implemented — all
+> Waves (1-3) of indicator migration are done and every incremental
+> indicator (~94) exchanges state through the `IndicatorSnapshot`
+> envelope and routes resume through `resolveResume`. The contract
+> ships in trendcraft 0.4.0 as a breaking change. 1.0 is still ahead;
+> the 0.x line continues to allow breaking changes per the project's
+> release practice.
 
 ## 1. Motivation
 
@@ -17,10 +19,10 @@ ind.peek(candle);       // → preview without mutating state
 ind.getState();         // → snapshot for persistence / resume
 ```
 
-The library has shipped ~90 such indicators. Through Phase 2 (canonical
-alignment) it became clear that the `getState` / `fromState`
-*contract* — what guarantees the API offers about resume — is not
-defined library-wide. Each indicator has reinvented its own version
+The library ships ~94 such indicators. Through earlier canonical-
+alignment work it became clear that the `getState` / `fromState`
+*contract* — what guarantees the API offers about resume — was not
+defined library-wide. Each indicator had reinvented its own version
 of the answer, sometimes inconsistently:
 
 1. **Snapshot has no version field.** Adding/removing a state field
@@ -220,8 +222,8 @@ Adding a new indicator to the library requires registering it in
 
 ## 3. Categorization process
 
-Phase 2 (migration) classifies each of the ~90 indicators into A-E by
-inspecting:
+Migration classified each of the ~94 incremental indicators into A-E
+by inspecting:
 
 - Does the state include a recursive accumulator (`prev*` field)?
   → at least Recursive/Mixed/Cascaded.
@@ -249,22 +251,20 @@ will fail the reconfig refuse test).
 - **Heikin-Ashi**: Recursive (`prevHaOpen`, `prevHaClose`). Refuse
   reconfig.
 
-### 3.2 Open classification (to resolve in Phase 2)
+### 3.2 Open classification — resolved during migration
 
-These need a closer look during migration:
+These were flagged during design as needing a closer look; their
+final classification (pinned by the contract tests) is:
 
-- **Linear regression**: state includes running sums; could be either
-  Windowed (sums computed from raw window) or Mixed depending on
-  implementation. Likely Windowed.
-- **Regime detection (volatility)**: uses windowed variance, no
-  recursion. Likely Windowed.
-- **Anchored VWAP**: cumulative from anchor; resetting anchor is the
-  "reconfig" — special. Possibly Recursive or its own category.
-- **CVD (Cumulative Volume Delta)**: pure cumulative; reconfig means
-  changing anchor. Possibly Recursive.
-- **Ichimoku**: multiple windowed components + future displacement
-  buffer. Likely a Windowed-cascade. Refuse reconfig matches the
-  Phase 2 fix.
+- **Linear regression**: Windowed — running sums are computed from the
+  raw window, no cross-param recursion.
+- **Regime detection (volatility)**: Windowed — windowed variance, no
+  recursion.
+- **Anchored VWAP**: Recursive — cumulative from anchor; re-anchoring
+  is a fresh start, not a resume reconfig.
+- **CVD (Cumulative Volume Delta)**: Recursive — pure cumulative.
+- **Ichimoku**: Windowed-cascade, treated as refuse-reconfig — multiple
+  windowed components plus a future-displacement buffer.
 
 ## 4. Errors and messages
 
@@ -442,20 +442,28 @@ incompatible snapshot`) before reaching the nested leaf. At that
 point the user-facing error becomes wrapper-scoped naturally — no
 bridge code needed and nothing to delete.
 
-## 6. Roadmap
+## 6. Roadmap — completed
 
-Five phases, ~4-5 weeks total. Each phase lands as a PR into
-`epic/state-contract`. Final merge to `main` is a single epic merge
-commit at 0.4.0 release time.
+The epic landed as a series of bundled PRs into `feat/state-contract-*`
+branches. All phases below are **done**; the contract ships in
+trendcraft 0.4.0.
 
-| Phase | Output | Duration |
+| Phase | Output | Status |
 |---|---|---|
-| **0. Decision doc** | This document + memory note + epic branch | 1 day |
-| **1. Foundation** | `state-contract.ts` (types + `resolveResume`), `describeContract` DSL skeleton, no indicator changes yet | 3-4 days |
-| **2. Indicator migration** | Wave 1: Category A (~20). Wave 2: B (~6). Wave 3: C/D (~25). Wave 4: E (~10). Wave 5: remaining (~30) | 2 weeks |
-| **3. Contract test rollout** | All indicators registered, latent edge cases surfaced + fixed in individual PRs | 1 week |
-| **4. Documentation** | `STATE_AND_RESUME.md` consumer guide, migration guide, JSDoc `@stateCategory` tags | 2-3 days |
-| **5. 0.4.0 release prep** | CHANGELOG BREAKING entry, perf check (meta wrapper overhead < 5%), final audit | 2 days |
+| **0. Decision doc** | This document + memory note + epic branch | ✓ Done |
+| **1. Foundation** | `state-contract.ts` (types + `resolveResume`), `describeContract` DSL | ✓ Done |
+| **2. Indicator migration** | All ~94 incremental indicators migrated across Wave 1 (Category A — windowed), Wave 2 (Category B — recursive, plus E — event log), Wave 3 (Categories C/D — mixed/cascaded, and the RSI/ATR/DMI Wilder-smoother cluster) | ✓ Done |
+| **3. Contract test rollout** | All indicators registered in `describeContract`; latent edge cases surfaced and fixed | ✓ Done |
+| **4. Documentation** | `STATE_CONTRACT.md` design doc, `docs/migration-0.3-to-0.4.md` consumer guide, CHANGELOG breaking entry | ✓ Done |
+| **5. 0.4.0 release prep** | CHANGELOG BREAKING entry, perf check, final audit | ✓ Done |
+
+> Wave numbering note: the original plan sketched five migration waves
+> by category; during execution the work consolidated into three waves
+> (Wave 1 = A, Wave 2 = B + E, Wave 3 = C/D + the Wilder-smoother
+> cluster). The Wilder smoothers (RSI/ATR/DMI internals) had no
+> standalone factory and were therefore migrated together with their
+> dependent cluster in Wave 3. The end state is identical: every
+> incremental indicator is migrated and registered.
 
 ## 7. Out of scope (deferred to later minors)
 

--- a/packages/core/docs/migration-0.3-to-0.4.md
+++ b/packages/core/docs/migration-0.3-to-0.4.md
@@ -1,0 +1,75 @@
+# Migrating trendcraft 0.3.x → 0.4.0
+
+The 0.4.0 release lands the **Indicator State Contract**. This is the
+only breaking change that affects incremental-indicator persistence.
+This page is a 5-minute summary; the full design is in
+[`STATE_CONTRACT.md`](./STATE_CONTRACT.md), and the consumer-facing
+detail lives in [`STATE_CONTRACT.md` §5](./STATE_CONTRACT.md#5-migration-guide-03x--040).
+
+## What broke
+
+Every incremental indicator's `getState()` / `fromState` now uses a
+versioned envelope instead of a bare state object:
+
+```ts
+type IndicatorSnapshot<TState> = {
+  meta: { version: number; indicator: string; params: Record<string, unknown> };
+  state: TState;
+};
+```
+
+- `getState()` returns `IndicatorSnapshot<TState>` (was bare `TState`).
+- `createXxx(options, { fromState })` expects an
+  `IndicatorSnapshot<TState>` (was bare `TState`).
+
+**Pre-0.4.0 snapshots cannot be resumed.** They have no `meta` field,
+so `fromState` throws `<indicator>: incompatible snapshot, re-warm
+required`. This applies equally to streaming session snapshots
+(`createLiveCandle` / `createPipeline` / `createSession`).
+
+## How to fix: re-warm
+
+The fix is always the same — re-warm the indicator from candle
+history instead of restoring the old snapshot:
+
+```ts
+let ind: ReturnType<typeof createSma>;
+try {
+  ind = createSma({ period: 20 }, { fromState: savedSnapshot });
+} catch {
+  // Pre-0.4.0 snapshot (or incompatible reconfig): re-warm.
+  ind = createSma({ period: 20 });
+  for (const candle of warmUpCandles) ind.next(candle);
+}
+```
+
+For long-running streaming processes, replay recent candle history
+through the rebuilt indicators on the first run after upgrading.
+Session-level state (aggregator state, completed candles) is
+unaffected — only the per-indicator snapshots inside a session blob
+are incompatible.
+
+## What is *not* affected
+
+- **Strategy JSON** (`serializeStrategy` / `parseStrategy`) describes
+  indicator *configurations*, not runtime state — unchanged.
+- **Non-incremental (batch) indicator functions** — `sma(candles)`,
+  `ema(candles)`, etc. take candle arrays and have no state to
+  persist — unchanged.
+
+## After upgrading: reconfig on resume
+
+Once you are on 0.4.0 envelopes, resume with *changed params* follows
+the state category:
+
+- **Windowed** (SMA, WMA, ALMA, Donchian, …) — `period` change is
+  supported via carry-forward; `source` change throws.
+- **Recursive / Mixed / Cascaded** (EMA, ZLEMA, FRAMA, KAMA, MACD,
+  DEMA, TEMA, HMA, …) — any state-shaping param change throws.
+- **Event log** (BOS, FVG, Pivot Points, …) — params change is
+  harmless; events keep appending.
+
+*Resume-invariant* params (those that only scale the state→output
+projection, e.g. a band-width multiplier) may change on resume in any
+category. See [`STATE_CONTRACT.md` §2.4](./STATE_CONTRACT.md#24-per-category-resume-rules)
+for the param-role axis.

--- a/packages/core/src/indicators/incremental/__tests__/auto-trend-line.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/auto-trend-line.test.ts
@@ -98,8 +98,8 @@ describe("createAutoTrendLine", () => {
       expect(vb.support).toBe(va.support);
     }
     const stateB = b.getState();
-    expect(stateB.leftBars).toBe(customLeft);
-    expect(stateB.rightBars).toBe(customRight);
+    expect(stateB.meta.params.leftBars).toBe(customLeft);
+    expect(stateB.meta.params.rightBars).toBe(customRight);
   });
 
   it("peek does not mutate state", () => {

--- a/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/branch-coverage.test.ts
@@ -663,14 +663,14 @@ describe("Elder Force Index", () => {
     const efi1 = createElderForceIndex(opts);
     for (let i = 0; i < 25; i++) efi1.next(makeCandle(i));
     const state = efi1.getState();
-    expect(state.shortPeriod).toBe(5);
-    expect(state.longPeriod).toBe(20);
+    expect(state.meta.params.shortPeriod).toBe(5);
+    expect(state.meta.params.longPeriod).toBe(20);
 
     // Resume without re-passing options — periods must come from the
     // snapshot, NOT silently revert to canonical 2 / 13.
     const efi2 = createElderForceIndex({}, { fromState: state });
-    expect(efi2.getState().shortPeriod).toBe(5);
-    expect(efi2.getState().longPeriod).toBe(20);
+    expect(efi2.getState().meta.params.shortPeriod).toBe(5);
+    expect(efi2.getState().meta.params.longPeriod).toBe(20);
 
     // Subsequent values must match what efi1 would have produced.
     for (let i = 25; i < 35; i++) {
@@ -681,62 +681,18 @@ describe("Elder Force Index", () => {
     }
   });
 
-  it("explicit periods on resume override persisted state", () => {
-    const efi1 = createElderForceIndex({ shortPeriod: 5, longPeriod: 20 });
-    for (let i = 0; i < 25; i++) efi1.next(makeCandle(i));
-    // Caller explicitly re-parameterizes on resume — the snapshot's
-    // periods are ignored.
-    const efi2 = createElderForceIndex(
-      { shortPeriod: 3, longPeriod: 10 },
-      { fromState: efi1.getState() },
-    );
-    expect(efi2.getState().shortPeriod).toBe(3);
-    expect(efi2.getState().longPeriod).toBe(10);
-  });
-
-  it("re-parameterizing on resume resets EMA state and produces a fresh warm-up", () => {
-    // The previous EMA / sum / count were accumulated under the old
-    // multipliers; replaying them with new multipliers would produce a
-    // mathematically incorrect series. The new indicator must start
-    // its warm-up from scratch and only inherit `prevClose` from the
-    // snapshot (so the first raw-force computation after resume is
-    // still correct).
+  it("re-parameterizing a cascaded indicator on resume is refused", () => {
+    // Under the State Contract, Elder Force Index is `cascaded`: its
+    // two EMAs permanently encode their construction-time periods, so
+    // resuming a snapshot with different periods is a hard refuse
+    // rather than a silent reset / re-warm.
     const efi1 = createElderForceIndex({ shortPeriod: 5, longPeriod: 20 });
     for (let i = 0; i < 25; i++) efi1.next(makeCandle(i));
     const snapshot = efi1.getState();
 
-    const efi2 = createElderForceIndex({ shortPeriod: 3, longPeriod: 10 }, { fromState: snapshot });
-
-    // EMAs / sums / count are reset for the new periods. prevClose
-    // carries over so the very next bar still has a valid raw force.
-    const reset = efi2.getState();
-    expect(reset.shortEma).toBeNull();
-    expect(reset.longEma).toBeNull();
-    expect(reset.shortSum).toBe(0);
-    expect(reset.longSum).toBe(0);
-    expect(reset.count).toBe(0);
-    expect(reset.prevClose).toBe(snapshot.prevClose);
-
-    // After feeding shortPeriod=3 bars, the short EMA must be the
-    // canonical SMA seed of the new bars' raw forces (NOT a value
-    // derived from the old 5-period multiplier on the snapshot's
-    // EMA). Compute it manually and compare.
-    const newBars: NormalizedCandle[] = [];
-    for (let i = 25; i < 28; i++) newBars.push(makeCandle(i));
-
-    let prevClose = snapshot.prevClose as number;
-    let sumRaw = 0;
-    for (const c of newBars) {
-      sumRaw += (c.close - prevClose) * c.volume;
-      prevClose = c.close;
-    }
-    const expectedShortSeed = sumRaw / 3;
-
-    let observedShort: number | null = null;
-    for (const c of newBars) observedShort = efi2.next(c).value.short;
-
-    expect(observedShort).not.toBeNull();
-    expect(observedShort as number).toBeCloseTo(expectedShortSeed, 8);
+    expect(() =>
+      createElderForceIndex({ shortPeriod: 3, longPeriod: 10 }, { fromState: snapshot }),
+    ).toThrow(/incompatible snapshot|cannot be reconfigured/);
   });
 
   it("isWarmedUp accounts for the larger of shortPeriod / longPeriod", () => {

--- a/packages/core/src/indicators/incremental/__tests__/channel-line.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/channel-line.test.ts
@@ -110,8 +110,8 @@ describe("createChannelLine", () => {
       expect(vb.lower).toBe(va.lower);
     }
     const stateB = b.getState();
-    expect(stateB.leftBars).toBe(customLeft);
-    expect(stateB.rightBars).toBe(customRight);
+    expect(stateB.meta.params.leftBars).toBe(customLeft);
+    expect(stateB.meta.params.rightBars).toBe(customRight);
   });
 
   it("peek does not mutate state", () => {

--- a/packages/core/src/indicators/incremental/__tests__/fibonacci-extension.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/fibonacci-extension.test.ts
@@ -116,9 +116,9 @@ describe("createFibonacciExtension", () => {
       }
     }
     const stateB = b.getState();
-    expect(stateB.leftBars).toBe(customLeft);
-    expect(stateB.rightBars).toBe(customRight);
-    expect(stateB.levels).toEqual(customLevels);
+    expect(stateB.meta.params.leftBars).toBe(customLeft);
+    expect(stateB.meta.params.rightBars).toBe(customRight);
+    expect(stateB.meta.params.levels).toEqual(customLevels);
   });
 
   it("peek does not mutate state", () => {

--- a/packages/core/src/indicators/incremental/__tests__/fibonacci-retracement.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/fibonacci-retracement.test.ts
@@ -146,9 +146,9 @@ describe("createFibonacciRetracement", () => {
       }
     }
     const stateB = b.getState();
-    expect(stateB.leftBars).toBe(customLeft);
-    expect(stateB.rightBars).toBe(customRight);
-    expect(stateB.levels).toEqual(customLevels);
+    expect(stateB.meta.params.leftBars).toBe(customLeft);
+    expect(stateB.meta.params.rightBars).toBe(customRight);
+    expect(stateB.meta.params.levels).toEqual(customLevels);
   });
 
   it("respects custom levels", () => {

--- a/packages/core/src/indicators/incremental/__tests__/new-indicators.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/new-indicators.test.ts
@@ -316,9 +316,9 @@ describe("Klinger incremental", () => {
     const state = ind1.getState();
 
     const ind2 = createKlinger({}, { fromState: state });
-    expect(ind2.getState().shortPeriod).toBe(20);
-    expect(ind2.getState().longPeriod).toBe(40);
-    expect(ind2.getState().signalPeriod).toBe(9);
+    expect(ind2.getState().meta.params.shortPeriod).toBe(20);
+    expect(ind2.getState().meta.params.longPeriod).toBe(40);
+    expect(ind2.getState().meta.params.signalPeriod).toBe(9);
   });
 
   it("refuses resume with a different shortPeriod", () => {

--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -21,20 +21,35 @@ import type {
   MacdValue,
   NormalizedCandle,
   PriceSource,
+  VolumeAnomalyValue,
+  VolumeTrendValue,
 } from "../../../types";
+import { roofingFilter } from "../../filter/roofing-filter";
+import { superSmoother } from "../../filter/super-smoother";
 import { adxr } from "../../momentum/adxr";
+import { aroon } from "../../momentum/aroon";
+import { awesomeOscillator } from "../../momentum/awesome-oscillator";
+import { balanceOfPower } from "../../momentum/balance-of-power";
+import { cci } from "../../momentum/cci";
 import { cmo } from "../../momentum/cmo";
 import { connorsRsi } from "../../momentum/connors-rsi";
 import { coppockCurve } from "../../momentum/coppock-curve";
 import { dmi } from "../../momentum/dmi";
+import { hurst } from "../../momentum/hurst";
+import { imi } from "../../momentum/imi";
+import { kst } from "../../momentum/kst";
 import { macd } from "../../momentum/macd";
 import { massIndex } from "../../momentum/mass-index";
 import { ppo } from "../../momentum/ppo";
+import { qstick } from "../../momentum/qstick";
 import { roc } from "../../momentum/roc";
 import { rsi } from "../../momentum/rsi";
 import { stochRsi } from "../../momentum/stoch-rsi";
+import { stochastics } from "../../momentum/stochastics";
 import { trix } from "../../momentum/trix";
 import { tsi } from "../../momentum/tsi";
+import { ultimateOscillator } from "../../momentum/ultimate-oscillator";
+import { williamsR } from "../../momentum/williams-r";
 import { alma } from "../../moving-average/alma";
 import { dema } from "../../moving-average/dema";
 import { ema } from "../../moving-average/ema";
@@ -49,12 +64,14 @@ import { tema } from "../../moving-average/tema";
 import { vwma } from "../../moving-average/vwma";
 import { wma } from "../../moving-average/wma";
 import { zlema } from "../../moving-average/zlema";
+import { heikinAshi } from "../../price/heikin-ashi";
 import { highest, lowest } from "../../price/highest-lowest";
 import { returns as returnsBatch } from "../../price/returns";
 import { linearRegression } from "../../trend/linear-regression";
 import { parabolicSar } from "../../trend/parabolic-sar";
 import { schaffTrendCycle } from "../../trend/schaff-trend-cycle";
 import { supertrend } from "../../trend/supertrend";
+import { vortex } from "../../trend/vortex";
 import { atr } from "../../volatility/atr";
 import { atrStops } from "../../volatility/atr-stops";
 import { bollingerBands } from "../../volatility/bollinger-bands";
@@ -68,13 +85,29 @@ import { standardDeviation } from "../../volatility/standard-deviation";
 import { ulcerIndex } from "../../volatility/ulcer-index";
 import { adl } from "../../volume/adl";
 import { anchoredVwap } from "../../volume/anchored-vwap";
+import { cmf } from "../../volume/cmf";
 import { cvd } from "../../volume/cvd";
+import { easeOfMovement } from "../../volume/ease-of-movement";
+import { elderForceIndex } from "../../volume/elder-force-index";
+import { klinger } from "../../volume/klinger";
+import { mfi } from "../../volume/mfi";
 import { nvi } from "../../volume/nvi";
 import { obv } from "../../volume/obv";
 import { pvt } from "../../volume/pvt";
 import { twap } from "../../volume/twap";
+import { volumeAnomaly } from "../../volume/volume-anomaly";
 import { vwap } from "../../volume/vwap";
+import { weisWave } from "../../volume/weis-wave";
+import { createRoofingFilter, type RoofingFilterState } from "../filter/roofing-filter";
+import { createSuperSmoother, type SuperSmootherState } from "../filter/super-smoother";
 import { type AdxrState, createAdxr } from "../momentum/adxr";
+import { type AroonState, type AroonValue, createAroon } from "../momentum/aroon";
+import {
+  type AwesomeOscillatorState,
+  createAwesomeOscillator,
+} from "../momentum/awesome-oscillator";
+import { type BalanceOfPowerState, createBalanceOfPower } from "../momentum/balance-of-power";
+import { type CciState, createCci } from "../momentum/cci";
 import { type CmoState, createCmo } from "../momentum/cmo";
 import {
   type ConnorsRsiState,
@@ -83,15 +116,31 @@ import {
 } from "../momentum/connors-rsi";
 import { type CoppockCurveState, createCoppockCurve } from "../momentum/coppock-curve";
 import { createDmi, type DmiState, type DmiValue } from "../momentum/dmi";
+import { createDpo, type DpoState } from "../momentum/dpo";
+import { createHurst, type HurstState } from "../momentum/hurst";
+import { createImi, type ImiState } from "../momentum/imi";
+import { createKst, type KstState, type KstValue } from "../momentum/kst";
 import { createMacd, type MacdState } from "../momentum/macd";
 import { createMassIndex, type MassIndexState } from "../momentum/mass-index";
 import { createPpo, type PpoState, type PpoValue } from "../momentum/ppo";
+import { createQStick, type QStickState } from "../momentum/qstick";
 import { createRoc, type RocState } from "../momentum/roc";
 import { createRsi, type RsiState } from "../momentum/rsi";
 import { createStc, type StcState } from "../momentum/schaff-trend-cycle";
 import { createStochRsi, type StochRsiState, type StochRsiValue } from "../momentum/stoch-rsi";
+import {
+  createStochastics,
+  type StochasticsState,
+  type StochasticsValue,
+} from "../momentum/stochastics";
 import { createTrix, type TrixState, type TrixValue } from "../momentum/trix";
 import { createTsi, type TsiState, type TsiValue } from "../momentum/tsi";
+import {
+  createUltimateOscillator,
+  type UltimateOscillatorState,
+} from "../momentum/ultimate-oscillator";
+import { createVortex, type VortexState, type VortexValue } from "../momentum/vortex";
+import { createWilliamsR, type WilliamsRState } from "../momentum/williams-r";
 import { type AlmaState, createAlma } from "../moving-average/alma";
 import { createDema, type DemaState } from "../moving-average/dema";
 import { createEma, type EmaState } from "../moving-average/ema";
@@ -113,8 +162,60 @@ import { createTema, type TemaState } from "../moving-average/tema";
 import { createVwma, type VwmaState } from "../moving-average/vwma";
 import { createWma, type WmaState } from "../moving-average/wma";
 import { createZlema, type ZlemaState } from "../moving-average/zlema";
+import {
+  type AutoTrendLineState,
+  type AutoTrendLineValue,
+  createAutoTrendLine,
+} from "../price/auto-trend-line";
+import {
+  type BosState,
+  type BosValue,
+  type ChochState,
+  createBreakOfStructure,
+  createChangeOfCharacter,
+} from "../price/break-of-structure";
+import {
+  type ChannelLineState,
+  type ChannelLineValue,
+  createChannelLine,
+} from "../price/channel-line";
+import { createFairValueGap, type FairValueGapState, type FvgValue } from "../price/fair-value-gap";
+import {
+  createFibonacciExtension,
+  type FibonacciExtensionState,
+  type FibonacciExtensionValue,
+} from "../price/fibonacci-extension";
+import {
+  createFibonacciRetracement,
+  type FibonacciRetracementState,
+  type FibonacciRetracementValue,
+} from "../price/fibonacci-retracement";
+import { createFractals, type FractalsState, type FractalValue } from "../price/fractals";
+import { createGapAnalysis, type GapAnalysisState, type GapValue } from "../price/gap-analysis";
+import { createHeikinAshi, type HeikinAshiState, type HeikinAshiValue } from "../price/heikin-ashi";
 import { createHighestLowest, type HighestLowestState } from "../price/highest-lowest";
+import {
+  createOpeningRange,
+  type OpeningRangeState,
+  type OpeningRangeValue,
+} from "../price/opening-range";
+import {
+  createPivotPoints,
+  type PivotPointsState,
+  type PivotPointsValue,
+} from "../price/pivot-points";
 import { createReturns, type ReturnsState } from "../price/returns";
+import {
+  createSwingPoints,
+  type SwingPointsState,
+  type SwingPointValue,
+} from "../price/swing-points";
+import { createZigzag, type ZigzagState, type ZigzagValue } from "../price/zigzag";
+import {
+  createLiquiditySweep,
+  type LiquiditySweepState,
+  type LiquiditySweepValue,
+} from "../smc/liquidity-sweep";
 import { createIchimoku, type IchimokuState, type IchimokuValue } from "../trend/ichimoku";
 import {
   createLinearRegression,
@@ -152,12 +253,25 @@ import {
 import { createUlcerIndex, type UlcerIndexState } from "../volatility/ulcer-index";
 import { type AdlState, createAdl } from "../volume/adl";
 import { type AnchoredVwapState, createAnchoredVwap } from "../volume/anchored-vwap";
+import { type CmfState, createCmf } from "../volume/cmf";
 import { type CvdState, createCvd } from "../volume/cvd";
+import { createEmv, type EmvState } from "../volume/ease-of-movement";
+import {
+  createElderForceIndex,
+  type ElderForceIndexState,
+  type ElderForceIndexValue,
+} from "../volume/elder-force-index";
+import { createKlinger, type KlingerState, type KlingerValue } from "../volume/klinger";
+import { createMfi, type MfiState } from "../volume/mfi";
 import { createNvi, type NviState } from "../volume/nvi";
 import { createObv, type ObvState } from "../volume/obv";
 import { createPvt, type PvtState } from "../volume/pvt";
 import { createTwap, type TwapState } from "../volume/twap";
+import { createVolumeAnomaly, type VolumeAnomalyState } from "../volume/volume-anomaly";
+import { createVolumeTrend, type VolumeTrendState } from "../volume/volume-trend";
 import { createVwap, type VwapState } from "../volume/vwap";
+import { createWeisWave, type WeisWaveState, type WeisWaveValue } from "../volume/weis-wave";
+import { createVsa, type VsaState, type VsaValue } from "../wyckoff/vsa";
 import { describeContract } from "./contract-helper";
 
 // ---- Shared candle generator ----
@@ -1735,4 +1849,888 @@ describeContract<RegimeValue | null, RegimeState>({
   reconfigParams: [{ atrPeriod: 10 }, { bbPeriod: 14 }, { dmiPeriod: 10 }],
   makeCandles,
   streamLength: 160,
+});
+
+// ---- Wave 3 Bundle L2: 13 incremental momentum indicators ----
+
+// Aroon — Windowed (period+1 high/low buffers; carry-forward on
+// reconfig). Composite output; up/down/oscillator emerge together.
+describeContract<AroonValue, AroonState>({
+  name: "aroon",
+  create: (opts, warmUp) => createAroon(opts as { period?: number }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 25 },
+  reconfigParams: [{ period: 14 }, { period: 30 }],
+  makeCandles,
+  streamLength: 120,
+  isNullishField: (v) =>
+    v === null || v === undefined || (typeof v === "object" && (v as { up: unknown }).up === null),
+  batchCompute: (opts, candles) => aroon(candles, opts as { period?: number }).map((s) => s.value),
+});
+
+// Awesome Oscillator — Cascaded (two inner SMAs over the median price).
+describeContract<number | null, AwesomeOscillatorState>({
+  name: "awesomeOscillator",
+  create: (opts, warmUp) =>
+    createAwesomeOscillator(opts as { fastPeriod?: number; slowPeriod?: number }, warmUp),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { fastPeriod: 5, slowPeriod: 34 },
+  reconfigParams: [{ fastPeriod: 3 }, { slowPeriod: 20 }],
+  makeCandles,
+  streamLength: 120,
+  batchCompute: (opts, candles) =>
+    awesomeOscillator(candles, opts as { fastPeriod?: number; slowPeriod?: number }).map(
+      (s) => s.value,
+    ),
+});
+
+// Balance of Power — Cascaded (one inner SMA over the raw BOP series).
+describeContract<number | null, BalanceOfPowerState>({
+  name: "balanceOfPower",
+  create: (opts, warmUp) => createBalanceOfPower(opts as { smoothPeriod?: number }, warmUp),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { smoothPeriod: 14 },
+  reconfigParams: [{ smoothPeriod: 10 }, { smoothPeriod: 20 }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    balanceOfPower(candles, opts as { smoothPeriod?: number }).map((s) => s.value),
+});
+
+// CCI — Windowed (typical-price buffer + running sum; carry-forward on
+// reconfig). `constant` is resume-invariant.
+describeContract<number | null, CciState>({
+  name: "cci",
+  create: (opts, warmUp) =>
+    createCci(opts as { period?: number; constant?: number; source?: PriceSource }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 20, constant: 0.015, source: "hlc3" },
+  reconfigParams: [{ period: 14 }, { period: 30 }, { constant: 0.02 }],
+  makeCandles,
+  streamLength: 120,
+  batchCompute: (opts, candles) =>
+    cci(candles, opts as { period?: number; constant?: number; source?: PriceSource }).map(
+      (s) => s.value,
+    ),
+});
+
+// DPO — Cascaded (inner SMA + pending-entry queue keyed on the
+// period-derived shift).
+describeContract<number | null, DpoState>({
+  name: "dpo",
+  create: (opts, warmUp) => createDpo(opts as { period?: number; source?: PriceSource }, warmUp),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { period: 20, source: "close" },
+  reconfigParams: [{ period: 14 }, { period: 30 }],
+  makeCandles,
+  streamLength: 120,
+  // batchCompute omitted: the incremental DPO emits a `shift`-delayed
+  // stream (time-shifted relative to the input bar), so per-index
+  // alignment against the batch `dpo()` output is structurally
+  // different — a pre-existing design difference, not a migration
+  // regression. Invariants [1]-[7] still run.
+});
+
+// Hurst — Windowed (single price buffer of size maxWindow;
+// carry-forward on reconfig). `minWindow` is resume-invariant.
+describeContract<number | null, HurstState>({
+  name: "hurst",
+  create: (opts, warmUp) =>
+    createHurst(opts as { minWindow?: number; maxWindow?: number; source?: PriceSource }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { minWindow: 20, maxWindow: 100, source: "close" },
+  reconfigParams: [{ maxWindow: 80 }, { maxWindow: 120 }, { minWindow: 10 }],
+  // The carry-forward buffer must fully rotate to post-resume prices
+  // before a resumed run matches a fresh run — `maxWindow` new bars.
+  reconfigMargin: (newOpts) => (newOpts.maxWindow as number) ?? 100,
+  makeCandles,
+  streamLength: 260,
+  batchCompute: (opts, candles) =>
+    hurst(candles, opts as { minWindow?: number; maxWindow?: number; source?: PriceSource }).map(
+      (s) => s.value,
+    ),
+});
+
+// IMI — Windowed (gains/losses buffers + running sums; carry-forward
+// on reconfig).
+describeContract<number | null, ImiState>({
+  name: "imi",
+  create: (opts, warmUp) => createImi(opts as { period?: number }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 14 },
+  reconfigParams: [{ period: 10 }, { period: 20 }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) => imi(candles, opts as { period?: number }).map((s) => s.value),
+});
+
+// KST — Cascaded (4 inner ROC + 4 inner SMA stages + 1 signal SMA).
+// Composite output; `signal` emerges last so the null predicate gates
+// on it to align with `isWarmedUp`.
+describeContract<KstValue | null, KstState>({
+  name: "kst",
+  create: (opts, warmUp) =>
+    createKst(
+      opts as {
+        rocPeriods?: [number, number, number, number];
+        smaPeriods?: [number, number, number, number];
+        weights?: [number, number, number, number];
+        signalPeriod?: number;
+        source?: PriceSource;
+      },
+      warmUp,
+    ),
+  category: "cascaded",
+  version: 1,
+  defaultParams: {
+    rocPeriods: [10, 15, 20, 30],
+    smaPeriods: [10, 10, 10, 15],
+    weights: [1, 2, 3, 4],
+    signalPeriod: 9,
+    source: "close",
+  },
+  reconfigParams: [{ signalPeriod: 5 }, { weights: [2, 3, 4, 5] }],
+  makeCandles,
+  streamLength: 160,
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { signal: unknown }).signal === null),
+  batchCompute: (opts, candles) =>
+    kst(
+      candles,
+      opts as {
+        rocPeriods?: [number, number, number, number];
+        smaPeriods?: [number, number, number, number];
+        weights?: [number, number, number, number];
+        signalPeriod?: number;
+        source?: PriceSource;
+      },
+    ).map((s) => s.value),
+});
+
+// QStick — Cascaded (one inner SMA over the close-minus-open series).
+describeContract<number | null, QStickState>({
+  name: "qstick",
+  create: (opts, warmUp) => createQStick(opts as { period?: number }, warmUp),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { period: 14 },
+  reconfigParams: [{ period: 10 }, { period: 20 }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) => qstick(candles, opts as { period?: number }).map((s) => s.value),
+});
+
+// Stochastics — Mixed (raw high/low buffers feed derived rawK/K
+// buffers + running sums). Composite output; `d` emerges last.
+describeContract<StochasticsValue, StochasticsState>({
+  name: "stochastics",
+  create: (opts, warmUp) =>
+    createStochastics(opts as { kPeriod?: number; dPeriod?: number; slowing?: number }, warmUp),
+  category: "mixed",
+  version: 1,
+  defaultParams: { kPeriod: 14, dPeriod: 3, slowing: 3 },
+  reconfigParams: [{ kPeriod: 10 }, { dPeriod: 5 }, { slowing: 1 }],
+  makeCandles,
+  streamLength: 120,
+  isNullishField: (v) =>
+    v === null || v === undefined || (typeof v === "object" && (v as { d: unknown }).d === null),
+  batchCompute: (opts, candles) =>
+    stochastics(candles, opts as { kPeriod?: number; dPeriod?: number; slowing?: number }).map(
+      (s) => s.value,
+    ),
+});
+
+// Ultimate Oscillator — Mixed (BP/TR buffers sized to the longest
+// period + carried-forward prevClose).
+describeContract<number | null, UltimateOscillatorState>({
+  name: "ultimateOscillator",
+  create: (opts, warmUp) =>
+    createUltimateOscillator(
+      opts as { period1?: number; period2?: number; period3?: number },
+      warmUp,
+    ),
+  category: "mixed",
+  version: 1,
+  defaultParams: { period1: 7, period2: 14, period3: 28 },
+  reconfigParams: [{ period1: 5 }, { period2: 10 }, { period3: 21 }],
+  makeCandles,
+  streamLength: 120,
+  batchCompute: (opts, candles) =>
+    ultimateOscillator(
+      candles,
+      opts as { period1?: number; period2?: number; period3?: number },
+    ).map((s) => s.value),
+});
+
+// Vortex — Mixed (VM+/VM-/TR buffers + carried-forward prevHigh/Low/
+// Close). Composite output; viPlus/viMinus emerge together.
+describeContract<VortexValue, VortexState>({
+  name: "vortex",
+  create: (opts, warmUp) => createVortex(opts as { period?: number }, warmUp),
+  category: "mixed",
+  version: 1,
+  defaultParams: { period: 14 },
+  reconfigParams: [{ period: 10 }, { period: 20 }],
+  makeCandles,
+  streamLength: 100,
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { viPlus: unknown }).viPlus === null),
+  batchCompute: (opts, candles) => vortex(candles, opts as { period?: number }).map((s) => s.value),
+});
+
+// Williams %R — Windowed (high/low buffers; carry-forward on reconfig).
+describeContract<number | null, WilliamsRState>({
+  name: "williamsR",
+  create: (opts, warmUp) => createWilliamsR(opts as { period?: number }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 14 },
+  reconfigParams: [{ period: 10 }, { period: 20 }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    williamsR(candles, opts as { period?: number }).map((s) => s.value),
+});
+
+// ---- Wave 3 Bundle L3: incremental volume indicators ----
+
+// CMF — Windowed (money-flow-volume + raw-volume buffers; carry-forward
+// on `period` change, running sums recomputed).
+describeContract<number | null, CmfState>({
+  name: "cmf",
+  create: (opts, warmUp) => createCmf(opts as { period?: number }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 20 },
+  reconfigParams: [{ period: 10 }, { period: 30 }],
+  makeCandles,
+  streamLength: 120,
+  batchCompute: (opts, candles) => cmf(candles, opts as { period?: number }).map((s) => s.value),
+});
+
+// EMV (Ease of Movement) — Mixed (buffer of derived raw EMV values +
+// running sum + prevHigh/prevLow). Refuses any param change on resume.
+describeContract<number | null, EmvState>({
+  name: "emv",
+  create: (opts, warmUp) => createEmv(opts as { period?: number; volumeDivisor?: number }, warmUp),
+  category: "mixed",
+  version: 1,
+  defaultParams: { period: 14, volumeDivisor: 100_000_000 },
+  reconfigParams: [{ period: 10 }, { volumeDivisor: 10_000 }],
+  makeCandles,
+  streamLength: 100,
+  // EMV's SMA running sum (incremental) and the batch's per-window
+  // re-summation accumulate the same terms in a different order; on the
+  // gap-candle stream the large raw EMV magnitudes surface a ~3e-9
+  // deterministic floating-point drift. Loosen [8] accordingly — this
+  // is summation-order noise, not algorithmic divergence.
+  consistencyTolerance: 1e-6,
+  batchCompute: (opts, candles) =>
+    easeOfMovement(candles, opts as { period?: number; volumeDivisor?: number }).map(
+      (s) => s.value,
+    ),
+});
+
+// Elder's Force Index — Cascaded (two recursive EMA channels). Composite
+// output `{ short, long }` whose fields are null during warmup.
+describeContract<ElderForceIndexValue, ElderForceIndexState>({
+  name: "elderForceIndex",
+  create: (opts, warmUp) =>
+    createElderForceIndex(opts as { shortPeriod?: number; longPeriod?: number }, warmUp),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { shortPeriod: 2, longPeriod: 13 },
+  reconfigParams: [{ shortPeriod: 5 }, { longPeriod: 20 }],
+  makeCandles,
+  streamLength: 100,
+  // The two channels warm up independently (`short` at shortPeriod,
+  // `long` at longPeriod). `isWarmedUp` waits for the slower channel,
+  // so the warmup gate must key on `long` rather than the all-null
+  // default predicate.
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { long: unknown }).long === null),
+  batchCompute: (opts, candles) =>
+    elderForceIndex(candles, opts as { shortPeriod?: number; longPeriod?: number }).map(
+      (s) => s.value,
+    ),
+});
+
+// Klinger Volume Oscillator — Cascaded (three recursive EMAs). Composite
+// output `{ kvo, signal, histogram }`, all null during warmup.
+describeContract<KlingerValue, KlingerState>({
+  name: "klinger",
+  create: (opts, warmUp) =>
+    createKlinger(
+      opts as { shortPeriod?: number; longPeriod?: number; signalPeriod?: number },
+      warmUp,
+    ),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { shortPeriod: 34, longPeriod: 55, signalPeriod: 13 },
+  reconfigParams: [{ shortPeriod: 20 }, { longPeriod: 80 }, { signalPeriod: 9 }],
+  makeCandles,
+  streamLength: 160,
+  // `kvo` warms up before `signal` (the signal EMA needs an extra
+  // `signalPeriod` valid KVO inputs). `isWarmedUp` waits for `signal`,
+  // so the warmup gate keys on `signal`.
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { signal: unknown }).signal === null),
+  batchCompute: (opts, candles) =>
+    klinger(
+      candles,
+      opts as { shortPeriod?: number; longPeriod?: number; signalPeriod?: number },
+    ).map((s) => s.value),
+});
+
+// MFI — Mixed (buffer of derived signed money flows + recursive prevTp).
+// Refuses `period` change on resume.
+describeContract<number | null, MfiState>({
+  name: "mfi",
+  create: (opts, warmUp) => createMfi(opts as { period?: number }, warmUp),
+  category: "mixed",
+  version: 1,
+  defaultParams: { period: 14 },
+  reconfigParams: [{ period: 10 }, { period: 20 }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) => mfi(candles, opts as { period?: number }).map((s) => s.value),
+});
+
+// Volume Anomaly — Windowed (single raw volume buffer). The threshold /
+// z-score params are resume-invariant — they only classify the
+// already-computed ratio / z-score. Composite output is never all-null;
+// `level` flips from null to "normal"/"high"/"extreme" at warmup.
+describeContract<VolumeAnomalyValue, VolumeAnomalyState>({
+  name: "volumeAnomaly",
+  create: (opts, warmUp) =>
+    createVolumeAnomaly(
+      opts as {
+        period?: number;
+        highThreshold?: number;
+        extremeThreshold?: number;
+        useZScore?: boolean;
+        zScoreThreshold?: number;
+      },
+      warmUp,
+    ),
+  category: "windowed",
+  version: 1,
+  defaultParams: {
+    period: 20,
+    highThreshold: 2.0,
+    extremeThreshold: 3.0,
+    useZScore: true,
+    zScoreThreshold: 2.0,
+  },
+  reconfigParams: [{ period: 10 }, { period: 30 }],
+  resumeInvariantReconfig: [{ highThreshold: 1.5 }, { zScoreThreshold: 3.0 }],
+  makeCandles,
+  streamLength: 100,
+  // `level` is the warmup gate: null until the buffer fills.
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { level: unknown }).level === null),
+  batchCompute: (opts, candles) =>
+    volumeAnomaly(
+      candles,
+      opts as {
+        period?: number;
+        highThreshold?: number;
+        extremeThreshold?: number;
+        useZScore?: boolean;
+        zScoreThreshold?: number;
+      },
+    ).map((s) => s.value),
+});
+
+// Volume Trend — Windowed (price / volume / volume-MA buffers + running
+// sum). `minPriceChange` is resume-invariant. The output object never
+// has null fields, so the warmup gate keys on the `neutral` price-trend
+// state the indicator emits until the buffers fill.
+describeContract<VolumeTrendValue, VolumeTrendState>({
+  name: "volumeTrend",
+  create: (opts, warmUp) =>
+    createVolumeTrend(
+      opts as {
+        pricePeriod?: number;
+        volumePeriod?: number;
+        maPeriod?: number;
+        minPriceChange?: number;
+      },
+      warmUp,
+    ),
+  category: "windowed",
+  version: 1,
+  defaultParams: { pricePeriod: 10, volumePeriod: 10, maPeriod: 20, minPriceChange: 2.0 },
+  reconfigParams: [{ pricePeriod: 6 }, { maPeriod: 30 }],
+  resumeInvariantReconfig: [{ minPriceChange: 3.0 }],
+  makeCandles,
+  streamLength: 120,
+  // Three independent windows must each refill after a reconfig; the
+  // default single-period margin is not enough, so wait for the
+  // largest of the new periods before comparing against a fresh run.
+  reconfigMargin: (o) =>
+    Math.max(Number(o.pricePeriod), Number(o.volumePeriod), Number(o.maPeriod)),
+  // During warmup the indicator emits a fully-neutral value; treat that
+  // as the null gate so invariant [7] aligns with `isWarmedUp`.
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { priceTrend: unknown }).priceTrend === "neutral"),
+  // batchCompute intentionally omitted: the batch `volumeTrend` and the
+  // incremental factory have a pre-existing trend-direction drift (batch
+  // can classify a bar `down` where the incremental emits `neutral`).
+  // The migration left `next` / `peek` untouched, so this is not a
+  // regression introduced here; the legacy parity test only compared
+  // `confidence` within tolerance and never exercised the direction
+  // fields. Chasing the batch-drift fix is out of scope for Bundle L3.
+});
+
+// Weis Wave — Recursive (`waveVolume` cumulative accumulator; reset
+// points depend on `method` / `threshold`). Warms up at the first bar.
+describeContract<WeisWaveValue, WeisWaveState>({
+  name: "weisWave",
+  create: (opts, warmUp) =>
+    createWeisWave(opts as { method?: "close" | "highlow"; threshold?: number }, warmUp),
+  category: "recursive",
+  version: 1,
+  defaultParams: { method: "close", threshold: 0 },
+  reconfigParams: [{ method: "highlow" }, { threshold: 5 }],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (opts, candles) =>
+    weisWave(candles, opts as { method?: "close" | "highlow"; threshold?: number }).map(
+      (s) => s.value,
+    ),
+});
+
+// ---- Wave 3 Bundle L4: price-structure / wyckoff / smc / filter ----
+
+// Swing Points — Event (a `leftBars + 1 + rightBars` raw OHLC window
+// plus persistent last-swing trackers). The trackers are conditioned
+// on the window the swing was confirmed under, so a `leftBars` /
+// `rightBars` reconfig cannot reproduce a fresh run bar-by-bar — past
+// swings stand. The warmup gate keys on both swing flags being false
+// (the indicator emits a fully-null composite until a swing is
+// detected). batchCompute omitted: the batch `swingPoints` uses
+// look-ahead confirmation while the incremental confirms with a
+// `rightBars` delay (shift-offset, not bar-aligned).
+describeContract<SwingPointValue, SwingPointsState>({
+  name: "swingPoints",
+  create: (opts, warmUp) =>
+    createSwingPoints(opts as { leftBars?: number; rightBars?: number }, warmUp),
+  category: "mixed",
+  version: 1,
+  defaultParams: { leftBars: 3, rightBars: 3 },
+  reconfigParams: [{ leftBars: 2, rightBars: 2 }, { rightBars: 4 }],
+  makeCandles,
+  streamLength: 120,
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" &&
+      !(v as { isSwingHigh: boolean }).isSwingHigh &&
+      !(v as { isSwingLow: boolean }).isSwingLow),
+});
+
+// Fractals — Windowed (a `2*period+1` raw OHLC window). Reconfig
+// carries the window forward. The warmup gate keys on both fractal
+// flags being false. batchCompute omitted: batch `fractals` confirms
+// with look-ahead while the incremental delays by `period` bars
+// (shift-offset, not bar-aligned).
+describeContract<FractalValue, FractalsState>({
+  name: "fractals",
+  create: (opts, warmUp) => createFractals(opts as { period?: number }, warmUp),
+  category: "windowed",
+  version: 1,
+  defaultParams: { period: 2 },
+  reconfigParams: [{ period: 3 }, { period: 4 }],
+  makeCandles,
+  streamLength: 120,
+  // Warmup is `2*period+1`.
+  reconfigMargin: (newOpts) => 2 * (newOpts.period as number) + 1,
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" &&
+      !(v as { upFractal: boolean }).upFractal &&
+      !(v as { downFractal: boolean }).downFractal),
+});
+
+// Break of Structure — Event (a `2*swingPeriod+1` raw high/low window
+// plus last-swing / trend trackers conditioned on the confirming
+// window). The warmup gate keys on `trend === "neutral"` (the
+// indicator emits a neutral trend until the first BOS). batchCompute
+// omitted: batch swing detection uses look-ahead.
+describeContract<BosValue, BosState>({
+  name: "breakOfStructure",
+  create: (opts, warmUp) => createBreakOfStructure(opts as { swingPeriod?: number }, warmUp),
+  category: "mixed",
+  version: 1,
+  defaultParams: { swingPeriod: 3 },
+  reconfigParams: [{ swingPeriod: 2 }, { swingPeriod: 4 }],
+  makeCandles,
+  streamLength: 120,
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { trend: unknown }).trend === "neutral"),
+});
+
+// Change of Character — Event (composes the inner BOS window).
+describeContract<BosValue, ChochState>({
+  name: "changeOfCharacter",
+  create: (opts, warmUp) => createChangeOfCharacter(opts as { swingPeriod?: number }, warmUp),
+  category: "mixed",
+  version: 1,
+  defaultParams: { swingPeriod: 3 },
+  reconfigParams: [{ swingPeriod: 2 }, { swingPeriod: 4 }],
+  makeCandles,
+  streamLength: 120,
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { trend: unknown }).trend === "neutral"),
+});
+
+// Pivot Points — Windowed (`prevCandle` is a raw one-bar OHLC
+// window). `method` is resume-invariant: it only selects the level
+// formula applied to the raw `prevCandle`. batchCompute omitted: the
+// batch `pivotPoints` aligns levels to the bar the prior OHLC came
+// from, a different convention than the incremental's same-bar
+// projection.
+describeContract<PivotPointsValue, PivotPointsState>({
+  name: "pivotPoints",
+  create: (opts, warmUp) =>
+    createPivotPoints(
+      opts as { method?: "standard" | "fibonacci" | "woodie" | "camarilla" | "demark" },
+      warmUp,
+    ),
+  category: "windowed",
+  version: 1,
+  defaultParams: { method: "standard" },
+  reconfigParams: [],
+  resumeInvariantReconfig: [{ method: "fibonacci" }, { method: "camarilla" }],
+  makeCandles,
+  streamLength: 100,
+});
+
+// Heikin-Ashi — Recursive (`prevHaOpen` / `prevHaClose`). No params,
+// so reconfig is not exercised. Batch parity is clean (pure recursive
+// transform). Never emits null, so the warmup gate is bar 0.
+describeContract<HeikinAshiValue, HeikinAshiState>({
+  name: "heikinAshi",
+  create: (opts, warmUp) => createHeikinAshi(opts as Record<string, never>, warmUp),
+  category: "recursive",
+  version: 1,
+  defaultParams: {},
+  reconfigParams: [],
+  makeCandles,
+  streamLength: 100,
+  batchCompute: (_opts, candles) => heikinAshi(candles).map((s) => s.value),
+});
+
+// Fair Value Gap — Event (an append-only log of active FVG zones).
+// Past detections stand on resume; reconfig of detection params only
+// affects future bars. batchCompute omitted: the batch FVG does a
+// retroactive fill pass while the incremental detects fills as they
+// occur.
+describeContract<FvgValue, FairValueGapState>({
+  name: "fairValueGap",
+  create: (opts, warmUp) =>
+    createFairValueGap(
+      opts as { minGapPercent?: number; maxActiveFvgs?: number; partialFill?: boolean },
+      warmUp,
+    ),
+  category: "mixed",
+  version: 1,
+  defaultParams: { minGapPercent: 0, maxActiveFvgs: 10, partialFill: true },
+  reconfigParams: [{ minGapPercent: 0.2 }, { maxActiveFvgs: 5 }],
+  makeCandles,
+  streamLength: 120,
+  // FVG never emits a bare-null value; the first two bars emit the
+  // empty result (needs 3 candles to detect). Treat "no detection,
+  // no active/filled zones" as the warmup gate so it aligns with the
+  // indicator's `count >= 3` `isWarmedUp` getter.
+  isNullishField: (v) => {
+    if (v === null || v === undefined) return true;
+    if (typeof v !== "object") return false;
+    const o = v as FvgValue;
+    return (
+      !o.newBullishFvg &&
+      !o.newBearishFvg &&
+      o.newFvg === null &&
+      o.activeBullishFvgs.length === 0 &&
+      o.activeBearishFvgs.length === 0 &&
+      o.filledFvgs.length === 0
+    );
+  },
+});
+
+// Gap Analysis — Event (an append-only log of active gap zones).
+// batchCompute omitted: batch does a retroactive fill pass.
+describeContract<GapValue, GapAnalysisState>({
+  name: "gapAnalysis",
+  create: (opts, warmUp) => createGapAnalysis(opts as { minGapPercent?: number }, warmUp),
+  category: "mixed",
+  version: 1,
+  defaultParams: { minGapPercent: 0.5 },
+  reconfigParams: [{ minGapPercent: 0.2 }, { minGapPercent: 1.0 }],
+  makeCandles,
+  streamLength: 120,
+  // The output object is never all-null (`gapPercent: 0`,
+  // `filled: false`); gate on `type === null` (no gap detected).
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { type: unknown }).type === null),
+});
+
+// Opening Range — Mixed (session-scoped accumulator; `orDurationMs`
+// and the reset rule are derived from params, so resume with changed
+// `minutes` / `sessionResetPeriod` is refused). batchCompute omitted:
+// no candle-aligned batch sibling with the same session semantics.
+describeContract<OpeningRangeValue, OpeningRangeState>({
+  name: "openingRange",
+  create: (opts, warmUp) =>
+    createOpeningRange(opts as { minutes?: number; sessionResetPeriod?: "day" | number }, warmUp),
+  category: "mixed",
+  version: 1,
+  defaultParams: { minutes: 30, sessionResetPeriod: 20 },
+  reconfigParams: [{ minutes: 60 }, { sessionResetPeriod: 30 }],
+  makeCandles,
+  streamLength: 120,
+  // `isWarmedUp` returns `orEstablished`; the indicator emits
+  // `high`/`low` while the range is still accumulating but only emits
+  // a non-null `breakout` once the range is established. Gate on
+  // `breakout === null` so the first non-nullish bar coincides with
+  // an established range.
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { breakout: unknown }).breakout === null),
+});
+
+// Auto Trend Line — Event (structure tracker wrapping swing points).
+// batchCompute omitted: batch swing detection uses look-ahead.
+describeContract<AutoTrendLineValue, AutoTrendLineState>({
+  name: "autoTrendLine",
+  create: (opts, warmUp) =>
+    createAutoTrendLine(opts as { leftBars?: number; rightBars?: number }, warmUp),
+  category: "mixed",
+  version: 1,
+  defaultParams: { leftBars: 3, rightBars: 3 },
+  reconfigParams: [{ leftBars: 2, rightBars: 2 }, { rightBars: 4 }],
+  makeCandles,
+  streamLength: 150,
+});
+
+// Channel Line — Mixed (structure tracker wrapping swing points).
+describeContract<ChannelLineValue, ChannelLineState>({
+  name: "channelLine",
+  create: (opts, warmUp) =>
+    createChannelLine(opts as { leftBars?: number; rightBars?: number }, warmUp),
+  category: "mixed",
+  version: 1,
+  defaultParams: { leftBars: 3, rightBars: 3 },
+  reconfigParams: [{ leftBars: 2, rightBars: 2 }, { rightBars: 4 }],
+  makeCandles,
+  streamLength: 150,
+});
+
+// Fibonacci Retracement — Mixed (structure tracker wrapping swing
+// points). `levels` is part of meta.params.
+describeContract<FibonacciRetracementValue, FibonacciRetracementState>({
+  name: "fibonacciRetracement",
+  create: (opts, warmUp) =>
+    createFibonacciRetracement(
+      opts as { leftBars?: number; rightBars?: number; levels?: number[] },
+      warmUp,
+    ),
+  category: "mixed",
+  version: 1,
+  defaultParams: { leftBars: 3, rightBars: 3, levels: [0, 0.236, 0.382, 0.5, 0.618, 0.786, 1] },
+  reconfigParams: [{ leftBars: 2, rightBars: 2 }, { levels: [0, 0.5, 1] }],
+  makeCandles,
+  streamLength: 150,
+});
+
+// Fibonacci Extension — Mixed (structure tracker wrapping swing
+// points).
+describeContract<FibonacciExtensionValue, FibonacciExtensionState>({
+  name: "fibonacciExtension",
+  create: (opts, warmUp) =>
+    createFibonacciExtension(
+      opts as { leftBars?: number; rightBars?: number; levels?: number[] },
+      warmUp,
+    ),
+  category: "mixed",
+  version: 1,
+  defaultParams: { leftBars: 3, rightBars: 3, levels: [0, 0.618, 1, 1.272, 1.618, 2, 2.618] },
+  reconfigParams: [{ leftBars: 2, rightBars: 2 }, { levels: [0, 1, 1.618] }],
+  makeCandles,
+  streamLength: 150,
+});
+
+// Liquidity Sweep — Mixed (inner swing-points snapshot + a
+// `swingPeriod + 1` scan ring buffer; both are conditioned on
+// construction params, so resume with a changed param is refused).
+// batchCompute omitted: batch swing detection uses look-ahead, and the
+// live indicator emits sweeps with up to `swingPeriod` bars of lag.
+describeContract<LiquiditySweepValue, LiquiditySweepState>({
+  name: "liquiditySweep",
+  create: (opts, warmUp) =>
+    createLiquiditySweep(
+      opts as {
+        swingPeriod?: number;
+        maxRecoveryBars?: number;
+        maxTrackedSweeps?: number;
+        minSweepDepth?: number;
+      },
+      warmUp,
+    ),
+  category: "mixed",
+  version: 1,
+  defaultParams: { swingPeriod: 3, maxRecoveryBars: 3, maxTrackedSweeps: 10, minSweepDepth: 0 },
+  reconfigParams: [{ maxRecoveryBars: 5 }, { minSweepDepth: 0.1 }],
+  makeCandles,
+  streamLength: 150,
+  // The output object is never all-null (`isSweep: false`, empty
+  // arrays); gate on `isSweep === false` so the first non-nullish bar
+  // is a real sweep detection (by which point the inner swing points
+  // are warmed).
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { isSweep: boolean }).isSweep === false),
+});
+
+// VSA — Mixed (inner recursive ATR + windowed SMA + own 10-bar candle
+// buffer). The four threshold params are resume-invariant — they only
+// classify already-computed spread / volume ratios. batchCompute
+// omitted: the batch `vsa` and the incremental factory have a
+// pre-existing classification drift on a handful of bars (the legacy
+// parity test compared only `spreadRelative` / `volumeRelative`
+// within tolerance, never the `barType` enum); the migration left
+// `next` / `peek` untouched, so this is not a regression. The
+// incremental never emits null (VSA classifies every bar from bar 0).
+describeContract<VsaValue, VsaState>({
+  name: "vsa",
+  create: (opts, warmUp) =>
+    createVsa(
+      opts as {
+        volumeMaPeriod?: number;
+        atrPeriod?: number;
+        highVolumeThreshold?: number;
+        lowVolumeThreshold?: number;
+        wideSpreadThreshold?: number;
+        narrowSpreadThreshold?: number;
+      },
+      warmUp,
+    ),
+  category: "mixed",
+  version: 1,
+  defaultParams: {
+    volumeMaPeriod: 20,
+    atrPeriod: 14,
+    highVolumeThreshold: 1.5,
+    lowVolumeThreshold: 0.7,
+    wideSpreadThreshold: 1.2,
+    narrowSpreadThreshold: 0.7,
+  },
+  reconfigParams: [{ volumeMaPeriod: 10 }, { atrPeriod: 20 }],
+  resumeInvariantReconfig: [{ highVolumeThreshold: 2.0 }, { narrowSpreadThreshold: 0.5 }],
+  makeCandles,
+  streamLength: 120,
+  // VSA never emits a bare-null value. Until the inner volume SMA is
+  // warmed, `volumeRelative` is exactly 1 (the `volMaVal == null`
+  // fallback). The SMA is the slowest-warming inner indicator, so
+  // gating on `volumeRelative === 1` aligns the first non-nullish bar
+  // with the indicator's `isWarmedUp` (ATR && SMA warmed).
+  isNullishField: (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "object" && (v as { volumeRelative: number }).volumeRelative === 1),
+});
+
+// Super Smoother — Recursive (two-tap IIR memory). Batch parity is
+// clean. First two bars emit null.
+describeContract<number | null, SuperSmootherState>({
+  name: "superSmoother",
+  create: (opts, warmUp) =>
+    createSuperSmoother(opts as { period?: number; source?: PriceSource }, warmUp),
+  category: "recursive",
+  version: 1,
+  defaultParams: { period: 10, source: "close" },
+  reconfigParams: [{ period: 8 }, { period: 20 }],
+  makeCandles,
+  streamLength: 120,
+  batchCompute: (opts, candles) =>
+    superSmoother(candles, opts as { period: number; source?: PriceSource }).map((s) => s.value),
+});
+
+// Roofing Filter — Cascaded (a 2-pole high-pass IIR feeding a 2-pole
+// Super Smoother IIR). Batch parity is clean. First two bars emit
+// null.
+describeContract<number | null, RoofingFilterState>({
+  name: "roofingFilter",
+  create: (opts, warmUp) =>
+    createRoofingFilter(
+      opts as { highPassPeriod?: number; lowPassPeriod?: number; source?: PriceSource },
+      warmUp,
+    ),
+  category: "cascaded",
+  version: 1,
+  defaultParams: { highPassPeriod: 48, lowPassPeriod: 10, source: "close" },
+  reconfigParams: [{ highPassPeriod: 40 }, { lowPassPeriod: 20 }],
+  makeCandles,
+  streamLength: 120,
+  batchCompute: (opts, candles) =>
+    roofingFilter(
+      candles,
+      opts as { highPassPeriod?: number; lowPassPeriod?: number; source?: PriceSource },
+    ).map((s) => s.value),
+});
+
+// Zigzag — Mixed (a recursive trend / running-extreme tracker
+// composed with an inner recursive ATR snapshot). Every param is
+// state-shaping (pivot-trigger threshold or inner ATR), so reconfig
+// is refused. Emits a fully-null value until the first pivot is
+// confirmed. batchCompute omitted: the batch `zigzag` emits one entry
+// per pivot bar with a different null-bar alignment than the
+// incremental's per-candle stream.
+describeContract<ZigzagValue, ZigzagState>({
+  name: "zigzag",
+  create: (opts, warmUp) =>
+    createZigzag(
+      opts as {
+        deviation?: number;
+        useAtr?: boolean;
+        atrPeriod?: number;
+        atrMultiplier?: number;
+      },
+      warmUp,
+    ),
+  category: "mixed",
+  version: 1,
+  defaultParams: { deviation: 5, useAtr: false, atrPeriod: 14, atrMultiplier: 2 },
+  reconfigParams: [{ deviation: 8 }, { atrMultiplier: 3 }],
+  makeCandles,
+  streamLength: 150,
 });

--- a/packages/core/src/indicators/incremental/__tests__/volume-indicators.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/volume-indicators.test.ts
@@ -307,13 +307,13 @@ describe("EMV incremental", () => {
     const ind1 = createEmv({ period: 14, volumeDivisor: 10000 });
     for (let i = 0; i < 30; i++) ind1.next(candles[i]);
     const state = ind1.getState();
-    expect(state.volumeDivisor).toBe(10000);
+    expect(state.meta.params.volumeDivisor).toBe(10000);
 
     // Resume without re-passing options — the legacy divisor must be
     // recovered from the snapshot, NOT silently swapped for the
     // canonical default.
     const ind2 = createEmv({ period: 14 }, { fromState: state });
-    expect(ind2.getState().volumeDivisor).toBe(10000);
+    expect(ind2.getState().meta.params.volumeDivisor).toBe(10000);
 
     for (let i = 30; i < 60; i++) {
       const v1 = ind1.next(candles[i]).value;
@@ -326,13 +326,16 @@ describe("EMV incremental", () => {
     }
   });
 
-  it("explicit volumeDivisor option wins over both fromState and the default", () => {
+  it("refuses resume with a different volumeDivisor", () => {
+    // Under the State Contract, EMV is `mixed`: `volumeDivisor` scales
+    // every buffered raw EMV value, so resuming a snapshot with a
+    // different divisor is a hard refuse rather than a silent override.
     const ind1 = createEmv({ period: 14, volumeDivisor: 10000 });
     for (let i = 0; i < 30; i++) ind1.next(candles[i]);
     const state = ind1.getState();
-    // Explicit option overrides the persisted snapshot value.
-    const ind2 = createEmv({ period: 14, volumeDivisor: 5000 }, { fromState: state });
-    expect(ind2.getState().volumeDivisor).toBe(5000);
+    expect(() => createEmv({ period: 14, volumeDivisor: 5000 }, { fromState: state })).toThrow(
+      /incompatible snapshot|cannot be reconfigured/,
+    );
   });
 });
 

--- a/packages/core/src/indicators/incremental/filter/roofing-filter.ts
+++ b/packages/core/src/indicators/incremental/filter/roofing-filter.ts
@@ -5,16 +5,31 @@
  * by a Super Smoother (removes high-frequency noise). Mirrors the batch
  * `roofingFilter()` exactly — first 2 bars emit null, subsequent bars
  * apply the cascaded recurrences.
+ *
+ * State category: **Cascaded** (a 2-pole high-pass IIR feeds a 2-pole
+ * Super Smoother IIR — two coupled recursive stages). `highPassPeriod`
+ * / `lowPassPeriod` set the per-stage coefficients and `source` the
+ * input series, so resuming with any of them changed is mathematically
+ * undefined and refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for the Roofing Filter. Params (`highPassPeriod`,
+ * `lowPassPeriod`, `source`) live in `meta.params` on the wire.
+ */
 export type RoofingFilterState = {
-  highPassPeriod: number;
-  lowPassPeriod: number;
-  source: PriceSource;
   /** price[i-1] */
   prevPrice: number | null;
   /** price[i-2] */
@@ -28,6 +43,15 @@ export type RoofingFilterState = {
   /** filt[i-2] */
   filtPrev2: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const ROOFING_FILTER_VERSION = 1;
+
+type RoofingFilterParams = {
+  highPassPeriod: number;
+  lowPassPeriod: number;
+  source: PriceSource;
 };
 
 function highPassCoeffs(period: number) {
@@ -64,18 +88,37 @@ function superSmootherCoeffs(period: number) {
  */
 export function createRoofingFilter(
   options: { highPassPeriod?: number; lowPassPeriod?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<RoofingFilterState>,
-): IncrementalIndicator<number | null, RoofingFilterState> {
-  // Saved snapshot wins so the cascaded HP / SS memories keep being applied
-  // with the coefficients they were computed under.
-  const highPassPeriod = warmUpOptions?.fromState?.highPassPeriod ?? options.highPassPeriod ?? 48;
-  const lowPassPeriod = warmUpOptions?.fromState?.lowPassPeriod ?? options.lowPassPeriod ?? 10;
-  const source: PriceSource = warmUpOptions?.fromState?.source ?? options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<RoofingFilterState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<RoofingFilterState>> {
+  const { params, state } = resolveResume<RoofingFilterParams, RoofingFilterState>({
+    indicator: "roofingFilter",
+    version: ROOFING_FILTER_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { highPassPeriod: 48, lowPassPeriod: 10, source: "close" },
+  });
 
   // See batch `roofingFilter()` for why the canonical formula requires
   // highPassPeriod >= 2 (only period=1 leaves the unit circle).
-  if (highPassPeriod < 2) throw new Error("Roofing filter highPassPeriod must be at least 2");
-  if (lowPassPeriod < 1) throw new Error("Roofing filter lowPassPeriod must be at least 1");
+  const highPassPeriod = requireParam(
+    "roofingFilter",
+    params,
+    "highPassPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 2,
+    "must be an integer >= 2",
+  );
+  const lowPassPeriod = requireParam(
+    "roofingFilter",
+    params,
+    "lowPassPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
 
   const hp = highPassCoeffs(highPassPeriod);
   const ss = superSmootherCoeffs(lowPassPeriod);
@@ -88,15 +131,14 @@ export function createRoofingFilter(
   let filtPrev2: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    prevPrice = s.prevPrice;
-    prevPrice2 = s.prevPrice2;
-    hpPrev1 = s.hpPrev1;
-    hpPrev2 = s.hpPrev2;
-    filtPrev1 = s.filtPrev1;
-    filtPrev2 = s.filtPrev2;
-    count = s.count;
+  if (state !== null) {
+    prevPrice = state.prevPrice;
+    prevPrice2 = state.prevPrice2;
+    hpPrev1 = state.hpPrev1;
+    hpPrev2 = state.hpPrev2;
+    filtPrev1 = state.filtPrev1;
+    filtPrev2 = state.filtPrev2;
+    count = state.count;
   } else {
     prevPrice = null;
     prevPrice2 = null;
@@ -117,7 +159,7 @@ export function createRoofingFilter(
     return { hpVal, filtVal };
   }
 
-  const indicator: IncrementalIndicator<number | null, RoofingFilterState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<RoofingFilterState>> = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
 
@@ -149,19 +191,21 @@ export function createRoofingFilter(
       return { time: candle.time, value: filtVal };
     },
 
-    getState(): RoofingFilterState {
-      return {
-        highPassPeriod,
-        lowPassPeriod,
-        source,
-        prevPrice,
-        prevPrice2,
-        hpPrev1,
-        hpPrev2,
-        filtPrev1,
-        filtPrev2,
-        count,
-      };
+    getState(): IndicatorSnapshot<RoofingFilterState> {
+      return makeSnapshot(
+        "roofingFilter",
+        ROOFING_FILTER_VERSION,
+        { highPassPeriod, lowPassPeriod, source },
+        {
+          prevPrice,
+          prevPrice2,
+          hpPrev1,
+          hpPrev2,
+          filtPrev1,
+          filtPrev2,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/filter/super-smoother.ts
+++ b/packages/core/src/indicators/incremental/filter/super-smoother.ts
@@ -8,21 +8,44 @@
  *
  * with coefficients derived from the cutoff `period`. State carries the
  * last input + last two outputs.
+ *
+ * State category: **Recursive** (the two-tap IIR memory `outPrev1` /
+ * `outPrev2` is the recursive accumulator). `period` determines the
+ * filter coefficients and `source` the input series, so resuming with
+ * either changed is mathematically undefined and refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for Super Smoother. Params (`period`, `source`)
+ * live in `meta.params` on the wire.
+ */
 export type SuperSmootherState = {
-  period: number;
-  source: PriceSource;
   prevPrice: number | null;
   /** Memory `out[i-2]` after the last `next()` call. */
   outPrev2: number;
   /** Memory `out[i-1]` after the last `next()` call. */
   outPrev1: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const SUPER_SMOOTHER_VERSION = 1;
+
+type SuperSmootherParams = {
+  period: number;
+  source: PriceSource;
 };
 
 function coefficients(period: number) {
@@ -49,16 +72,28 @@ function coefficients(period: number) {
  */
 export function createSuperSmoother(
   options: { period?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<SuperSmootherState>,
-): IncrementalIndicator<number | null, SuperSmootherState> {
-  // Saved snapshot wins so the IIR memories (outPrev1/outPrev2) keep being
-  // applied with the coefficients they were computed under.
-  const period = warmUpOptions?.fromState?.period ?? options.period ?? 10;
-  const source: PriceSource = warmUpOptions?.fromState?.source ?? options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<SuperSmootherState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<SuperSmootherState>> {
+  const { params, state } = resolveResume<SuperSmootherParams, SuperSmootherState>({
+    indicator: "superSmoother",
+    version: SUPER_SMOOTHER_VERSION,
+    category: "recursive",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 10, source: "close" },
+  });
 
-  if (period < 1) {
-    throw new Error("Super Smoother period must be at least 1");
-  }
+  const period = requireParam(
+    "superSmoother",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
 
   const { c1, c2, c3 } = coefficients(period);
 
@@ -67,12 +102,11 @@ export function createSuperSmoother(
   let outPrev1: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    prevPrice = s.prevPrice;
-    outPrev2 = s.outPrev2;
-    outPrev1 = s.outPrev1;
-    count = s.count;
+  if (state !== null) {
+    prevPrice = state.prevPrice;
+    outPrev2 = state.outPrev2;
+    outPrev1 = state.outPrev1;
+    count = state.count;
   } else {
     prevPrice = null;
     outPrev2 = 0;
@@ -80,7 +114,7 @@ export function createSuperSmoother(
     count = 0;
   }
 
-  const indicator: IncrementalIndicator<number | null, SuperSmootherState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<SuperSmootherState>> = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
 
@@ -117,8 +151,13 @@ export function createSuperSmoother(
       return { time: candle.time, value: out };
     },
 
-    getState(): SuperSmootherState {
-      return { period, source, prevPrice, outPrev2, outPrev1, count };
+    getState(): IndicatorSnapshot<SuperSmootherState> {
+      return makeSnapshot(
+        "superSmoother",
+        SUPER_SMOOTHER_VERSION,
+        { period, source },
+        { prevPrice, outPrev2, outPrev1, count },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/aroon.ts
+++ b/packages/core/src/indicators/incremental/momentum/aroon.ts
@@ -3,11 +3,23 @@
  *
  * Aroon Up = ((period - bars since highest high) / period) × 100
  * Aroon Down = ((period - bars since lowest low) / period) × 100
+ *
+ * State category: **Windowed** (fixed-size high/low raw-value buffers,
+ * no recursion). Resume with a different `period` carries the high/low
+ * values forward into the resized buffers.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type AroonValue = {
   up: number | null;
@@ -15,11 +27,20 @@ export type AroonValue = {
   oscillator: number | null;
 };
 
+/**
+ * Bare state shape for Aroon. Params (`period`) live in `meta.params`.
+ */
 export type AroonState = {
-  period: number;
   highBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   lowBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const AROON_VERSION = 1;
+
+type AroonParams = {
+  period: number;
 };
 
 /**
@@ -36,22 +57,58 @@ export type AroonState = {
  */
 export function createAroon(
   options: { period?: number } = {},
-  warmUpOptions?: WarmUpOptions<AroonState>,
-): IncrementalIndicator<AroonValue, AroonState> {
-  const period = options.period ?? 25;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<AroonState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<AroonValue, IndicatorSnapshot<AroonState>> {
+  const { params, state, reconfigured } = resolveResume<AroonParams, AroonState>({
+    indicator: "aroon",
+    version: AROON_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 25 },
+  });
+
+  const period = requireParam(
+    "aroon",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+
+  const capacity = period + 1;
 
   let highBuffer: CircularBuffer<number>;
   let lowBuffer: CircularBuffer<number>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    highBuffer = CircularBuffer.fromSnapshot(s.highBuffer);
-    lowBuffer = CircularBuffer.fromSnapshot(s.lowBuffer);
-    count = s.count;
+  function carryForward(
+    snapshot: ReturnType<CircularBuffer<number>["snapshot"]>,
+  ): CircularBuffer<number> {
+    const old = CircularBuffer.fromSnapshot<number>(snapshot);
+    const next = new CircularBuffer<number>(capacity);
+    const carry = Math.min(old.length, capacity);
+    for (let i = old.length - carry; i < old.length; i++) {
+      next.push(old.get(i));
+    }
+    return next;
+  }
+
+  if (state !== null) {
+    if (reconfigured) {
+      highBuffer = carryForward(state.highBuffer);
+      lowBuffer = carryForward(state.lowBuffer);
+    } else {
+      highBuffer = CircularBuffer.fromSnapshot(state.highBuffer);
+      lowBuffer = CircularBuffer.fromSnapshot(state.lowBuffer);
+    }
+    count = state.count;
   } else {
-    highBuffer = new CircularBuffer<number>(period + 1);
-    lowBuffer = new CircularBuffer<number>(period + 1);
+    highBuffer = new CircularBuffer<number>(capacity);
+    lowBuffer = new CircularBuffer<number>(capacity);
     count = 0;
   }
 
@@ -78,7 +135,7 @@ export function createAroon(
     return { up, down, oscillator: up - down };
   }
 
-  const indicator: IncrementalIndicator<AroonValue, AroonState> = {
+  const indicator: IncrementalIndicator<AroonValue, IndicatorSnapshot<AroonState>> = {
     next(candle: NormalizedCandle) {
       count++;
       highBuffer.push(candle.high);
@@ -94,13 +151,17 @@ export function createAroon(
       return { time: candle.time, value: compute(peekH, peekL) };
     },
 
-    getState(): AroonState {
-      return {
-        period,
-        highBuffer: highBuffer.snapshot(),
-        lowBuffer: lowBuffer.snapshot(),
-        count,
-      };
+    getState(): IndicatorSnapshot<AroonState> {
+      return makeSnapshot(
+        "aroon",
+        AROON_VERSION,
+        { period },
+        {
+          highBuffer: highBuffer.snapshot(),
+          lowBuffer: lowBuffer.snapshot(),
+          count,
+        },
+      );
     },
 
     get count() {
@@ -108,7 +169,10 @@ export function createAroon(
     },
 
     get isWarmedUp() {
-      return count > period;
+      // Gate on buffer fill, not `count`: after a period-growing resume
+      // the carried buffer is shorter than the old `count`, and
+      // compute() returns nulls until it refills to period + 1.
+      return highBuffer.length >= period + 1;
     },
   };
 

--- a/packages/core/src/indicators/incremental/momentum/awesome-oscillator.ts
+++ b/packages/core/src/indicators/incremental/momentum/awesome-oscillator.ts
@@ -4,22 +4,39 @@
  * AO = SMA(median, fastPeriod) - SMA(median, slowPeriod)
  * where median = (high + low) / 2
  *
- * Measures market momentum by comparing recent momentum to a larger timeframe.
+ * State category: **Cascaded** (composes two inner incremental SMAs).
+ * Resume with a different `fastPeriod` / `slowPeriod` is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { SmaState } from "../moving-average/sma";
-import { createSma } from "../moving-average/sma";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { createSma, type SmaState } from "../moving-average/sma";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { makeCandle } from "../utils";
 
+/**
+ * Bare state shape for Awesome Oscillator. Params (`fastPeriod`,
+ * `slowPeriod`) live in `meta.params` on the wire.
+ */
 export type AwesomeOscillatorState = {
   fastSmaState: IndicatorSnapshot<SmaState>;
   slowSmaState: IndicatorSnapshot<SmaState>;
+  count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const AWESOME_OSCILLATOR_VERSION = 1;
+
+type AwesomeOscillatorParams = {
   fastPeriod: number;
   slowPeriod: number;
-  count: number;
 };
 
 /**
@@ -36,20 +53,44 @@ export type AwesomeOscillatorState = {
  */
 export function createAwesomeOscillator(
   options: { fastPeriod?: number; slowPeriod?: number } = {},
-  warmUpOptions?: WarmUpOptions<AwesomeOscillatorState>,
-): IncrementalIndicator<number | null, AwesomeOscillatorState> {
-  const fastPeriod = options.fastPeriod ?? 5;
-  const slowPeriod = options.slowPeriod ?? 34;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<AwesomeOscillatorState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<AwesomeOscillatorState>> {
+  const { params, state } = resolveResume<AwesomeOscillatorParams, AwesomeOscillatorState>({
+    indicator: "awesomeOscillator",
+    version: AWESOME_OSCILLATOR_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { fastPeriod: 5, slowPeriod: 34 },
+  });
+
+  const isPositiveInt = (v: number): v is number => Number.isInteger(v) && v >= 1;
+  const fastPeriod = requireParam(
+    "awesomeOscillator",
+    params,
+    "fastPeriod",
+    isPositiveInt,
+    "must be a positive integer",
+  );
+  const slowPeriod = requireParam(
+    "awesomeOscillator",
+    params,
+    "slowPeriod",
+    isPositiveInt,
+    "must be a positive integer",
+  );
 
   let fastSma: ReturnType<typeof createSma>;
   let slowSma: ReturnType<typeof createSma>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    fastSma = createSma({ period: fastPeriod }, { fromState: s.fastSmaState });
-    slowSma = createSma({ period: slowPeriod }, { fromState: s.slowSmaState });
-    count = s.count;
+  if (state !== null) {
+    fastSma = createSma({ period: fastPeriod }, { fromState: state.fastSmaState });
+    slowSma = createSma({ period: slowPeriod }, { fromState: state.slowSmaState });
+    count = state.count;
   } else {
     fastSma = createSma({ period: fastPeriod });
     slowSma = createSma({ period: slowPeriod });
@@ -74,7 +115,10 @@ export function createAwesomeOscillator(
     return { time: candle.time, value: fastVal - slowVal };
   }
 
-  const indicator: IncrementalIndicator<number | null, AwesomeOscillatorState> = {
+  const indicator: IncrementalIndicator<
+    number | null,
+    IndicatorSnapshot<AwesomeOscillatorState>
+  > = {
     next(candle: NormalizedCandle) {
       count++;
       return computeAo(candle, false);
@@ -84,14 +128,17 @@ export function createAwesomeOscillator(
       return computeAo(candle, true);
     },
 
-    getState(): AwesomeOscillatorState {
-      return {
-        fastSmaState: fastSma.getState(),
-        slowSmaState: slowSma.getState(),
-        fastPeriod,
-        slowPeriod,
-        count,
-      };
+    getState(): IndicatorSnapshot<AwesomeOscillatorState> {
+      return makeSnapshot(
+        "awesomeOscillator",
+        AWESOME_OSCILLATOR_VERSION,
+        { fastPeriod, slowPeriod },
+        {
+          fastSmaState: fastSma.getState(),
+          slowSmaState: slowSma.getState(),
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/balance-of-power.ts
+++ b/packages/core/src/indicators/incremental/momentum/balance-of-power.ts
@@ -3,19 +3,39 @@
  *
  * BOP = SMA((close - open) / (high - low), smoothPeriod)
  * Measures the strength of buyers vs sellers by relating the price change to the range.
+ *
+ * State category: **Cascaded** (composes an inner incremental SMA over
+ * the per-candle raw BOP series). Resume with a different
+ * `smoothPeriod` is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { SmaState } from "../moving-average/sma";
-import { createSma } from "../moving-average/sma";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { createSma, type SmaState } from "../moving-average/sma";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { makeCandle } from "../utils";
 
+/**
+ * Bare state shape for Balance of Power. Params (`smoothPeriod`) live
+ * in `meta.params` on the wire.
+ */
 export type BalanceOfPowerState = {
   smaState: IndicatorSnapshot<SmaState>;
-  smoothPeriod: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const BALANCE_OF_POWER_VERSION = 1;
+
+type BalanceOfPowerParams = {
+  smoothPeriod: number;
 };
 
 /**
@@ -32,17 +52,34 @@ export type BalanceOfPowerState = {
  */
 export function createBalanceOfPower(
   options: { smoothPeriod?: number } = {},
-  warmUpOptions?: WarmUpOptions<BalanceOfPowerState>,
-): IncrementalIndicator<number | null, BalanceOfPowerState> {
-  const smoothPeriod = options.smoothPeriod ?? 14;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<BalanceOfPowerState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<BalanceOfPowerState>> {
+  const { params, state } = resolveResume<BalanceOfPowerParams, BalanceOfPowerState>({
+    indicator: "balanceOfPower",
+    version: BALANCE_OF_POWER_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { smoothPeriod: 14 },
+  });
+
+  const smoothPeriod = requireParam(
+    "balanceOfPower",
+    params,
+    "smoothPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
 
   let sma: ReturnType<typeof createSma>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    sma = createSma({ period: smoothPeriod }, { fromState: s.smaState });
-    count = s.count;
+  if (state !== null) {
+    sma = createSma({ period: smoothPeriod }, { fromState: state.smaState });
+    count = state.count;
   } else {
     sma = createSma({ period: smoothPeriod });
     count = 0;
@@ -54,7 +91,7 @@ export function createBalanceOfPower(
     return (candle.close - candle.open) / range;
   }
 
-  const indicator: IncrementalIndicator<number | null, BalanceOfPowerState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<BalanceOfPowerState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const bop = rawBop(candle);
@@ -66,12 +103,16 @@ export function createBalanceOfPower(
       return sma.peek(makeCandle(candle.time, bop));
     },
 
-    getState(): BalanceOfPowerState {
-      return {
-        smaState: sma.getState(),
-        smoothPeriod,
-        count,
-      };
+    getState(): IndicatorSnapshot<BalanceOfPowerState> {
+      return makeSnapshot(
+        "balanceOfPower",
+        BALANCE_OF_POWER_VERSION,
+        { smoothPeriod },
+        {
+          smaState: sma.getState(),
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/cci.ts
+++ b/packages/core/src/indicators/incremental/momentum/cci.ts
@@ -4,23 +4,43 @@
  * CCI = (Typical Price - SMA of TP) / (constant × Mean Deviation)
  * Typical Price = (High + Low + Close) / 3
  *
- * Uses CircularBuffer for the lookback window of typical prices.
+ * State category: **Windowed** (a fixed-size typical-price buffer plus
+ * a running `sum`). Resume with a different `period` carries the raw
+ * typical prices forward and recomputes the running sum; `source`
+ * change is refused. `constant` is a resume-invariant param — it only
+ * scales the final projection, never the buffer or sum.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
 /**
- * State for incremental CCI
+ * Bare state shape for CCI. Params (`period`, `constant`, `source`)
+ * live in `meta.params` on the wire.
  */
 export type CciState = {
-  period: number;
-  constant: number;
   buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   sum: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const CCI_VERSION = 1;
+
+type CciParams = {
+  period: number;
+  constant: number;
+  source: PriceSource;
 };
 
 /**
@@ -36,22 +56,55 @@ export type CciState = {
  * ```
  */
 export function createCci(
-  options: { period: number; constant?: number; source?: PriceSource },
-  warmUpOptions?: WarmUpOptions<CciState>,
-): IncrementalIndicator<number | null, CciState> {
-  const period = options.period;
-  const constant = options.constant ?? 0.015;
-  const source = options.source ?? "hlc3";
+  options: { period?: number; constant?: number; source?: PriceSource } = {},
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<CciState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<CciState>> {
+  const { params, state, reconfigured } = resolveResume<CciParams, CciState>({
+    indicator: "cci",
+    version: CCI_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { constant: 0.015, source: "hlc3" },
+    resumeInvariantParams: ["constant"],
+  });
+
+  const period = requireParam(
+    "cci",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const constant = params.constant;
+  const source = params.source;
 
   let buffer: CircularBuffer<number>;
   let sum: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    sum = s.sum;
-    count = s.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // Period changed — carry the raw typical prices forward and
+      // recompute the running sum against the new window.
+      const old = CircularBuffer.fromSnapshot<number>(state.buffer);
+      buffer = new CircularBuffer<number>(period);
+      const carry = Math.min(old.length, period);
+      for (let i = old.length - carry; i < old.length; i++) {
+        buffer.push(old.get(i));
+      }
+      sum = 0;
+      for (let i = 0; i < buffer.length; i++) {
+        sum += buffer.get(i);
+      }
+    } else {
+      buffer = CircularBuffer.fromSnapshot(state.buffer);
+      sum = state.sum;
+    }
+    count = state.count;
   } else {
     buffer = new CircularBuffer<number>(period);
     sum = 0;
@@ -73,7 +126,7 @@ export function createCci(
     return meanDev !== 0 ? (tp - smaTP) / (constant * meanDev) : 0;
   }
 
-  const indicator: IncrementalIndicator<number | null, CciState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<CciState>> = {
     next(candle: NormalizedCandle) {
       const tp = getSourcePrice(candle, source);
 
@@ -107,8 +160,13 @@ export function createCci(
       return { time: candle.time, value };
     },
 
-    getState(): CciState {
-      return { period, constant, buffer: buffer.snapshot(), sum, count };
+    getState(): IndicatorSnapshot<CciState> {
+      return makeSnapshot(
+        "cci",
+        CCI_VERSION,
+        { period, constant, source },
+        { buffer: buffer.snapshot(), sum, count },
+      );
     },
 
     get count() {
@@ -116,7 +174,10 @@ export function createCci(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      // Gate on buffer fill, not `count`: after a period-growing resume
+      // the carried buffer is shorter than the old `count`, and
+      // computeCci() still returns null until it refills.
+      return buffer.length >= period;
     },
   };
 

--- a/packages/core/src/indicators/incremental/momentum/dpo.ts
+++ b/packages/core/src/indicators/incremental/momentum/dpo.ts
@@ -8,13 +8,23 @@
  * required SMA (shift bars later) becomes available. Output is emitted in
  * order with the correct timestamps, but with a delay of `shift` bars.
  * Bars near the end of a finite series will be null (no future SMA).
+ *
+ * State category: **Cascaded** (composes an inner incremental SMA plus
+ * a pending-entry queue keyed on `shift`, which is derived from
+ * `period`). Resume with a different `period` / `source` is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import type { SmaState } from "../moving-average/sma";
-import { createSma } from "../moving-average/sma";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { createSma, type SmaState } from "../moving-average/sma";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
 /**
@@ -22,16 +32,25 @@ import { getSourcePrice } from "../utils";
  */
 type PendingEntry = { time: number; price: number };
 
+/**
+ * Bare state shape for DPO. Params (`period`, `source`) live in
+ * `meta.params` on the wire; `shift` is derived from `period`.
+ */
 export type DpoState = {
-  period: number;
-  source: PriceSource;
-  shift: number;
   smaState: IndicatorSnapshot<SmaState>;
   pending: PendingEntry[];
   /** Number of entries already resolved and removed from pending head */
   resolvedOffset: number;
   count: number;
   outputCount: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const DPO_VERSION = 1;
+
+type DpoParams = {
+  period: number;
+  source: PriceSource;
 };
 
 /**
@@ -54,10 +73,28 @@ export type DpoState = {
  */
 export function createDpo(
   options: { period?: number; source?: PriceSource } = {},
-  warmUpOptions?: WarmUpOptions<DpoState>,
-): IncrementalIndicator<number | null, DpoState> {
-  const period = options.period ?? 20;
-  const source: PriceSource = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<DpoState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<DpoState>> {
+  const { params, state } = resolveResume<DpoParams, DpoState>({
+    indicator: "dpo",
+    version: DPO_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 20, source: "close" },
+  });
+
+  const period = requireParam(
+    "dpo",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const source = params.source;
   const shift = Math.floor(period / 2) + 1;
 
   let sma: ReturnType<typeof createSma>;
@@ -66,13 +103,12 @@ export function createDpo(
   let count: number;
   let outputCount: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    sma = createSma({ period, source }, { fromState: s.smaState });
-    pending = [...s.pending];
-    resolvedOffset = s.resolvedOffset;
-    count = s.count;
-    outputCount = s.outputCount;
+  if (state !== null) {
+    sma = createSma({ period, source }, { fromState: state.smaState });
+    pending = [...state.pending];
+    resolvedOffset = state.resolvedOffset;
+    count = state.count;
+    outputCount = state.outputCount;
   } else {
     sma = createSma({ period, source });
     pending = [];
@@ -81,7 +117,7 @@ export function createDpo(
     outputCount = 0;
   }
 
-  const indicator: IncrementalIndicator<number | null, DpoState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<DpoState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const price = getSourcePrice(candle, source);
@@ -134,17 +170,19 @@ export function createDpo(
       return { time: candle.time, value: null };
     },
 
-    getState(): DpoState {
-      return {
-        period,
-        source,
-        shift,
-        smaState: sma.getState(),
-        pending: [...pending],
-        resolvedOffset,
-        count,
-        outputCount,
-      };
+    getState(): IndicatorSnapshot<DpoState> {
+      return makeSnapshot(
+        "dpo",
+        DPO_VERSION,
+        { period, source },
+        {
+          smaState: sma.getState(),
+          pending: [...pending],
+          resolvedOffset,
+          count,
+          outputCount,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/hurst.ts
+++ b/packages/core/src/indicators/incremental/momentum/hurst.ts
@@ -5,21 +5,42 @@
  * window of prices. H > 0.5 indicates trend persistence, H < 0.5 indicates
  * mean reversion, and H ~ 0.5 indicates a random walk.
  *
- * Uses a CircularBuffer to store the most recent `maxWindow` prices and
- * performs R/S analysis across multiple sub-window sizes (geometric progression).
+ * State category: **Windowed** (a single raw price buffer of size
+ * `maxWindow`). A `maxWindow` change carries the most recent prices
+ * forward into the resized buffer; `minWindow` is a resume-invariant
+ * param (it only affects the R/S sub-window projection, never the
+ * buffered data); `source` change is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
+/**
+ * Bare state shape for Hurst. Params (`minWindow`, `maxWindow`,
+ * `source`) live in `meta.params` on the wire.
+ */
 export type HurstState = {
   priceBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
+  count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const HURST_VERSION = 1;
+
+type HurstParams = {
   minWindow: number;
   maxWindow: number;
   source: PriceSource;
-  count: number;
 };
 
 /**
@@ -170,31 +191,67 @@ export function createHurst(
     maxWindow?: number;
     source?: PriceSource;
   } = {},
-  warmUpOptions?: WarmUpOptions<HurstState>,
-): IncrementalIndicator<number | null, HurstState> {
-  const minWindow = options.minWindow ?? 20;
-  const maxWindow = options.maxWindow ?? 100;
-  const source: PriceSource = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<HurstState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<HurstState>> {
+  const { params, state, reconfigured } = resolveResume<HurstParams, HurstState>({
+    indicator: "hurst",
+    version: HURST_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { minWindow: 20, maxWindow: 100, source: "close" },
+    resumeInvariantParams: ["minWindow"],
+  });
+
+  const minWindow = requireParam(
+    "hurst",
+    params,
+    "minWindow",
+    (v): v is number => Number.isInteger(v) && v >= 2,
+    "must be an integer >= 2",
+  );
+  const maxWindow = requireParam(
+    "hurst",
+    params,
+    "maxWindow",
+    (v): v is number => Number.isInteger(v) && v >= 2,
+    "must be an integer >= 2",
+  );
+  const source = params.source;
 
   let priceBuffer: CircularBuffer<number>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    priceBuffer = CircularBuffer.fromSnapshot(s.priceBuffer);
-    count = s.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // maxWindow changed — carry the most recent prices forward.
+      const old = CircularBuffer.fromSnapshot<number>(state.priceBuffer);
+      priceBuffer = new CircularBuffer<number>(maxWindow);
+      const carry = Math.min(old.length, maxWindow);
+      for (let i = old.length - carry; i < old.length; i++) {
+        priceBuffer.push(old.get(i));
+      }
+    } else {
+      priceBuffer = CircularBuffer.fromSnapshot(state.priceBuffer);
+    }
+    count = state.count;
   } else {
     priceBuffer = new CircularBuffer<number>(maxWindow);
     count = 0;
   }
 
-  const indicator: IncrementalIndicator<number | null, HurstState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<HurstState>> = {
     next(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
       priceBuffer.push(price);
       count++;
 
-      if (count < maxWindow) {
+      // Gate on buffer fill, not `count`: after a maxWindow-growing
+      // resume the carried buffer is shorter than the old `count`.
+      if (priceBuffer.length < maxWindow) {
         return { time: candle.time, value: null };
       }
 
@@ -205,9 +262,10 @@ export function createHurst(
 
     peek(candle: NormalizedCandle) {
       const price = getSourcePrice(candle, source);
-      const peekCount = count + 1;
 
-      if (peekCount < maxWindow) {
+      // After the simulated push the buffer holds
+      // min(length + 1, maxWindow) prices.
+      if (priceBuffer.length + 1 < maxWindow) {
         return { time: candle.time, value: null };
       }
 
@@ -227,14 +285,16 @@ export function createHurst(
       return { time: candle.time, value };
     },
 
-    getState(): HurstState {
-      return {
-        priceBuffer: priceBuffer.snapshot(),
-        minWindow,
-        maxWindow,
-        source,
-        count,
-      };
+    getState(): IndicatorSnapshot<HurstState> {
+      return makeSnapshot(
+        "hurst",
+        HURST_VERSION,
+        { minWindow, maxWindow, source },
+        {
+          priceBuffer: priceBuffer.snapshot(),
+          count,
+        },
+      );
     },
 
     get count() {
@@ -242,7 +302,7 @@ export function createHurst(
     },
 
     get isWarmedUp() {
-      return count >= maxWindow;
+      return priceBuffer.length >= maxWindow;
     },
   };
 

--- a/packages/core/src/indicators/incremental/momentum/imi.ts
+++ b/packages/core/src/indicators/incremental/momentum/imi.ts
@@ -2,20 +2,42 @@
  * Incremental IMI (Intraday Momentum Index)
  *
  * IMI = 100 × SUM(gains, n) / (SUM(gains, n) + SUM(losses, n))
- * Uses simple rolling sums with a circular buffer window.
+ *
+ * State category: **Windowed** (fixed-size gains/losses buffers plus
+ * running sums). The buffered gains/losses are derived per-candle
+ * independently (each from a single candle's open/close), so a
+ * `period` change carries them forward and recomputes the running
+ * sums against the new window.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
+/**
+ * Bare state shape for IMI. Params (`period`) live in `meta.params`.
+ */
 export type ImiState = {
-  period: number;
   gainsBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   lossesBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   sumGain: number;
   sumLoss: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const IMI_VERSION = 1;
+
+type ImiParams = {
+  period: number;
 };
 
 /**
@@ -32,9 +54,27 @@ export type ImiState = {
  */
 export function createImi(
   options: { period?: number } = {},
-  warmUpOptions?: WarmUpOptions<ImiState>,
-): IncrementalIndicator<number | null, ImiState> {
-  const period = options.period ?? 14;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<ImiState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<ImiState>> {
+  const { params, state, reconfigured } = resolveResume<ImiParams, ImiState>({
+    indicator: "imi",
+    version: IMI_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 14 },
+  });
+
+  const period = requireParam(
+    "imi",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
 
   let gainsBuffer: CircularBuffer<number>;
   let lossesBuffer: CircularBuffer<number>;
@@ -42,13 +82,37 @@ export function createImi(
   let sumLoss: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    gainsBuffer = CircularBuffer.fromSnapshot(s.gainsBuffer);
-    lossesBuffer = CircularBuffer.fromSnapshot(s.lossesBuffer);
-    sumGain = s.sumGain;
-    sumLoss = s.sumLoss;
-    count = s.count;
+  function carryForward(
+    snapshot: ReturnType<CircularBuffer<number>["snapshot"]>,
+  ): CircularBuffer<number> {
+    const old = CircularBuffer.fromSnapshot<number>(snapshot);
+    const next = new CircularBuffer<number>(period);
+    const carry = Math.min(old.length, period);
+    for (let i = old.length - carry; i < old.length; i++) {
+      next.push(old.get(i));
+    }
+    return next;
+  }
+
+  function bufferSum(buf: CircularBuffer<number>): number {
+    let s = 0;
+    for (let i = 0; i < buf.length; i++) s += buf.get(i);
+    return s;
+  }
+
+  if (state !== null) {
+    if (reconfigured) {
+      gainsBuffer = carryForward(state.gainsBuffer);
+      lossesBuffer = carryForward(state.lossesBuffer);
+      sumGain = bufferSum(gainsBuffer);
+      sumLoss = bufferSum(lossesBuffer);
+    } else {
+      gainsBuffer = CircularBuffer.fromSnapshot(state.gainsBuffer);
+      lossesBuffer = CircularBuffer.fromSnapshot(state.lossesBuffer);
+      sumGain = state.sumGain;
+      sumLoss = state.sumLoss;
+    }
+    count = state.count;
   } else {
     gainsBuffer = new CircularBuffer<number>(period);
     lossesBuffer = new CircularBuffer<number>(period);
@@ -62,7 +126,7 @@ export function createImi(
     return total === 0 ? 50 : (100 * sg) / total;
   }
 
-  const indicator: IncrementalIndicator<number | null, ImiState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<ImiState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -80,7 +144,9 @@ export function createImi(
       gainsBuffer.push(gain);
       lossesBuffer.push(loss);
 
-      if (count < period) {
+      // Gate on buffer fill, not `count`: after a period-growing
+      // resume the carried buffer is shorter than the old `count`.
+      if (gainsBuffer.length < period) {
         return { time: candle.time, value: null };
       }
 
@@ -88,7 +154,7 @@ export function createImi(
     },
 
     peek(candle: NormalizedCandle) {
-      if (count + 1 < period) {
+      if (gainsBuffer.length < period - 1) {
         return { time: candle.time, value: null };
       }
 
@@ -106,15 +172,19 @@ export function createImi(
       return { time: candle.time, value: computeImi(peekSumGain, peekSumLoss) };
     },
 
-    getState(): ImiState {
-      return {
-        period,
-        gainsBuffer: gainsBuffer.snapshot(),
-        lossesBuffer: lossesBuffer.snapshot(),
-        sumGain,
-        sumLoss,
-        count,
-      };
+    getState(): IndicatorSnapshot<ImiState> {
+      return makeSnapshot(
+        "imi",
+        IMI_VERSION,
+        { period },
+        {
+          gainsBuffer: gainsBuffer.snapshot(),
+          lossesBuffer: lossesBuffer.snapshot(),
+          sumGain,
+          sumLoss,
+          count,
+        },
+      );
     },
 
     get count() {
@@ -122,7 +192,7 @@ export function createImi(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      return gainsBuffer.length >= period;
     },
   };
 

--- a/packages/core/src/indicators/incremental/momentum/kst.ts
+++ b/packages/core/src/indicators/incremental/momentum/kst.ts
@@ -4,24 +4,30 @@
  * KST = w1*SMA(ROC(r1), s1) + w2*SMA(ROC(r2), s2) + w3*SMA(ROC(r3), s3) + w4*SMA(ROC(r4), s4)
  * Signal = SMA(KST, signalPeriod)
  *
- * Uses 4 ROC + 4 SMA sub-indicators for the weighted components,
- * plus 1 SMA for the signal line.
+ * State category: **Cascaded** (composes 4 inner ROC + 4 inner SMA
+ * stages plus 1 signal SMA). Resume with any changed period / weight /
+ * source param is refused — all inner recursive/windowed stages are
+ * conditioned on their construction-time params.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import type { SmaState } from "../moving-average/sma";
-import { createSma } from "../moving-average/sma";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { createSma, type SmaState } from "../moving-average/sma";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { makeCandle } from "../utils";
-import type { RocState } from "./roc";
-import { createRoc } from "./roc";
+import { createRoc, type RocState } from "./roc";
 
 export type KstValue = {
   kst: number;
   signal: number | null;
 };
 
+/**
+ * Bare state shape for KST. Params (`rocPeriods`, `smaPeriods`,
+ * `weights`, `signalPeriod`, `source`) live in `meta.params`.
+ */
 export type KstState = {
   rocStates: [
     IndicatorSnapshot<RocState>,
@@ -36,12 +42,20 @@ export type KstState = {
     IndicatorSnapshot<SmaState>,
   ];
   signalSmaState: IndicatorSnapshot<SmaState>;
-  rocPeriods: [number, number, number, number];
-  smaPeriods: [number, number, number, number];
-  weights: [number, number, number, number];
+  count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const KST_VERSION = 1;
+
+type Quad = [number, number, number, number];
+
+type KstParams = {
+  rocPeriods: Quad;
+  smaPeriods: Quad;
+  weights: Quad;
   signalPeriod: number;
   source: PriceSource;
-  count: number;
 };
 
 /**
@@ -63,33 +77,50 @@ export type KstState = {
  */
 export function createKst(
   options: {
-    rocPeriods?: [number, number, number, number];
-    smaPeriods?: [number, number, number, number];
-    weights?: [number, number, number, number];
+    rocPeriods?: Quad;
+    smaPeriods?: Quad;
+    weights?: Quad;
     signalPeriod?: number;
     source?: PriceSource;
   } = {},
-  warmUpOptions?: WarmUpOptions<KstState>,
-): IncrementalIndicator<KstValue | null, KstState> {
-  const rocPeriods: [number, number, number, number] = options.rocPeriods ?? [10, 15, 20, 30];
-  const smaPeriods: [number, number, number, number] = options.smaPeriods ?? [10, 10, 10, 15];
-  const weights: [number, number, number, number] = options.weights ?? [1, 2, 3, 4];
-  const signalPeriod = options.signalPeriod ?? 9;
-  const source: PriceSource = options.source ?? "close";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<KstState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<KstValue | null, IndicatorSnapshot<KstState>> {
+  const { params, state } = resolveResume<KstParams, KstState>({
+    indicator: "kst",
+    version: KST_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: {
+      rocPeriods: [10, 15, 20, 30],
+      smaPeriods: [10, 10, 10, 15],
+      weights: [1, 2, 3, 4],
+      signalPeriod: 9,
+      source: "close",
+    },
+  });
+
+  const rocPeriods = params.rocPeriods;
+  const smaPeriods = params.smaPeriods;
+  const weights = params.weights;
+  const signalPeriod = params.signalPeriod;
+  const source = params.source;
 
   let rocs: ReturnType<typeof createRoc>[];
   let smas: ReturnType<typeof createSma>[];
   let signalSma: ReturnType<typeof createSma>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    rocs = s.rocStates.map((rs, i) =>
+  if (state !== null) {
+    rocs = state.rocStates.map((rs, i) =>
       createRoc({ period: rocPeriods[i], source }, { fromState: rs }),
     );
-    smas = s.smaStates.map((ss, i) => createSma({ period: smaPeriods[i] }, { fromState: ss }));
-    signalSma = createSma({ period: signalPeriod }, { fromState: s.signalSmaState });
-    count = s.count;
+    smas = state.smaStates.map((ss, i) => createSma({ period: smaPeriods[i] }, { fromState: ss }));
+    signalSma = createSma({ period: signalPeriod }, { fromState: state.signalSmaState });
+    count = state.count;
   } else {
     rocs = rocPeriods.map((p) => createRoc({ period: p, source }));
     smas = smaPeriods.map((p) => createSma({ period: p }));
@@ -168,7 +199,7 @@ export function createKst(
     return { time: candle.time, value: { kst: kstVal, signal: signalVal } };
   }
 
-  const indicator: IncrementalIndicator<KstValue | null, KstState> = {
+  const indicator: IncrementalIndicator<KstValue | null, IndicatorSnapshot<KstState>> = {
     next(candle: NormalizedCandle) {
       return computeNext(candle);
     },
@@ -177,28 +208,28 @@ export function createKst(
       return computePeek(candle);
     },
 
-    getState(): KstState {
-      return {
-        rocStates: rocs.map((r) => r.getState()) as [
-          IndicatorSnapshot<RocState>,
-          IndicatorSnapshot<RocState>,
-          IndicatorSnapshot<RocState>,
-          IndicatorSnapshot<RocState>,
-        ],
-        smaStates: smas.map((s) => s.getState()) as [
-          IndicatorSnapshot<SmaState>,
-          IndicatorSnapshot<SmaState>,
-          IndicatorSnapshot<SmaState>,
-          IndicatorSnapshot<SmaState>,
-        ],
-        signalSmaState: signalSma.getState(),
-        rocPeriods,
-        smaPeriods,
-        weights,
-        signalPeriod,
-        source,
-        count,
-      };
+    getState(): IndicatorSnapshot<KstState> {
+      return makeSnapshot(
+        "kst",
+        KST_VERSION,
+        { rocPeriods, smaPeriods, weights, signalPeriod, source },
+        {
+          rocStates: rocs.map((r) => r.getState()) as [
+            IndicatorSnapshot<RocState>,
+            IndicatorSnapshot<RocState>,
+            IndicatorSnapshot<RocState>,
+            IndicatorSnapshot<RocState>,
+          ],
+          smaStates: smas.map((s) => s.getState()) as [
+            IndicatorSnapshot<SmaState>,
+            IndicatorSnapshot<SmaState>,
+            IndicatorSnapshot<SmaState>,
+            IndicatorSnapshot<SmaState>,
+          ],
+          signalSmaState: signalSma.getState(),
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/qstick.ts
+++ b/packages/core/src/indicators/incremental/momentum/qstick.ts
@@ -3,19 +3,38 @@
  *
  * QStick = SMA(close - open, period)
  * Measures the dominance of buying or selling pressure via candlestick body.
+ *
+ * State category: **Cascaded** (composes an inner incremental SMA over
+ * the per-candle close-minus-open series). Resume with a different
+ * `period` is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { SmaState } from "../moving-average/sma";
-import { createSma } from "../moving-average/sma";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { createSma, type SmaState } from "../moving-average/sma";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import { makeCandle } from "../utils";
 
+/**
+ * Bare state shape for QStick. Params (`period`) live in `meta.params`.
+ */
 export type QStickState = {
   smaState: IndicatorSnapshot<SmaState>;
-  period: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const QSTICK_VERSION = 1;
+
+type QStickParams = {
+  period: number;
 };
 
 /**
@@ -32,23 +51,40 @@ export type QStickState = {
  */
 export function createQStick(
   options: { period?: number } = {},
-  warmUpOptions?: WarmUpOptions<QStickState>,
-): IncrementalIndicator<number | null, QStickState> {
-  const period = options.period ?? 14;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<QStickState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<QStickState>> {
+  const { params, state } = resolveResume<QStickParams, QStickState>({
+    indicator: "qstick",
+    version: QSTICK_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 14 },
+  });
+
+  const period = requireParam(
+    "qstick",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
 
   let sma: ReturnType<typeof createSma>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    sma = createSma({ period }, { fromState: s.smaState });
-    count = s.count;
+  if (state !== null) {
+    sma = createSma({ period }, { fromState: state.smaState });
+    count = state.count;
   } else {
     sma = createSma({ period });
     count = 0;
   }
 
-  const indicator: IncrementalIndicator<number | null, QStickState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<QStickState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const diff = candle.close - candle.open;
@@ -60,12 +96,16 @@ export function createQStick(
       return sma.peek(makeCandle(candle.time, diff));
     },
 
-    getState(): QStickState {
-      return {
-        smaState: sma.getState(),
-        period,
-        count,
-      };
+    getState(): IndicatorSnapshot<QStickState> {
+      return makeSnapshot(
+        "qstick",
+        QSTICK_VERSION,
+        { period },
+        {
+          smaState: sma.getState(),
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/stochastics.ts
+++ b/packages/core/src/indicators/incremental/momentum/stochastics.ts
@@ -2,21 +2,36 @@
  * Incremental Stochastics
  *
  * Implements %K and %D using sliding window min/max + SMA smoothing.
+ *
+ * State category: **Mixed** (raw high/low buffers feed derived rawK /
+ * K buffers and their running sums). The rawK / K buffers hold values
+ * derived from the whole `kPeriod` / `slowing` windows, so a param
+ * change cannot be reconciled — resume with different
+ * `kPeriod` / `dPeriod` / `slowing` is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type StochasticsValue = {
   k: number | null;
   d: number | null;
 };
 
+/**
+ * Bare state shape for Stochastics. Params (`kPeriod`, `dPeriod`,
+ * `slowing`) live in `meta.params` on the wire.
+ */
 export type StochasticsState = {
-  kPeriod: number;
-  dPeriod: number;
-  slowing: number;
   highBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   lowBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   rawKBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
@@ -26,6 +41,15 @@ export type StochasticsState = {
   kSum: number;
   kValidCount: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const STOCHASTICS_VERSION = 1;
+
+type StochasticsParams = {
+  kPeriod: number;
+  dPeriod: number;
+  slowing: number;
 };
 
 /**
@@ -42,11 +66,42 @@ export type StochasticsState = {
  */
 export function createStochastics(
   options: { kPeriod?: number; dPeriod?: number; slowing?: number } = {},
-  warmUpOptions?: WarmUpOptions<StochasticsState>,
-): IncrementalIndicator<StochasticsValue, StochasticsState> {
-  const kPeriod = options.kPeriod ?? 14;
-  const dPeriod = options.dPeriod ?? 3;
-  const slowing = options.slowing ?? 3;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<StochasticsState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<StochasticsValue, IndicatorSnapshot<StochasticsState>> {
+  const { params, state } = resolveResume<StochasticsParams, StochasticsState>({
+    indicator: "stochastics",
+    version: STOCHASTICS_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { kPeriod: 14, dPeriod: 3, slowing: 3 },
+  });
+
+  const isPositiveInt = (v: number): v is number => Number.isInteger(v) && v >= 1;
+  const kPeriod = requireParam(
+    "stochastics",
+    params,
+    "kPeriod",
+    isPositiveInt,
+    "must be a positive integer",
+  );
+  const dPeriod = requireParam(
+    "stochastics",
+    params,
+    "dPeriod",
+    isPositiveInt,
+    "must be a positive integer",
+  );
+  const slowing = requireParam(
+    "stochastics",
+    params,
+    "slowing",
+    isPositiveInt,
+    "must be a positive integer",
+  );
 
   let highBuffer: CircularBuffer<number>;
   let lowBuffer: CircularBuffer<number>;
@@ -58,17 +113,16 @@ export function createStochastics(
   let kValidCount: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    highBuffer = CircularBuffer.fromSnapshot(s.highBuffer);
-    lowBuffer = CircularBuffer.fromSnapshot(s.lowBuffer);
-    rawKBuffer = CircularBuffer.fromSnapshot(s.rawKBuffer);
-    kBuffer = CircularBuffer.fromSnapshot(s.kBuffer);
-    rawKSum = s.rawKSum;
-    rawKValidCount = s.rawKValidCount;
-    kSum = s.kSum;
-    kValidCount = s.kValidCount;
-    count = s.count;
+  if (state !== null) {
+    highBuffer = CircularBuffer.fromSnapshot(state.highBuffer);
+    lowBuffer = CircularBuffer.fromSnapshot(state.lowBuffer);
+    rawKBuffer = CircularBuffer.fromSnapshot(state.rawKBuffer);
+    kBuffer = CircularBuffer.fromSnapshot(state.kBuffer);
+    rawKSum = state.rawKSum;
+    rawKValidCount = state.rawKValidCount;
+    kSum = state.kSum;
+    kValidCount = state.kValidCount;
+    count = state.count;
   } else {
     highBuffer = new CircularBuffer<number>(kPeriod);
     lowBuffer = new CircularBuffer<number>(kPeriod);
@@ -99,7 +153,7 @@ export function createStochastics(
 
   const nullValue: StochasticsValue = { k: null, d: null };
 
-  const indicator: IncrementalIndicator<StochasticsValue, StochasticsState> = {
+  const indicator: IncrementalIndicator<StochasticsValue, IndicatorSnapshot<StochasticsState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -195,21 +249,23 @@ export function createStochastics(
       return { time: candle.time, value: { k: kVal, d: dVal } };
     },
 
-    getState(): StochasticsState {
-      return {
-        kPeriod,
-        dPeriod,
-        slowing,
-        highBuffer: highBuffer.snapshot(),
-        lowBuffer: lowBuffer.snapshot(),
-        rawKBuffer: rawKBuffer.snapshot(),
-        kBuffer: kBuffer.snapshot(),
-        rawKSum,
-        rawKValidCount,
-        kSum,
-        kValidCount,
-        count,
-      };
+    getState(): IndicatorSnapshot<StochasticsState> {
+      return makeSnapshot(
+        "stochastics",
+        STOCHASTICS_VERSION,
+        { kPeriod, dPeriod, slowing },
+        {
+          highBuffer: highBuffer.snapshot(),
+          lowBuffer: lowBuffer.snapshot(),
+          rawKBuffer: rawKBuffer.snapshot(),
+          kBuffer: kBuffer.snapshot(),
+          rawKSum,
+          rawKValidCount,
+          kSum,
+          kValidCount,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/ultimate-oscillator.ts
+++ b/packages/core/src/indicators/incremental/momentum/ultimate-oscillator.ts
@@ -9,24 +9,42 @@
  *   Avg_n = sum(BP, n) / sum(TR, n)
  *   UO = 100 * (4 * Avg1 + 2 * Avg2 + Avg3) / 7
  *
- * Uses CircularBuffer for BP and TR values (sized to longest period).
+ * State category: **Mixed** (BP/TR buffers sized to the longest period
+ * plus the carried-forward `prevClose`). The buffered BP/TR values are
+ * each derived from a candle *and its predecessor*, so a period change
+ * is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 /**
- * State for incremental Ultimate Oscillator
+ * Bare state shape for Ultimate Oscillator. Params (`period1`,
+ * `period2`, `period3`) live in `meta.params` on the wire.
  */
 export type UltimateOscillatorState = {
-  period1: number;
-  period2: number;
-  period3: number;
   bpBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   trBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   prevClose: number | null;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const ULTIMATE_OSCILLATOR_VERSION = 1;
+
+type UltimateOscillatorParams = {
+  period1: number;
+  period2: number;
+  period3: number;
 };
 
 /**
@@ -43,11 +61,42 @@ export type UltimateOscillatorState = {
  */
 export function createUltimateOscillator(
   options: { period1?: number; period2?: number; period3?: number } = {},
-  warmUpOptions?: WarmUpOptions<UltimateOscillatorState>,
-): IncrementalIndicator<number | null, UltimateOscillatorState> {
-  const period1 = options.period1 ?? 7;
-  const period2 = options.period2 ?? 14;
-  const period3 = options.period3 ?? 28;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<UltimateOscillatorState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<UltimateOscillatorState>> {
+  const { params, state } = resolveResume<UltimateOscillatorParams, UltimateOscillatorState>({
+    indicator: "ultimateOscillator",
+    version: ULTIMATE_OSCILLATOR_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period1: 7, period2: 14, period3: 28 },
+  });
+
+  const isPositiveInt = (v: number): v is number => Number.isInteger(v) && v >= 1;
+  const period1 = requireParam(
+    "ultimateOscillator",
+    params,
+    "period1",
+    isPositiveInt,
+    "must be a positive integer",
+  );
+  const period2 = requireParam(
+    "ultimateOscillator",
+    params,
+    "period2",
+    isPositiveInt,
+    "must be a positive integer",
+  );
+  const period3 = requireParam(
+    "ultimateOscillator",
+    params,
+    "period3",
+    isPositiveInt,
+    "must be a positive integer",
+  );
   const maxPeriod = Math.max(period1, period2, period3);
 
   let bpBuffer: CircularBuffer<number>;
@@ -55,12 +104,11 @@ export function createUltimateOscillator(
   let prevClose: number | null;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    bpBuffer = CircularBuffer.fromSnapshot(s.bpBuffer);
-    trBuffer = CircularBuffer.fromSnapshot(s.trBuffer);
-    prevClose = s.prevClose;
-    count = s.count;
+  if (state !== null) {
+    bpBuffer = CircularBuffer.fromSnapshot(state.bpBuffer);
+    trBuffer = CircularBuffer.fromSnapshot(state.trBuffer);
+    prevClose = state.prevClose;
+    count = state.count;
   } else {
     bpBuffer = new CircularBuffer<number>(maxPeriod);
     trBuffer = new CircularBuffer<number>(maxPeriod);
@@ -96,7 +144,10 @@ export function createUltimateOscillator(
     return (100 * (4 * avg1 + 2 * avg2 + avg3)) / 7;
   }
 
-  const indicator: IncrementalIndicator<number | null, UltimateOscillatorState> = {
+  const indicator: IncrementalIndicator<
+    number | null,
+    IndicatorSnapshot<UltimateOscillatorState>
+  > = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -135,16 +186,18 @@ export function createUltimateOscillator(
       return { time: candle.time, value };
     },
 
-    getState(): UltimateOscillatorState {
-      return {
-        period1,
-        period2,
-        period3,
-        bpBuffer: bpBuffer.snapshot(),
-        trBuffer: trBuffer.snapshot(),
-        prevClose,
-        count,
-      };
+    getState(): IndicatorSnapshot<UltimateOscillatorState> {
+      return makeSnapshot(
+        "ultimateOscillator",
+        ULTIMATE_OSCILLATOR_VERSION,
+        { period1, period2, period3 },
+        {
+          bpBuffer: bpBuffer.snapshot(),
+          trBuffer: trBuffer.snapshot(),
+          prevClose,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/vortex.ts
+++ b/packages/core/src/indicators/incremental/momentum/vortex.ts
@@ -3,19 +3,35 @@
  *
  * VI+ = sum(VM+, period) / sum(TR, period)
  * VI- = sum(VM-, period) / sum(TR, period)
+ *
+ * State category: **Mixed** (fixed-size VM+/VM-/TR buffers plus the
+ * carried-forward `prevHigh` / `prevLow` / `prevClose`). The buffered
+ * VM/TR values are each derived from a candle *and its predecessor*,
+ * so a `period` change cannot be reconciled — resume with a different
+ * `period` is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type VortexValue = {
   viPlus: number | null;
   viMinus: number | null;
 };
 
+/**
+ * Bare state shape for Vortex. Params (`period`) live in `meta.params`.
+ */
 export type VortexState = {
-  period: number;
   vmPlusBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   vmMinusBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   trBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
@@ -23,6 +39,13 @@ export type VortexState = {
   prevLow: number | null;
   prevClose: number | null;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const VORTEX_VERSION = 1;
+
+type VortexParams = {
+  period: number;
 };
 
 /**
@@ -39,9 +62,27 @@ export type VortexState = {
  */
 export function createVortex(
   options: { period?: number } = {},
-  warmUpOptions?: WarmUpOptions<VortexState>,
-): IncrementalIndicator<VortexValue, VortexState> {
-  const period = options.period ?? 14;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<VortexState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<VortexValue, IndicatorSnapshot<VortexState>> {
+  const { params, state } = resolveResume<VortexParams, VortexState>({
+    indicator: "vortex",
+    version: VORTEX_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 14 },
+  });
+
+  const period = requireParam(
+    "vortex",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
 
   let vmPlusBuffer: CircularBuffer<number>;
   let vmMinusBuffer: CircularBuffer<number>;
@@ -51,15 +92,14 @@ export function createVortex(
   let prevClose: number | null;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    vmPlusBuffer = CircularBuffer.fromSnapshot(s.vmPlusBuffer);
-    vmMinusBuffer = CircularBuffer.fromSnapshot(s.vmMinusBuffer);
-    trBuffer = CircularBuffer.fromSnapshot(s.trBuffer);
-    prevHigh = s.prevHigh;
-    prevLow = s.prevLow;
-    prevClose = s.prevClose;
-    count = s.count;
+  if (state !== null) {
+    vmPlusBuffer = CircularBuffer.fromSnapshot(state.vmPlusBuffer);
+    vmMinusBuffer = CircularBuffer.fromSnapshot(state.vmMinusBuffer);
+    trBuffer = CircularBuffer.fromSnapshot(state.trBuffer);
+    prevHigh = state.prevHigh;
+    prevLow = state.prevLow;
+    prevClose = state.prevClose;
+    count = state.count;
   } else {
     vmPlusBuffer = new CircularBuffer<number>(period);
     vmMinusBuffer = new CircularBuffer<number>(period);
@@ -94,7 +134,7 @@ export function createVortex(
     };
   }
 
-  const indicator: IncrementalIndicator<VortexValue, VortexState> = {
+  const indicator: IncrementalIndicator<VortexValue, IndicatorSnapshot<VortexState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -150,17 +190,21 @@ export function createVortex(
       return { time: candle.time, value: computeFromBuffers(peekVmP, peekVmM, peekTr) };
     },
 
-    getState(): VortexState {
-      return {
-        period,
-        vmPlusBuffer: vmPlusBuffer.snapshot(),
-        vmMinusBuffer: vmMinusBuffer.snapshot(),
-        trBuffer: trBuffer.snapshot(),
-        prevHigh,
-        prevLow,
-        prevClose,
-        count,
-      };
+    getState(): IndicatorSnapshot<VortexState> {
+      return makeSnapshot(
+        "vortex",
+        VORTEX_VERSION,
+        { period },
+        {
+          vmPlusBuffer: vmPlusBuffer.snapshot(),
+          vmMinusBuffer: vmMinusBuffer.snapshot(),
+          trBuffer: trBuffer.snapshot(),
+          prevHigh,
+          prevLow,
+          prevClose,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/momentum/williams-r.ts
+++ b/packages/core/src/indicators/incremental/momentum/williams-r.ts
@@ -3,22 +3,38 @@
  *
  * Williams %R = (Highest High - Close) / (Highest High - Lowest Low) × -100
  *
- * Uses CircularBuffer for high/low lookback windows.
- * Range: -100 to 0.
+ * State category: **Windowed** (high/low raw-value buffers, no
+ * recursion). Resume with a different `period` carries the high/low
+ * values forward into the resized buffers. Range: -100 to 0.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 /**
- * State for incremental Williams %R
+ * Bare state shape for Williams %R. Params (`period`) live in
+ * `meta.params` on the wire.
  */
 export type WilliamsRState = {
-  period: number;
   highBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   lowBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const WILLIAMS_R_VERSION = 1;
+
+type WilliamsRParams = {
+  period: number;
 };
 
 /**
@@ -58,20 +74,54 @@ function bufferMin(buf: CircularBuffer<number>): number {
  * ```
  */
 export function createWilliamsR(
-  options: { period: number },
-  warmUpOptions?: WarmUpOptions<WilliamsRState>,
-): IncrementalIndicator<number | null, WilliamsRState> {
-  const period = options.period;
+  options: { period?: number } = {},
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<WilliamsRState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<WilliamsRState>> {
+  const { params, state, reconfigured } = resolveResume<WilliamsRParams, WilliamsRState>({
+    indicator: "williamsR",
+    version: WILLIAMS_R_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: {},
+  });
+
+  const period = requireParam(
+    "williamsR",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
 
   let highBuffer: CircularBuffer<number>;
   let lowBuffer: CircularBuffer<number>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    highBuffer = CircularBuffer.fromSnapshot(s.highBuffer);
-    lowBuffer = CircularBuffer.fromSnapshot(s.lowBuffer);
-    count = s.count;
+  function carryForward(
+    snapshot: ReturnType<CircularBuffer<number>["snapshot"]>,
+  ): CircularBuffer<number> {
+    const old = CircularBuffer.fromSnapshot<number>(snapshot);
+    const next = new CircularBuffer<number>(period);
+    const carry = Math.min(old.length, period);
+    for (let i = old.length - carry; i < old.length; i++) {
+      next.push(old.get(i));
+    }
+    return next;
+  }
+
+  if (state !== null) {
+    if (reconfigured) {
+      highBuffer = carryForward(state.highBuffer);
+      lowBuffer = carryForward(state.lowBuffer);
+    } else {
+      highBuffer = CircularBuffer.fromSnapshot(state.highBuffer);
+      lowBuffer = CircularBuffer.fromSnapshot(state.lowBuffer);
+    }
+    count = state.count;
   } else {
     highBuffer = new CircularBuffer<number>(period);
     lowBuffer = new CircularBuffer<number>(period);
@@ -79,27 +129,26 @@ export function createWilliamsR(
   }
 
   function compute(
-    _high: number,
-    _low: number,
     close: number,
     hBuf: CircularBuffer<number>,
     lBuf: CircularBuffer<number>,
-    n: number,
   ): number | null {
-    if (n < period) return null;
+    // Gate on buffer fill, not a historical `count`: after a
+    // period-growing resume the carried buffer is shorter than `count`.
+    if (hBuf.length < period) return null;
     const highestHigh = bufferMax(hBuf);
     const lowestLow = bufferMin(lBuf);
     const range = highestHigh - lowestLow;
     return range !== 0 ? ((highestHigh - close) / range) * -100 : -50;
   }
 
-  const indicator: IncrementalIndicator<number | null, WilliamsRState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<WilliamsRState>> = {
     next(candle: NormalizedCandle) {
       highBuffer.push(candle.high);
       lowBuffer.push(candle.low);
       count++;
 
-      const value = compute(candle.high, candle.low, candle.close, highBuffer, lowBuffer, count);
+      const value = compute(candle.close, highBuffer, lowBuffer);
       return { time: candle.time, value };
     },
 
@@ -110,17 +159,21 @@ export function createWilliamsR(
       tempHigh.push(candle.high);
       tempLow.push(candle.low);
 
-      const value = compute(candle.high, candle.low, candle.close, tempHigh, tempLow, count + 1);
+      const value = compute(candle.close, tempHigh, tempLow);
       return { time: candle.time, value };
     },
 
-    getState(): WilliamsRState {
-      return {
-        period,
-        highBuffer: highBuffer.snapshot(),
-        lowBuffer: lowBuffer.snapshot(),
-        count,
-      };
+    getState(): IndicatorSnapshot<WilliamsRState> {
+      return makeSnapshot(
+        "williamsR",
+        WILLIAMS_R_VERSION,
+        { period },
+        {
+          highBuffer: highBuffer.snapshot(),
+          lowBuffer: lowBuffer.snapshot(),
+          count,
+        },
+      );
     },
 
     get count() {
@@ -128,7 +181,7 @@ export function createWilliamsR(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      return highBuffer.length >= period;
     },
   };
 

--- a/packages/core/src/indicators/incremental/price/auto-trend-line.ts
+++ b/packages/core/src/indicators/incremental/price/auto-trend-line.ts
@@ -15,8 +15,9 @@
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
-import { cloneShallow, pushBounded, resolveSwingConfig } from "./swing-helpers";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
+import { cloneShallow, pushBounded, validateSwingConfig } from "./swing-helpers";
 import { createSwingPoints, type SwingPointsState } from "./swing-points";
 
 export type AutoTrendLineValue = {
@@ -38,10 +39,13 @@ type SwingPoint = {
   price: number;
 };
 
+/**
+ * Bare state shape for Auto Trend Line. Params (`leftBars`,
+ * `rightBars`) live in `meta.params`; the inner swing-points snapshot
+ * is itself an `IndicatorSnapshot`.
+ */
 export type AutoTrendLineState = {
-  leftBars: number;
-  rightBars: number;
-  swings: SwingPointsState;
+  swings: IndicatorSnapshot<SwingPointsState>;
   lastTwoHighs: SwingPoint[];
   lastTwoLows: SwingPoint[];
   hasResistance: boolean;
@@ -55,12 +59,30 @@ export type AutoTrendLineState = {
   count: number;
 };
 
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const AUTO_TREND_LINE_VERSION = 1;
+
+type AutoTrendLineParams = {
+  leftBars: number;
+  rightBars: number;
+};
+
 export function createAutoTrendLine(
   options: AutoTrendLineOptions = {},
-  warmUpOptions?: WarmUpOptions<AutoTrendLineState>,
-): IncrementalIndicator<AutoTrendLineValue, AutoTrendLineState> {
-  const fromState = warmUpOptions?.fromState;
-  const { leftBars, rightBars } = resolveSwingConfig(options, fromState);
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<AutoTrendLineState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<AutoTrendLineValue, IndicatorSnapshot<AutoTrendLineState>> {
+  const { params, state } = resolveResume<AutoTrendLineParams, AutoTrendLineState>({
+    indicator: "autoTrendLine",
+    version: AUTO_TREND_LINE_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { leftBars: 10, rightBars: 10 },
+  });
+  const { leftBars, rightBars } = validateSwingConfig(params.leftBars, params.rightBars);
 
   let swings: ReturnType<typeof createSwingPoints>;
   let lastTwoHighs: SwingPoint[];
@@ -75,19 +97,19 @@ export function createAutoTrendLine(
   let supAnchorPrice: number;
   let count: number;
 
-  if (fromState) {
-    swings = createSwingPoints({ leftBars, rightBars }, { fromState: fromState.swings });
-    lastTwoHighs = cloneShallow(fromState.lastTwoHighs);
-    lastTwoLows = cloneShallow(fromState.lastTwoLows);
-    hasResistance = fromState.hasResistance;
-    resSlope = fromState.resSlope;
-    resAnchorIdx = fromState.resAnchorIdx;
-    resAnchorPrice = fromState.resAnchorPrice;
-    hasSupport = fromState.hasSupport;
-    supSlope = fromState.supSlope;
-    supAnchorIdx = fromState.supAnchorIdx;
-    supAnchorPrice = fromState.supAnchorPrice;
-    count = fromState.count;
+  if (state !== null) {
+    swings = createSwingPoints({ leftBars, rightBars }, { fromState: state.swings });
+    lastTwoHighs = cloneShallow(state.lastTwoHighs);
+    lastTwoLows = cloneShallow(state.lastTwoLows);
+    hasResistance = state.hasResistance;
+    resSlope = state.resSlope;
+    resAnchorIdx = state.resAnchorIdx;
+    resAnchorPrice = state.resAnchorPrice;
+    hasSupport = state.hasSupport;
+    supSlope = state.supSlope;
+    supAnchorIdx = state.supAnchorIdx;
+    supAnchorPrice = state.supAnchorPrice;
+    count = state.count;
   } else {
     swings = createSwingPoints({ leftBars, rightBars });
     lastTwoHighs = [];
@@ -103,7 +125,10 @@ export function createAutoTrendLine(
     count = 0;
   }
 
-  const indicator: IncrementalIndicator<AutoTrendLineValue, AutoTrendLineState> = {
+  const indicator: IncrementalIndicator<
+    AutoTrendLineValue,
+    IndicatorSnapshot<AutoTrendLineState>
+  > = {
     next(candle: NormalizedCandle) {
       count++;
       const swingResult = swings.next(candle);
@@ -151,7 +176,7 @@ export function createAutoTrendLine(
     },
 
     peek(candle: NormalizedCandle) {
-      const saved = indicator.getState();
+      const saved = indicator.getState().state;
       const result = indicator.next(candle);
       swings = createSwingPoints({ leftBars, rightBars }, { fromState: saved.swings });
       lastTwoHighs = cloneShallow(saved.lastTwoHighs);
@@ -168,23 +193,26 @@ export function createAutoTrendLine(
       return result;
     },
 
-    getState(): AutoTrendLineState {
-      return {
-        leftBars,
-        rightBars,
-        swings: swings.getState(),
-        lastTwoHighs: cloneShallow(lastTwoHighs),
-        lastTwoLows: cloneShallow(lastTwoLows),
-        hasResistance,
-        resSlope,
-        resAnchorIdx,
-        resAnchorPrice,
-        hasSupport,
-        supSlope,
-        supAnchorIdx,
-        supAnchorPrice,
-        count,
-      };
+    getState(): IndicatorSnapshot<AutoTrendLineState> {
+      return makeSnapshot(
+        "autoTrendLine",
+        AUTO_TREND_LINE_VERSION,
+        { leftBars, rightBars },
+        {
+          swings: swings.getState(),
+          lastTwoHighs: cloneShallow(lastTwoHighs),
+          lastTwoLows: cloneShallow(lastTwoLows),
+          hasResistance,
+          resSlope,
+          resAnchorIdx,
+          resAnchorPrice,
+          hasSupport,
+          supSlope,
+          supAnchorIdx,
+          supAnchorPrice,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/price/break-of-structure.ts
+++ b/packages/core/src/indicators/incremental/price/break-of-structure.ts
@@ -9,11 +9,21 @@
  *
  * CHoCH derives from BOS: it marks only the first BOS that flips the prior
  * trend direction.
+ *
+ * State category: **Mixed** (a fixed-size `2*swingPeriod+1` raw
+ * high/low window plus persistent last-swing / trend trackers
+ * conditioned on the window the swing was confirmed under). A
+ * `swingPeriod` change re-times confirmation and would re-emit
+ * pre-snapshot structure from the carried window, so any param change
+ * on resume is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type BosValue = {
   bullishBos: boolean;
@@ -26,13 +36,23 @@ export type BosValue = {
 
 type WindowEntry = { high: number; low: number };
 
+/**
+ * Bare state shape for Break of Structure. The param (`swingPeriod`)
+ * lives in `meta.params` on the wire.
+ */
 export type BosState = {
-  swingPeriod: number;
   buffer: ReturnType<CircularBuffer<WindowEntry>["snapshot"]>;
   lastSwingHigh: number | null;
   lastSwingLow: number | null;
   trend: "bullish" | "bearish" | "neutral";
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const BREAK_OF_STRUCTURE_VERSION = 1;
+
+type BosParams = {
+  swingPeriod: number;
 };
 
 /**
@@ -49,9 +69,21 @@ export type BosState = {
  */
 export function createBreakOfStructure(
   options: { swingPeriod?: number } = {},
-  warmUpOptions?: WarmUpOptions<BosState>,
-): IncrementalIndicator<BosValue, BosState> {
-  const swingPeriod = options.swingPeriod ?? 5;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<BosState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<BosValue, IndicatorSnapshot<BosState>> {
+  const { params, state, reconfigured } = resolveResume<BosParams, BosState>({
+    indicator: "breakOfStructure",
+    version: BREAK_OF_STRUCTURE_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { swingPeriod: 5 },
+  });
+
+  const swingPeriod = params.swingPeriod;
   if (swingPeriod < 1) throw new Error("swingPeriod must be at least 1");
 
   const windowSize = 2 * swingPeriod + 1;
@@ -62,13 +94,21 @@ export function createBreakOfStructure(
   let trend: "bullish" | "bearish" | "neutral";
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    lastSwingHigh = s.lastSwingHigh;
-    lastSwingLow = s.lastSwingLow;
-    trend = s.trend;
-    count = s.count;
+  if (state !== null) {
+    const old = CircularBuffer.fromSnapshot(state.buffer);
+    if (reconfigured) {
+      buffer = new CircularBuffer<WindowEntry>(windowSize);
+      const carry = Math.min(old.length, windowSize);
+      for (let i = old.length - carry; i < old.length; i++) {
+        buffer.push(old.get(i));
+      }
+    } else {
+      buffer = old;
+    }
+    lastSwingHigh = state.lastSwingHigh;
+    lastSwingLow = state.lastSwingLow;
+    trend = state.trend;
+    count = state.count;
   } else {
     buffer = new CircularBuffer<WindowEntry>(windowSize);
     lastSwingHigh = null;
@@ -92,7 +132,7 @@ export function createBreakOfStructure(
     return { isHigh, isLow, mid };
   }
 
-  const indicator: IncrementalIndicator<BosValue, BosState> = {
+  const indicator: IncrementalIndicator<BosValue, IndicatorSnapshot<BosState>> = {
     next(candle: NormalizedCandle) {
       buffer.push({ high: candle.high, low: candle.low });
       count++;
@@ -140,7 +180,7 @@ export function createBreakOfStructure(
     },
 
     peek(candle: NormalizedCandle) {
-      const saved = indicator.getState();
+      const saved = indicator.getState().state;
       const result = indicator.next(candle);
       buffer = CircularBuffer.fromSnapshot(saved.buffer);
       lastSwingHigh = saved.lastSwingHigh;
@@ -150,15 +190,19 @@ export function createBreakOfStructure(
       return result;
     },
 
-    getState(): BosState {
-      return {
-        swingPeriod,
-        buffer: buffer.snapshot(),
-        lastSwingHigh,
-        lastSwingLow,
-        trend,
-        count,
-      };
+    getState(): IndicatorSnapshot<BosState> {
+      return makeSnapshot(
+        "breakOfStructure",
+        BREAK_OF_STRUCTURE_VERSION,
+        { swingPeriod },
+        {
+          buffer: buffer.snapshot(),
+          lastSwingHigh,
+          lastSwingLow,
+          trend,
+          count,
+        },
+      );
     },
 
     get count() {
@@ -166,7 +210,7 @@ export function createBreakOfStructure(
     },
 
     get isWarmedUp() {
-      return count >= windowSize;
+      return buffer.length >= windowSize;
     },
   };
 
@@ -179,15 +223,25 @@ export function createBreakOfStructure(
   return indicator;
 }
 
+/**
+ * Bare state shape for Change of Character. Composes an inner BOS
+ * snapshot. The param (`swingPeriod`) lives in `meta.params`.
+ */
 export type ChochState = {
-  bosState: BosState;
+  bosState: IndicatorSnapshot<BosState>;
   prevTrend: "bullish" | "bearish" | "neutral";
 };
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const CHANGE_OF_CHARACTER_VERSION = 1;
 
 /**
  * Create an incremental Change of Character indicator.
  *
  * CHoCH is a BOS in the opposite direction of the previous (post-BOS) trend.
+ *
+ * State category: **Mixed** — wraps an inner BOS snapshot; a
+ * `swingPeriod` change on resume is refused (as for BOS itself).
  *
  * @example
  * ```ts
@@ -200,17 +254,28 @@ export type ChochState = {
  */
 export function createChangeOfCharacter(
   options: { swingPeriod?: number } = {},
-  warmUpOptions?: WarmUpOptions<ChochState>,
-): IncrementalIndicator<BosValue, ChochState> {
-  const bos = createBreakOfStructure(
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<ChochState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<BosValue, IndicatorSnapshot<ChochState>> {
+  const { params, state } = resolveResume<BosParams, ChochState>({
+    indicator: "changeOfCharacter",
+    version: CHANGE_OF_CHARACTER_VERSION,
+    category: "mixed",
     options,
-    warmUpOptions?.fromState ? { fromState: warmUpOptions.fromState.bosState } : undefined,
-  );
-  let prevTrend: "bullish" | "bearish" | "neutral" = warmUpOptions?.fromState
-    ? warmUpOptions.fromState.prevTrend
-    : "neutral";
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { swingPeriod: 5 },
+  });
 
-  const indicator: IncrementalIndicator<BosValue, ChochState> = {
+  const swingPeriod = params.swingPeriod;
+  const bos = createBreakOfStructure(
+    { swingPeriod },
+    state ? { fromState: state.bosState } : undefined,
+  );
+  let prevTrend: "bullish" | "bearish" | "neutral" = state ? state.prevTrend : "neutral";
+
+  const indicator: IncrementalIndicator<BosValue, IndicatorSnapshot<ChochState>> = {
     next(candle: NormalizedCandle) {
       const { time, value } = bos.next(candle);
       const isBullishChoch = value.bullishBos && prevTrend === "bearish";
@@ -243,8 +308,13 @@ export function createChangeOfCharacter(
       };
     },
 
-    getState(): ChochState {
-      return { bosState: bos.getState(), prevTrend };
+    getState(): IndicatorSnapshot<ChochState> {
+      return makeSnapshot(
+        "changeOfCharacter",
+        CHANGE_OF_CHARACTER_VERSION,
+        { swingPeriod },
+        { bosState: bos.getState(), prevTrend },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/price/channel-line.ts
+++ b/packages/core/src/indicators/incremental/price/channel-line.ts
@@ -24,8 +24,9 @@
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
-import { cloneShallow, pushBounded, resolveSwingConfig } from "./swing-helpers";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
+import { cloneShallow, pushBounded, validateSwingConfig } from "./swing-helpers";
 import { createSwingPoints, type SwingPointsState } from "./swing-points";
 
 export type ChannelLineValue = {
@@ -51,10 +52,13 @@ type SwingPoint = {
   price: number;
 };
 
+/**
+ * Bare state shape for Channel Line. Params (`leftBars`, `rightBars`)
+ * live in `meta.params`; the inner swing-points snapshot is itself an
+ * `IndicatorSnapshot`.
+ */
 export type ChannelLineState = {
-  leftBars: number;
-  rightBars: number;
-  swings: SwingPointsState;
+  swings: IndicatorSnapshot<SwingPointsState>;
   lastTwoHighs: SwingPoint[];
   lastTwoLows: SwingPoint[];
   highsSinceLastSwingLow: SwingPoint[];
@@ -70,12 +74,30 @@ export type ChannelLineState = {
   count: number;
 };
 
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const CHANNEL_LINE_VERSION = 1;
+
+type ChannelLineParams = {
+  leftBars: number;
+  rightBars: number;
+};
+
 export function createChannelLine(
   options: ChannelLineOptions = {},
-  warmUpOptions?: WarmUpOptions<ChannelLineState>,
-): IncrementalIndicator<ChannelLineValue, ChannelLineState> {
-  const fromState = warmUpOptions?.fromState;
-  const { leftBars, rightBars } = resolveSwingConfig(options, fromState);
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<ChannelLineState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<ChannelLineValue, IndicatorSnapshot<ChannelLineState>> {
+  const { params, state } = resolveResume<ChannelLineParams, ChannelLineState>({
+    indicator: "channelLine",
+    version: CHANNEL_LINE_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { leftBars: 10, rightBars: 10 },
+  });
+  const { leftBars, rightBars } = validateSwingConfig(params.leftBars, params.rightBars);
 
   let swings: ReturnType<typeof createSwingPoints>;
   let lastTwoHighs: SwingPoint[];
@@ -92,21 +114,21 @@ export function createChannelLine(
   let parallelOffset: number;
   let count: number;
 
-  if (fromState) {
-    swings = createSwingPoints({ leftBars, rightBars }, { fromState: fromState.swings });
-    lastTwoHighs = cloneShallow(fromState.lastTwoHighs);
-    lastTwoLows = cloneShallow(fromState.lastTwoLows);
-    highsSinceLastSwingLow = cloneShallow(fromState.highsSinceLastSwingLow);
-    lowsSinceLastSwingHigh = cloneShallow(fromState.lowsSinceLastSwingHigh);
-    highsBetweenLastTwoLows = cloneShallow(fromState.highsBetweenLastTwoLows);
-    lowsBetweenLastTwoHighs = cloneShallow(fromState.lowsBetweenLastTwoHighs);
-    channelDefined = fromState.channelDefined;
-    channelDir = fromState.channelDir;
-    primarySlope = fromState.primarySlope;
-    primaryAnchorIdx = fromState.primaryAnchorIdx;
-    primaryAnchorPrice = fromState.primaryAnchorPrice;
-    parallelOffset = fromState.parallelOffset;
-    count = fromState.count;
+  if (state !== null) {
+    swings = createSwingPoints({ leftBars, rightBars }, { fromState: state.swings });
+    lastTwoHighs = cloneShallow(state.lastTwoHighs);
+    lastTwoLows = cloneShallow(state.lastTwoLows);
+    highsSinceLastSwingLow = cloneShallow(state.highsSinceLastSwingLow);
+    lowsSinceLastSwingHigh = cloneShallow(state.lowsSinceLastSwingHigh);
+    highsBetweenLastTwoLows = cloneShallow(state.highsBetweenLastTwoLows);
+    lowsBetweenLastTwoHighs = cloneShallow(state.lowsBetweenLastTwoHighs);
+    channelDefined = state.channelDefined;
+    channelDir = state.channelDir;
+    primarySlope = state.primarySlope;
+    primaryAnchorIdx = state.primaryAnchorIdx;
+    primaryAnchorPrice = state.primaryAnchorPrice;
+    parallelOffset = state.parallelOffset;
+    count = state.count;
   } else {
     swings = createSwingPoints({ leftBars, rightBars });
     lastTwoHighs = [];
@@ -236,7 +258,7 @@ export function createChannelLine(
     };
   }
 
-  const indicator: IncrementalIndicator<ChannelLineValue, ChannelLineState> = {
+  const indicator: IncrementalIndicator<ChannelLineValue, IndicatorSnapshot<ChannelLineState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const swingResult = swings.next(candle);
@@ -275,7 +297,7 @@ export function createChannelLine(
     },
 
     peek(candle: NormalizedCandle) {
-      const saved = indicator.getState();
+      const saved = indicator.getState().state;
       const result = indicator.next(candle);
       swings = createSwingPoints({ leftBars, rightBars }, { fromState: saved.swings });
       lastTwoHighs = cloneShallow(saved.lastTwoHighs);
@@ -294,25 +316,28 @@ export function createChannelLine(
       return result;
     },
 
-    getState(): ChannelLineState {
-      return {
-        leftBars,
-        rightBars,
-        swings: swings.getState(),
-        lastTwoHighs: cloneShallow(lastTwoHighs),
-        lastTwoLows: cloneShallow(lastTwoLows),
-        highsSinceLastSwingLow: cloneShallow(highsSinceLastSwingLow),
-        lowsSinceLastSwingHigh: cloneShallow(lowsSinceLastSwingHigh),
-        highsBetweenLastTwoLows: cloneShallow(highsBetweenLastTwoLows),
-        lowsBetweenLastTwoHighs: cloneShallow(lowsBetweenLastTwoHighs),
-        channelDefined,
-        channelDir,
-        primarySlope,
-        primaryAnchorIdx,
-        primaryAnchorPrice,
-        parallelOffset,
-        count,
-      };
+    getState(): IndicatorSnapshot<ChannelLineState> {
+      return makeSnapshot(
+        "channelLine",
+        CHANNEL_LINE_VERSION,
+        { leftBars, rightBars },
+        {
+          swings: swings.getState(),
+          lastTwoHighs: cloneShallow(lastTwoHighs),
+          lastTwoLows: cloneShallow(lastTwoLows),
+          highsSinceLastSwingLow: cloneShallow(highsSinceLastSwingLow),
+          lowsSinceLastSwingHigh: cloneShallow(lowsSinceLastSwingHigh),
+          highsBetweenLastTwoLows: cloneShallow(highsBetweenLastTwoLows),
+          lowsBetweenLastTwoHighs: cloneShallow(lowsBetweenLastTwoHighs),
+          channelDefined,
+          channelDir,
+          primarySlope,
+          primaryAnchorIdx,
+          primaryAnchorPrice,
+          parallelOffset,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/price/fair-value-gap.ts
+++ b/packages/core/src/indicators/incremental/price/fair-value-gap.ts
@@ -4,10 +4,19 @@
  * Detects 3-candle imbalance patterns and tracks fill status.
  * Bullish FVG: prev2.high < current.low (gap between candle 1 high and candle 3 low)
  * Bearish FVG: prev2.low > current.high (gap between candle 3 high and candle 1 low)
+ *
+ * State category: **Mixed** — the `active*Fvgs` lists are not a frozen
+ * append-only log: `minGapPercent` / `maxActiveFvgs` / `partialFill`
+ * decide which gaps were recorded, retained, or already considered
+ * filled, so they shape the persisted state. Resume with any of those
+ * changed cannot match a fresh run and is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type FvgGap = {
   type: "bullish" | "bearish";
@@ -44,15 +53,25 @@ export type FvgValue = {
 
 type StoredCandle = { high: number; low: number; time: number };
 
+/**
+ * Bare state shape for Fair Value Gap. Params (`minGapPercent`,
+ * `maxActiveFvgs`, `partialFill`) live in `meta.params` on the wire.
+ */
 export type FairValueGapState = {
   prev2: StoredCandle | null;
   prev1: StoredCandle | null;
   activeBullishFvgs: FvgGap[];
   activeBearishFvgs: FvgGap[];
+  count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const FAIR_VALUE_GAP_VERSION = 1;
+
+type FairValueGapParams = {
   minGapPercent: number;
   maxActiveFvgs: number;
   partialFill: boolean;
-  count: number;
 };
 
 const emptyValue: FvgValue = {
@@ -86,11 +105,23 @@ const emptyValue: FvgValue = {
  */
 export function createFairValueGap(
   options: { minGapPercent?: number; maxActiveFvgs?: number; partialFill?: boolean } = {},
-  warmUpOptions?: WarmUpOptions<FairValueGapState>,
-): IncrementalIndicator<FvgValue, FairValueGapState> {
-  const minGapPercent = options.minGapPercent ?? 0;
-  const maxActiveFvgs = options.maxActiveFvgs ?? 10;
-  const partialFill = options.partialFill ?? true;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<FairValueGapState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<FvgValue, IndicatorSnapshot<FairValueGapState>> {
+  const { params, state } = resolveResume<FairValueGapParams, FairValueGapState>({
+    indicator: "fairValueGap",
+    version: FAIR_VALUE_GAP_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { minGapPercent: 0, maxActiveFvgs: 10, partialFill: true },
+  });
+
+  const minGapPercent = params.minGapPercent;
+  const maxActiveFvgs = params.maxActiveFvgs;
+  const partialFill = params.partialFill;
 
   let prev2: StoredCandle | null;
   let prev1: StoredCandle | null;
@@ -98,13 +129,12 @@ export function createFairValueGap(
   let activeBearishFvgs: FvgGap[];
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    prev2 = s.prev2 ? { ...s.prev2 } : null;
-    prev1 = s.prev1 ? { ...s.prev1 } : null;
-    activeBullishFvgs = s.activeBullishFvgs.map((g) => ({ ...g }));
-    activeBearishFvgs = s.activeBearishFvgs.map((g) => ({ ...g }));
-    count = s.count;
+  if (state !== null) {
+    prev2 = state.prev2 ? { ...state.prev2 } : null;
+    prev1 = state.prev1 ? { ...state.prev1 } : null;
+    activeBullishFvgs = state.activeBullishFvgs.map((g) => ({ ...g }));
+    activeBearishFvgs = state.activeBearishFvgs.map((g) => ({ ...g }));
+    count = state.count;
   } else {
     prev2 = null;
     prev1 = null;
@@ -150,7 +180,7 @@ export function createFairValueGap(
     return filled;
   }
 
-  const indicator: IncrementalIndicator<FvgValue, FairValueGapState> = {
+  const indicator: IncrementalIndicator<FvgValue, IndicatorSnapshot<FairValueGapState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const barIndex = count - 1;
@@ -236,17 +266,36 @@ export function createFairValueGap(
         return { time: candle.time, value: emptyValue };
       }
 
-      // Simulate fill check without mutating
+      // `next` increments `count` then uses `barIndex = count - 1`, so
+      // the bar index of the incoming candle equals the current
+      // (pre-increment) `count`.
+      const barIndex = count;
+
+      // Simulate fill check without mutating. Mirror `next`'s
+      // `checkFills` exactly — including the reverse iteration order,
+      // which determines `filledFvgs` ordering — so peek matches next.
       const peekFilledFvgs: FvgGap[] = [];
-      for (const g of activeBullishFvgs) {
+      for (let i = activeBullishFvgs.length - 1; i >= 0; i--) {
+        const g = activeBullishFvgs[i];
         const isFilled = partialFill ? candle.low <= g.high : candle.low <= g.low;
         if (isFilled)
-          peekFilledFvgs.push({ ...g, filled: true, filledIndex: count, filledTime: candle.time });
+          peekFilledFvgs.push({
+            ...g,
+            filled: true,
+            filledIndex: barIndex,
+            filledTime: candle.time,
+          });
       }
-      for (const g of activeBearishFvgs) {
+      for (let i = activeBearishFvgs.length - 1; i >= 0; i--) {
+        const g = activeBearishFvgs[i];
         const isFilled = partialFill ? candle.high >= g.low : candle.high >= g.high;
         if (isFilled)
-          peekFilledFvgs.push({ ...g, filled: true, filledIndex: count, filledTime: candle.time });
+          peekFilledFvgs.push({
+            ...g,
+            filled: true,
+            filledIndex: barIndex,
+            filledTime: candle.time,
+          });
       }
 
       let newBullishFvg = false;
@@ -255,16 +304,15 @@ export function createFairValueGap(
 
       if (candle.low > prev2.high) {
         const gapSize = candle.low - prev2.high;
-        const midPrice = (prev2.high + candle.low) / 2;
-        const gapPct = midPrice > 0 ? (gapSize / midPrice) * 100 : 0;
+        const gapPct = prev2.high > 0 ? (gapSize / prev2.high) * 100 : 0;
         if (gapPct >= minGapPercent) {
           newBullishFvg = true;
           newFvg = {
             type: "bullish",
             high: candle.low,
             low: prev2.high,
-            startIndex: count - 1,
-            startTime: prev1.time,
+            startIndex: barIndex,
+            startTime: candle.time,
             filled: false,
             filledIndex: null,
             filledTime: null,
@@ -274,16 +322,15 @@ export function createFairValueGap(
 
       if (candle.high < prev2.low) {
         const gapSize = prev2.low - candle.high;
-        const midPrice = (prev2.low + candle.high) / 2;
-        const gapPct = midPrice > 0 ? (gapSize / midPrice) * 100 : 0;
+        const gapPct = prev2.low > 0 ? (gapSize / prev2.low) * 100 : 0;
         if (gapPct >= minGapPercent) {
           newBearishFvg = true;
           newFvg = {
             type: "bearish",
             high: prev2.low,
             low: candle.high,
-            startIndex: count - 1,
-            startTime: prev1.time,
+            startIndex: barIndex,
+            startTime: candle.time,
             filled: false,
             filledIndex: null,
             filledTime: null,
@@ -318,17 +365,19 @@ export function createFairValueGap(
       };
     },
 
-    getState(): FairValueGapState {
-      return {
-        prev2: prev2 ? { ...prev2 } : null,
-        prev1: prev1 ? { ...prev1 } : null,
-        activeBullishFvgs: activeBullishFvgs.map((g) => ({ ...g })),
-        activeBearishFvgs: activeBearishFvgs.map((g) => ({ ...g })),
-        minGapPercent,
-        maxActiveFvgs,
-        partialFill,
-        count,
-      };
+    getState(): IndicatorSnapshot<FairValueGapState> {
+      return makeSnapshot(
+        "fairValueGap",
+        FAIR_VALUE_GAP_VERSION,
+        { minGapPercent, maxActiveFvgs, partialFill },
+        {
+          prev2: prev2 ? { ...prev2 } : null,
+          prev1: prev1 ? { ...prev1 } : null,
+          activeBullishFvgs: activeBullishFvgs.map((g) => ({ ...g })),
+          activeBearishFvgs: activeBearishFvgs.map((g) => ({ ...g })),
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/price/fibonacci-extension.ts
+++ b/packages/core/src/indicators/incremental/price/fibonacci-extension.ts
@@ -16,13 +16,9 @@
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
-import {
-  cloneShallow,
-  pushBounded,
-  resolveLevelsConfig,
-  resolveSwingConfig,
-} from "./swing-helpers";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
+import { cloneShallow, pushBounded, resolveLevels, validateSwingConfig } from "./swing-helpers";
 import { createSwingPoints, type SwingPointsState } from "./swing-points";
 
 export type FibonacciExtensionValue = {
@@ -53,11 +49,13 @@ type AlternatingPoint = {
   type: "high" | "low";
 };
 
+/**
+ * Bare state shape for Fibonacci Extension. Params (`leftBars`,
+ * `rightBars`, `levels`) live in `meta.params`; the inner swing-points
+ * snapshot is itself an `IndicatorSnapshot`.
+ */
 export type FibonacciExtensionState = {
-  leftBars: number;
-  rightBars: number;
-  levels: number[];
-  swings: SwingPointsState;
+  swings: IndicatorSnapshot<SwingPointsState>;
   alternating: AlternatingPoint[];
   currentLevels: Record<string, number> | null;
   currentPointA: number | null;
@@ -67,15 +65,34 @@ export type FibonacciExtensionState = {
   count: number;
 };
 
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const FIBONACCI_EXTENSION_VERSION = 1;
+
 const DEFAULT_LEVELS: readonly number[] = [0, 0.618, 1, 1.272, 1.618, 2, 2.618];
+
+type FibonacciExtensionParams = {
+  leftBars: number;
+  rightBars: number;
+  levels: number[];
+};
 
 export function createFibonacciExtension(
   options: FibonacciExtensionOptions = {},
-  warmUpOptions?: WarmUpOptions<FibonacciExtensionState>,
-): IncrementalIndicator<FibonacciExtensionValue, FibonacciExtensionState> {
-  const fromState = warmUpOptions?.fromState;
-  const { leftBars, rightBars } = resolveSwingConfig(options, fromState);
-  const { levels, ratioKeys } = resolveLevelsConfig(options, fromState, DEFAULT_LEVELS);
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<FibonacciExtensionState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<FibonacciExtensionValue, IndicatorSnapshot<FibonacciExtensionState>> {
+  const { params, state } = resolveResume<FibonacciExtensionParams, FibonacciExtensionState>({
+    indicator: "fibonacciExtension",
+    version: FIBONACCI_EXTENSION_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { leftBars: 10, rightBars: 10, levels: DEFAULT_LEVELS.slice() },
+  });
+  const { leftBars, rightBars } = validateSwingConfig(params.leftBars, params.rightBars);
+  const { levels, ratioKeys } = resolveLevels(params.levels);
 
   let swings: ReturnType<typeof createSwingPoints>;
   // The pattern only ever needs the last 3 alternating points. Trim to that
@@ -88,15 +105,15 @@ export function createFibonacciExtension(
   let currentDirection: "bullish" | "bearish" | null;
   let count: number;
 
-  if (fromState) {
-    swings = createSwingPoints({ leftBars, rightBars }, { fromState: fromState.swings });
-    alternating = cloneShallow(fromState.alternating);
-    currentLevels = fromState.currentLevels ? { ...fromState.currentLevels } : null;
-    currentPointA = fromState.currentPointA;
-    currentPointB = fromState.currentPointB;
-    currentPointC = fromState.currentPointC;
-    currentDirection = fromState.currentDirection;
-    count = fromState.count;
+  if (state !== null) {
+    swings = createSwingPoints({ leftBars, rightBars }, { fromState: state.swings });
+    alternating = cloneShallow(state.alternating);
+    currentLevels = state.currentLevels ? { ...state.currentLevels } : null;
+    currentPointA = state.currentPointA;
+    currentPointB = state.currentPointB;
+    currentPointC = state.currentPointC;
+    currentDirection = state.currentDirection;
+    count = state.count;
   } else {
     swings = createSwingPoints({ leftBars, rightBars });
     alternating = [];
@@ -175,7 +192,10 @@ export function createFibonacciExtension(
     return value;
   }
 
-  const indicator: IncrementalIndicator<FibonacciExtensionValue, FibonacciExtensionState> = {
+  const indicator: IncrementalIndicator<
+    FibonacciExtensionValue,
+    IndicatorSnapshot<FibonacciExtensionState>
+  > = {
     next(candle: NormalizedCandle) {
       count++;
       const swingResult = swings.next(candle);
@@ -203,7 +223,7 @@ export function createFibonacciExtension(
     },
 
     peek(candle: NormalizedCandle) {
-      const saved = indicator.getState();
+      const saved = indicator.getState().state;
       const result = indicator.next(candle);
       swings = createSwingPoints({ leftBars, rightBars }, { fromState: saved.swings });
       alternating = cloneShallow(saved.alternating);
@@ -217,20 +237,22 @@ export function createFibonacciExtension(
       return result;
     },
 
-    getState(): FibonacciExtensionState {
-      return {
-        leftBars,
-        rightBars,
-        levels: levels.slice(),
-        swings: swings.getState(),
-        alternating: cloneShallow(alternating),
-        currentLevels: currentLevels ? { ...currentLevels } : null,
-        currentPointA,
-        currentPointB,
-        currentPointC,
-        currentDirection,
-        count,
-      };
+    getState(): IndicatorSnapshot<FibonacciExtensionState> {
+      return makeSnapshot(
+        "fibonacciExtension",
+        FIBONACCI_EXTENSION_VERSION,
+        { leftBars, rightBars, levels: levels.slice() },
+        {
+          swings: swings.getState(),
+          alternating: cloneShallow(alternating),
+          currentLevels: currentLevels ? { ...currentLevels } : null,
+          currentPointA,
+          currentPointB,
+          currentPointC,
+          currentDirection,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/price/fibonacci-retracement.ts
+++ b/packages/core/src/indicators/incremental/price/fibonacci-retracement.ts
@@ -20,8 +20,9 @@
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
-import { resolveLevelsConfig, resolveSwingConfig } from "./swing-helpers";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
+import { resolveLevels, validateSwingConfig } from "./swing-helpers";
 import { createSwingPoints, type SwingPointsState } from "./swing-points";
 
 export type FibonacciRetracementValue = {
@@ -44,11 +45,13 @@ export type FibonacciRetracementOptions = {
   levels?: number[];
 };
 
+/**
+ * Bare state shape for Fibonacci Retracement. Params (`leftBars`,
+ * `rightBars`, `levels`) live in `meta.params`; the inner swing-points
+ * snapshot is itself an `IndicatorSnapshot`.
+ */
 export type FibonacciRetracementState = {
-  leftBars: number;
-  rightBars: number;
-  levels: number[];
-  swings: SwingPointsState;
+  swings: IndicatorSnapshot<SwingPointsState>;
   lastSwingHighPrice: number | null;
   lastSwingHighIdx: number | null;
   lastSwingLowPrice: number | null;
@@ -56,15 +59,34 @@ export type FibonacciRetracementState = {
   count: number;
 };
 
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const FIBONACCI_RETRACEMENT_VERSION = 1;
+
 const DEFAULT_LEVELS: readonly number[] = [0, 0.236, 0.382, 0.5, 0.618, 0.786, 1];
+
+type FibonacciRetracementParams = {
+  leftBars: number;
+  rightBars: number;
+  levels: number[];
+};
 
 export function createFibonacciRetracement(
   options: FibonacciRetracementOptions = {},
-  warmUpOptions?: WarmUpOptions<FibonacciRetracementState>,
-): IncrementalIndicator<FibonacciRetracementValue, FibonacciRetracementState> {
-  const fromState = warmUpOptions?.fromState;
-  const { leftBars, rightBars } = resolveSwingConfig(options, fromState);
-  const { levels, ratioKeys } = resolveLevelsConfig(options, fromState, DEFAULT_LEVELS);
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<FibonacciRetracementState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<FibonacciRetracementValue, IndicatorSnapshot<FibonacciRetracementState>> {
+  const { params, state } = resolveResume<FibonacciRetracementParams, FibonacciRetracementState>({
+    indicator: "fibonacciRetracement",
+    version: FIBONACCI_RETRACEMENT_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { leftBars: 10, rightBars: 10, levels: DEFAULT_LEVELS.slice() },
+  });
+  const { leftBars, rightBars } = validateSwingConfig(params.leftBars, params.rightBars);
+  const { levels, ratioKeys } = resolveLevels(params.levels);
 
   let swings: ReturnType<typeof createSwingPoints>;
   let lastSwingHighPrice: number | null;
@@ -81,13 +103,13 @@ export function createFibonacciRetracement(
   let cachedHighIdx: number | null = null;
   let cachedLowIdx: number | null = null;
 
-  if (fromState) {
-    swings = createSwingPoints({ leftBars, rightBars }, { fromState: fromState.swings });
-    lastSwingHighPrice = fromState.lastSwingHighPrice;
-    lastSwingHighIdx = fromState.lastSwingHighIdx;
-    lastSwingLowPrice = fromState.lastSwingLowPrice;
-    lastSwingLowIdx = fromState.lastSwingLowIdx;
-    count = fromState.count;
+  if (state !== null) {
+    swings = createSwingPoints({ leftBars, rightBars }, { fromState: state.swings });
+    lastSwingHighPrice = state.lastSwingHighPrice;
+    lastSwingHighIdx = state.lastSwingHighIdx;
+    lastSwingLowPrice = state.lastSwingLowPrice;
+    lastSwingLowIdx = state.lastSwingLowIdx;
+    count = state.count;
   } else {
     swings = createSwingPoints({ leftBars, rightBars });
     lastSwingHighPrice = null;
@@ -136,7 +158,10 @@ export function createFibonacciRetracement(
     return value;
   }
 
-  const indicator: IncrementalIndicator<FibonacciRetracementValue, FibonacciRetracementState> = {
+  const indicator: IncrementalIndicator<
+    FibonacciRetracementValue,
+    IndicatorSnapshot<FibonacciRetracementState>
+  > = {
     next(candle: NormalizedCandle) {
       count++;
       const swingResult = swings.next(candle);
@@ -160,7 +185,7 @@ export function createFibonacciRetracement(
     },
 
     peek(candle: NormalizedCandle) {
-      const saved = indicator.getState();
+      const saved = indicator.getState().state;
       const result = indicator.next(candle);
       swings = createSwingPoints({ leftBars, rightBars }, { fromState: saved.swings });
       lastSwingHighPrice = saved.lastSwingHighPrice;
@@ -171,18 +196,20 @@ export function createFibonacciRetracement(
       return result;
     },
 
-    getState(): FibonacciRetracementState {
-      return {
-        leftBars,
-        rightBars,
-        levels: levels.slice(),
-        swings: swings.getState(),
-        lastSwingHighPrice,
-        lastSwingHighIdx,
-        lastSwingLowPrice,
-        lastSwingLowIdx,
-        count,
-      };
+    getState(): IndicatorSnapshot<FibonacciRetracementState> {
+      return makeSnapshot(
+        "fibonacciRetracement",
+        FIBONACCI_RETRACEMENT_VERSION,
+        { leftBars, rightBars, levels: levels.slice() },
+        {
+          swings: swings.getState(),
+          lastSwingHighPrice,
+          lastSwingHighIdx,
+          lastSwingLowPrice,
+          lastSwingLowIdx,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/price/fractals.ts
+++ b/packages/core/src/indicators/incremental/price/fractals.ts
@@ -4,11 +4,18 @@
  * Detects Williams fractal patterns: a bar whose high (or low) is the
  * extreme among 2*period+1 surrounding bars. Output is delayed by `period`
  * bars since right-side confirmation is required.
+ *
+ * State category: **Windowed** (a fixed-size `2*period+1` raw OHLC
+ * window). Resuming with a different `period` carries the most-recent
+ * window entries forward into a buffer sized at the new window.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type FractalValue = {
   upFractal: boolean;
@@ -19,10 +26,20 @@ export type FractalValue = {
 
 type FractalEntry = { high: number; low: number; time: number };
 
+/**
+ * Bare state shape for Fractals. The param (`period`) lives in
+ * `meta.params` on the wire.
+ */
 export type FractalsState = {
-  period: number;
   buffer: ReturnType<CircularBuffer<FractalEntry>["snapshot"]>;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const FRACTALS_VERSION = 1;
+
+type FractalsParams = {
+  period: number;
 };
 
 const nullValue: FractalValue = {
@@ -50,18 +67,41 @@ const nullValue: FractalValue = {
  */
 export function createFractals(
   options: { period?: number } = {},
-  warmUpOptions?: WarmUpOptions<FractalsState>,
-): IncrementalIndicator<FractalValue, FractalsState> {
-  const period = options.period ?? 2;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<FractalsState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<FractalValue, IndicatorSnapshot<FractalsState>> {
+  const { params, state, reconfigured } = resolveResume<FractalsParams, FractalsState>({
+    indicator: "fractals",
+    version: FRACTALS_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 2 },
+  });
+
+  const period = params.period;
+  if (!Number.isInteger(period) || period < 1) {
+    throw new Error('fractals: option "period" must be a positive integer');
+  }
   const windowSize = 2 * period + 1;
 
   let buffer: CircularBuffer<FractalEntry>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    count = s.count;
+  if (state !== null) {
+    const old = CircularBuffer.fromSnapshot(state.buffer);
+    if (reconfigured) {
+      buffer = new CircularBuffer<FractalEntry>(windowSize);
+      const carry = Math.min(old.length, windowSize);
+      for (let i = old.length - carry; i < old.length; i++) {
+        buffer.push(old.get(i));
+      }
+    } else {
+      buffer = old;
+    }
+    count = state.count;
   } else {
     buffer = new CircularBuffer<FractalEntry>(windowSize);
     count = 0;
@@ -91,7 +131,7 @@ export function createFractals(
     };
   }
 
-  const indicator: IncrementalIndicator<FractalValue, FractalsState> = {
+  const indicator: IncrementalIndicator<FractalValue, IndicatorSnapshot<FractalsState>> = {
     next(candle: NormalizedCandle) {
       buffer.push({ high: candle.high, low: candle.low, time: candle.time });
       count++;
@@ -147,12 +187,16 @@ export function createFractals(
       };
     },
 
-    getState(): FractalsState {
-      return {
-        period,
-        buffer: buffer.snapshot(),
-        count,
-      };
+    getState(): IndicatorSnapshot<FractalsState> {
+      return makeSnapshot(
+        "fractals",
+        FRACTALS_VERSION,
+        { period },
+        {
+          buffer: buffer.snapshot(),
+          count,
+        },
+      );
     },
 
     get count() {
@@ -160,7 +204,7 @@ export function createFractals(
     },
 
     get isWarmedUp() {
-      return count >= windowSize;
+      return buffer.length >= windowSize;
     },
   };
 

--- a/packages/core/src/indicators/incremental/price/gap-analysis.ts
+++ b/packages/core/src/indicators/incremental/price/gap-analysis.ts
@@ -8,10 +8,19 @@
  * Note: Unlike the batch version which does a retroactive final pass,
  * the incremental version detects gap fills as they occur in subsequent bars.
  * The `filled` field on the gap-creation bar stays false until a later bar fills it.
+ *
+ * State category: **Mixed** — the `activeGaps` list is shaped by
+ * `minGapPercent`: it decides which gaps were ever recorded. Resuming
+ * under a different threshold cannot recreate older gaps that were
+ * never tracked (or drop ones a fresh run would skip), so a
+ * `minGapPercent` change on resume is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type GapValue = {
   /** Gap direction, null if no gap */
@@ -31,11 +40,21 @@ type ActiveGap = {
   prevClose: number;
 };
 
+/**
+ * Bare state shape for Gap Analysis. The param (`minGapPercent`)
+ * lives in `meta.params` on the wire.
+ */
 export type GapAnalysisState = {
   prevCandle: { high: number; low: number; close: number } | null;
   activeGaps: ActiveGap[];
-  minGapPercent: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const GAP_ANALYSIS_VERSION = 1;
+
+type GapAnalysisParams = {
+  minGapPercent: number;
 };
 
 const nullValue: GapValue = {
@@ -63,19 +82,30 @@ const nullValue: GapValue = {
  */
 export function createGapAnalysis(
   options: { minGapPercent?: number } = {},
-  warmUpOptions?: WarmUpOptions<GapAnalysisState>,
-): IncrementalIndicator<GapValue, GapAnalysisState> {
-  const minGapPercent = options.minGapPercent ?? 0.5;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<GapAnalysisState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<GapValue, IndicatorSnapshot<GapAnalysisState>> {
+  const { params, state } = resolveResume<GapAnalysisParams, GapAnalysisState>({
+    indicator: "gapAnalysis",
+    version: GAP_ANALYSIS_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { minGapPercent: 0.5 },
+  });
+
+  const minGapPercent = params.minGapPercent;
 
   let prevCandle: { high: number; low: number; close: number } | null;
   let activeGaps: ActiveGap[];
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    prevCandle = s.prevCandle ? { ...s.prevCandle } : null;
-    activeGaps = s.activeGaps.map((g) => ({ ...g }));
-    count = s.count;
+  if (state !== null) {
+    prevCandle = state.prevCandle ? { ...state.prevCandle } : null;
+    activeGaps = state.activeGaps.map((g) => ({ ...g }));
+    count = state.count;
   } else {
     prevCandle = null;
     activeGaps = [];
@@ -157,7 +187,7 @@ export function createGapAnalysis(
     return { value: nullValue, newGap: null, filledIndices };
   }
 
-  const indicator: IncrementalIndicator<GapValue, GapAnalysisState> = {
+  const indicator: IncrementalIndicator<GapValue, IndicatorSnapshot<GapAnalysisState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -182,13 +212,17 @@ export function createGapAnalysis(
       return { time: candle.time, value };
     },
 
-    getState(): GapAnalysisState {
-      return {
-        prevCandle: prevCandle ? { ...prevCandle } : null,
-        activeGaps: activeGaps.map((g) => ({ ...g })),
-        minGapPercent,
-        count,
-      };
+    getState(): IndicatorSnapshot<GapAnalysisState> {
+      return makeSnapshot(
+        "gapAnalysis",
+        GAP_ANALYSIS_VERSION,
+        { minGapPercent },
+        {
+          prevCandle: prevCandle ? { ...prevCandle } : null,
+          activeGaps: activeGaps.map((g) => ({ ...g })),
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/price/heikin-ashi.ts
+++ b/packages/core/src/indicators/incremental/price/heikin-ashi.ts
@@ -2,10 +2,17 @@
  * Incremental Heikin-Ashi
  *
  * Smoothed candles that depend on the previous HA open/close.
+ *
+ * State category: **Recursive** (`prevHaOpen` / `prevHaClose` are the
+ * recursive accumulators). Heikin-Ashi takes no params, so there is
+ * nothing to reconfigure — every resume is a verbatim restore.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 const EPSILON = 1e-10;
 
@@ -17,11 +24,21 @@ export type HeikinAshiValue = {
   trend: 1 | -1 | 0;
 };
 
+/**
+ * Bare state shape for Heikin-Ashi. Heikin-Ashi has no params, so
+ * `meta.params` is an empty object on the wire.
+ */
 export type HeikinAshiState = {
   prevHaOpen: number | null;
   prevHaClose: number | null;
   count: number;
 };
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const HEIKIN_ASHI_VERSION = 1;
+
+// biome-ignore lint/complexity/noBannedTypes: Heikin-Ashi genuinely has no params.
+type HeikinAshiParams = {};
 
 /**
  * Create an incremental Heikin-Ashi indicator.
@@ -37,16 +54,28 @@ export type HeikinAshiState = {
  */
 export function createHeikinAshi(
   _options: Record<string, never> = {},
-  warmUpOptions?: WarmUpOptions<HeikinAshiState>,
-): IncrementalIndicator<HeikinAshiValue, HeikinAshiState> {
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<HeikinAshiState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<HeikinAshiValue, IndicatorSnapshot<HeikinAshiState>> {
+  const { state } = resolveResume<HeikinAshiParams, HeikinAshiState>({
+    indicator: "heikinAshi",
+    version: HEIKIN_ASHI_VERSION,
+    category: "recursive",
+    options: {},
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: {},
+  });
+
   let prevHaOpen: number | null;
   let prevHaClose: number | null;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    prevHaOpen = warmUpOptions.fromState.prevHaOpen;
-    prevHaClose = warmUpOptions.fromState.prevHaClose;
-    count = warmUpOptions.fromState.count;
+  if (state !== null) {
+    prevHaOpen = state.prevHaOpen;
+    prevHaClose = state.prevHaClose;
+    count = state.count;
   } else {
     prevHaOpen = null;
     prevHaClose = null;
@@ -76,7 +105,7 @@ export function createHeikinAshi(
     return { open: haOpen, high: haHigh, low: haLow, close: haClose, trend };
   }
 
-  const indicator: IncrementalIndicator<HeikinAshiValue, HeikinAshiState> = {
+  const indicator: IncrementalIndicator<HeikinAshiValue, IndicatorSnapshot<HeikinAshiState>> = {
     next(candle: NormalizedCandle) {
       const value = compute(candle, prevHaOpen, prevHaClose);
       prevHaOpen = value.open;
@@ -89,8 +118,13 @@ export function createHeikinAshi(
       return { time: candle.time, value: compute(candle, prevHaOpen, prevHaClose) };
     },
 
-    getState(): HeikinAshiState {
-      return { prevHaOpen, prevHaClose, count };
+    getState(): IndicatorSnapshot<HeikinAshiState> {
+      return makeSnapshot(
+        "heikinAshi",
+        HEIKIN_ASHI_VERSION,
+        {},
+        { prevHaOpen, prevHaClose, count },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/price/opening-range.ts
+++ b/packages/core/src/indicators/incremental/price/opening-range.ts
@@ -3,10 +3,19 @@
  *
  * Tracks the opening range high/low during the first N minutes of a session,
  * then detects breakouts above or below the established range.
+ *
+ * State category: **Mixed** (a session-scoped accumulator: the current
+ * session's running high/low and the derived `orDurationMs` / reset
+ * rule are all conditioned on construction-time params). Resume with a
+ * different `minutes` / `sessionResetPeriod` would silently re-time or
+ * restart the in-flight session, so any param change is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type OpeningRangeValue = {
   /** Opening range high, null until first bar */
@@ -17,16 +26,33 @@ export type OpeningRangeValue = {
   breakout: "above" | "below" | null;
 };
 
+/**
+ * Bare state shape for Opening Range. Params (`minutes`,
+ * `sessionResetPeriod`) live in `meta.params` on the wire.
+ */
 export type OpeningRangeState = {
   sessionStartTime: number | null;
   sessionStartBarIndex: number;
   orHigh: number | null;
   orLow: number | null;
   orEstablished: boolean;
+  /**
+   * Sticky flag: `true` once any session's opening range has been
+   * established. `orEstablished` resets per session, but the
+   * indicator's overall warm-up is a one-way latch — this drives the
+   * monotonic `isWarmedUp` getter.
+   */
+  everEstablished: boolean;
   lastDayIndex: number;
+  count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const OPENING_RANGE_VERSION = 1;
+
+type OpeningRangeParams = {
   minutes: number;
   sessionResetPeriod: "day" | number;
-  count: number;
 };
 
 const nullValue: OpeningRangeValue = { high: null, low: null, breakout: null };
@@ -78,10 +104,22 @@ function isNewSession(
  */
 export function createOpeningRange(
   options: { minutes?: number; sessionResetPeriod?: "day" | number } = {},
-  warmUpOptions?: WarmUpOptions<OpeningRangeState>,
-): IncrementalIndicator<OpeningRangeValue, OpeningRangeState> {
-  const minutes = options.minutes ?? 30;
-  const sessionResetPeriod = options.sessionResetPeriod ?? "day";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<OpeningRangeState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<OpeningRangeValue, IndicatorSnapshot<OpeningRangeState>> {
+  const { params, state } = resolveResume<OpeningRangeParams, OpeningRangeState>({
+    indicator: "openingRange",
+    version: OPENING_RANGE_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { minutes: 30, sessionResetPeriod: "day" },
+  });
+
+  const minutes = params.minutes;
+  const sessionResetPeriod = params.sessionResetPeriod;
   const orDurationMs = minutes * 60 * 1000;
 
   let sessionStartTime: number | null;
@@ -89,24 +127,26 @@ export function createOpeningRange(
   let orHigh: number | null;
   let orLow: number | null;
   let orEstablished: boolean;
+  let everEstablished: boolean;
   let lastDayIndex: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    sessionStartTime = s.sessionStartTime;
-    sessionStartBarIndex = s.sessionStartBarIndex;
-    orHigh = s.orHigh;
-    orLow = s.orLow;
-    orEstablished = s.orEstablished;
-    lastDayIndex = s.lastDayIndex;
-    count = s.count;
+  if (state !== null) {
+    sessionStartTime = state.sessionStartTime;
+    sessionStartBarIndex = state.sessionStartBarIndex;
+    orHigh = state.orHigh;
+    orLow = state.orLow;
+    orEstablished = state.orEstablished;
+    everEstablished = state.everEstablished ?? state.orEstablished;
+    lastDayIndex = state.lastDayIndex;
+    count = state.count;
   } else {
     sessionStartTime = null;
     sessionStartBarIndex = 0;
     orHigh = null;
     orLow = null;
     orEstablished = false;
+    everEstablished = false;
     lastDayIndex = 0;
     count = 0;
   }
@@ -128,7 +168,7 @@ export function createOpeningRange(
     return { high: h, low: l, breakout };
   }
 
-  const indicator: IncrementalIndicator<OpeningRangeValue, OpeningRangeState> = {
+  const indicator: IncrementalIndicator<OpeningRangeValue, IndicatorSnapshot<OpeningRangeState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -160,6 +200,7 @@ export function createOpeningRange(
         }
         // OR period just ended
         orEstablished = true;
+        everEstablished = true;
       }
 
       return { time: candle.time, value: computeValue(candle, orHigh, orLow, orEstablished) };
@@ -192,18 +233,22 @@ export function createOpeningRange(
       return { time: candle.time, value: computeValue(candle, orHigh, orLow, orEstablished) };
     },
 
-    getState(): OpeningRangeState {
-      return {
-        sessionStartTime,
-        sessionStartBarIndex,
-        orHigh,
-        orLow,
-        orEstablished,
-        lastDayIndex,
-        minutes,
-        sessionResetPeriod,
-        count,
-      };
+    getState(): IndicatorSnapshot<OpeningRangeState> {
+      return makeSnapshot(
+        "openingRange",
+        OPENING_RANGE_VERSION,
+        { minutes, sessionResetPeriod },
+        {
+          sessionStartTime,
+          sessionStartBarIndex,
+          orHigh,
+          orLow,
+          orEstablished,
+          everEstablished,
+          lastDayIndex,
+          count,
+        },
+      );
     },
 
     get count() {
@@ -211,7 +256,10 @@ export function createOpeningRange(
     },
 
     get isWarmedUp() {
-      return orEstablished;
+      // Monotonic: once any session's opening range has been
+      // established the indicator is considered warmed up, even though
+      // `orEstablished` itself resets at each new session.
+      return everEstablished;
     },
   };
 

--- a/packages/core/src/indicators/incremental/price/pivot-points.ts
+++ b/packages/core/src/indicators/incremental/price/pivot-points.ts
@@ -3,10 +3,18 @@
  *
  * Computes classic pivot point levels from the previous candle's OHLC.
  * Supports Standard, Fibonacci, Woodie, Camarilla, and DeMark methods.
+ *
+ * State category: **Windowed** (`prevCandle` is a raw one-bar OHLC
+ * window). `method` is a **resume-invariant param**: it only selects
+ * the level formula applied to the raw `prevCandle`, never touches the
+ * stored state — so changing it on resume is mathematically safe.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type PivotMethod = "standard" | "fibonacci" | "woodie" | "camarilla" | "demark";
 
@@ -20,10 +28,20 @@ export type PivotPointsValue = {
   s3: number | null;
 };
 
+/**
+ * Bare state shape for Pivot Points. The param (`method`) lives in
+ * `meta.params` on the wire.
+ */
 export type PivotPointsState = {
   prevCandle: { high: number; low: number; close: number } | null;
-  method: PivotMethod;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const PIVOT_POINTS_VERSION = 1;
+
+type PivotPointsParams = {
+  method: PivotMethod;
 };
 
 const nullValue: PivotPointsValue = {
@@ -138,23 +156,35 @@ function computePivot(
  */
 export function createPivotPoints(
   options: { method?: PivotMethod } = {},
-  warmUpOptions?: WarmUpOptions<PivotPointsState>,
-): IncrementalIndicator<PivotPointsValue, PivotPointsState> {
-  const method: PivotMethod = options.method ?? "standard";
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<PivotPointsState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<PivotPointsValue, IndicatorSnapshot<PivotPointsState>> {
+  const { params, state } = resolveResume<PivotPointsParams, PivotPointsState>({
+    indicator: "pivotPoints",
+    version: PIVOT_POINTS_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { method: "standard" },
+    resumeInvariantParams: ["method"],
+  });
+
+  const method: PivotMethod = params.method;
 
   let prevCandle: { high: number; low: number; close: number } | null;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    prevCandle = s.prevCandle ? { ...s.prevCandle } : null;
-    count = s.count;
+  if (state !== null) {
+    prevCandle = state.prevCandle ? { ...state.prevCandle } : null;
+    count = state.count;
   } else {
     prevCandle = null;
     count = 0;
   }
 
-  const indicator: IncrementalIndicator<PivotPointsValue, PivotPointsState> = {
+  const indicator: IncrementalIndicator<PivotPointsValue, IndicatorSnapshot<PivotPointsState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -189,12 +219,16 @@ export function createPivotPoints(
       return { time: candle.time, value };
     },
 
-    getState(): PivotPointsState {
-      return {
-        prevCandle: prevCandle ? { ...prevCandle } : null,
-        method,
-        count,
-      };
+    getState(): IndicatorSnapshot<PivotPointsState> {
+      return makeSnapshot(
+        "pivotPoints",
+        PIVOT_POINTS_VERSION,
+        { method },
+        {
+          prevCandle: prevCandle ? { ...prevCandle } : null,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/price/swing-helpers.ts
+++ b/packages/core/src/indicators/incremental/price/swing-helpers.ts
@@ -13,38 +13,39 @@
  */
 
 /**
- * Resolve `leftBars` / `rightBars` with the canonical precedence:
- *   snapshot state → constructor options → defaults (10).
+ * Validate `leftBars` / `rightBars` (both `>= 1`).
  *
- * Validates that both values are `>= 1`.
+ * Under the 0.4.0 State Contract the precedence merge
+ * (defaults < snapshot.params < options) is done by `resolveResume`;
+ * this helper only performs the shared range validation.
  */
-export function resolveSwingConfig(
-  options: { leftBars?: number; rightBars?: number } | undefined,
-  fromState: { leftBars: number; rightBars: number } | undefined,
-): { leftBars: number; rightBars: number } {
-  const leftBars = fromState?.leftBars ?? options?.leftBars ?? 10;
-  const rightBars = fromState?.rightBars ?? options?.rightBars ?? 10;
+export function validateSwingConfig(
+  leftBars: number,
+  rightBars: number,
+): {
+  leftBars: number;
+  rightBars: number;
+} {
   if (leftBars < 1) throw new Error("leftBars must be at least 1");
   if (rightBars < 1) throw new Error("rightBars must be at least 1");
   return { leftBars, rightBars };
 }
 
 /**
- * Resolve a Fibonacci-style `levels: number[]` with the same precedence and
- * return both the (defensively copied) levels array and a pre-computed array
- * of `String(ratio)` keys so the hot path can skip per-bar coercion.
+ * Validate a Fibonacci-style `levels: number[]` (non-empty array) and
+ * return both the (defensively copied) levels array and a pre-computed
+ * array of `String(ratio)` keys so the hot path can skip per-bar
+ * coercion.
  */
-export function resolveLevelsConfig(
-  options: { levels?: number[] } | undefined,
-  fromState: { levels: number[] } | undefined,
-  defaults: readonly number[],
-): { levels: number[]; ratioKeys: string[] } {
-  const source = fromState?.levels ?? options?.levels ?? defaults;
-  if (!Array.isArray(source) || source.length === 0) {
+export function resolveLevels(levels: readonly number[]): {
+  levels: number[];
+  ratioKeys: string[];
+} {
+  if (!Array.isArray(levels) || levels.length === 0) {
     throw new Error("levels must be a non-empty array");
   }
-  const levels = source.slice();
-  return { levels, ratioKeys: levels.map(String) };
+  const copy = levels.slice();
+  return { levels: copy, ratioKeys: copy.map(String) };
 }
 
 /**

--- a/packages/core/src/indicators/incremental/price/swing-points.ts
+++ b/packages/core/src/indicators/incremental/price/swing-points.ts
@@ -10,11 +10,21 @@
  * time), following the same convention as `createFractals`. During the warm-up
  * window the output time falls back to the streaming candle's time with all
  * fields nulled.
+ *
+ * State category: **Mixed** (a fixed-size `leftBars + 1 + rightBars`
+ * raw OHLC window plus persistent last-swing trackers conditioned on
+ * the window the swing was confirmed under). A `leftBars` / `rightBars`
+ * change resizes the scan window and re-times confirmation, which would
+ * re-emit pre-snapshot swings from the carried buffer — so any param
+ * change on resume is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type SwingPointValue = {
   isSwingHigh: boolean;
@@ -29,9 +39,11 @@ export type SwingPointValue = {
 
 type WindowEntry = { high: number; low: number; time: number; index: number };
 
+/**
+ * Bare state shape for Swing Points. Params (`leftBars`, `rightBars`)
+ * live in `meta.params` on the wire.
+ */
 export type SwingPointsState = {
-  leftBars: number;
-  rightBars: number;
   buffer: ReturnType<CircularBuffer<WindowEntry>["snapshot"]>;
   /** Index of the last confirmed swing high (absolute bar index, 0-based) */
   lastSwingHighIdx: number | null;
@@ -39,6 +51,14 @@ export type SwingPointsState = {
   lastSwingLowIdx: number | null;
   lastSwingLowPrice: number | null;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const SWING_POINTS_VERSION = 1;
+
+type SwingPointsParams = {
+  leftBars: number;
+  rightBars: number;
 };
 
 const nullValue: SwingPointValue = {
@@ -68,11 +88,22 @@ const nullValue: SwingPointValue = {
  */
 export function createSwingPoints(
   options: { leftBars?: number; rightBars?: number } = {},
-  warmUpOptions?: WarmUpOptions<SwingPointsState>,
-): IncrementalIndicator<SwingPointValue, SwingPointsState> {
-  const leftBars = options.leftBars ?? 5;
-  const rightBars = options.rightBars ?? 5;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<SwingPointsState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<SwingPointValue, IndicatorSnapshot<SwingPointsState>> {
+  const { params, state, reconfigured } = resolveResume<SwingPointsParams, SwingPointsState>({
+    indicator: "swingPoints",
+    version: SWING_POINTS_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { leftBars: 5, rightBars: 5 },
+  });
 
+  const leftBars = params.leftBars;
+  const rightBars = params.rightBars;
   if (leftBars < 1) throw new Error("leftBars must be at least 1");
   if (rightBars < 1) throw new Error("rightBars must be at least 1");
 
@@ -85,14 +116,24 @@ export function createSwingPoints(
   let lastSwingLowPrice: number | null;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    lastSwingHighIdx = s.lastSwingHighIdx;
-    lastSwingHighPrice = s.lastSwingHighPrice;
-    lastSwingLowIdx = s.lastSwingLowIdx;
-    lastSwingLowPrice = s.lastSwingLowPrice;
-    count = s.count;
+  if (state !== null) {
+    const old = CircularBuffer.fromSnapshot(state.buffer);
+    if (reconfigured) {
+      // leftBars / rightBars changed — carry the most-recent window
+      // entries into a buffer sized at the new window.
+      buffer = new CircularBuffer<WindowEntry>(windowSize);
+      const carry = Math.min(old.length, windowSize);
+      for (let i = old.length - carry; i < old.length; i++) {
+        buffer.push(old.get(i));
+      }
+    } else {
+      buffer = old;
+    }
+    lastSwingHighIdx = state.lastSwingHighIdx;
+    lastSwingHighPrice = state.lastSwingHighPrice;
+    lastSwingLowIdx = state.lastSwingLowIdx;
+    lastSwingLowPrice = state.lastSwingLowPrice;
+    count = state.count;
   } else {
     buffer = new CircularBuffer<WindowEntry>(windowSize);
     lastSwingHighIdx = null;
@@ -125,7 +166,7 @@ export function createSwingPoints(
     return { isHigh, isLow, mid };
   }
 
-  const indicator: IncrementalIndicator<SwingPointValue, SwingPointsState> = {
+  const indicator: IncrementalIndicator<SwingPointValue, IndicatorSnapshot<SwingPointsState>> = {
     next(candle: NormalizedCandle) {
       buffer.push({
         high: candle.high,
@@ -205,17 +246,20 @@ export function createSwingPoints(
       };
     },
 
-    getState(): SwingPointsState {
-      return {
-        leftBars,
-        rightBars,
-        buffer: buffer.snapshot(),
-        lastSwingHighIdx,
-        lastSwingHighPrice,
-        lastSwingLowIdx,
-        lastSwingLowPrice,
-        count,
-      };
+    getState(): IndicatorSnapshot<SwingPointsState> {
+      return makeSnapshot(
+        "swingPoints",
+        SWING_POINTS_VERSION,
+        { leftBars, rightBars },
+        {
+          buffer: buffer.snapshot(),
+          lastSwingHighIdx,
+          lastSwingHighPrice,
+          lastSwingLowIdx,
+          lastSwingLowPrice,
+          count,
+        },
+      );
     },
 
     get count() {
@@ -223,7 +267,7 @@ export function createSwingPoints(
     },
 
     get isWarmedUp() {
-      return count >= windowSize;
+      return buffer.length >= windowSize;
     },
   };
 

--- a/packages/core/src/indicators/incremental/price/zigzag.ts
+++ b/packages/core/src/indicators/incremental/price/zigzag.ts
@@ -9,11 +9,24 @@
  *  - when no pivot is confirmed, the current candle's time with a null value
  *  - when a pivot is confirmed, the original time of the extremum bar (so
  *    streamed output aligns with batch zigzag() output on pivot bars)
+ *
+ * State category: **Mixed** (a recursive trend / running-extreme
+ * tracker composed with an inner recursive ATR snapshot). Every param
+ * (`deviation`, `useAtr`, `atrPeriod`, `atrMultiplier`) affects either
+ * the pivot-trigger threshold or the inner ATR, so resuming with any
+ * changed is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import type { AtrState } from "../volatility/atr";
 import { createAtr } from "../volatility/atr";
 
@@ -23,11 +36,13 @@ export type ZigzagValue = {
   changePercent: number | null;
 };
 
+/**
+ * Bare state shape for Zigzag. Params (`deviation`, `useAtr`,
+ * `atrPeriod`, `atrMultiplier`) live in `meta.params`; the derived
+ * `maxInitBars` is recomputed in the factory. The inner ATR snapshot
+ * is itself an `IndicatorSnapshot` (or `null` when `useAtr` is false).
+ */
 export type ZigzagState = {
-  deviation: number;
-  useAtr: boolean;
-  atrPeriod: number;
-  atrMultiplier: number;
   trend: "up" | "down" | null;
   lastPivotPrice: number;
   currentHigh: number;
@@ -37,8 +52,17 @@ export type ZigzagState = {
   firstHigh: number;
   firstLow: number;
   count: number;
-  maxInitBars: number;
   atrState: IndicatorSnapshot<AtrState> | null;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const ZIGZAG_VERSION = 1;
+
+type ZigzagParams = {
+  deviation: number;
+  useAtr: boolean;
+  atrPeriod: number;
+  atrMultiplier: number;
 };
 
 const nullValue: ZigzagValue = { point: null, price: null, changePercent: null };
@@ -62,16 +86,30 @@ export function createZigzag(
     atrPeriod?: number;
     atrMultiplier?: number;
   } = {},
-  warmUpOptions?: WarmUpOptions<ZigzagState>,
-): IncrementalIndicator<ZigzagValue, ZigzagState> {
-  const deviation = options.deviation ?? 5;
-  const useAtr = options.useAtr ?? false;
-  const atrPeriod = options.atrPeriod ?? 14;
-  const atrMultiplier = options.atrMultiplier ?? 2;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<ZigzagState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<ZigzagValue, IndicatorSnapshot<ZigzagState>> {
+  const { params, state } = resolveResume<ZigzagParams, ZigzagState>({
+    indicator: "zigzag",
+    version: ZIGZAG_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { deviation: 5, useAtr: false, atrPeriod: 14, atrMultiplier: 2 },
+  });
 
-  if (deviation <= 0) {
-    throw new Error("Zigzag deviation must be positive");
-  }
+  const deviation = requireParam(
+    "zigzag",
+    params,
+    "deviation",
+    (v): v is number => typeof v === "number" && Number.isFinite(v) && v > 0,
+    "must be a positive number",
+  );
+  const useAtr = params.useAtr;
+  const atrPeriod = params.atrPeriod;
+  const atrMultiplier = params.atrMultiplier;
 
   const maxInitBars = Math.max(20, atrPeriod * 2);
 
@@ -86,19 +124,18 @@ export function createZigzag(
   let count: number;
   let atr: IncrementalIndicator<number | null, IndicatorSnapshot<AtrState>> | null;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    trend = s.trend;
-    lastPivotPrice = s.lastPivotPrice;
-    currentHigh = s.currentHigh;
-    currentHighTime = s.currentHighTime;
-    currentLow = s.currentLow;
-    currentLowTime = s.currentLowTime;
-    firstHigh = s.firstHigh;
-    firstLow = s.firstLow;
-    count = s.count;
+  if (state !== null) {
+    trend = state.trend;
+    lastPivotPrice = state.lastPivotPrice;
+    currentHigh = state.currentHigh;
+    currentHighTime = state.currentHighTime;
+    currentLow = state.currentLow;
+    currentLowTime = state.currentLowTime;
+    firstHigh = state.firstHigh;
+    firstLow = state.firstLow;
+    count = state.count;
     atr = useAtr
-      ? createAtr({ period: atrPeriod }, s.atrState ? { fromState: s.atrState } : undefined)
+      ? createAtr({ period: atrPeriod }, state.atrState ? { fromState: state.atrState } : undefined)
       : null;
   } else {
     trend = null;
@@ -118,7 +155,7 @@ export function createZigzag(
     return Math.abs(anchorPrice) * (deviation / 100);
   }
 
-  const indicator: IncrementalIndicator<ZigzagValue, ZigzagState> = {
+  const indicator: IncrementalIndicator<ZigzagValue, IndicatorSnapshot<ZigzagState>> = {
     next(candle: NormalizedCandle) {
       const atrVal = atr ? atr.next(candle).value : null;
       const isFirst = count === 0;
@@ -235,7 +272,7 @@ export function createZigzag(
     },
 
     peek(candle: NormalizedCandle) {
-      const saved = indicator.getState();
+      const saved = indicator.getState().state;
       const result = indicator.next(candle);
       // restore
       trend = saved.trend;
@@ -256,24 +293,24 @@ export function createZigzag(
       return result;
     },
 
-    getState(): ZigzagState {
-      return {
-        deviation,
-        useAtr,
-        atrPeriod,
-        atrMultiplier,
-        trend,
-        lastPivotPrice,
-        currentHigh,
-        currentHighTime,
-        currentLow,
-        currentLowTime,
-        firstHigh,
-        firstLow,
-        count,
-        maxInitBars,
-        atrState: atr ? atr.getState() : null,
-      };
+    getState(): IndicatorSnapshot<ZigzagState> {
+      return makeSnapshot(
+        "zigzag",
+        ZIGZAG_VERSION,
+        { deviation, useAtr, atrPeriod, atrMultiplier },
+        {
+          trend,
+          lastPivotPrice,
+          currentHigh,
+          currentHighTime,
+          currentLow,
+          currentLowTime,
+          firstHigh,
+          firstLow,
+          count,
+          atrState: atr ? atr.getState() : null,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/smc/liquidity-sweep.ts
+++ b/packages/core/src/indicators/incremental/smc/liquidity-sweep.ts
@@ -22,12 +22,21 @@
  * The set of sweeps observed by the live indicator eventually matches batch,
  * but emission lags real time by up to `swingPeriod` bars. Tests compare the
  * multiset of detected sweeps after both sides finish processing.
+ *
+ * State category: **Mixed** (an inner `createSwingPoints` snapshot
+ * plus a `swingPeriod + 1` scan ring buffer). The buffer capacity and
+ * the inner detector are conditioned on construction-time params, so
+ * resume with a different `swingPeriod` / `maxRecoveryBars` /
+ * `maxTrackedSweeps` / `minSweepDepth` is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
 import { createSwingPoints, type SwingPointsState } from "../price/swing-points";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type LiquiditySweep = {
   type: "bullish" | "bearish";
@@ -71,12 +80,14 @@ type BufferedCandle = {
   index: number;
 };
 
+/**
+ * Bare state shape for Liquidity Sweep. Params (`swingPeriod`,
+ * `maxRecoveryBars`, `maxTrackedSweeps`, `minSweepDepth`) live in
+ * `meta.params`; the inner swing-points snapshot is an
+ * `IndicatorSnapshot`.
+ */
 export type LiquiditySweepState = {
-  swingPeriod: number;
-  maxRecoveryBars: number;
-  maxTrackedSweeps: number;
-  minSweepDepth: number;
-  swings: SwingPointsState;
+  swings: IndicatorSnapshot<SwingPointsState>;
   buffer: ReturnType<CircularBuffer<BufferedCandle>["snapshot"]>;
   recentSwingHigh: { level: number; index: number } | null;
   recentSwingLow: { level: number; index: number } | null;
@@ -84,14 +95,36 @@ export type LiquiditySweepState = {
   count: number;
 };
 
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const LIQUIDITY_SWEEP_VERSION = 1;
+
+type LiquiditySweepParams = {
+  swingPeriod: number;
+  maxRecoveryBars: number;
+  maxTrackedSweeps: number;
+  minSweepDepth: number;
+};
+
 export function createLiquiditySweep(
   options: LiquiditySweepOptions = {},
-  warmUpOptions?: WarmUpOptions<LiquiditySweepState>,
-): IncrementalIndicator<LiquiditySweepValue, LiquiditySweepState> {
-  const swingPeriod = options.swingPeriod ?? 5;
-  const maxRecoveryBars = options.maxRecoveryBars ?? 3;
-  const maxTrackedSweeps = options.maxTrackedSweeps ?? 10;
-  const minSweepDepth = options.minSweepDepth ?? 0;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<LiquiditySweepState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<LiquiditySweepValue, IndicatorSnapshot<LiquiditySweepState>> {
+  const { params, state } = resolveResume<LiquiditySweepParams, LiquiditySweepState>({
+    indicator: "liquiditySweep",
+    version: LIQUIDITY_SWEEP_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { swingPeriod: 5, maxRecoveryBars: 3, maxTrackedSweeps: 10, minSweepDepth: 0 },
+  });
+
+  const swingPeriod = params.swingPeriod;
+  const maxRecoveryBars = params.maxRecoveryBars;
+  const maxTrackedSweeps = params.maxTrackedSweeps;
+  const minSweepDepth = params.minSweepDepth;
 
   if (swingPeriod < 1) throw new Error("swingPeriod must be at least 1");
   if (maxRecoveryBars < 1) throw new Error("maxRecoveryBars must be at least 1");
@@ -107,17 +140,16 @@ export function createLiquiditySweep(
   let recentSweeps: LiquiditySweep[];
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
+  if (state !== null) {
     swings = createSwingPoints(
       { leftBars: swingPeriod, rightBars: swingPeriod },
-      { fromState: s.swings },
+      { fromState: state.swings },
     );
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    recentSwingHigh = s.recentSwingHigh ? { ...s.recentSwingHigh } : null;
-    recentSwingLow = s.recentSwingLow ? { ...s.recentSwingLow } : null;
-    recentSweeps = s.recentSweeps.map((sw) => ({ ...sw }));
-    count = s.count;
+    buffer = CircularBuffer.fromSnapshot(state.buffer);
+    recentSwingHigh = state.recentSwingHigh ? { ...state.recentSwingHigh } : null;
+    recentSwingLow = state.recentSwingLow ? { ...state.recentSwingLow } : null;
+    recentSweeps = state.recentSweeps.map((sw) => ({ ...sw }));
+    count = state.count;
   } else {
     swings = createSwingPoints({ leftBars: swingPeriod, rightBars: swingPeriod });
     buffer = new CircularBuffer<BufferedCandle>(bufferCapacity);
@@ -187,7 +219,10 @@ export function createLiquiditySweep(
     return null;
   }
 
-  const indicator: IncrementalIndicator<LiquiditySweepValue, LiquiditySweepState> = {
+  const indicator: IncrementalIndicator<
+    LiquiditySweepValue,
+    IndicatorSnapshot<LiquiditySweepState>
+  > = {
     next(candle: NormalizedCandle) {
       const idx = count;
       buffer.push({
@@ -296,7 +331,7 @@ export function createLiquiditySweep(
     },
 
     peek(candle: NormalizedCandle) {
-      const saved = indicator.getState();
+      const saved = indicator.getState().state;
       const result = indicator.next(candle);
       swings = createSwingPoints(
         { leftBars: swingPeriod, rightBars: swingPeriod },
@@ -310,19 +345,20 @@ export function createLiquiditySweep(
       return result;
     },
 
-    getState(): LiquiditySweepState {
-      return {
-        swingPeriod,
-        maxRecoveryBars,
-        maxTrackedSweeps,
-        minSweepDepth,
-        swings: swings.getState(),
-        buffer: buffer.snapshot(),
-        recentSwingHigh: recentSwingHigh ? { ...recentSwingHigh } : null,
-        recentSwingLow: recentSwingLow ? { ...recentSwingLow } : null,
-        recentSweeps: recentSweeps.map((sw) => ({ ...sw })),
-        count,
-      };
+    getState(): IndicatorSnapshot<LiquiditySweepState> {
+      return makeSnapshot(
+        "liquiditySweep",
+        LIQUIDITY_SWEEP_VERSION,
+        { swingPeriod, maxRecoveryBars, maxTrackedSweeps, minSweepDepth },
+        {
+          swings: swings.getState(),
+          buffer: buffer.snapshot(),
+          recentSwingHigh: recentSwingHigh ? { ...recentSwingHigh } : null,
+          recentSwingLow: recentSwingLow ? { ...recentSwingLow } : null,
+          recentSweeps: recentSweeps.map((sw) => ({ ...sw })),
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/volume/cmf.ts
+++ b/packages/core/src/indicators/incremental/volume/cmf.ts
@@ -1,18 +1,40 @@
 /**
  * Incremental CMF (Chaikin Money Flow)
+ *
+ * State category: **Windowed** (two fixed-size buffers — money-flow
+ * volume and raw volume — plus running sums). Resume with a different
+ * `period` carries both buffers forward and recomputes the running
+ * sums against the new window.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
+/**
+ * Bare state shape for CMF. `period` lives in `meta.params`.
+ */
 export type CmfState = {
-  period: number;
   mfvBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   volBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   mfvSum: number;
   volSum: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const CMF_VERSION = 1;
+
+type CmfParams = {
+  period: number;
 };
 
 /**
@@ -29,9 +51,27 @@ export type CmfState = {
  */
 export function createCmf(
   options: { period?: number } = {},
-  warmUpOptions?: WarmUpOptions<CmfState>,
-): IncrementalIndicator<number | null, CmfState> {
-  const period = options.period ?? 20;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<CmfState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<CmfState>> {
+  const { params, state, reconfigured } = resolveResume<CmfParams, CmfState>({
+    indicator: "cmf",
+    version: CMF_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 20 },
+  });
+
+  const period = requireParam(
+    "cmf",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
 
   let mfvBuffer: CircularBuffer<number>;
   let volBuffer: CircularBuffer<number>;
@@ -39,13 +79,32 @@ export function createCmf(
   let volSum: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    mfvBuffer = CircularBuffer.fromSnapshot(s.mfvBuffer);
-    volBuffer = CircularBuffer.fromSnapshot(s.volBuffer);
-    mfvSum = s.mfvSum;
-    volSum = s.volSum;
-    count = s.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // Period changed — carry both derived buffers forward and
+      // recompute the running sums against the new window.
+      const oldMfv = CircularBuffer.fromSnapshot(state.mfvBuffer);
+      const oldVol = CircularBuffer.fromSnapshot(state.volBuffer);
+      mfvBuffer = new CircularBuffer<number>(period);
+      volBuffer = new CircularBuffer<number>(period);
+      const carry = Math.min(oldMfv.length, period);
+      for (let i = oldMfv.length - carry; i < oldMfv.length; i++) {
+        mfvBuffer.push(oldMfv.get(i));
+        volBuffer.push(oldVol.get(i));
+      }
+      mfvSum = 0;
+      volSum = 0;
+      for (let i = 0; i < mfvBuffer.length; i++) {
+        mfvSum += mfvBuffer.get(i);
+        volSum += volBuffer.get(i);
+      }
+    } else {
+      mfvBuffer = CircularBuffer.fromSnapshot(state.mfvBuffer);
+      volBuffer = CircularBuffer.fromSnapshot(state.volBuffer);
+      mfvSum = state.mfvSum;
+      volSum = state.volSum;
+    }
+    count = state.count;
   } else {
     mfvBuffer = new CircularBuffer<number>(period);
     volBuffer = new CircularBuffer<number>(period);
@@ -60,7 +119,7 @@ export function createCmf(
     return multiplier * candle.volume;
   }
 
-  const indicator: IncrementalIndicator<number | null, CmfState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<CmfState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -78,7 +137,7 @@ export function createCmf(
       mfvBuffer.push(mfv);
       volBuffer.push(vol);
 
-      if (count < period) {
+      if (mfvBuffer.length < period) {
         return { time: candle.time, value: null };
       }
 
@@ -87,7 +146,7 @@ export function createCmf(
     },
 
     peek(candle: NormalizedCandle) {
-      if (count + 1 < period) {
+      if (mfvBuffer.length + 1 < period && !mfvBuffer.isFull) {
         return { time: candle.time, value: null };
       }
 
@@ -109,15 +168,19 @@ export function createCmf(
       return { time: candle.time, value };
     },
 
-    getState(): CmfState {
-      return {
-        period,
-        mfvBuffer: mfvBuffer.snapshot(),
-        volBuffer: volBuffer.snapshot(),
-        mfvSum,
-        volSum,
-        count,
-      };
+    getState(): IndicatorSnapshot<CmfState> {
+      return makeSnapshot(
+        "cmf",
+        CMF_VERSION,
+        { period },
+        {
+          mfvBuffer: mfvBuffer.snapshot(),
+          volBuffer: volBuffer.snapshot(),
+          mfvSum,
+          volSum,
+          count,
+        },
+      );
     },
 
     get count() {
@@ -125,7 +188,7 @@ export function createCmf(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      return mfvBuffer.length >= period;
     },
   };
 

--- a/packages/core/src/indicators/incremental/volume/ease-of-movement.ts
+++ b/packages/core/src/indicators/incremental/volume/ease-of-movement.ts
@@ -4,21 +4,46 @@
  * EMV = ((H+L)/2 - prev(H+L)/2) / ((Volume / divisor) / (H - L))
  * Smoothed with SMA over `period` bars. Windows containing any null
  * raw EMV values produce null output (matching batch behavior).
+ *
+ * State category: **Mixed** (a fixed-size buffer of *derived* raw EMV
+ * values plus a recursive running `sum` and the `prevHigh` / `prevLow`
+ * carry-over needed to compute the next raw EMV). Resume with any
+ * param change is refused — `period` resizes the SMA window and
+ * `volumeDivisor` changes every buffered raw EMV value, so neither can
+ * be reconciled with the saved buffer.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
+/**
+ * Bare state shape for EMV. Params (`period`, `volumeDivisor`) live in
+ * `meta.params`.
+ */
 export type EmvState = {
   prevHigh: number | null;
   prevLow: number | null;
   /** Circular buffer of raw EMV values; NaN marks null slots */
-  buffer: { data: number[]; head: number; length: number; capacity: number };
+  buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   sum: number;
+  count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const EMV_VERSION = 1;
+
+type EmvParams = {
   period: number;
   volumeDivisor: number;
-  count: number;
 };
 
 /**
@@ -35,17 +60,36 @@ export type EmvState = {
  */
 export function createEmv(
   options: { period?: number; volumeDivisor?: number } = {},
-  warmUpOptions?: WarmUpOptions<EmvState>,
-): IncrementalIndicator<number | null, EmvState> {
-  const period = options.period ?? 14;
-  // Resume order: explicit option > persisted state > canonical default
-  // (1e8, matching StockCharts / ChartSchool). Reading the snapshot first
-  // is critical — a state captured under the legacy 10000 divisor would
-  // otherwise jump to 1e8 mid-stream after a library upgrade and produce
-  // a discontinuous EMV at the resume boundary.
-  // Keep in sync with `easeOfMovement()` in indicators/volume/ease-of-movement.ts.
-  const volumeDivisor =
-    options.volumeDivisor ?? warmUpOptions?.fromState?.volumeDivisor ?? 100_000_000;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<EmvState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<EmvState>> {
+  const { params, state } = resolveResume<EmvParams, EmvState>({
+    indicator: "emv",
+    version: EMV_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    // Canonical divisor 1e8, matching StockCharts / ChartSchool and
+    // `easeOfMovement()` in indicators/volume/ease-of-movement.ts.
+    defaults: { period: 14, volumeDivisor: 100_000_000 },
+  });
+
+  const period = requireParam(
+    "emv",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const volumeDivisor = requireParam(
+    "emv",
+    params,
+    "volumeDivisor",
+    (v): v is number => typeof v === "number" && v > 0,
+    "must be a positive number",
+  );
 
   let prevHigh: number | null;
   let prevLow: number | null;
@@ -53,13 +97,12 @@ export function createEmv(
   let sum: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    prevHigh = s.prevHigh;
-    prevLow = s.prevLow;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    sum = s.sum;
-    count = s.count;
+  if (state !== null) {
+    prevHigh = state.prevHigh;
+    prevLow = state.prevLow;
+    buffer = CircularBuffer.fromSnapshot(state.buffer);
+    sum = state.sum;
+    count = state.count;
   } else {
     prevHigh = null;
     prevLow = null;
@@ -92,7 +135,7 @@ export function createEmv(
     return sum / period;
   }
 
-  const indicator: IncrementalIndicator<number | null, EmvState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<EmvState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const raw = computeRawEmv(candle);
@@ -153,16 +196,19 @@ export function createEmv(
       return { time: candle.time, value: peekSum / period };
     },
 
-    getState(): EmvState {
-      return {
-        prevHigh,
-        prevLow,
-        buffer: buffer.snapshot(),
-        sum,
-        period,
-        volumeDivisor,
-        count,
-      };
+    getState(): IndicatorSnapshot<EmvState> {
+      return makeSnapshot(
+        "emv",
+        EMV_VERSION,
+        { period, volumeDivisor },
+        {
+          prevHigh,
+          prevLow,
+          buffer: buffer.snapshot(),
+          sum,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/volume/elder-force-index.ts
+++ b/packages/core/src/indicators/incremental/volume/elder-force-index.ts
@@ -4,19 +4,33 @@
  * Tracks both short-period (entry timing) and long-period (trend bias)
  * EMAs of raw FI(1) = `(close − prevClose) * volume` in lockstep, the
  * canonical Elder pairing.
+ *
+ * State category: **Cascaded** (two recursive EMA stages, each
+ * permanently conditioned on its construction-time period). Resume
+ * with a different `shortPeriod` / `longPeriod` is refused.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type ElderForceIndexValue = {
   short: number | null;
   long: number | null;
 };
 
+/**
+ * Bare state shape for Elder's Force Index. Params (`shortPeriod`,
+ * `longPeriod`) live in `meta.params`.
+ */
 export type ElderForceIndexState = {
-  shortPeriod: number;
-  longPeriod: number;
   prevClose: number | null;
   shortEma: number | null;
   longEma: number | null;
@@ -24,6 +38,14 @@ export type ElderForceIndexState = {
   shortSum: number;
   longSum: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const ELDER_FORCE_INDEX_VERSION = 1;
+
+type ElderForceIndexParams = {
+  shortPeriod: number;
+  longPeriod: number;
 };
 
 /**
@@ -43,23 +65,34 @@ export type ElderForceIndexState = {
  */
 export function createElderForceIndex(
   options: { shortPeriod?: number; longPeriod?: number } = {},
-  warmUpOptions?: WarmUpOptions<ElderForceIndexState>,
-): IncrementalIndicator<ElderForceIndexValue, ElderForceIndexState> {
-  // Resume order: explicit option > persisted state > canonical default.
-  // Reading the snapshot first is critical — a state captured under
-  // custom periods (e.g. shortPeriod=5, longPeriod=20) would otherwise
-  // silently switch to 2 / 13 mid-stream after restore, producing a
-  // discontinuous EMA. Explicit options still win for callers that
-  // intentionally re-parameterize on resume.
-  const shortPeriod = options.shortPeriod ?? warmUpOptions?.fromState?.shortPeriod ?? 2;
-  const longPeriod = options.longPeriod ?? warmUpOptions?.fromState?.longPeriod ?? 13;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<ElderForceIndexState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<ElderForceIndexValue, IndicatorSnapshot<ElderForceIndexState>> {
+  const { params, state } = resolveResume<ElderForceIndexParams, ElderForceIndexState>({
+    indicator: "elderForceIndex",
+    version: ELDER_FORCE_INDEX_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { shortPeriod: 2, longPeriod: 13 },
+  });
 
-  if (shortPeriod < 1) {
-    throw new Error("Elder Force Index shortPeriod must be at least 1");
-  }
-  if (longPeriod < 1) {
-    throw new Error("Elder Force Index longPeriod must be at least 1");
-  }
+  const shortPeriod = requireParam(
+    "elderForceIndex",
+    params,
+    "shortPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const longPeriod = requireParam(
+    "elderForceIndex",
+    params,
+    "longPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
 
   const shortMultiplier = 2 / (shortPeriod + 1);
   const longMultiplier = 2 / (longPeriod + 1);
@@ -71,32 +104,13 @@ export function createElderForceIndex(
   let longSum: number;
   let count: number;
 
-  const fs = warmUpOptions?.fromState ?? null;
-  const periodsMatchSnapshot =
-    fs !== null && fs.shortPeriod === shortPeriod && fs.longPeriod === longPeriod;
-
-  if (fs !== null && periodsMatchSnapshot) {
-    // Full restore — same periods, all EMA state is mathematically valid.
-    prevClose = fs.prevClose;
-    shortEma = fs.shortEma;
-    longEma = fs.longEma;
-    shortSum = fs.shortSum;
-    longSum = fs.longSum;
-    count = fs.count;
-  } else if (fs !== null) {
-    // The caller resumed with explicit periods that differ from the
-    // snapshot — intentional re-parameterization. The previous EMA /
-    // sum / count were accumulated under the old multipliers and can't
-    // be reused; replaying them with new multipliers would produce a
-    // mathematically incorrect series. Reset the EMA state and let the
-    // new periods warm up from scratch. We keep `prevClose` so the
-    // first raw-force computation after resume is still correct.
-    prevClose = fs.prevClose;
-    shortEma = null;
-    longEma = null;
-    shortSum = 0;
-    longSum = 0;
-    count = 0;
+  if (state !== null) {
+    prevClose = state.prevClose;
+    shortEma = state.shortEma;
+    longEma = state.longEma;
+    shortSum = state.shortSum;
+    longSum = state.longSum;
+    count = state.count;
   } else {
     prevClose = null;
     shortEma = null;
@@ -133,7 +147,10 @@ export function createElderForceIndex(
     return { ema: raw * multiplier + (prev ?? 0) * (1 - multiplier), sum };
   }
 
-  const indicator: IncrementalIndicator<ElderForceIndexValue, ElderForceIndexState> = {
+  const indicator: IncrementalIndicator<
+    ElderForceIndexValue,
+    IndicatorSnapshot<ElderForceIndexState>
+  > = {
     next(candle: NormalizedCandle) {
       const raw = computeRawForce(candle);
       count++;
@@ -173,17 +190,20 @@ export function createElderForceIndex(
       };
     },
 
-    getState(): ElderForceIndexState {
-      return {
-        shortPeriod,
-        longPeriod,
-        prevClose,
-        shortEma,
-        longEma,
-        shortSum,
-        longSum,
-        count,
-      };
+    getState(): IndicatorSnapshot<ElderForceIndexState> {
+      return makeSnapshot(
+        "elderForceIndex",
+        ELDER_FORCE_INDEX_VERSION,
+        { shortPeriod, longPeriod },
+        {
+          prevClose,
+          shortEma,
+          longEma,
+          shortSum,
+          longSum,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/volume/klinger.ts
+++ b/packages/core/src/indicators/incremental/volume/klinger.ts
@@ -7,10 +7,18 @@
  * single-pole recursive). The EMAs permanently encode past periods,
  * so resume requires identical `shortPeriod`, `longPeriod`, and
  * `signalPeriod` (or omit them and let the snapshot's params win).
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type KlingerValue = {
   kvo: number | null;
@@ -18,10 +26,12 @@ export type KlingerValue = {
   histogram: number | null;
 };
 
+/**
+ * Bare state shape for Klinger. Params (`shortPeriod`, `longPeriod`,
+ * `signalPeriod`) live in `meta.params`; the three inner EMA states
+ * carry only runtime accumulators.
+ */
 export type KlingerState = {
-  shortPeriod: number;
-  longPeriod: number;
-  signalPeriod: number;
   prevHlc: number | null;
   prevTrend: number;
   cm: number;
@@ -37,6 +47,15 @@ type EmaInternalState = {
   sum: number;
   validCount: number;
   prevEma: number | null;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const KLINGER_VERSION = 1;
+
+type KlingerParams = {
+  shortPeriod: number;
+  longPeriod: number;
+  signalPeriod: number;
 };
 
 /**
@@ -103,13 +122,41 @@ function createInternalEma(
  */
 export function createKlinger(
   options: { shortPeriod?: number; longPeriod?: number; signalPeriod?: number } = {},
-  warmUpOptions?: WarmUpOptions<KlingerState>,
-): IncrementalIndicator<KlingerValue, KlingerState> {
-  // Resume order: explicit option > snapshot value > canonical default.
-  const fs = warmUpOptions?.fromState ?? null;
-  const shortPeriod = options.shortPeriod ?? fs?.shortPeriod ?? 34;
-  const longPeriod = options.longPeriod ?? fs?.longPeriod ?? 55;
-  const signalPeriod = options.signalPeriod ?? fs?.signalPeriod ?? 13;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<KlingerState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<KlingerValue, IndicatorSnapshot<KlingerState>> {
+  const { params, state } = resolveResume<KlingerParams, KlingerState>({
+    indicator: "klinger",
+    version: KLINGER_VERSION,
+    category: "cascaded",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { shortPeriod: 34, longPeriod: 55, signalPeriod: 13 },
+  });
+
+  const shortPeriod = requireParam(
+    "klinger",
+    params,
+    "shortPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const longPeriod = requireParam(
+    "klinger",
+    params,
+    "longPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const signalPeriod = requireParam(
+    "klinger",
+    params,
+    "signalPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
 
   let prevHlc: number | null;
   let prevTrend: number;
@@ -119,23 +166,14 @@ export function createKlinger(
   let signalEma: ReturnType<typeof createInternalEma>;
   let count: number;
 
-  if (fs) {
-    // Cascaded: three internal recursive EMAs permanently encode past
-    // periods, so reconfiguring mid-stream produces a hybrid series.
-    if (
-      fs.shortPeriod !== shortPeriod ||
-      fs.longPeriod !== longPeriod ||
-      fs.signalPeriod !== signalPeriod
-    ) {
-      throw new Error("Klinger: incompatible snapshot, re-warm required");
-    }
-    prevHlc = fs.prevHlc;
-    prevTrend = fs.prevTrend;
-    cm = fs.cm;
-    shortEma = createInternalEma(shortPeriod, fs.shortEma);
-    longEma = createInternalEma(longPeriod, fs.longEma);
-    signalEma = createInternalEma(signalPeriod, fs.signalEma);
-    count = fs.count;
+  if (state !== null) {
+    prevHlc = state.prevHlc;
+    prevTrend = state.prevTrend;
+    cm = state.cm;
+    shortEma = createInternalEma(shortPeriod, state.shortEma);
+    longEma = createInternalEma(longPeriod, state.longEma);
+    signalEma = createInternalEma(signalPeriod, state.signalEma);
+    count = state.count;
   } else {
     prevHlc = null;
     prevTrend = 1;
@@ -169,7 +207,7 @@ export function createKlinger(
     return { vf, newHlc: hlc, newTrend: trend, newCm };
   }
 
-  const indicator: IncrementalIndicator<KlingerValue, KlingerState> = {
+  const indicator: IncrementalIndicator<KlingerValue, IndicatorSnapshot<KlingerState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -226,19 +264,21 @@ export function createKlinger(
       return { time: candle.time, value: { kvo, signal, histogram } };
     },
 
-    getState(): KlingerState {
-      return {
-        shortPeriod,
-        longPeriod,
-        signalPeriod,
-        prevHlc,
-        prevTrend,
-        cm,
-        shortEma: shortEma.getState(),
-        longEma: longEma.getState(),
-        signalEma: signalEma.getState(),
-        count,
-      };
+    getState(): IndicatorSnapshot<KlingerState> {
+      return makeSnapshot(
+        "klinger",
+        KLINGER_VERSION,
+        { shortPeriod, longPeriod, signalPeriod },
+        {
+          prevHlc,
+          prevTrend,
+          cm,
+          shortEma: shortEma.getState(),
+          longEma: longEma.getState(),
+          signalEma: signalEma.getState(),
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/volume/mfi.ts
+++ b/packages/core/src/indicators/incremental/volume/mfi.ts
@@ -11,23 +11,42 @@
  * 5. MFI = 100 - 100 / (1 + Positive MF / Negative MF)
  *
  * Uses CircularBuffer to store money flow direction/amount for the lookback window.
+ *
+ * State category: **Mixed** (a fixed-size buffer of *derived* signed
+ * money flows plus the recursive `prevTp` carry-over needed to sign
+ * the next flow). Resume with a different `period` is refused — the
+ * window length is baked into the buffered flows.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 /**
- * State for incremental MFI
+ * Bare state shape for MFI. `period` lives in `meta.params`.
  */
 export type MfiState = {
-  period: number;
   prevTp: number | null;
   /** Buffer stores signed money flows: positive=up, negative=down, 0=unchanged */
   flowBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   positiveSum: number;
   negativeSum: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const MFI_VERSION = 1;
+
+type MfiParams = {
+  period: number;
 };
 
 /**
@@ -43,10 +62,28 @@ export type MfiState = {
  * ```
  */
 export function createMfi(
-  options: { period: number },
-  warmUpOptions?: WarmUpOptions<MfiState>,
-): IncrementalIndicator<number | null, MfiState> {
-  const period = options.period;
+  options: { period?: number } = {},
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<MfiState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<number | null, IndicatorSnapshot<MfiState>> {
+  const { params, state } = resolveResume<MfiParams, MfiState>({
+    indicator: "mfi",
+    version: MFI_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { period: 14 },
+  });
+
+  const period = requireParam(
+    "mfi",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
 
   let prevTp: number | null;
   let flowBuffer: CircularBuffer<number>;
@@ -54,13 +91,12 @@ export function createMfi(
   let negativeSum: number;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    prevTp = s.prevTp;
-    flowBuffer = CircularBuffer.fromSnapshot(s.flowBuffer);
-    positiveSum = s.positiveSum;
-    negativeSum = s.negativeSum;
-    count = s.count;
+  if (state !== null) {
+    prevTp = state.prevTp;
+    flowBuffer = CircularBuffer.fromSnapshot(state.flowBuffer);
+    positiveSum = state.positiveSum;
+    negativeSum = state.negativeSum;
+    count = state.count;
   } else {
     prevTp = null;
     flowBuffer = new CircularBuffer<number>(period);
@@ -117,7 +153,7 @@ export function createMfi(
     return 100 - 100 / (1 + ratio);
   }
 
-  const indicator: IncrementalIndicator<number | null, MfiState> = {
+  const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<MfiState>> = {
     next(candle: NormalizedCandle) {
       const value = computeNext(candle);
       return { time: candle.time, value };
@@ -125,28 +161,37 @@ export function createMfi(
 
     peek(candle: NormalizedCandle) {
       // Save and restore for peek
-      const savedState = indicator.getState();
+      const savedTp = prevTp;
+      const savedBuffer = flowBuffer.snapshot();
+      const savedPositive = positiveSum;
+      const savedNegative = negativeSum;
+      const savedCount = count;
+
       const result = indicator.next(candle);
 
       // Restore
-      prevTp = savedState.prevTp;
-      flowBuffer = CircularBuffer.fromSnapshot(savedState.flowBuffer);
-      positiveSum = savedState.positiveSum;
-      negativeSum = savedState.negativeSum;
-      count = savedState.count;
+      prevTp = savedTp;
+      flowBuffer = CircularBuffer.fromSnapshot(savedBuffer);
+      positiveSum = savedPositive;
+      negativeSum = savedNegative;
+      count = savedCount;
 
       return result;
     },
 
-    getState(): MfiState {
-      return {
-        period,
-        prevTp,
-        flowBuffer: flowBuffer.snapshot(),
-        positiveSum,
-        negativeSum,
-        count,
-      };
+    getState(): IndicatorSnapshot<MfiState> {
+      return makeSnapshot(
+        "mfi",
+        MFI_VERSION,
+        { period },
+        {
+          prevTp,
+          flowBuffer: flowBuffer.snapshot(),
+          positiveSum,
+          negativeSum,
+          count,
+        },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/volume/volume-anomaly.ts
+++ b/packages/core/src/indicators/incremental/volume/volume-anomaly.ts
@@ -2,20 +2,45 @@
  * Incremental Volume Anomaly Detection
  *
  * Detects abnormal volume spikes using ratio and z-score methods.
+ *
+ * State category: **Windowed** (a single fixed-size raw volume
+ * buffer). Resume with a different `period` carries the raw volume
+ * buffer forward. `highThreshold` / `extremeThreshold` / `useZScore` /
+ * `zScoreThreshold` are resume-invariant — they only classify the
+ * already-computed ratio / z-score, never the buffer.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, VolumeAnomalyValue } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
+/**
+ * Bare state shape for Volume Anomaly. Params (`period`,
+ * `highThreshold`, `extremeThreshold`, `useZScore`, `zScoreThreshold`)
+ * live in `meta.params`.
+ */
 export type VolumeAnomalyState = {
+  buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
+  count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const VOLUME_ANOMALY_VERSION = 1;
+
+type VolumeAnomalyParams = {
   period: number;
   highThreshold: number;
   extremeThreshold: number;
   useZScore: boolean;
   zScoreThreshold: number;
-  buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
-  count: number;
 };
 
 /**
@@ -38,21 +63,55 @@ export function createVolumeAnomaly(
     useZScore?: boolean;
     zScoreThreshold?: number;
   } = {},
-  warmUpOptions?: WarmUpOptions<VolumeAnomalyState>,
-): IncrementalIndicator<VolumeAnomalyValue, VolumeAnomalyState> {
-  const period = options.period ?? 20;
-  const highThreshold = options.highThreshold ?? 2.0;
-  const extremeThreshold = options.extremeThreshold ?? 3.0;
-  const useZScore = options.useZScore ?? true;
-  const zScoreThreshold = options.zScoreThreshold ?? 2.0;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<VolumeAnomalyState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<VolumeAnomalyValue, IndicatorSnapshot<VolumeAnomalyState>> {
+  const { params, state, reconfigured } = resolveResume<VolumeAnomalyParams, VolumeAnomalyState>({
+    indicator: "volumeAnomaly",
+    version: VOLUME_ANOMALY_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: {
+      period: 20,
+      highThreshold: 2.0,
+      extremeThreshold: 3.0,
+      useZScore: true,
+      zScoreThreshold: 2.0,
+    },
+    resumeInvariantParams: ["highThreshold", "extremeThreshold", "useZScore", "zScoreThreshold"],
+  });
+
+  const period = requireParam(
+    "volumeAnomaly",
+    params,
+    "period",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const highThreshold = params.highThreshold;
+  const extremeThreshold = params.extremeThreshold;
+  const useZScore = params.useZScore;
+  const zScoreThreshold = params.zScoreThreshold;
 
   let buffer: CircularBuffer<number>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    buffer = CircularBuffer.fromSnapshot(s.buffer);
-    count = s.count;
+  if (state !== null) {
+    if (reconfigured) {
+      // Period changed — carry the raw volume buffer forward.
+      const old = CircularBuffer.fromSnapshot(state.buffer);
+      buffer = new CircularBuffer<number>(period);
+      const carry = Math.min(old.length, period);
+      for (let i = old.length - carry; i < old.length; i++) {
+        buffer.push(old.get(i));
+      }
+    } else {
+      buffer = CircularBuffer.fromSnapshot(state.buffer);
+    }
+    count = state.count;
   } else {
     buffer = new CircularBuffer<number>(period);
     count = 0;
@@ -110,7 +169,10 @@ export function createVolumeAnomaly(
     return { volume, avgVolume, ratio, isAnomaly, level, zScore };
   }
 
-  const indicator: IncrementalIndicator<VolumeAnomalyValue, VolumeAnomalyState> = {
+  const indicator: IncrementalIndicator<
+    VolumeAnomalyValue,
+    IndicatorSnapshot<VolumeAnomalyState>
+  > = {
     next(candle: NormalizedCandle) {
       count++;
       buffer.push(candle.volume);
@@ -125,16 +187,13 @@ export function createVolumeAnomaly(
       return { time: candle.time, value: computeFromBuffer(candle.volume, peekBuf) };
     },
 
-    getState(): VolumeAnomalyState {
-      return {
-        period,
-        highThreshold,
-        extremeThreshold,
-        useZScore,
-        zScoreThreshold,
-        buffer: buffer.snapshot(),
-        count,
-      };
+    getState(): IndicatorSnapshot<VolumeAnomalyState> {
+      return makeSnapshot(
+        "volumeAnomaly",
+        VOLUME_ANOMALY_VERSION,
+        { period, highThreshold, extremeThreshold, useZScore, zScoreThreshold },
+        { buffer: buffer.snapshot(), count },
+      );
     },
 
     get count() {
@@ -142,7 +201,7 @@ export function createVolumeAnomaly(
     },
 
     get isWarmedUp() {
-      return count >= period;
+      return buffer.length >= period;
     },
   };
 

--- a/packages/core/src/indicators/incremental/volume/volume-trend.ts
+++ b/packages/core/src/indicators/incremental/volume/volume-trend.ts
@@ -3,22 +3,47 @@
  *
  * Analyzes whether volume confirms or diverges from price trend
  * using rolling windows for price linear regression and volume comparison.
+ *
+ * State category: **Windowed** (three fixed-size raw buffers — closes,
+ * volumes, and volume-MA volumes — plus a running volume sum). Resume
+ * with different `pricePeriod` / `volumePeriod` / `maPeriod` carries
+ * the raw buffers forward at the new capacities and recomputes the
+ * volume-MA running sum. `minPriceChange` is resume-invariant — it
+ * only classifies the already-computed trend, never the buffers.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle, VolumeTrendValue } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
+/**
+ * Bare state shape for Volume Trend. Params (`pricePeriod`,
+ * `volumePeriod`, `maPeriod`, `minPriceChange`) live in `meta.params`.
+ */
 export type VolumeTrendState = {
   priceBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   volumeBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
   volumeSum: number;
   volumeMaBuffer: ReturnType<CircularBuffer<number>["snapshot"]>;
+  count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const VOLUME_TREND_VERSION = 1;
+
+type VolumeTrendParams = {
   pricePeriod: number;
   volumePeriod: number;
   maPeriod: number;
   minPriceChange: number;
-  count: number;
 };
 
 /**
@@ -51,13 +76,43 @@ export function createVolumeTrend(
     maPeriod?: number;
     minPriceChange?: number;
   } = {},
-  warmUpOptions?: WarmUpOptions<VolumeTrendState>,
-): IncrementalIndicator<VolumeTrendValue, VolumeTrendState> {
-  const pricePeriod = options.pricePeriod ?? 10;
-  const volumePeriod = options.volumePeriod ?? 10;
-  const maPeriod = options.maPeriod ?? 20;
-  const minPriceChange = options.minPriceChange ?? 2.0;
-  const minPeriod = Math.max(pricePeriod, volumePeriod, maPeriod);
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<VolumeTrendState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<VolumeTrendValue, IndicatorSnapshot<VolumeTrendState>> {
+  const { params, state, reconfigured } = resolveResume<VolumeTrendParams, VolumeTrendState>({
+    indicator: "volumeTrend",
+    version: VOLUME_TREND_VERSION,
+    category: "windowed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { pricePeriod: 10, volumePeriod: 10, maPeriod: 20, minPriceChange: 2.0 },
+    resumeInvariantParams: ["minPriceChange"],
+  });
+
+  const pricePeriod = requireParam(
+    "volumeTrend",
+    params,
+    "pricePeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const volumePeriod = requireParam(
+    "volumeTrend",
+    params,
+    "volumePeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const maPeriod = requireParam(
+    "volumeTrend",
+    params,
+    "maPeriod",
+    (v): v is number => Number.isInteger(v) && v >= 1,
+    "must be a positive integer",
+  );
+  const minPriceChange = params.minPriceChange;
 
   let priceBuffer: CircularBuffer<number>;
   let volumeBuffer: CircularBuffer<number>;
@@ -65,13 +120,38 @@ export function createVolumeTrend(
   let volumeMaBuffer: CircularBuffer<number>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    priceBuffer = CircularBuffer.fromSnapshot(s.priceBuffer);
-    volumeBuffer = CircularBuffer.fromSnapshot(s.volumeBuffer);
-    volumeSum = s.volumeSum;
-    volumeMaBuffer = CircularBuffer.fromSnapshot(s.volumeMaBuffer);
-    count = s.count;
+  /** Rebuild a buffer at `capacity`, carrying the most recent values forward. */
+  function carryBuffer(
+    snapshot: ReturnType<CircularBuffer<number>["snapshot"]>,
+    capacity: number,
+  ): CircularBuffer<number> {
+    const old = CircularBuffer.fromSnapshot(snapshot);
+    const next = new CircularBuffer<number>(capacity);
+    const carry = Math.min(old.length, capacity);
+    for (let i = old.length - carry; i < old.length; i++) {
+      next.push(old.get(i));
+    }
+    return next;
+  }
+
+  if (state !== null) {
+    if (reconfigured) {
+      // One or more periods changed — carry every raw buffer forward
+      // at its new capacity and recompute the volume-MA running sum.
+      priceBuffer = carryBuffer(state.priceBuffer, pricePeriod);
+      volumeBuffer = carryBuffer(state.volumeBuffer, volumePeriod);
+      volumeMaBuffer = carryBuffer(state.volumeMaBuffer, maPeriod);
+      volumeSum = 0;
+      for (let i = 0; i < volumeMaBuffer.length; i++) {
+        volumeSum += volumeMaBuffer.get(i);
+      }
+    } else {
+      priceBuffer = CircularBuffer.fromSnapshot(state.priceBuffer);
+      volumeBuffer = CircularBuffer.fromSnapshot(state.volumeBuffer);
+      volumeMaBuffer = CircularBuffer.fromSnapshot(state.volumeMaBuffer);
+      volumeSum = state.volumeSum;
+    }
+    count = state.count;
   } else {
     priceBuffer = new CircularBuffer<number>(pricePeriod);
     volumeBuffer = new CircularBuffer<number>(volumePeriod);
@@ -228,7 +308,9 @@ export function createVolumeTrend(
     volumeSum += candle.volume;
     volumeMaBuffer.push(candle.volume);
 
-    if (count < minPeriod) {
+    // Gate on buffer fill, not `count`: after a period-growing resume
+    // the carried buffers are shorter than the old `count`.
+    if (!priceBuffer.isFull || !volumeBuffer.isFull || !volumeMaBuffer.isFull) {
       return neutralValue;
     }
 
@@ -237,7 +319,7 @@ export function createVolumeTrend(
     return evaluate(priceTrend, volTrend);
   }
 
-  const indicator: IncrementalIndicator<VolumeTrendValue, VolumeTrendState> = {
+  const indicator: IncrementalIndicator<VolumeTrendValue, IndicatorSnapshot<VolumeTrendState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const value = processCandle(candle);
@@ -245,11 +327,14 @@ export function createVolumeTrend(
     },
 
     peek(candle: NormalizedCandle) {
-      // For peek we need to simulate without mutating state
-      // Create temporary copies of buffers
-      const peekCount = count + 1;
-
-      if (peekCount < minPeriod) {
+      // For peek we simulate without mutating state. After the
+      // simulated push each buffer is full iff it currently holds
+      // at least `period - 1` values.
+      if (
+        priceBuffer.length < pricePeriod - 1 ||
+        volumeBuffer.length < volumePeriod - 1 ||
+        volumeMaBuffer.length < maPeriod - 1
+      ) {
         return { time: candle.time, value: neutralValue };
       }
 
@@ -342,18 +427,19 @@ export function createVolumeTrend(
       return { time: candle.time, value: evaluate(priceTrend, volTrend) };
     },
 
-    getState(): VolumeTrendState {
-      return {
-        priceBuffer: priceBuffer.snapshot(),
-        volumeBuffer: volumeBuffer.snapshot(),
-        volumeSum,
-        volumeMaBuffer: volumeMaBuffer.snapshot(),
-        pricePeriod,
-        volumePeriod,
-        maPeriod,
-        minPriceChange,
-        count,
-      };
+    getState(): IndicatorSnapshot<VolumeTrendState> {
+      return makeSnapshot(
+        "volumeTrend",
+        VOLUME_TREND_VERSION,
+        { pricePeriod, volumePeriod, maPeriod, minPriceChange },
+        {
+          priceBuffer: priceBuffer.snapshot(),
+          volumeBuffer: volumeBuffer.snapshot(),
+          volumeSum,
+          volumeMaBuffer: volumeMaBuffer.snapshot(),
+          count,
+        },
+      );
     },
 
     get count() {
@@ -361,7 +447,7 @@ export function createVolumeTrend(
     },
 
     get isWarmedUp() {
-      return count >= minPeriod;
+      return priceBuffer.isFull && volumeBuffer.isFull && volumeMaBuffer.isFull;
     },
   };
 

--- a/packages/core/src/indicators/incremental/volume/weis-wave.ts
+++ b/packages/core/src/indicators/incremental/volume/weis-wave.ts
@@ -3,23 +3,46 @@
  *
  * Accumulates volume within directional price waves.
  * When price direction reverses (exceeding threshold), a new wave begins.
+ *
+ * State category: **Recursive** (`waveVolume` is a cumulative
+ * accumulator whose reset points depend on `method` / `threshold`).
+ * Resume with a different `method` or `threshold` is refused — the
+ * saved wave was accumulated under the old reversal rule.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireParam,
+  resolveResume,
+} from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 
 export type WeisWaveValue = {
   waveVolume: number;
   direction: "up" | "down";
 };
 
+/**
+ * Bare state shape for Weis Wave. Params (`method`, `threshold`) live
+ * in `meta.params`.
+ */
 export type WeisWaveState = {
   waveVolume: number;
   direction: "up" | "down";
   prevCandle: { close: number; high: number; low: number } | null;
-  method: string;
-  threshold: number;
   count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const WEIS_WAVE_VERSION = 1;
+
+type WeisWaveParams = {
+  method: "close" | "highlow";
+  threshold: number;
 };
 
 /**
@@ -40,22 +63,45 @@ export type WeisWaveState = {
  */
 export function createWeisWave(
   options: { method?: "close" | "highlow"; threshold?: number } = {},
-  warmUpOptions?: WarmUpOptions<WeisWaveState>,
-): IncrementalIndicator<WeisWaveValue, WeisWaveState> {
-  const method = options.method ?? "close";
-  const threshold = options.threshold ?? 0;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<WeisWaveState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<WeisWaveValue, IndicatorSnapshot<WeisWaveState>> {
+  const { params, state } = resolveResume<WeisWaveParams, WeisWaveState>({
+    indicator: "weisWave",
+    version: WEIS_WAVE_VERSION,
+    category: "recursive",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: { method: "close", threshold: 0 },
+  });
+
+  const method = requireParam(
+    "weisWave",
+    params,
+    "method",
+    (v): v is "close" | "highlow" => v === "close" || v === "highlow",
+    'must be "close" or "highlow"',
+  );
+  const threshold = requireParam(
+    "weisWave",
+    params,
+    "threshold",
+    (v): v is number => typeof v === "number" && v >= 0,
+    "must be a non-negative number",
+  );
 
   let waveVolume: number;
   let direction: "up" | "down";
   let prevCandle: { close: number; high: number; low: number } | null;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    waveVolume = s.waveVolume;
-    direction = s.direction;
-    prevCandle = s.prevCandle;
-    count = s.count;
+  if (state !== null) {
+    waveVolume = state.waveVolume;
+    direction = state.direction;
+    prevCandle = state.prevCandle;
+    count = state.count;
   } else {
     waveVolume = 0;
     direction = "up";
@@ -96,7 +142,7 @@ export function createWeisWave(
     return { waveVolume, direction };
   }
 
-  const indicator: IncrementalIndicator<WeisWaveValue, WeisWaveState> = {
+  const indicator: IncrementalIndicator<WeisWaveValue, IndicatorSnapshot<WeisWaveState>> = {
     next(candle: NormalizedCandle) {
       count++;
       const value = processCandle(candle);
@@ -128,8 +174,13 @@ export function createWeisWave(
       return { time: candle.time, value: { waveVolume: peekVolume, direction: peekDir } };
     },
 
-    getState(): WeisWaveState {
-      return { waveVolume, direction, prevCandle, method, threshold, count };
+    getState(): IndicatorSnapshot<WeisWaveState> {
+      return makeSnapshot(
+        "weisWave",
+        WEIS_WAVE_VERSION,
+        { method, threshold },
+        { waveVolume, direction, prevCandle, count },
+      );
     },
 
     get count() {

--- a/packages/core/src/indicators/incremental/wyckoff/vsa.ts
+++ b/packages/core/src/indicators/incremental/wyckoff/vsa.ts
@@ -7,14 +7,25 @@
  *
  * Based on Richard Wyckoff's principles of reading the market through
  * volume and price action.
+ *
+ * State category: **Mixed** (an inner recursive ATR snapshot and an
+ * inner windowed SMA snapshot composed with an own 10-bar candle
+ * buffer). `volumeMaPeriod` / `atrPeriod` shape the inner indicators
+ * and are refused on resume. The four threshold params
+ * (`highVolumeThreshold`, `lowVolumeThreshold`, `wideSpreadThreshold`,
+ * `narrowSpreadThreshold`) are **resume-invariant** — they only
+ * classify already-computed spread / volume ratios and never touch
+ * state, so changing them on resume is mathematically safe.
+ *
+ * Migrated to the 0.4.0 State Contract.
  */
 
 import type { NormalizedCandle } from "../../../types";
 import { CircularBuffer } from "../circular-buffer";
 import type { SmaState } from "../moving-average/sma";
 import { createSma } from "../moving-average/sma";
-import type { IndicatorSnapshot } from "../state-contract";
-import type { IncrementalIndicator, WarmUpOptions } from "../types";
+import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import type { IncrementalIndicator } from "../types";
 import type { AtrState } from "../volatility/atr";
 import { createAtr } from "../volatility/atr";
 
@@ -53,17 +64,28 @@ type CandleEntry = {
   close: number;
 };
 
+/**
+ * Bare state shape for VSA. Params (`volumeMaPeriod`, `atrPeriod`,
+ * threshold params) live in `meta.params`; the inner ATR / SMA
+ * snapshots are themselves `IndicatorSnapshot`s.
+ */
 export type VsaState = {
   atrState: IndicatorSnapshot<AtrState>;
   volumeSmaState: IndicatorSnapshot<SmaState>;
   candleBuffer: ReturnType<CircularBuffer<CandleEntry>["snapshot"]>;
+  count: number;
+};
+
+/** Per-indicator schema version. Bumped on any breaking state change. */
+export const VSA_VERSION = 1;
+
+type VsaParams = {
   volumeMaPeriod: number;
   atrPeriod: number;
   highVolumeThreshold: number;
   lowVolumeThreshold: number;
   wideSpreadThreshold: number;
   narrowSpreadThreshold: number;
-  count: number;
 };
 
 export type VsaOptions = {
@@ -186,14 +208,39 @@ function classifyBar(
  */
 export function createVsa(
   options: VsaOptions = {},
-  warmUpOptions?: WarmUpOptions<VsaState>,
-): IncrementalIndicator<VsaValue, VsaState> {
-  const volumeMaPeriod = options.volumeMaPeriod ?? 20;
-  const atrPeriod = options.atrPeriod ?? 14;
-  const highVolumeThreshold = options.highVolumeThreshold ?? 1.5;
-  const lowVolumeThreshold = options.lowVolumeThreshold ?? 0.7;
-  const wideSpreadThreshold = options.wideSpreadThreshold ?? 1.2;
-  const narrowSpreadThreshold = options.narrowSpreadThreshold ?? 0.7;
+  warmUpOptions?: {
+    fromState?: IndicatorSnapshot<VsaState>;
+    warmUp?: NormalizedCandle[];
+  },
+): IncrementalIndicator<VsaValue, IndicatorSnapshot<VsaState>> {
+  const { params, state } = resolveResume<VsaParams, VsaState>({
+    indicator: "vsa",
+    version: VSA_VERSION,
+    category: "mixed",
+    options,
+    fromState: warmUpOptions?.fromState ?? null,
+    defaults: {
+      volumeMaPeriod: 20,
+      atrPeriod: 14,
+      highVolumeThreshold: 1.5,
+      lowVolumeThreshold: 0.7,
+      wideSpreadThreshold: 1.2,
+      narrowSpreadThreshold: 0.7,
+    },
+    resumeInvariantParams: [
+      "highVolumeThreshold",
+      "lowVolumeThreshold",
+      "wideSpreadThreshold",
+      "narrowSpreadThreshold",
+    ],
+  });
+
+  const volumeMaPeriod = params.volumeMaPeriod;
+  const atrPeriod = params.atrPeriod;
+  const highVolumeThreshold = params.highVolumeThreshold;
+  const lowVolumeThreshold = params.lowVolumeThreshold;
+  const wideSpreadThreshold = params.wideSpreadThreshold;
+  const narrowSpreadThreshold = params.narrowSpreadThreshold;
 
   // 10-bar candle buffer for test detection (needs lookback of 10)
   const candleBufferSize = 10;
@@ -203,15 +250,14 @@ export function createVsa(
   let candleBuffer: CircularBuffer<CandleEntry>;
   let count: number;
 
-  if (warmUpOptions?.fromState) {
-    const s = warmUpOptions.fromState;
-    atrIndicator = createAtr({ period: atrPeriod }, { fromState: s.atrState });
+  if (state !== null) {
+    atrIndicator = createAtr({ period: atrPeriod }, { fromState: state.atrState });
     volumeSma = createSma(
       { period: volumeMaPeriod, source: "volume" },
-      { fromState: s.volumeSmaState },
+      { fromState: state.volumeSmaState },
     );
-    candleBuffer = CircularBuffer.fromSnapshot(s.candleBuffer);
-    count = s.count;
+    candleBuffer = CircularBuffer.fromSnapshot(state.candleBuffer);
+    count = state.count;
   } else {
     atrIndicator = createAtr({ period: atrPeriod });
     volumeSma = createSma({ period: volumeMaPeriod, source: "volume" });
@@ -231,7 +277,7 @@ export function createVsa(
     return { spreadRelative, closePosition, volumeRelative };
   }
 
-  const indicator: IncrementalIndicator<VsaValue, VsaState> = {
+  const indicator: IncrementalIndicator<VsaValue, IndicatorSnapshot<VsaState>> = {
     next(candle: NormalizedCandle) {
       count++;
 
@@ -343,19 +389,25 @@ export function createVsa(
       };
     },
 
-    getState(): VsaState {
-      return {
-        atrState: atrIndicator.getState(),
-        volumeSmaState: volumeSma.getState(),
-        candleBuffer: candleBuffer.snapshot(),
-        volumeMaPeriod,
-        atrPeriod,
-        highVolumeThreshold,
-        lowVolumeThreshold,
-        wideSpreadThreshold,
-        narrowSpreadThreshold,
-        count,
-      };
+    getState(): IndicatorSnapshot<VsaState> {
+      return makeSnapshot(
+        "vsa",
+        VSA_VERSION,
+        {
+          volumeMaPeriod,
+          atrPeriod,
+          highVolumeThreshold,
+          lowVolumeThreshold,
+          wideSpreadThreshold,
+          narrowSpreadThreshold,
+        },
+        {
+          atrState: atrIndicator.getState(),
+          volumeSmaState: volumeSma.getState(),
+          candleBuffer: candleBuffer.snapshot(),
+          count,
+        },
+      );
     },
 
     get count() {


### PR DESCRIPTION
## Summary

Wave 3 Bundle L2-L5 — the final implementation PR of the State Contract epic. Migrates the remaining **39 incremental indicators** to the 0.4.0 State Contract, completing the epic: every incremental indicator now returns `IndicatorSnapshot<TState>` from `getState()`.

4 commits, one per Bundle:

| Commit | Bundle | Scope |
|---|---|---|
| `e75b771` | L2 | momentum 13 (Aroon, AO, BOP, CCI, DPO, Hurst, IMI, KST, QStick, Stochastics, Ultimate Osc, Vortex, Williams %R) |
| `02ca23c` | L3 | volume 8 (CMF, EOM, EFI, Klinger, MFI, Volume Anomaly, Volume Trend, Weis Wave) |
| `324b61d` | L4 | price 14 + smc 1 + wyckoff 1 + filter 2 |
| `d6faecd` | L5 | docs (migration guide, CHANGELOG, STATE_CONTRACT.md) + describeContract coverage + test updates |

## Key decisions

- **Windowed warmup gates** key on buffer fill, not a monotonic `count`, so a period-growing resume re-warms correctly rather than emitting from a truncated window.
- **Price-structure indicators are Mixed, not Event.** Their detection params (`swingPeriod`, `minGapPercent`, `maxActiveFvgs`, …) shape which structure / gaps / swings were recorded, so a param change cannot reproduce a fresh run and is refused. The Event category is left intentionally unused by the current indicator set.
- **Resume-invariant params** (param-role axis): `cci.constant`, `hurst.minWindow`, Volume Anomaly thresholds, `volumeTrend.minPriceChange`, `pivotPoints.method`.
- `swing-helpers` is a shared helper with no factory — not migrated.

## Review trail

Codex review ran 6 rounds. Rounds 1-5 surfaced two systematic weaknesses in the bulk migration — count-based windowed warmup gates and Event-category misclassification — each fixed together with its same-shape siblings. A manual audit then verified all 25 windowed indicators' warmup gates (the count-gate failure is invisible to invariant [4], which skips the reconfig margin). Round 6 came back clean.

## Carve-outs (pre-existing batch drift, 0.5.0 consistency-audit items)

`batchCompute` is omitted for DPO, Volume Trend, and the swing/structure indicators — their batch siblings use look-ahead confirmation or retroactive fill passes, so they are intentionally shift-offset / not bar-aligned. Not migration regressions (next/peek logic unchanged). Invariants [1]-[7][9] still run for these.

## Test plan

- [x] `pnpm test` — core 5973 passing
- [x] `pnpm lint` — clean
- [x] `pnpm build` — success
- [x] `tsc --noEmit --ignoreDeprecations 6.0` — pre-existing errors only, 0 new