### PR TITLE
chore(strategy-studio): use chart.removeAllPrimitives() in fullRebuild

### DIFF
--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -615,7 +615,12 @@ export function App() {
     const fullRebuild = chartChanged || sliceMoved || candlesChanged;
 
     if (fullRebuild) {
-      for (const handle of handles.values()) handle.remove();
+      // `chart.removeAllPrimitives()` drops every registered primitive and
+      // fires their `destroy` hooks in one call — same outcome as iterating
+      // `handles` and calling `.remove()` on each, but it's the canonical
+      // pattern documented in COOKBOOK Recipe 14. Studio is the sole
+      // primitive owner on this chart instance, so a "remove all" is safe.
+      chart.removeAllPrimitives();
       handles.clear();
     } else {
       for (const [kind, handle] of [...handles]) {


### PR DESCRIPTION
## Summary

Replaces Studio's manual handle iteration in the plugin rebuild effect with the new \`chart.removeAllPrimitives()\` helper from PR #230. Same outcome, one canonical call instead of an inline loop that reinvented the pattern.

\`\`\`diff
 if (fullRebuild) {
-  for (const handle of handles.values()) handle.remove();
+  chart.removeAllPrimitives();
   handles.clear();
 }
\`\`\`

## Why

PR #230 introduced \`chart.removeAllPrimitives()\` + COOKBOOK Recipe 14 as the official pattern for host-driven primitive cleanup before \`setCandles\`. Studio's existing inline loop predates that helper and is functionally identical, but it makes the example look like a workaround when the helper now exists.

The diff path (toggle-only changes) is unchanged because it needs selective per-kind removal driven by \`enabledPlugins.has(kind)\`, which the chart can't infer.

## Test plan

- [x] \`pnpm test\` (studio): 97/97 PASS.
- [x] \`pnpm test\` (chart): 887/887 PASS post-merge.
- [x] \`pnpm lint\`: clean.
- [x] \`npx tsc --noEmit\`: clean.
- [x] Manual repro: Studio loaded with SMC Layer + Price Patterns enabled, anchored Replay (triggers fullRebuild path) → step 3 bars → exit Replay → 1000 bars restored, no console errors, all primitives rendered against the current slice.

## Notes

Tiny change (+6/-1) but keeps the example aligned with the documented chart-side helper. No public API change.