### PR TITLE
feat(chart): removeAllPrimitives() helper for setCandles dataset swaps

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `chart.removeAllPrimitives()` helper
+
+A new method on `ChartInstance` drops every primitive registered via
+`registerPrimitive` in one call. Intended for the common host pattern
+of swapping in an unrelated candle dataset (different symbol,
+timeframe, file upload, etc.) — primitives capture `(time, price)`
+coordinates at registration and don't auto-invalidate, so they would
+otherwise keep rendering at the previous data's coordinates against
+the new view.
+
+This matches the documented host-driven primitive lifecycle (see
+`connectPricePatterns` JSDoc and the new COOKBOOK recipe) and the
+behavior of other charting libraries (TradingView Lightweight Charts,
+Highcharts annotations, etc.); the chart still does not auto-remove
+primitives in `setCandles`, but the helper gives the cleanup pattern
+a named API so hosts don't have to track every handle individually.
+
+- `setCandles` JSDoc now documents the lifecycle gotcha explicitly.
+- `simple-chart` example fixed: enabling SMC / Wyckoff / Regime
+  Heatmap / S/R Confluence / Session Zones on the daily view and
+  then toggling Simulate (which calls `setCandles(simHistory)`) used
+  to carry the daily-anchored primitives onto the 1-min simulation
+  view, drawing at meaningless coordinates. The example now calls
+  `removeAllPrimitives()` before each `setCandles` transition.
+
+Renderers, series, drawings, and indicators are not affected by the
+new helper.
+
 ### Added — `markers` option on scalar line series for "discrete-per-bar" affordance
 
 `SeriesConfig.markers?: boolean | { radius?: number; color?: string }`

--- a/packages/chart/docs/COOKBOOK.md
+++ b/packages/chart/docs/COOKBOOK.md
@@ -308,7 +308,44 @@ For series-type plugins (e.g. footprint candles), use `defineSeriesRenderer`. Se
 
 ---
 
-## Recipe 14: PNG export
+## Recipe 14: Swapping the candle dataset (symbol / timeframe change)
+
+**Goal:** Replace the chart's candles with an unrelated dataset (a different symbol, a new timeframe, a freshly uploaded file) without leaving primitive overlays anchored to the old (time, price) coordinates.
+
+Chart primitives — anything registered via `registerPrimitive` or the built-in `connectPricePatterns` / `connectVolumeProfile` / `connectSrConfluence` / etc. — capture their coordinates at build time and **do not** auto-invalidate when `setCandles` runs. This is intentional and matches TradingView Lightweight Charts and Highcharts behavior, where annotations stay attached and re-project from `(time, price)` each frame. The downside is that primitives built from the previous data can render at coordinates that happen to overlap the new view, silently misleading the reader.
+
+The cleanup pattern:
+
+```typescript
+function loadDataset(next: CandleData[]) {
+  // Drop overlays anchored to the old candles. Renderers, series, and
+  // drawings are independent — they update on their own.
+  chart.removeAllPrimitives();
+  chart.setCandles(next);
+
+  // Re-register any primitives that should follow the new data,
+  // recomputed from the fresh candles.
+  if (showPatterns) {
+    connectPricePatterns(chart, [
+      ...doubleBottom(next),
+      ...doubleTop(next),
+      ...inverseHeadAndShoulders(next),
+      ...headAndShoulders(next),
+    ]);
+  }
+}
+```
+
+When *not* to call `removeAllPrimitives`:
+
+- `updateCandle(latest)` / streaming bar appends — the time axis only grows; existing primitives still anchor to valid coordinates.
+- User drawing tools anchored to specific dates the user picked — those are owned by the chart's drawing layer (`addDrawing` / `removeDrawing`), not primitives.
+
+For React / Vue wrappers, calling `chart.removeAllPrimitives()` before the effect that calls `setCandles` (or making it part of the same `useEffect` deps trigger) is the equivalent host-side pattern.
+
+---
+
+## Recipe 15: PNG export
 
 **Goal:** Save the current chart as a PNG.
 
@@ -326,7 +363,7 @@ URL.revokeObjectURL(url);
 
 ---
 
-## Recipe 15: Headless usage (SSR / tests)
+## Recipe 16: Headless usage (SSR / tests)
 
 **Goal:** Compute layout, scales, or LTTB-decimated series on the server.
 

--- a/packages/chart/examples/simple-chart/src/main.ts
+++ b/packages/chart/examples/simple-chart/src/main.ts
@@ -237,6 +237,39 @@ const allIndicatorBtns = ["btn-sma", "btn-bb", "btn-ichimoku", "btn-rsi", "btn-m
 
 let simTimer: ReturnType<typeof setInterval> | null = null;
 
+/**
+ * Drop every primitive overlay before swapping the candle dataset
+ * (simulation start / stop). Primitives capture (time, price)
+ * coordinates at registration and don't auto-invalidate, so without
+ * this they keep rendering at the old dataset's coordinates on the
+ * new view. Also clears the local handle refs + button state so the
+ * user can re-toggle freshly without the UI showing a primitive as
+ * active while the overlay is gone, and without the next click landing
+ * on the wrong branch of a toggle (e.g. `srActive` flipping to `false`
+ * when the overlay was already removed).
+ */
+function resetPrimitivesBeforeDataSwap(): void {
+  chart.removeAllPrimitives();
+  tradeAnalysisHandle = null;
+  regimeHandle = null;
+  smcHandle = null;
+  wyckoffHandle = null;
+  srConfHandle = null;
+  sessionHandle = null;
+  srActive = false;
+  for (const id of [
+    "btn-mfe-mae",
+    "btn-regime",
+    "btn-smc",
+    "btn-wyckoff",
+    "btn-sr-confluence",
+    "btn-sessions",
+    "btn-plugin-sr",
+  ]) {
+    document.getElementById(id)?.classList.remove("active");
+  }
+}
+
 document.getElementById("btn-simulate")?.addEventListener("click", (e) => {
   const btn = e.target as HTMLButtonElement;
   if (simTimer) {
@@ -249,6 +282,9 @@ document.getElementById("btn-simulate")?.addEventListener("click", (e) => {
     liveCandle = null;
     activeLiveIndicators.clear();
     volOverlayLive = false;
+
+    // Drop primitives anchored to simulation candles before restoring daily.
+    resetPrimitivesBeforeDataSwap();
 
     // Restore full data + re-add active indicators
     chart.setCandles(candles);
@@ -279,6 +315,9 @@ document.getElementById("btn-simulate")?.addEventListener("click", (e) => {
       ref.value = null;
     }
   }
+  // And drop daily-anchored primitives so they don't bleed onto the
+  // simulated 1-min view at stale (time, price) coordinates.
+  resetPrimitivesBeforeDataSwap();
 
   // Pre-generate 50 candles of 1-min history (epoch-aligned times)
   const startPrice = candles[candles.length - 1].close;

--- a/packages/chart/src/__tests__/plugin-system.test.ts
+++ b/packages/chart/src/__tests__/plugin-system.test.ts
@@ -112,6 +112,66 @@ describe("RendererRegistry", () => {
     expect(() => registry.removePrimitive("nonexistent")).not.toThrow();
   });
 
+  it("removeAllPrimitives drops every primitive and fires their destroy hooks", () => {
+    const registry = new RendererRegistry();
+    const destroyA = vi.fn();
+    const destroyB = vi.fn();
+    registry.registerPrimitive(
+      definePrimitive({
+        name: "a",
+        pane: "main",
+        zOrder: "above",
+        defaultState: null,
+        render: vi.fn(),
+        destroy: destroyA,
+      }),
+    );
+    registry.registerPrimitive(
+      definePrimitive({
+        name: "b",
+        pane: "volume",
+        zOrder: "below",
+        defaultState: null,
+        render: vi.fn(),
+        destroy: destroyB,
+      }),
+    );
+
+    registry.removeAllPrimitives();
+
+    expect(registry.getPrimitives("main", "above")).toHaveLength(0);
+    expect(registry.getPrimitives("volume", "below")).toHaveLength(0);
+    expect(destroyA).toHaveBeenCalledOnce();
+    expect(destroyB).toHaveBeenCalledOnce();
+    // Renderers are untouched.
+    expect(registry.isEmpty).toBe(true);
+  });
+
+  it("removeAllPrimitives leaves renderers alone", () => {
+    const registry = new RendererRegistry();
+    registry.registerRenderer(defineSeriesRenderer({ type: "keep-me", render: vi.fn() }));
+    registry.registerPrimitive(
+      definePrimitive({
+        name: "drop",
+        pane: "main",
+        zOrder: "above",
+        defaultState: null,
+        render: vi.fn(),
+      }),
+    );
+
+    registry.removeAllPrimitives();
+
+    expect(registry.getRenderer("keep-me")).toBeDefined();
+    expect(registry.getPrimitives("main", "above")).toHaveLength(0);
+  });
+
+  it("removeAllPrimitives is a no-op when empty", () => {
+    const registry = new RendererRegistry();
+    expect(() => registry.removeAllPrimitives()).not.toThrow();
+    expect(registry.isEmpty).toBe(true);
+  });
+
   it("calls update hook on getPrimitives", () => {
     const registry = new RendererRegistry();
     registry.registerPrimitive(

--- a/packages/chart/src/core/renderer-registry.ts
+++ b/packages/chart/src/core/renderer-registry.ts
@@ -59,6 +59,18 @@ export class RendererRegistry {
     }
   }
 
+  /**
+   * Remove every registered primitive in one call. Runs each plugin's
+   * `destroy` hook before dropping the entry. Renderers are not touched.
+   */
+  removeAllPrimitives(): void {
+    if (this._primitives.size === 0) return;
+    for (const entry of this._primitives.values()) {
+      entry.plugin.destroy?.();
+    }
+    this._primitives.clear();
+  }
+
   private static readonly _emptyPrimitives: PrimitiveEntry[] = [];
 
   /** Get all primitives for a given pane and z-order */

--- a/packages/chart/src/core/types/chart-instance.ts
+++ b/packages/chart/src/core/types/chart-instance.ts
@@ -21,6 +21,20 @@ import type { ThemeColors } from "./theme";
 
 export type ChartInstance = {
   // Data
+  /**
+   * Replace the chart's candle dataset.
+   *
+   * **Primitive lifecycle note**: primitives registered via
+   * `registerPrimitive` are not removed by `setCandles`. They capture
+   * their `(time, price)` coordinates at registration and continue
+   * rendering at those coordinates against the new candle dataset.
+   * When the new data is unrelated to the previous (different symbol,
+   * timeframe, etc.), call `removeAllPrimitives()` first so primitives
+   * built from the previous data don't bleed into the new view.
+   *
+   * Series, indicators, drawings, and the chart's own overlays are
+   * managed independently and update automatically.
+   */
   setCandles(candles: CandleData[]): void;
   updateCandle(candle: CandleData): void;
   /** Batch multiple updates into a single render frame.
@@ -104,6 +118,16 @@ export type ChartInstance = {
   registerPrimitive<TState>(plugin: import("../plugin-types").PrimitivePlugin<TState>): void;
   /** Remove a primitive by name */
   removePrimitive(name: string): void;
+  /**
+   * Remove every registered primitive in one call. Useful before
+   * `setCandles()` swaps in an unrelated dataset (different symbol,
+   * timeframe, etc.) — primitives capture their `(time, price)`
+   * coordinates at build time and don't auto-invalidate, so they would
+   * otherwise keep rendering at coordinates from the previous data.
+   *
+   * Renderers, series, drawings, and indicators are not affected.
+   */
+  removeAllPrimitives(): void;
 
   // Extensibility
   /** Register a custom introspection rule for shape detection */

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -1005,6 +1005,11 @@ export class CanvasChart implements ChartInstance {
     this._needsRender = true;
   }
 
+  removeAllPrimitives(): void {
+    this._rendererRegistry.removeAllPrimitives();
+    this._needsRender = true;
+  }
+
   // ---- Public API: Extensibility ----
 
   addRule(rule: IntrospectionRule): void {


### PR DESCRIPTION
## Summary

- Adds `chart.removeAllPrimitives()` to `ChartInstance` so hosts can drop every registered primitive in one call before `setCandles()` swaps in an unrelated dataset (different symbol, timeframe, file upload).
- Strengthens `setCandles` JSDoc with an explicit primitive-lifecycle note.
- New COOKBOOK recipe + CHANGELOG entry.
- Fixes `simple-chart`'s Simulate toggle, which previously left daily-anchored primitives drawing at stale (time, price) coordinates on the 1-min simulation view.

## Why

Strategy Studio surfaced a bug class where chart primitives (`connectPricePatterns`, `connectVolumeProfile`, etc.) kept rendering at coordinates from a previous candle dataset after `setCandles(newData)`. Industry research showed the host-driven contract is correct and shared with every major charting library (TradingView Lightweight Charts, Highcharts annotations, ECharts markPoint, Chart.js annotation plugin, Plotly) — no library auto-removes primitives on data swap. What was missing was a **named API** for the host's cleanup pattern. Tracking every handle individually is error-prone (the original \`simple-chart\` audit missed one primitive and one of the button ids on first pass), so the helper turns a multi-line per-handle loop into a single call.

The chart still does not auto-invalidate on \`setCandles\` — this is purely an additive helper.

## Test plan

- [x] \`pnpm test\` — chart **836/836 PASS** (4 new tests in \`plugin-system.test.ts\` covering: drops every primitive, runs destroy hooks, leaves renderers alone, no-op when empty).
- [x] \`pnpm build\` — all packages green.
- [x] \`pnpm lint\` — clean.
- [x] \`pnpm size-check\` — Main bundle 37.62 → 37.66 kB (limit 38 kB).
- [x] \`pnpm dev\` + manual repro on \`simple-chart\`: enable SMC / Wyckoff / Regime Heatmap / S/R Confluence on daily view → Start Simulate → overlays cleared, no stale labels on 1-min view → Stop → daily restored cleanly.
- [x] Codex review: clean.

## Notes

- 2 commits (chart feature + simple-chart fix). Either could squash; left split because the chart change is the public-facing addition and the example fix is independent maintenance.
- Out-of-scope future work captured in the design memo: ECharts-style declarative re-registration with stable IDs (not warranted at today's ~10 primitive types).