### PR TITLE
docs(core): export IndicatorSnapshot type + correct state-category docs

### DIFF
--- a/packages/core/docs/STATE_CONTRACT.md
+++ b/packages/core/docs/STATE_CONTRACT.md
@@ -80,11 +80,11 @@ when the contract is introduced.
 
 | Category | State shape | Reconfig on resume | Examples |
 |---|---|---|---|
-| **A. Windowed** | Raw price/data buffer of N samples | ✓ Carry-forward (period change), refuse source change | SMA, WMA, ALMA, Highest/Lowest, Donchian, Returns |
+| **A. Windowed** | Raw price/data buffer of N samples | ✓ Carry-forward (period change), refuse source change | SMA, WMA, ALMA, Highest/Lowest, Donchian, Returns, Pivot Points |
 | **B. Recursive** | Single recursive accumulator (`prevValue`) | ✗ Always refuse | EMA, McGinley, ZLEMA, Wilder smoothers (RSI internal, ATR internal) |
-| **C. Mixed** | Windowed buffer + recursive value | ✗ Always refuse (recursive part is poisoned by past params) | FRAMA, KAMA, Super Smoother |
+| **C. Mixed** | Windowed buffer + recursive value | ✗ Always refuse (recursive part is poisoned by past params) | FRAMA, KAMA, Super Smoother, BOS, CHoCH, FVG, Liquidity Sweep, Swing Points |
 | **D. Cascaded** | Multiple recursive stages | ✗ Always refuse (every stage's recursion encodes past params) | MACD, DEMA, TEMA, TRIX, Roofing Filter, STC, Klinger, HMA |
-| **E. Event log** | Append-only event list | ✓ Append-only (params change does not invalidate past events) | BOS, FVG, Liquidity Sweep, Pivot Points, Order Block, Swing Points |
+| **E. Event log** | Append-only event list | ✓ Append-only (params change does not invalidate past events) | *(reserved — no 0.4.0 indicator is a pure event log; see note below)* |
 
 **Important note on ALMA vs FRAMA**: ALMA's formula is
 `sum(weights[i] * buffer[i])` — its state is just the raw price
@@ -92,6 +92,18 @@ buffer, no recursion. ALMA is **Category A**. FRAMA combines a raw
 price buffer (for fractal-dim calc) with a recursive `prevFrama` value
 — FRAMA is **Category C**. This distinction is why ALMA can support
 period change on resume (carry forward what fits) while FRAMA cannot.
+
+**Important note on Category E**: the contract and `resolveResume`
+fully support an append-only event-log category, but **no 0.4.0
+indicator is classified into it**. The structure-tracking indicators
+that look event-like — BOS, CHoCH, FVG, Liquidity Sweep, Swing Points
+— each pair an event list with a parameter-sized *detection window*
+(e.g. a `2*swingPeriod+1` high/low buffer). Because that window cannot
+be carried forward across a window-sizing param change, they are
+classified **Category C (Mixed)** and refuse reconfig. Pivot Points
+keeps only a one-bar OHLC window, so it is **Category A (Windowed)**.
+Category E remains defined for a future indicator whose entire state
+is a pure timestamped log.
 
 ### 2.4 Per-category resume rules
 
@@ -452,7 +464,7 @@ trendcraft 0.4.0.
 |---|---|---|
 | **0. Decision doc** | This document + memory note + epic branch | ✓ Done |
 | **1. Foundation** | `state-contract.ts` (types + `resolveResume`), `describeContract` DSL | ✓ Done |
-| **2. Indicator migration** | All ~94 incremental indicators migrated across Wave 1 (Category A — windowed), Wave 2 (Category B — recursive, plus E — event log), Wave 3 (Categories C/D — mixed/cascaded, and the RSI/ATR/DMI Wilder-smoother cluster) | ✓ Done |
+| **2. Indicator migration** | All ~94 incremental indicators migrated across Wave 1 (Category A — windowed), Wave 2 (Category B — recursive), Wave 3 (Categories C/D — mixed/cascaded, and the RSI/ATR/DMI Wilder-smoother cluster) | ✓ Done |
 | **3. Contract test rollout** | All indicators registered in `describeContract`; latent edge cases surfaced and fixed | ✓ Done |
 | **4. Documentation** | `STATE_CONTRACT.md` design doc, `docs/migration-0.3-to-0.4.md` consumer guide, CHANGELOG breaking entry | ✓ Done |
 | **5. 0.4.0 release prep** | CHANGELOG BREAKING entry, perf check, final audit | ✓ Done |

--- a/packages/core/docs/migration-0.3-to-0.4.md
+++ b/packages/core/docs/migration-0.3-to-0.4.md
@@ -62,12 +62,17 @@ are incompatible.
 Once you are on 0.4.0 envelopes, resume with *changed params* follows
 the state category:
 
-- **Windowed** (SMA, WMA, ALMA, Donchian, …) — `period` change is
-  supported via carry-forward; `source` change throws.
+- **Windowed** (SMA, WMA, ALMA, Donchian, Pivot Points, …) — `period`
+  change is supported via carry-forward; `source` change throws.
 - **Recursive / Mixed / Cascaded** (EMA, ZLEMA, FRAMA, KAMA, MACD,
-  DEMA, TEMA, HMA, …) — any state-shaping param change throws.
-- **Event log** (BOS, FVG, Pivot Points, …) — params change is
-  harmless; events keep appending.
+  DEMA, TEMA, HMA, and the structure trackers BOS, CHoCH, FVG,
+  Liquidity Sweep, Swing Points, …) — any state-shaping param change
+  throws.
+
+The contract also defines an append-only **Event log** category, but
+no 0.4.0 indicator is classified into it — the structure trackers that
+look event-like keep a parameter-sized detection window, so they are
+Mixed (see [`STATE_CONTRACT.md` §2.3](./STATE_CONTRACT.md#23-five-resume-categories)).
 
 *Resume-invariant* params (those that only scale the state→output
 projection, e.g. a band-width multiplier) may change on resume in any

--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -2383,9 +2383,10 @@ describeContract<FractalValue, FractalsState>({
       !(v as { downFractal: boolean }).downFractal),
 });
 
-// Break of Structure — Event (a `2*swingPeriod+1` raw high/low window
+// Break of Structure — Mixed (a `2*swingPeriod+1` raw high/low window
 // plus last-swing / trend trackers conditioned on the confirming
-// window). The warmup gate keys on `trend === "neutral"` (the
+// window). `swingPeriod` sizes the detection window, so reconfig is
+// refused. The warmup gate keys on `trend === "neutral"` (the
 // indicator emits a neutral trend until the first BOS). batchCompute
 // omitted: batch swing detection uses look-ahead.
 describeContract<BosValue, BosState>({
@@ -2403,7 +2404,8 @@ describeContract<BosValue, BosState>({
     (typeof v === "object" && (v as { trend: unknown }).trend === "neutral"),
 });
 
-// Change of Character — Event (composes the inner BOS window).
+// Change of Character — Mixed (composes the inner BOS window, which
+// is sized by `swingPeriod` — reconfig refused).
 // batchCompute omitted: it inherits the inner Break of Structure's
 // look-ahead swing detection, so batch and incremental align pivots
 // differently (same reason as breakOfStructure).
@@ -2459,9 +2461,9 @@ describeContract<HeikinAshiValue, HeikinAshiState>({
   batchCompute: (_opts, candles) => heikinAshi(candles).map((s) => s.value),
 });
 
-// Fair Value Gap — Event (an append-only log of active FVG zones).
-// Past detections stand on resume; reconfig of detection params only
-// affects future bars. batchCompute omitted: the batch FVG does a
+// Fair Value Gap — Mixed (an append-only log of active FVG zones plus
+// a two-candle detection window). Resume refuses any param change.
+// batchCompute omitted: the batch FVG does a
 // retroactive fill pass while the incremental detects fills as they
 // occur.
 describeContract<FvgValue, FairValueGapState>({
@@ -2496,7 +2498,8 @@ describeContract<FvgValue, FairValueGapState>({
   },
 });
 
-// Gap Analysis — Event (an append-only log of active gap zones).
+// Gap Analysis — Mixed (an append-only log of active gap zones plus a
+// one-candle detection window). Resume refuses any param change.
 // batchCompute omitted: batch does a retroactive fill pass.
 describeContract<GapValue, GapAnalysisState>({
   name: "gapAnalysis",
@@ -2540,7 +2543,8 @@ describeContract<OpeningRangeValue, OpeningRangeState>({
     (typeof v === "object" && (v as { breakout: unknown }).breakout === null),
 });
 
-// Auto Trend Line — Event (structure tracker wrapping swing points).
+// Auto Trend Line — Mixed (structure tracker wrapping swing points;
+// the swing window is param-sized, so reconfig is refused).
 // batchCompute omitted: batch swing detection uses look-ahead.
 describeContract<AutoTrendLineValue, AutoTrendLineState>({
   name: "autoTrendLine",

--- a/packages/core/src/indicators/incremental/index.ts
+++ b/packages/core/src/indicators/incremental/index.ts
@@ -180,6 +180,11 @@ export type {
 } from "./smc/liquidity-sweep";
 // SMC
 export { createLiquiditySweep } from "./smc/liquidity-sweep";
+// State Contract — the versioned envelope every `getState()` returns and
+// every `fromState` accepts. Exported so TypeScript consumers can name
+// the snapshot type. (Distinct from the looser `streaming` snapshot
+// type of the same name; this is the per-indicator state envelope.)
+export type { IndicatorSnapshot, SnapshotMeta } from "./state-contract";
 export type { IchimokuState, IchimokuValue as IncrementalIchimokuValue } from "./trend/ichimoku";
 export { createIchimoku } from "./trend/ichimoku";
 export type {


### PR DESCRIPTION
## Summary

Two consistency gaps surfaced by a pre-merge review of the State
Contract epic. Docs / comments / one type re-export only — no
behavior change.

## Finding 1 — `IndicatorSnapshot` not exported

`IndicatorSnapshot<TState>` is the versioned envelope every
`getState()` returns and every `fromState` accepts (the 0.4.0
breaking contract), but it was not exported from
`trendcraft/incremental` — TypeScript consumers could not name the
type to annotate a snapshot variable.

`incremental/index.ts` now re-exports `IndicatorSnapshot` and
`SnapshotMeta`. A separate, looser `IndicatorSnapshot` already exists
under `trendcraft/streaming`; the two are namespace-separated (no hard
collision) and a comment notes the distinction. Renaming the streaming
type is out of scope here — possible 0.5.0 cleanup.

## Finding 2 — docs claimed event-log category for Mixed indicators

`STATE_CONTRACT.md` and `migration-0.3-to-0.4.md` listed BOS / CHoCH /
FVG / Liquidity Sweep / Pivot Points / Swing Points as **Category E
(event log, append-only reconfig)**. The implementations actually
classify them as **Mixed** (refuse reconfig) — they pair an event list
with a parameter-sized detection window — except Pivot Points, which
is **Windowed**. No 0.4.0 indicator is a pure event log.

The migration guide's "Event log … params change is harmless" line
was actively misleading: a caller following it would expect reconfig
to succeed and instead get a throw.

Corrected:

- `STATE_CONTRACT.md` — category table examples, a new note explaining
  why the structure trackers are Mixed, and the Wave 2 line (dropped a
  stale "plus E — event log" claim).
- `migration-0.3-to-0.4.md` — reconfig section now lists the structure
  trackers under Recursive/Mixed/Cascaded and Pivot Points under
  Windowed.
- `state-contract-integration.test.ts` — five prose comments
  (breakOfStructure, changeOfCharacter, fairValueGap, gapAnalysis,
  autoTrendLine) that called these indicators "Event" corrected to
  "Mixed"; removed FVG's inaccurate "reconfig only affects future
  bars" line.

Category E stays defined in the contract and `resolveResume` — it is
simply unused in 0.4.0, reserved for a future pure-event-log indicator.

FVG specifically could be re-classified to a true event log (its only
window is two fixed candles), but that is a behavior change and is
left as a 0.5.0 follow-up.

## Verification

- Integration test — 821 pass
- Full core suite — 5981 pass
- `pnpm build` passes (the re-export resolves into the built
  `incremental` `.d.ts`); lint clean; `tsc` clean for changed files