### PR TITLE
fix(core): align incremental Volume Trend / Chandelier Exit with batch

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -73,6 +73,30 @@ plus structural equality after parse. No production behavior change;
 this is regression coverage for the JSON layer that downstream
 consumers (MCP, Strategy Studio, Strategy DNA) all build on.
 
+### Fixed — incremental Volume Trend / Chandelier Exit match their batch functions
+
+Two incremental indicators diverged from their batch counterparts
+on a handful of bars; both are now corrected so the streaming and
+batch APIs produce identical output.
+
+- **Volume Trend** — when the price trend was `neutral`, the
+  incremental `createVolumeTrend` discarded the `volumeTrend`
+  reading and reported `volumeTrend: "neutral"`. The volume trend
+  is an independent measurement and is now reported on every bar,
+  matching batch `volumeTrend()`. `isConfirmed` / `hasDivergence` /
+  `confidence` are still zeroed when the price trend is neutral.
+- **Chandelier Exit** — the incremental `createChandelierExit`
+  emitted a running partial `highestHigh` / `lowestLow` during the
+  warmup period, while batch `chandelierExit()` (and the library's
+  `highest()` / `lowest()`) report `null` until the lookback window
+  is full. The incremental now reports `null` for these fields
+  during warmup. The actual exit levels (`longExit` / `shortExit` /
+  `direction`) were already correct and are unchanged.
+
+The `consistency.test.ts` suite now also asserts the previously
+unchecked `highestHigh` / `lowestLow` / `atr` fields and gains a
+Volume Trend batch-parity block.
+
 ### Fixed — GARCH / EWMA volatility input and stationarity guards
 
 - `garch(returns)` and `ewmaVolatility(returns)` now throw early when

--- a/packages/core/src/indicators/incremental/__tests__/consistency.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/consistency.test.ts
@@ -12,6 +12,7 @@ import type {
   MacdValue,
   NormalizedCandle,
   VolumeAnomalyValue,
+  VolumeTrendValue,
 } from "../../../types";
 import type { AroonValue } from "../../momentum/aroon";
 import { aroon } from "../../momentum/aroon";
@@ -62,6 +63,7 @@ import { mfi } from "../../volume/mfi";
 import { obv } from "../../volume/obv";
 import { twap } from "../../volume/twap";
 import { volumeAnomaly } from "../../volume/volume-anomaly";
+import { volumeTrend } from "../../volume/volume-trend";
 import type { VwapValue } from "../../volume/vwap";
 import { vwap } from "../../volume/vwap";
 import { processAll } from "../bridge";
@@ -108,6 +110,7 @@ import { createMfi } from "../volume/mfi";
 import { createObv } from "../volume/obv";
 import { createTwap } from "../volume/twap";
 import { createVolumeAnomaly } from "../volume/volume-anomaly";
+import { createVolumeTrend } from "../volume/volume-trend";
 import { createVwap } from "../volume/vwap";
 
 /**
@@ -174,6 +177,18 @@ function assertConsistency(
       expect(iv).not.toBeNull();
       expect(Math.abs(iv! - bv)).toBeLessThan(tolerance);
     }
+  }
+}
+
+/**
+ * Compare a single nullable numeric field: both null, or both close.
+ */
+function expectNullableClose(incremental: number | null, batch: number | null, tolerance = 1e-8) {
+  if (batch === null) {
+    expect(incremental).toBeNull();
+  } else {
+    expect(incremental).not.toBeNull();
+    expect(Math.abs(incremental! - batch)).toBeLessThan(tolerance);
   }
 }
 
@@ -1095,6 +1110,9 @@ describe("Chandelier Exit consistency", () => {
         expect(Math.abs(iv.shortExit! - bv.shortExit)).toBeLessThan(1e-8);
       }
 
+      expectNullableClose(iv.highestHigh, bv.highestHigh);
+      expectNullableClose(iv.lowestLow, bv.lowestLow);
+      expectNullableClose(iv.atr, bv.atr);
       expect(iv.direction).toBe(bv.direction);
       expect(iv.isCrossover).toBe(bv.isCrossover);
     }
@@ -1117,9 +1135,42 @@ describe("Chandelier Exit consistency", () => {
         expect(Math.abs(iv.longExit! - bv.longExit)).toBeLessThan(1e-8);
       }
 
+      expectNullableClose(iv.highestHigh, bv.highestHigh);
+      expectNullableClose(iv.lowestLow, bv.lowestLow);
       expect(iv.direction).toBe(bv.direction);
       expect(iv.isCrossover).toBe(bv.isCrossover);
     }
+  });
+});
+
+describe("Volume Trend consistency", () => {
+  function expectVolumeTrendMatch(opts?: Parameters<typeof createVolumeTrend>[0]) {
+    const batch = volumeTrend(candles, opts);
+    const incremental = processAll(createVolumeTrend(opts), candles);
+
+    expect(incremental.length).toBe(batch.length);
+    for (let i = 0; i < batch.length; i++) {
+      expect(incremental[i].time).toBe(batch[i].time);
+
+      const bv = batch[i].value as VolumeTrendValue;
+      const iv = incremental[i].value as VolumeTrendValue;
+
+      // priceTrend / volumeTrend must agree on every bar — including
+      // bars where priceTrend is neutral but volume is still trending.
+      expect(iv.priceTrend).toBe(bv.priceTrend);
+      expect(iv.volumeTrend).toBe(bv.volumeTrend);
+      expect(iv.isConfirmed).toBe(bv.isConfirmed);
+      expect(iv.hasDivergence).toBe(bv.hasDivergence);
+      expect(iv.confidence).toBe(bv.confidence);
+    }
+  }
+
+  it("default params match batch", () => {
+    expectVolumeTrendMatch();
+  });
+
+  it("custom params match batch", () => {
+    expectVolumeTrendMatch({ pricePeriod: 8, volumePeriod: 12, maPeriod: 15 });
   });
 });
 

--- a/packages/core/src/indicators/incremental/volatility/chandelier-exit.ts
+++ b/packages/core/src/indicators/incremental/volatility/chandelier-exit.ts
@@ -147,14 +147,19 @@ export function createChandelierExit(
       highBuffer.push(candle.high);
       lowBuffer.push(candle.low);
 
-      const highestHigh = getHighest(highBuffer);
-      const lowestLow = getLowest(lowBuffer);
+      // Highest High / Lowest Low are only defined once the lookback
+      // window is full. Batch `chandelierExit` sources these from
+      // `highest()` / `lowest()`, which emit null during warmup; mirror
+      // that here instead of reporting a running partial extreme.
+      const hlWarmedUp = highBuffer.isFull;
+      const highestHigh = hlWarmedUp ? getHighest(highBuffer) : null;
+      const lowestLow = hlWarmedUp ? getLowest(lowBuffer) : null;
       const atrVal = atrResult.value;
 
       let longExit: number | null = null;
       let shortExit: number | null = null;
 
-      if (atrVal !== null) {
+      if (atrVal !== null && highestHigh !== null && lowestLow !== null) {
         const atrDist = atrVal * multiplier;
         longExit = highestHigh - atrDist;
         shortExit = lowestLow + atrDist;
@@ -213,12 +218,19 @@ export function createChandelierExit(
         }
       }
 
+      // After the simulated push the lookback window is full iff the
+      // current buffer already holds `hlLookback - 1` values. Mirror
+      // `next`: report null Highest High / Lowest Low during warmup.
+      const hlWarmedUp = highBuffer.length >= hlLookback - 1;
+      const highestHigh = hlWarmedUp ? hh : null;
+      const lowestLow = hlWarmedUp ? ll : null;
+
       let longExit: number | null = null;
       let shortExit: number | null = null;
 
-      if (atrVal !== null) {
-        longExit = hh - atrVal * multiplier;
-        shortExit = ll + atrVal * multiplier;
+      if (atrVal !== null && highestHigh !== null && lowestLow !== null) {
+        longExit = highestHigh - atrVal * multiplier;
+        shortExit = lowestLow + atrVal * multiplier;
       }
 
       let direction: 1 | -1 | 0 = 0;
@@ -244,8 +256,8 @@ export function createChandelierExit(
           shortExit,
           direction,
           isCrossover,
-          highestHigh: hh,
-          lowestLow: ll,
+          highestHigh,
+          lowestLow,
           atr: atrVal,
         },
       };

--- a/packages/core/src/indicators/incremental/volume/volume-trend.ts
+++ b/packages/core/src/indicators/incremental/volume/volume-trend.ts
@@ -187,7 +187,17 @@ export function createVolumeTrend(
     volTrend: { direction: "up" | "down" | "neutral"; strength: number },
   ): VolumeTrendValue {
     if (priceTrend.direction === "neutral") {
-      return neutralValue;
+      // A neutral price trend means no confirmation or divergence is
+      // possible, but the volume trend is an independent measurement
+      // and must still be reported (matches batch `volumeTrend()`,
+      // which only zeroes the confirmation fields here).
+      return {
+        priceTrend: "neutral",
+        volumeTrend: volTrend.direction,
+        isConfirmed: false,
+        hasDivergence: false,
+        confidence: 0,
+      };
     }
 
     const isConfirmed =


### PR DESCRIPTION
## Summary

A pre-merge parity audit found two incremental indicators that
disagree with their batch counterparts on a handful of bars. Both
are corrected so the streaming and batch APIs produce identical
output. These are pre-existing bugs (not regressions) — they exist
independently of any in-flight work.

## Bugs fixed

### Volume Trend
When the price trend was `neutral`, the incremental `evaluate()`
returned the full neutral value, discarding the
independently-computed `volumeTrend` reading and reporting
`volumeTrend: "neutral"`. Batch `volumeTrend()` only zeroes the
confirmation fields (`isConfirmed` / `hasDivergence` / `confidence`)
and still reports the real volume trend.

The incremental now matches batch: the volume trend is reported on
every bar; only the confirmation fields are zeroed on a neutral
price trend.

### Chandelier Exit
The incremental emitted a running partial `highestHigh` /
`lowestLow` during the warmup period, while batch `chandelierExit()`
sources those fields from `highest()` / `lowest()`, which report
`null` until the lookback window is full.

`null`-during-warmup is the library-wide convention for rolling
extremes (`highestLowest` follows it, and it matches TA-Lib's
MAX/MIN unstable period). The incremental `next` / `peek` now report
`null` for `highestHigh` / `lowestLow` during warmup. The exit
levels (`longExit` / `shortExit` / `direction` / `isCrossover`) were
already correct and are unchanged.

## Tests

The `consistency.test.ts` Chandelier Exit suite previously asserted
only `longExit` / `shortExit` / `direction` / `isCrossover` — it
never checked `highestHigh` / `lowestLow` / `atr`, which is the gap
that let the divergence hide. It now asserts those fields too, and a
new Volume Trend batch-parity block is added.

## Verification

- `consistency.test.ts` — 95 tests pass (including the strengthened
  Chandelier Exit checks and the new Volume Trend block)
- Full core suite — 5101 tests pass, no regressions
- `pnpm build` passes; `packages/core/src` is lint-clean