### PR TITLE
feat(core): extend BacktestResult with Sortino/Calmar/CAGR/Expectancy/Exposure

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added — Extended `BacktestResult` metrics (Sortino, Calmar, CAGR, Expectancy, Exposure, per-trade aggregates)
 
-`BacktestResult` gains nine new fields filled in by every call to
+`BacktestResult` gains **eleven** new fields filled in by every call to
 `runBacktest` / `runScaledEntryBacktest`:
 
 - `sortinoRatio` — like Sharpe but divides by *downside* deviation
@@ -24,25 +24,43 @@
 - `exposurePercent` — total holding time divided by the candle span.
   A Sharpe of 2 at 10% exposure is materially different from a
   Sharpe of 2 at 100% exposure; this surfaces that distinction.
+  **Computed via merged `(entryTime, exitTime)` intervals** so
+  scale-out / partial-exit strategies (which emit several `Trade`
+  records that share an entry time) report the actual time-in-market
+  rather than the naive `sum(holdingDays)` that would double-count.
 - `avgWinPercent` / `avgLossPercent` — average % return of winning /
   losing trades. `avgLossPercent` is reported as a positive number
   ("how much did the average loser lose").
 - `largestWinPercent` / `largestLossPercent` — best / worst single-
   trade return, same positive-for-loss convention.
+- `firstBarTime` / `lastBarTime` — the candle span the backtest ran
+  over (epoch ms). Stored so derived analyses (equity-curve filter,
+  slicing, post-hoc annualization) can recompute time-based metrics
+  without re-supplying the window.
 
 Matches TradingView Performance Summary, QuantifiedStrategies'
 checklist, and Van Tharp's metrics framework — what veteran traders
 expect to see in a backtest summary.
 
-`calculateStats` (internal) gained an optional `span` parameter
-(`{ firstTime, lastTime }`). Engines that have candle data
-(`runBacktest`, `runScaledEntryBacktest`) pass it automatically so
-CAGR / exposure are accurate. External consumers wrapping
-`calculateStats` directly get `0` for these two fields if they don't
-supply `span` — back-compatible.
+The metric math is consolidated into a single
+`computeExtendedMetrics(...)` helper exported from
+`backtest/engine-utils.ts`, used by every `BacktestResult`
+construction site — the main `runBacktest` engine, the scaled-entry
+engine, and `meta-strategy/equity-curve.ts:rebuildResult` (which
+filters trades and recomputes metrics against the same candle
+window).
+
+`calculateStats` and `emptyResult` (internal) gained an optional
+`span` parameter (`{ firstTime, lastTime }`). Engines that have
+candle data pass it automatically so CAGR / exposure are accurate.
+External consumers wrapping `calculateStats` directly get `0` for
+those metrics if they don't supply `span` — back-compatible.
 
 All new fields default to `0` in `emptyResult` and round to 2 decimal
-places. No existing field semantics change.
+places. No existing field semantics change. **Type-level note:**
+because the new fields are required on `BacktestResult`, external
+code that *constructs* this type (e.g. test fixtures, mock results)
+must supply the new properties. Reading code is unaffected.
 
 ### Breaking — Indicator State Contract (`getState` / `fromState` wire format)
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 ## Unreleased
 
+### Added — Extended `BacktestResult` metrics (Sortino, Calmar, CAGR, Expectancy, Exposure, per-trade aggregates)
+
+`BacktestResult` gains nine new fields filled in by every call to
+`runBacktest` / `runScaledEntryBacktest`:
+
+- `sortinoRatio` — like Sharpe but divides by *downside* deviation
+  only, so upside volatility no longer penalizes the score. `0` when
+  there are no negative returns. Annualized with `sqrt(252)` to match
+  Sharpe's convention.
+- `calmarRatio` — `cagrPercent / maxDrawdown`. Industry-standard
+  "return per unit of pain". `0` when `maxDrawdown` is zero.
+- `cagrPercent` — compound annual growth rate, computed from the
+  candle span (first bar time → last bar time). Replaces having to
+  guess at "what's my actual annualized return" from
+  `totalReturnPercent` + holding period.
+- `expectancyPercent` — average of `trade.returnPercent` across all
+  trades. Equivalent to `(winRate × avgWin) − (lossRate × avgLoss)`.
+  Positive = strategy is profitable per trade on average; the
+  canonical "is this an edge?" check.
+- `exposurePercent` — total holding time divided by the candle span.
+  A Sharpe of 2 at 10% exposure is materially different from a
+  Sharpe of 2 at 100% exposure; this surfaces that distinction.
+- `avgWinPercent` / `avgLossPercent` — average % return of winning /
+  losing trades. `avgLossPercent` is reported as a positive number
+  ("how much did the average loser lose").
+- `largestWinPercent` / `largestLossPercent` — best / worst single-
+  trade return, same positive-for-loss convention.
+
+Matches TradingView Performance Summary, QuantifiedStrategies'
+checklist, and Van Tharp's metrics framework — what veteran traders
+expect to see in a backtest summary.
+
+`calculateStats` (internal) gained an optional `span` parameter
+(`{ firstTime, lastTime }`). Engines that have candle data
+(`runBacktest`, `runScaledEntryBacktest`) pass it automatically so
+CAGR / exposure are accurate. External consumers wrapping
+`calculateStats` directly get `0` for these two fields if they don't
+supply `span` — back-compatible.
+
+All new fields default to `0` in `emptyResult` and round to 2 decimal
+places. No existing field semantics change.
+
 ### Breaking — Indicator State Contract (`getState` / `fromState` wire format)
 
 Every incremental indicator (`createSma`, `createEma`, `createMacd`,

--- a/packages/core/src/backtest/__tests__/backtest-result-fixture.ts
+++ b/packages/core/src/backtest/__tests__/backtest-result-fixture.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared spread-in fixture for the extended `BacktestResult` fields
+ * added in this release. Test files that build mock results inline use
+ * this so the type stays satisfied without each fixture duplicating
+ * eleven zero-valued lines.
+ */
+
+export const EMPTY_EXTENDED_METRICS_FIXTURE = {
+  sortinoRatio: 0,
+  calmarRatio: 0,
+  cagrPercent: 0,
+  expectancyPercent: 0,
+  exposurePercent: 0,
+  avgWinPercent: 0,
+  avgLossPercent: 0,
+  largestWinPercent: 0,
+  largestLossPercent: 0,
+  firstBarTime: 0,
+  lastBarTime: 0,
+} as const;

--- a/packages/core/src/backtest/__tests__/extended-metrics.test.ts
+++ b/packages/core/src/backtest/__tests__/extended-metrics.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+import type { BacktestSettings, DrawdownPeriod, Trade } from "../../types";
+import { calculateStats, emptyResult, MS_PER_DAY } from "../scaled-entry-utils";
+
+const SETTINGS: BacktestSettings = {
+  capital: 100_000,
+  commission: 0,
+  taxRate: 0,
+  stopLoss: 0,
+  takeProfit: 0,
+  trailingStop: 0,
+  scaledEntry: false,
+  scalingTranches: 1,
+  scalingDistribution: "equal",
+  slippage: 0,
+  fillMode: "close",
+};
+
+function makeTrade(
+  index: number,
+  returnPercent: number,
+  holdingDays: number,
+  initialCapital: number,
+): Trade {
+  const entryTime = new Date(2024, 0, 1 + index * 5).getTime();
+  const exitTime = entryTime + holdingDays * MS_PER_DAY;
+  const entryPrice = 100;
+  const exitPrice = 100 + returnPercent;
+  return {
+    entryTime,
+    entryPrice,
+    exitTime,
+    exitPrice,
+    return: (initialCapital * returnPercent) / 100,
+    returnPercent,
+    holdingDays,
+  };
+}
+
+describe("extended BacktestResult metrics", () => {
+  it("emptyResult includes zero values for new metric fields", () => {
+    const result = emptyResult(100_000, SETTINGS);
+    expect(result.sortinoRatio).toBe(0);
+    expect(result.calmarRatio).toBe(0);
+    expect(result.cagrPercent).toBe(0);
+    expect(result.expectancyPercent).toBe(0);
+    expect(result.exposurePercent).toBe(0);
+    expect(result.avgWinPercent).toBe(0);
+    expect(result.avgLossPercent).toBe(0);
+    expect(result.largestWinPercent).toBe(0);
+    expect(result.largestLossPercent).toBe(0);
+  });
+
+  it("expectancy equals the arithmetic mean of trade.returnPercent", () => {
+    // 3 wins of 5%, 2 losses of 3% → expectancy = (3*5 - 2*3)/5 = 1.8%
+    const trades: Trade[] = [
+      makeTrade(0, 5, 4, 100_000),
+      makeTrade(1, 5, 4, 100_000),
+      makeTrade(2, 5, 4, 100_000),
+      makeTrade(3, -3, 4, 100_000),
+      makeTrade(4, -3, 4, 100_000),
+    ];
+    const returns = trades.map((t) => t.returnPercent / 100);
+    const result = calculateStats(trades, returns, 100_000, 109_000, 5, SETTINGS, []);
+    expect(result.expectancyPercent).toBe(1.8);
+  });
+
+  it("avgWin / avgLoss / largestWin / largestLoss are reported as positive percentages", () => {
+    const trades: Trade[] = [
+      makeTrade(0, 2, 4, 100_000),
+      makeTrade(1, 8, 4, 100_000),
+      makeTrade(2, -4, 4, 100_000),
+      makeTrade(3, -1, 4, 100_000),
+    ];
+    const returns = trades.map((t) => t.returnPercent / 100);
+    const result = calculateStats(trades, returns, 100_000, 105_000, 5, SETTINGS, []);
+    expect(result.avgWinPercent).toBe(5); // (2 + 8) / 2
+    expect(result.avgLossPercent).toBe(2.5); // |(-4 + -1) / 2|
+    expect(result.largestWinPercent).toBe(8);
+    expect(result.largestLossPercent).toBe(4); // |min(-4, -1)|
+  });
+
+  it("Sortino is 0 when there are no negative returns", () => {
+    const trades: Trade[] = [
+      makeTrade(0, 2, 4, 100_000),
+      makeTrade(1, 3, 4, 100_000),
+      makeTrade(2, 1, 4, 100_000),
+    ];
+    const returns = trades.map((t) => t.returnPercent / 100);
+    const result = calculateStats(trades, returns, 100_000, 106_000, 0, SETTINGS, []);
+    expect(result.sortinoRatio).toBe(0);
+    // Sharpe should still be non-zero (stddev of strictly positive returns is non-zero)
+    expect(result.sharpeRatio).toBeGreaterThan(0);
+  });
+
+  it("Sortino divides by downside deviation only (penalizes losses, ignores upside variance)", () => {
+    // 3 wins of +4%, 1 loss of -2%. The wins contribute upside
+    // variance Sharpe penalizes but Sortino doesn't — so Sortino
+    // should come in higher than Sharpe on this shape.
+    const trades: Trade[] = [
+      makeTrade(0, 4, 4, 100_000),
+      makeTrade(1, 4, 4, 100_000),
+      makeTrade(2, 4, 4, 100_000),
+      makeTrade(3, -2, 4, 100_000),
+    ];
+    const returns = trades.map((t) => t.returnPercent / 100);
+    const result = calculateStats(trades, returns, 100_000, 110_000, 2, SETTINGS, []);
+    expect(result.sortinoRatio).toBeGreaterThan(0);
+    expect(result.sortinoRatio).toBeGreaterThan(result.sharpeRatio);
+  });
+
+  it("exposure is 100% when trades cover the full backtest span", () => {
+    // 5 trades, each 20 days, contiguous → 100 days total holding
+    // span = 100 days exactly → 100% exposure
+    const startTime = new Date(2024, 0, 1).getTime();
+    const trades: Trade[] = Array.from({ length: 5 }, (_, i) => {
+      const entryTime = startTime + i * 20 * MS_PER_DAY;
+      const exitTime = entryTime + 20 * MS_PER_DAY;
+      return {
+        entryTime,
+        entryPrice: 100,
+        exitTime,
+        exitPrice: 101,
+        return: 100,
+        returnPercent: 1,
+        holdingDays: 20,
+      };
+    });
+    const returns = trades.map((t) => t.returnPercent / 100);
+    const result = calculateStats(trades, returns, 100_000, 105_000, 1, SETTINGS, [], {
+      firstTime: startTime,
+      lastTime: startTime + 100 * MS_PER_DAY,
+    });
+    expect(result.exposurePercent).toBe(100);
+  });
+
+  it("exposure is half when trades cover half the backtest span", () => {
+    const startTime = new Date(2024, 0, 1).getTime();
+    const trades: Trade[] = [
+      {
+        entryTime: startTime,
+        entryPrice: 100,
+        exitTime: startTime + 25 * MS_PER_DAY,
+        exitPrice: 101,
+        return: 100,
+        returnPercent: 1,
+        holdingDays: 25,
+      },
+      {
+        entryTime: startTime + 50 * MS_PER_DAY,
+        entryPrice: 100,
+        exitTime: startTime + 75 * MS_PER_DAY,
+        exitPrice: 101,
+        return: 100,
+        returnPercent: 1,
+        holdingDays: 25,
+      },
+    ];
+    const returns = trades.map((t) => t.returnPercent / 100);
+    const result = calculateStats(trades, returns, 100_000, 102_000, 1, SETTINGS, [], {
+      firstTime: startTime,
+      lastTime: startTime + 100 * MS_PER_DAY,
+    });
+    expect(result.exposurePercent).toBe(50);
+  });
+
+  it("exposure is 0 when no span info is provided", () => {
+    const trades = [makeTrade(0, 5, 4, 100_000)];
+    const returns = trades.map((t) => t.returnPercent / 100);
+    const result = calculateStats(trades, returns, 100_000, 105_000, 1, SETTINGS, []);
+    expect(result.exposurePercent).toBe(0);
+    expect(result.cagrPercent).toBe(0);
+  });
+
+  it("CAGR matches the geometric annualized return for a 1-year backtest", () => {
+    // +21% over 365.25 days → CAGR ≈ 21%
+    const startTime = new Date(2024, 0, 1).getTime();
+    const trade = makeTrade(0, 21, 200, 100_000);
+    trade.entryTime = startTime;
+    trade.exitTime = startTime + 200 * MS_PER_DAY;
+    const trades = [trade];
+    const returns = trades.map((t) => t.returnPercent / 100);
+    const result = calculateStats(trades, returns, 100_000, 121_000, 5, SETTINGS, [], {
+      firstTime: startTime,
+      lastTime: startTime + Math.round(365.25) * MS_PER_DAY,
+    });
+    expect(result.cagrPercent).toBeCloseTo(21, 0);
+  });
+
+  it("Calmar is CAGR divided by max drawdown when both are positive", () => {
+    const startTime = new Date(2024, 0, 1).getTime();
+    const trade = makeTrade(0, 20, 100, 100_000);
+    trade.entryTime = startTime;
+    trade.exitTime = startTime + 100 * MS_PER_DAY;
+    const trades = [trade];
+    const returns = trades.map((t) => t.returnPercent / 100);
+    const result = calculateStats(trades, returns, 100_000, 120_000, 10, SETTINGS, [], {
+      firstTime: startTime,
+      lastTime: startTime + Math.round(365.25) * MS_PER_DAY,
+    });
+    // CAGR ≈ 20%, DD = 10% → Calmar ≈ 2.0
+    expect(result.calmarRatio).toBeCloseTo(2, 0);
+  });
+
+  it("Calmar is 0 when max drawdown is 0 (no drawdown observed)", () => {
+    const startTime = new Date(2024, 0, 1).getTime();
+    const trade = makeTrade(0, 5, 100, 100_000);
+    trade.entryTime = startTime;
+    trade.exitTime = startTime + 100 * MS_PER_DAY;
+    const trades = [trade];
+    const returns = trades.map((t) => t.returnPercent / 100);
+    const result = calculateStats(trades, returns, 100_000, 105_000, 0, SETTINGS, [], {
+      firstTime: startTime,
+      lastTime: startTime + Math.round(365.25) * MS_PER_DAY,
+    });
+    expect(result.calmarRatio).toBe(0);
+  });
+
+  it("downstream drawdownPeriods passthrough still works", () => {
+    const trades = [makeTrade(0, 5, 4, 100_000)];
+    const returns = trades.map((t) => t.returnPercent / 100);
+    const periods: DrawdownPeriod[] = [
+      {
+        startTime: 0,
+        peakEquity: 100_000,
+        troughTime: 1000,
+        troughEquity: 95_000,
+        maxDepthPercent: 5,
+        durationBars: 10,
+      },
+    ];
+    const result = calculateStats(trades, returns, 100_000, 105_000, 5, SETTINGS, periods);
+    expect(result.drawdownPeriods).toBe(periods);
+  });
+});

--- a/packages/core/src/backtest/__tests__/extended-metrics.test.ts
+++ b/packages/core/src/backtest/__tests__/extended-metrics.test.ts
@@ -1,19 +1,16 @@
 import { describe, expect, it } from "vitest";
-import type { BacktestSettings, DrawdownPeriod, Trade } from "../../types";
+import type { BacktestSettings, DrawdownPeriod, NormalizedCandle, Trade } from "../../types";
+import { deadCross, goldenCross } from "../conditions/ma-cross";
+import { runBacktest } from "../engine";
 import { calculateStats, emptyResult, MS_PER_DAY } from "../scaled-entry-utils";
 
 const SETTINGS: BacktestSettings = {
-  capital: 100_000,
-  commission: 0,
-  taxRate: 0,
-  stopLoss: 0,
-  takeProfit: 0,
-  trailingStop: 0,
-  scaledEntry: false,
-  scalingTranches: 1,
-  scalingDistribution: "equal",
+  fillMode: "next-bar-open",
+  slTpMode: "close-only",
   slippage: 0,
-  fillMode: "close",
+  commission: 0,
+  commissionRate: 0,
+  taxRate: 0,
 };
 
 function makeTrade(
@@ -231,5 +228,106 @@ describe("extended BacktestResult metrics", () => {
     ];
     const result = calculateStats(trades, returns, 100_000, 105_000, 5, SETTINGS, periods);
     expect(result.drawdownPeriods).toBe(periods);
+  });
+
+  it("exposure does NOT double-count partial-exit (scale-out) trades", () => {
+    // Single position from t=10 to t=100 (90 days), split into 3 partial
+    // exits at t=40, t=70, t=100. The merged window is (10, 100) = 90
+    // days, so exposure should be 90 / 100 = 90% — not 180% (which
+    // `sum(holdingDays)` would give: 30 + 60 + 90 = 180).
+    const startTime = new Date(2024, 0, 1).getTime();
+    const positionEntry = startTime + 10 * MS_PER_DAY;
+    const trades: Trade[] = [
+      {
+        entryTime: positionEntry,
+        entryPrice: 100,
+        exitTime: positionEntry + 30 * MS_PER_DAY,
+        exitPrice: 102,
+        return: 200,
+        returnPercent: 0.67,
+        holdingDays: 30,
+        isPartial: true,
+      },
+      {
+        entryTime: positionEntry,
+        entryPrice: 100,
+        exitTime: positionEntry + 60 * MS_PER_DAY,
+        exitPrice: 105,
+        return: 500,
+        returnPercent: 1.67,
+        holdingDays: 60,
+        isPartial: true,
+      },
+      {
+        entryTime: positionEntry,
+        entryPrice: 100,
+        exitTime: positionEntry + 90 * MS_PER_DAY,
+        exitPrice: 108,
+        return: 800,
+        returnPercent: 2.67,
+        holdingDays: 90,
+      },
+    ];
+    const returns = trades.map((t) => t.returnPercent / 100);
+    const result = calculateStats(trades, returns, 100_000, 101_500, 1, SETTINGS, [], {
+      firstTime: startTime,
+      lastTime: startTime + 100 * MS_PER_DAY,
+    });
+    // Position window is 90 days, total span is 100 days → 90% exposure.
+    expect(result.exposurePercent).toBe(90);
+    // And critically: not the naive 180% that holdingDays-sum would give.
+    expect(result.exposurePercent).toBeLessThanOrEqual(100);
+  });
+});
+
+/** Synthetic candles with a clear cross pattern to drive runBacktest. */
+function generateCrossingCandles(): NormalizedCandle[] {
+  const candles: NormalizedCandle[] = [];
+  const start = new Date(2024, 0, 1).getTime();
+  for (let i = 0; i < 200; i++) {
+    // Two phases: 0-99 rising, 100-199 falling-then-rising — generates
+    // multiple golden + dead crosses for a 5/25 SMA strategy.
+    const t = start + i * MS_PER_DAY;
+    const close =
+      i < 100 ? 100 + i * 0.5 + Math.sin(i / 5) * 2 : 150 - (i - 100) * 0.3 + Math.cos(i / 7) * 3;
+    candles.push({
+      time: t,
+      open: close - 0.1,
+      high: close + 0.5,
+      low: close - 0.5,
+      close,
+      volume: 1000,
+    });
+  }
+  return candles;
+}
+
+describe("runBacktest end-to-end: extended metrics populated", () => {
+  it("populates Sortino/Calmar/CAGR/Expectancy/Exposure and span fields via the engine path", () => {
+    // This catches the engine-utils calculateStats path that PR #232's
+    // initial implementation missed — the scaled-entry-utils edits
+    // only covered the scaled-entry engine, not the main runBacktest.
+    const candles = generateCrossingCandles();
+    const result = runBacktest(candles, goldenCross(5, 25), deadCross(5, 25), {
+      capital: 100_000,
+    });
+    expect(result.tradeCount).toBeGreaterThan(0);
+    // All new fields must be present (TypeScript enforces, but assert
+    // at runtime so an accidental `undefined` slip-through fails fast).
+    expect(typeof result.sortinoRatio).toBe("number");
+    expect(typeof result.calmarRatio).toBe("number");
+    expect(typeof result.cagrPercent).toBe("number");
+    expect(typeof result.expectancyPercent).toBe("number");
+    expect(typeof result.exposurePercent).toBe("number");
+    expect(typeof result.avgWinPercent).toBe("number");
+    expect(typeof result.avgLossPercent).toBe("number");
+    expect(typeof result.largestWinPercent).toBe("number");
+    expect(typeof result.largestLossPercent).toBe("number");
+    // Span fields reflect the candle window.
+    expect(result.firstBarTime).toBe(candles[0].time);
+    expect(result.lastBarTime).toBe(candles[candles.length - 1].time);
+    // Exposure is bounded.
+    expect(result.exposurePercent).toBeGreaterThanOrEqual(0);
+    expect(result.exposurePercent).toBeLessThanOrEqual(100);
   });
 });

--- a/packages/core/src/backtest/__tests__/scoring.test.ts
+++ b/packages/core/src/backtest/__tests__/scoring.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { BacktestResult } from "../../types";
 import { scoreBacktestResult } from "../scoring";
+import { EMPTY_EXTENDED_METRICS_FIXTURE } from "./backtest-result-fixture";
 
 function makeResult(overrides: Partial<BacktestResult> = {}): BacktestResult {
   return {
@@ -12,6 +13,7 @@ function makeResult(overrides: Partial<BacktestResult> = {}): BacktestResult {
     winRate: 55,
     maxDrawdown: 10,
     sharpeRatio: 1.5,
+    ...EMPTY_EXTENDED_METRICS_FIXTURE,
     profitFactor: 1.8,
     avgHoldingDays: 5,
     trades: [],

--- a/packages/core/src/backtest/engine-utils.ts
+++ b/packages/core/src/backtest/engine-utils.ts
@@ -229,6 +229,159 @@ export function calculateMfeUtilization(returnPercent: number, mfe: number): num
 }
 
 /**
+ * Span info used for time-based metrics (CAGR, exposure). Engines that
+ * have access to the candle array pass `firstTime` / `lastTime` directly
+ * to avoid the inaccuracy of inferring the backtest window from trade
+ * timestamps (which would exclude pre-first-trade warmup time).
+ */
+export type BacktestSpanInfo = {
+  firstTime: number;
+  lastTime: number;
+};
+
+/**
+ * The nine "extended" backtest metrics added in this release. Extracted
+ * as a helper so every `BacktestResult` construction site (the main
+ * engine, scaled-entry engine, equity-curve rebuildResult) can call a
+ * single implementation instead of duplicating the math.
+ */
+export type ExtendedBacktestMetrics = {
+  sortinoRatio: number;
+  calmarRatio: number;
+  cagrPercent: number;
+  expectancyPercent: number;
+  exposurePercent: number;
+  avgWinPercent: number;
+  avgLossPercent: number;
+  largestWinPercent: number;
+  largestLossPercent: number;
+};
+
+/** Zero-filled `ExtendedBacktestMetrics`. Used by empty-result paths. */
+export const ZERO_EXTENDED_METRICS: ExtendedBacktestMetrics = {
+  sortinoRatio: 0,
+  calmarRatio: 0,
+  cagrPercent: 0,
+  expectancyPercent: 0,
+  exposurePercent: 0,
+  avgWinPercent: 0,
+  avgLossPercent: 0,
+  largestWinPercent: 0,
+  largestLossPercent: 0,
+};
+
+/**
+ * Compute total market-exposure time from trades, **merging overlapping
+ * `(entryTime, exitTime)` intervals** so the same wall-clock minute is
+ * counted at most once. Scale-out / partial-exit strategies emit several
+ * `Trade` records that share an entry time and have increasing exits;
+ * a naive `sum(holdingDays)` would multiply the actual exposure by the
+ * number of tranches. The merged-interval form returns the union of
+ * trade windows, which is what "time in market" actually means.
+ */
+function computeMergedExposureDays(trades: Trade[]): number {
+  if (trades.length === 0) return 0;
+  const intervals = trades
+    .map((t) => ({ start: t.entryTime, end: t.exitTime }))
+    .sort((a, b) => a.start - b.start);
+  let totalMs = 0;
+  let curStart = intervals[0].start;
+  let curEnd = intervals[0].end;
+  for (let i = 1; i < intervals.length; i++) {
+    const iv = intervals[i];
+    if (iv.start > curEnd) {
+      totalMs += curEnd - curStart;
+      curStart = iv.start;
+      curEnd = iv.end;
+    } else if (iv.end > curEnd) {
+      curEnd = iv.end;
+    }
+  }
+  totalMs += curEnd - curStart;
+  return totalMs / MS_PER_DAY;
+}
+
+/**
+ * Compute the nine extended backtest metrics from raw trade / return /
+ * capital inputs. Pure function; no side effects. Callers spread the
+ * result into the final `BacktestResult` they construct.
+ *
+ * `span` (the candle window) is optional. CAGR and exposure are
+ * meaningful only when the host knows the backtest window: when `span`
+ * is omitted, both are reported as `0`.
+ */
+export function computeExtendedMetrics(
+  trades: Trade[],
+  returns: number[],
+  initialCapital: number,
+  finalCapital: number,
+  maxDrawdown: number,
+  span?: BacktestSpanInfo,
+): ExtendedBacktestMetrics {
+  if (trades.length === 0 || returns.length === 0) {
+    return { ...ZERO_EXTENDED_METRICS };
+  }
+
+  // Sortino: like Sharpe but only penalizes downside deviation.
+  // Target return = 0; downside-only squared deviation over min(0, r).
+  const avgReturn = returns.reduce((s, r) => s + r, 0) / returns.length;
+  const downsideSqSum = returns.reduce((s, r) => s + (r < 0 ? r * r : 0), 0);
+  const downsideStd = Math.sqrt(downsideSqSum / returns.length);
+  const sortinoRatio = downsideStd > 0 ? (avgReturn / downsideStd) * Math.sqrt(252) : 0;
+
+  // Per-trade % aggregates. avgLoss / largestLoss are reported as
+  // positive numbers so they read naturally side-by-side with wins.
+  const winningTrades = trades.filter((t) => t.return > 0);
+  const losingTrades = trades.filter((t) => t.return <= 0);
+  const avgWinPercent =
+    winningTrades.length > 0
+      ? winningTrades.reduce((s, t) => s + t.returnPercent, 0) / winningTrades.length
+      : 0;
+  const avgLossPercent =
+    losingTrades.length > 0
+      ? Math.abs(losingTrades.reduce((s, t) => s + t.returnPercent, 0) / losingTrades.length)
+      : 0;
+  const largestWinPercent =
+    winningTrades.length > 0 ? Math.max(...winningTrades.map((t) => t.returnPercent)) : 0;
+  const largestLossPercent =
+    losingTrades.length > 0 ? Math.abs(Math.min(...losingTrades.map((t) => t.returnPercent))) : 0;
+
+  // Expectancy: arithmetic mean of returnPercent. Equivalent to
+  // (winRate × avgWin) − (lossRate × avgLoss) but cleaner to compute.
+  const expectancyPercent = trades.reduce((s, t) => s + t.returnPercent, 0) / trades.length;
+
+  // Time-based metrics. Only meaningful with a known candle span.
+  let cagrPercent = 0;
+  let exposurePercent = 0;
+  if (span && span.lastTime > span.firstTime) {
+    const spanDays = (span.lastTime - span.firstTime) / MS_PER_DAY;
+    if (spanDays > 0) {
+      const exposureDays = computeMergedExposureDays(trades);
+      exposurePercent = Math.min(100, (exposureDays / spanDays) * 100);
+      const years = spanDays / 365.25;
+      if (years > 0 && finalCapital > 0 && initialCapital > 0) {
+        cagrPercent = ((finalCapital / initialCapital) ** (1 / years) - 1) * 100;
+      }
+    }
+  }
+
+  // Calmar: CAGR / maxDrawdown. Industry "return per unit of pain".
+  const calmarRatio = maxDrawdown > 0 ? cagrPercent / maxDrawdown : 0;
+
+  return {
+    sortinoRatio: Math.round(sortinoRatio * 100) / 100,
+    calmarRatio: Math.round(calmarRatio * 100) / 100,
+    cagrPercent: Math.round(cagrPercent * 100) / 100,
+    expectancyPercent: Math.round(expectancyPercent * 100) / 100,
+    exposurePercent: Math.round(exposurePercent * 100) / 100,
+    avgWinPercent: Math.round(avgWinPercent * 100) / 100,
+    avgLossPercent: Math.round(avgLossPercent * 100) / 100,
+    largestWinPercent: Math.round(largestWinPercent * 100) / 100,
+    largestLossPercent: Math.round(largestLossPercent * 100) / 100,
+  };
+}
+
+/**
  * Calculate backtest statistics
  */
 export function calculateStats(
@@ -239,9 +392,10 @@ export function calculateStats(
   maxDrawdown: number,
   settings: BacktestSettings,
   drawdownPeriods: DrawdownPeriod[] = [],
+  span?: BacktestSpanInfo,
 ): BacktestResult {
   if (trades.length === 0) {
-    return emptyResult(initialCapital, settings);
+    return emptyResult(initialCapital, settings, span);
   }
 
   const totalReturn = finalCapital - initialCapital;
@@ -266,6 +420,15 @@ export function calculateStats(
   // Annualize using sqrt(252) - standard annualization factor for daily returns
   const sharpeRatio = stdReturn > 0 ? (avgReturn / stdReturn) * Math.sqrt(252) : 0;
 
+  const extended = computeExtendedMetrics(
+    trades,
+    returns,
+    initialCapital,
+    finalCapital,
+    maxDrawdown,
+    span,
+  );
+
   return {
     initialCapital,
     finalCapital: Math.round(finalCapital * 100) / 100,
@@ -275,6 +438,9 @@ export function calculateStats(
     winRate: Math.round(winRate * 100) / 100,
     maxDrawdown: Math.round(maxDrawdown * 100) / 100,
     sharpeRatio: Math.round(sharpeRatio * 100) / 100,
+    ...extended,
+    firstBarTime: span?.firstTime ?? 0,
+    lastBarTime: span?.lastTime ?? 0,
     profitFactor: Math.round(profitFactor * 100) / 100,
     avgHoldingDays: Math.round(avgHoldingDays * 10) / 10,
     trades,
@@ -324,7 +490,11 @@ export function applyVolumeConstraint(
 /**
  * Return empty result for edge cases
  */
-export function emptyResult(capital: number, settings: BacktestSettings): BacktestResult {
+export function emptyResult(
+  capital: number,
+  settings: BacktestSettings,
+  span?: BacktestSpanInfo,
+): BacktestResult {
   return {
     initialCapital: capital,
     finalCapital: capital,
@@ -334,6 +504,9 @@ export function emptyResult(capital: number, settings: BacktestSettings): Backte
     winRate: 0,
     maxDrawdown: 0,
     sharpeRatio: 0,
+    ...ZERO_EXTENDED_METRICS,
+    firstBarTime: span?.firstTime ?? 0,
+    lastBarTime: span?.lastTime ?? 0,
     profitFactor: 0,
     avgHoldingDays: 0,
     trades: [],

--- a/packages/core/src/backtest/engine.ts
+++ b/packages/core/src/backtest/engine.ts
@@ -932,5 +932,8 @@ export function runBacktest(
     maxDrawdown,
     settings,
     ddTracker.getPeriods(),
+    candles.length >= 2
+      ? { firstTime: candles[0].time, lastTime: candles[candles.length - 1].time }
+      : undefined,
   );
 }

--- a/packages/core/src/backtest/scaled-entry-utils.ts
+++ b/packages/core/src/backtest/scaled-entry-utils.ts
@@ -16,8 +16,18 @@ import type {
 } from "../types";
 import type { ExtendedCondition } from "./conditions";
 import { runBacktest } from "./engine";
+import {
+  type BacktestSpanInfo,
+  computeExtendedMetrics,
+  MS_PER_DAY as ENGINE_MS_PER_DAY,
+  ZERO_EXTENDED_METRICS,
+} from "./engine-utils";
 
-export const MS_PER_DAY = 24 * 60 * 60 * 1000;
+/**
+ * Re-export of `engine-utils`'s `MS_PER_DAY` so existing consumers
+ * importing from this module still resolve the same constant.
+ */
+export const MS_PER_DAY = ENGINE_MS_PER_DAY;
 
 /**
  * Standard (non-scaled) backtest - delegates to main engine
@@ -43,18 +53,19 @@ export function applySlippage(price: number, slippage: number, direction: "buy" 
 }
 
 /**
- * Span info used for time-based metrics (CAGR, exposure). Engines that
- * have access to the candle array pass `firstTime` / `lastTime` directly
- * to avoid the inaccuracy of inferring the backtest window from trade
- * timestamps (which would exclude pre-first-trade warmup time).
+ * Re-export of `BacktestSpanInfo` from `engine-utils`. Some host code
+ * imported it from this module before the helper was consolidated;
+ * keeping the re-export avoids a breaking import-path change.
  */
-export type BacktestSpanInfo = {
-  firstTime: number;
-  lastTime: number;
-};
+export type { BacktestSpanInfo };
 
 /**
- * Calculate backtest statistics
+ * Calculate backtest statistics.
+ *
+ * Delegates the new extended metrics (Sortino / Calmar / CAGR /
+ * Expectancy / Exposure / per-trade aggregates) to
+ * `computeExtendedMetrics` in `engine-utils` so every backtest path
+ * shares a single implementation.
  */
 export function calculateStats(
   trades: Trade[],
@@ -67,7 +78,7 @@ export function calculateStats(
   span?: BacktestSpanInfo,
 ): BacktestResult {
   if (trades.length === 0) {
-    return emptyResult(initialCapital, settings);
+    return emptyResult(initialCapital, settings, span);
   }
 
   const totalReturn = finalCapital - initialCapital;
@@ -83,75 +94,21 @@ export function calculateStats(
 
   const avgHoldingDays = trades.reduce((sum, t) => sum + t.holdingDays, 0) / trades.length;
 
-  // Sharpe ratio: annualized mean-return / stddev. Mirrors the daily
-  // assumption Sortino uses below (sqrt(252) trading days per year).
+  // Sharpe ratio: annualized mean-return / stddev.
   const avgReturn = returns.reduce((sum, r) => sum + r, 0) / returns.length;
   const stdReturn = Math.sqrt(
     returns.reduce((sum, r) => sum + (r - avgReturn) ** 2, 0) / returns.length,
   );
   const sharpeRatio = stdReturn > 0 ? (avgReturn / stdReturn) * Math.sqrt(252) : 0;
 
-  // Sortino ratio: like Sharpe but only penalizes downside deviation.
-  // Standard convention is target return = 0; downside-only squared
-  // deviation is computed over `min(0, r)` so upside doesn't inflate
-  // the denominator. When no negative returns exist, Sortino is `0`
-  // (signal that the metric isn't meaningful here) — mirrors how
-  // Sharpe handles `stdReturn === 0`.
-  const downsideSqSum = returns.reduce((sum, r) => sum + (r < 0 ? r * r : 0), 0);
-  const downsideStd = Math.sqrt(downsideSqSum / returns.length);
-  const sortinoRatio = downsideStd > 0 ? (avgReturn / downsideStd) * Math.sqrt(252) : 0;
-
-  // Per-trade % stats. `returnPercent` is already in percent units
-  // (e.g. 2.5 means +2.5%). Average loss / largest loss are reported
-  // as positive numbers ("how much did the average / worst loser
-  // lose") so they read naturally in UI side-by-side with wins.
-  const avgWinPercent =
-    winningTrades.length > 0
-      ? winningTrades.reduce((s, t) => s + t.returnPercent, 0) / winningTrades.length
-      : 0;
-  const avgLossPercent =
-    losingTrades.length > 0
-      ? Math.abs(losingTrades.reduce((s, t) => s + t.returnPercent, 0) / losingTrades.length)
-      : 0;
-  const largestWinPercent =
-    winningTrades.length > 0 ? Math.max(...winningTrades.map((t) => t.returnPercent)) : 0;
-  const largestLossPercent =
-    losingTrades.length > 0 ? Math.abs(Math.min(...losingTrades.map((t) => t.returnPercent))) : 0;
-
-  // Expectancy: average `returnPercent` across all trades. Equivalent
-  // to `(winRate × avgWin) − (lossRate × avgLoss)` — the win/loss form
-  // is intuitive but the raw mean is the canonical definition.
-  const expectancyPercent = trades.reduce((s, t) => s + t.returnPercent, 0) / trades.length;
-
-  // Time-based metrics. `span` is optional so callers that don't have
-  // candle access (none in core today, but external users wrapping
-  // `calculateStats` may not) still get a valid result with these
-  // metrics zeroed. Engines that have candles pass it and get
-  // accurate CAGR / exposure.
-  let cagrPercent = 0;
-  let exposurePercent = 0;
-  if (span && span.lastTime > span.firstTime) {
-    const spanDays = (span.lastTime - span.firstTime) / MS_PER_DAY;
-    if (spanDays > 0) {
-      // Exposure: time in market vs total backtest span. `holdingDays`
-      // is per-trade and additive (partial exits are recorded as
-      // separate trades with their own holding window).
-      const holdingDaysSum = trades.reduce((s, t) => s + t.holdingDays, 0);
-      exposurePercent = Math.min(100, (holdingDaysSum / spanDays) * 100);
-      // CAGR: only meaningful when there's a return and positive span.
-      // `(final/initial)^(365.25/spanDays) − 1` annualizes the geometric
-      // return; capped against negative or zero finalCapital.
-      const years = spanDays / 365.25;
-      if (years > 0 && finalCapital > 0 && initialCapital > 0) {
-        cagrPercent = ((finalCapital / initialCapital) ** (1 / years) - 1) * 100;
-      }
-    }
-  }
-
-  // Calmar: CAGR / maxDrawdown. Industry-standard "return per unit of
-  // pain". When max drawdown is zero (no drawdown observed) the ratio
-  // is undefined; report `0` so the result stays JSON-serializable.
-  const calmarRatio = maxDrawdown > 0 ? cagrPercent / maxDrawdown : 0;
+  const extended = computeExtendedMetrics(
+    trades,
+    returns,
+    initialCapital,
+    finalCapital,
+    maxDrawdown,
+    span,
+  );
 
   return {
     initialCapital,
@@ -162,15 +119,9 @@ export function calculateStats(
     winRate: Math.round(winRate * 100) / 100,
     maxDrawdown: Math.round(maxDrawdown * 100) / 100,
     sharpeRatio: Math.round(sharpeRatio * 100) / 100,
-    sortinoRatio: Math.round(sortinoRatio * 100) / 100,
-    calmarRatio: Math.round(calmarRatio * 100) / 100,
-    cagrPercent: Math.round(cagrPercent * 100) / 100,
-    expectancyPercent: Math.round(expectancyPercent * 100) / 100,
-    exposurePercent: Math.round(exposurePercent * 100) / 100,
-    avgWinPercent: Math.round(avgWinPercent * 100) / 100,
-    avgLossPercent: Math.round(avgLossPercent * 100) / 100,
-    largestWinPercent: Math.round(largestWinPercent * 100) / 100,
-    largestLossPercent: Math.round(largestLossPercent * 100) / 100,
+    ...extended,
+    firstBarTime: span?.firstTime ?? 0,
+    lastBarTime: span?.lastTime ?? 0,
     profitFactor: Math.round(profitFactor * 100) / 100,
     avgHoldingDays: Math.round(avgHoldingDays * 10) / 10,
     trades,
@@ -182,7 +133,11 @@ export function calculateStats(
 /**
  * Return empty result for edge cases
  */
-export function emptyResult(capital: number, settings: BacktestSettings): BacktestResult {
+export function emptyResult(
+  capital: number,
+  settings: BacktestSettings,
+  span?: BacktestSpanInfo,
+): BacktestResult {
   return {
     initialCapital: capital,
     finalCapital: capital,
@@ -192,15 +147,9 @@ export function emptyResult(capital: number, settings: BacktestSettings): Backte
     winRate: 0,
     maxDrawdown: 0,
     sharpeRatio: 0,
-    sortinoRatio: 0,
-    calmarRatio: 0,
-    cagrPercent: 0,
-    expectancyPercent: 0,
-    exposurePercent: 0,
-    avgWinPercent: 0,
-    avgLossPercent: 0,
-    largestWinPercent: 0,
-    largestLossPercent: 0,
+    ...ZERO_EXTENDED_METRICS,
+    firstBarTime: span?.firstTime ?? 0,
+    lastBarTime: span?.lastTime ?? 0,
     profitFactor: 0,
     avgHoldingDays: 0,
     trades: [],

--- a/packages/core/src/backtest/scaled-entry-utils.ts
+++ b/packages/core/src/backtest/scaled-entry-utils.ts
@@ -43,6 +43,17 @@ export function applySlippage(price: number, slippage: number, direction: "buy" 
 }
 
 /**
+ * Span info used for time-based metrics (CAGR, exposure). Engines that
+ * have access to the candle array pass `firstTime` / `lastTime` directly
+ * to avoid the inaccuracy of inferring the backtest window from trade
+ * timestamps (which would exclude pre-first-trade warmup time).
+ */
+export type BacktestSpanInfo = {
+  firstTime: number;
+  lastTime: number;
+};
+
+/**
  * Calculate backtest statistics
  */
 export function calculateStats(
@@ -53,6 +64,7 @@ export function calculateStats(
   maxDrawdown: number,
   settings: BacktestSettings,
   drawdownPeriods: DrawdownPeriod[] = [],
+  span?: BacktestSpanInfo,
 ): BacktestResult {
   if (trades.length === 0) {
     return emptyResult(initialCapital, settings);
@@ -71,12 +83,75 @@ export function calculateStats(
 
   const avgHoldingDays = trades.reduce((sum, t) => sum + t.holdingDays, 0) / trades.length;
 
-  // Calculate Sharpe Ratio
+  // Sharpe ratio: annualized mean-return / stddev. Mirrors the daily
+  // assumption Sortino uses below (sqrt(252) trading days per year).
   const avgReturn = returns.reduce((sum, r) => sum + r, 0) / returns.length;
   const stdReturn = Math.sqrt(
     returns.reduce((sum, r) => sum + (r - avgReturn) ** 2, 0) / returns.length,
   );
   const sharpeRatio = stdReturn > 0 ? (avgReturn / stdReturn) * Math.sqrt(252) : 0;
+
+  // Sortino ratio: like Sharpe but only penalizes downside deviation.
+  // Standard convention is target return = 0; downside-only squared
+  // deviation is computed over `min(0, r)` so upside doesn't inflate
+  // the denominator. When no negative returns exist, Sortino is `0`
+  // (signal that the metric isn't meaningful here) — mirrors how
+  // Sharpe handles `stdReturn === 0`.
+  const downsideSqSum = returns.reduce((sum, r) => sum + (r < 0 ? r * r : 0), 0);
+  const downsideStd = Math.sqrt(downsideSqSum / returns.length);
+  const sortinoRatio = downsideStd > 0 ? (avgReturn / downsideStd) * Math.sqrt(252) : 0;
+
+  // Per-trade % stats. `returnPercent` is already in percent units
+  // (e.g. 2.5 means +2.5%). Average loss / largest loss are reported
+  // as positive numbers ("how much did the average / worst loser
+  // lose") so they read naturally in UI side-by-side with wins.
+  const avgWinPercent =
+    winningTrades.length > 0
+      ? winningTrades.reduce((s, t) => s + t.returnPercent, 0) / winningTrades.length
+      : 0;
+  const avgLossPercent =
+    losingTrades.length > 0
+      ? Math.abs(losingTrades.reduce((s, t) => s + t.returnPercent, 0) / losingTrades.length)
+      : 0;
+  const largestWinPercent =
+    winningTrades.length > 0 ? Math.max(...winningTrades.map((t) => t.returnPercent)) : 0;
+  const largestLossPercent =
+    losingTrades.length > 0 ? Math.abs(Math.min(...losingTrades.map((t) => t.returnPercent))) : 0;
+
+  // Expectancy: average `returnPercent` across all trades. Equivalent
+  // to `(winRate × avgWin) − (lossRate × avgLoss)` — the win/loss form
+  // is intuitive but the raw mean is the canonical definition.
+  const expectancyPercent = trades.reduce((s, t) => s + t.returnPercent, 0) / trades.length;
+
+  // Time-based metrics. `span` is optional so callers that don't have
+  // candle access (none in core today, but external users wrapping
+  // `calculateStats` may not) still get a valid result with these
+  // metrics zeroed. Engines that have candles pass it and get
+  // accurate CAGR / exposure.
+  let cagrPercent = 0;
+  let exposurePercent = 0;
+  if (span && span.lastTime > span.firstTime) {
+    const spanDays = (span.lastTime - span.firstTime) / MS_PER_DAY;
+    if (spanDays > 0) {
+      // Exposure: time in market vs total backtest span. `holdingDays`
+      // is per-trade and additive (partial exits are recorded as
+      // separate trades with their own holding window).
+      const holdingDaysSum = trades.reduce((s, t) => s + t.holdingDays, 0);
+      exposurePercent = Math.min(100, (holdingDaysSum / spanDays) * 100);
+      // CAGR: only meaningful when there's a return and positive span.
+      // `(final/initial)^(365.25/spanDays) − 1` annualizes the geometric
+      // return; capped against negative or zero finalCapital.
+      const years = spanDays / 365.25;
+      if (years > 0 && finalCapital > 0 && initialCapital > 0) {
+        cagrPercent = ((finalCapital / initialCapital) ** (1 / years) - 1) * 100;
+      }
+    }
+  }
+
+  // Calmar: CAGR / maxDrawdown. Industry-standard "return per unit of
+  // pain". When max drawdown is zero (no drawdown observed) the ratio
+  // is undefined; report `0` so the result stays JSON-serializable.
+  const calmarRatio = maxDrawdown > 0 ? cagrPercent / maxDrawdown : 0;
 
   return {
     initialCapital,
@@ -87,6 +162,15 @@ export function calculateStats(
     winRate: Math.round(winRate * 100) / 100,
     maxDrawdown: Math.round(maxDrawdown * 100) / 100,
     sharpeRatio: Math.round(sharpeRatio * 100) / 100,
+    sortinoRatio: Math.round(sortinoRatio * 100) / 100,
+    calmarRatio: Math.round(calmarRatio * 100) / 100,
+    cagrPercent: Math.round(cagrPercent * 100) / 100,
+    expectancyPercent: Math.round(expectancyPercent * 100) / 100,
+    exposurePercent: Math.round(exposurePercent * 100) / 100,
+    avgWinPercent: Math.round(avgWinPercent * 100) / 100,
+    avgLossPercent: Math.round(avgLossPercent * 100) / 100,
+    largestWinPercent: Math.round(largestWinPercent * 100) / 100,
+    largestLossPercent: Math.round(largestLossPercent * 100) / 100,
     profitFactor: Math.round(profitFactor * 100) / 100,
     avgHoldingDays: Math.round(avgHoldingDays * 10) / 10,
     trades,
@@ -108,6 +192,15 @@ export function emptyResult(capital: number, settings: BacktestSettings): Backte
     winRate: 0,
     maxDrawdown: 0,
     sharpeRatio: 0,
+    sortinoRatio: 0,
+    calmarRatio: 0,
+    cagrPercent: 0,
+    expectancyPercent: 0,
+    exposurePercent: 0,
+    avgWinPercent: 0,
+    avgLossPercent: 0,
+    largestWinPercent: 0,
+    largestLossPercent: 0,
     profitFactor: 0,
     avgHoldingDays: 0,
     trades: [],

--- a/packages/core/src/backtest/scaled-entry.ts
+++ b/packages/core/src/backtest/scaled-entry.ts
@@ -526,5 +526,16 @@ export function runBacktestScaled(
     returns.push(returnPercent / 100);
   }
 
-  return calculateStats(trades, returns, capital, currentCapital, maxDrawdown, settings);
+  return calculateStats(
+    trades,
+    returns,
+    capital,
+    currentCapital,
+    maxDrawdown,
+    settings,
+    [],
+    candles.length >= 2
+      ? { firstTime: candles[0].time, lastTime: candles[candles.length - 1].time }
+      : undefined,
+  );
 }

--- a/packages/core/src/meta-strategy/__tests__/equity-curve.test.ts
+++ b/packages/core/src/meta-strategy/__tests__/equity-curve.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { EMPTY_EXTENDED_METRICS_FIXTURE } from "../../backtest/__tests__/backtest-result-fixture";
 import type { BacktestResult, Trade } from "../../types";
 import { applyEquityCurveFilter, equityCurveHealth } from "../equity-curve";
 
@@ -34,6 +35,7 @@ function makeResult(trades: Trade[]): BacktestResult {
     winRate: trades.length > 0 ? (wins.length / trades.length) * 100 : 0,
     maxDrawdown: 10,
     sharpeRatio: 1.0,
+    ...EMPTY_EXTENDED_METRICS_FIXTURE,
     profitFactor:
       grossLoss > 0 ? grossProfit / grossLoss : grossProfit > 0 ? Number.POSITIVE_INFINITY : 0,
     avgHoldingDays:

--- a/packages/core/src/meta-strategy/__tests__/strategy-rotation.test.ts
+++ b/packages/core/src/meta-strategy/__tests__/strategy-rotation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { EMPTY_EXTENDED_METRICS_FIXTURE } from "../../backtest/__tests__/backtest-result-fixture";
 import type { BacktestResult, Trade } from "../../types";
 import { rotateStrategies } from "../strategy-rotation";
 
@@ -26,6 +27,7 @@ function makeResult(tradeReturns: number[]): BacktestResult {
     winRate: trades.filter((t) => t.return > 0).length / (trades.length || 1),
     maxDrawdown: 0.1,
     sharpeRatio: 1.0,
+    ...EMPTY_EXTENDED_METRICS_FIXTURE,
     profitFactor: 1.5,
     avgHoldingDays: 1,
     trades,

--- a/packages/core/src/meta-strategy/equity-curve.ts
+++ b/packages/core/src/meta-strategy/equity-curve.ts
@@ -8,6 +8,7 @@
  * @packageDocumentation
  */
 
+import { computeExtendedMetrics, ZERO_EXTENDED_METRICS } from "../backtest/engine-utils";
 import type { BacktestResult, EquityPoint, Trade } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -153,6 +154,14 @@ function computeProfitFactor(grossProfit: number, grossLoss: number): number {
 
 function rebuildResult(trades: Trade[], original: BacktestResult): BacktestResult {
   const initialCapital = original.initialCapital;
+  // Preserve the backtest's time window — the filter removes trades
+  // but doesn't change the underlying candle span, so CAGR / exposure
+  // must be recomputed against the *same* (firstBarTime, lastBarTime).
+  const span =
+    original.lastBarTime > original.firstBarTime
+      ? { firstTime: original.firstBarTime, lastTime: original.lastBarTime }
+      : undefined;
+
   if (trades.length === 0) {
     return {
       ...original,
@@ -163,6 +172,7 @@ function rebuildResult(trades: Trade[], original: BacktestResult): BacktestResul
       winRate: 0,
       maxDrawdown: 0,
       sharpeRatio: 0,
+      ...ZERO_EXTENDED_METRICS,
       profitFactor: 0,
       avgHoldingDays: 0,
       trades: [],
@@ -186,6 +196,7 @@ function rebuildResult(trades: Trade[], original: BacktestResult): BacktestResul
     const dd = peak > 0 ? (peak - e) / peak : 0;
     if (dd > maxDd) maxDd = dd;
   }
+  const maxDrawdownPercent = maxDd * 100;
 
   // Simple Sharpe from trade returns
   const tradeReturns = trades.map((t) => t.returnPercent / 100);
@@ -193,6 +204,18 @@ function rebuildResult(trades: Trade[], original: BacktestResult): BacktestResul
   const variance = tradeReturns.reduce((s, r) => s + (r - meanRet) ** 2, 0) / tradeReturns.length;
   const stdDev = Math.sqrt(variance);
   const sharpe = stdDev > 0 ? (meanRet / stdDev) * Math.sqrt(252) : 0;
+
+  // Reuse the canonical metric helper so filter results match the
+  // shape an unfiltered backtest produces — important for the panel
+  // that diffs `original` vs `filtered` cell-by-cell.
+  const extended = computeExtendedMetrics(
+    trades,
+    tradeReturns,
+    initialCapital,
+    finalCapital,
+    maxDrawdownPercent,
+    span,
+  );
 
   return {
     initialCapital,
@@ -204,8 +227,11 @@ function rebuildResult(trades: Trade[], original: BacktestResult): BacktestResul
     // (0-100), not fraction (0-1). Aligning with runBacktest so callers can
     // compare both shapes directly (e.g. applyEquityCurveFilter.improvement).
     winRate: (wins.length / trades.length) * 100,
-    maxDrawdown: maxDd * 100,
+    maxDrawdown: maxDrawdownPercent,
     sharpeRatio: sharpe,
+    ...extended,
+    firstBarTime: original.firstBarTime,
+    lastBarTime: original.lastBarTime,
     profitFactor: computeProfitFactor(grossProfit, grossLoss),
     avgHoldingDays: trades.reduce((sum, t) => sum + t.holdingDays, 0) / trades.length,
     trades,

--- a/packages/core/src/optimization/__tests__/metrics.test.ts
+++ b/packages/core/src/optimization/__tests__/metrics.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { EMPTY_EXTENDED_METRICS_FIXTURE } from "../../backtest/__tests__/backtest-result-fixture";
 import type { BacktestResult, NormalizedCandle } from "../../types";
 import {
   annualizeReturn,
@@ -48,6 +49,7 @@ function createMockBacktestResult(overrides: Partial<BacktestResult> = {}): Back
     winRate: 60,
     maxDrawdown: 5,
     sharpeRatio: 1.5,
+    ...EMPTY_EXTENDED_METRICS_FIXTURE,
     profitFactor: 2.0,
     avgHoldingDays: 5,
     trades: [],

--- a/packages/core/src/optimization/__tests__/monte-carlo.test.ts
+++ b/packages/core/src/optimization/__tests__/monte-carlo.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { EMPTY_EXTENDED_METRICS_FIXTURE } from "../../backtest/__tests__/backtest-result-fixture";
 import type { BacktestResult, Trade } from "../../types";
 import {
   calculateStatistics,
@@ -111,6 +112,7 @@ function createMockBacktestResult(
     winRate: (wins.length / trades.length) * 100,
     maxDrawdown: 10,
     sharpeRatio: 1.2,
+    ...EMPTY_EXTENDED_METRICS_FIXTURE,
     profitFactor: totalLoss > 0 ? totalProfit / totalLoss : 999,
     avgHoldingDays: 7,
     trades,

--- a/packages/core/src/robustness/__tests__/full.test.ts
+++ b/packages/core/src/robustness/__tests__/full.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_EXTENDED_METRICS_FIXTURE } from "../../backtest/__tests__/backtest-result-fixture";
 import { and } from "../../backtest/conditions/core";
 import { deadCross, goldenCross } from "../../backtest/conditions/ma-cross";
 import { runBacktest } from "../../backtest/engine";
@@ -65,6 +66,7 @@ function mockBacktestResult(overrides: Partial<BacktestResult> = {}): BacktestRe
     winRate: 60,
     maxDrawdown: 10,
     sharpeRatio: 1.5,
+    ...EMPTY_EXTENDED_METRICS_FIXTURE,
     profitFactor: 1.8,
     avgHoldingDays: 5,
     trades: [],

--- a/packages/core/src/robustness/__tests__/quick.test.ts
+++ b/packages/core/src/robustness/__tests__/quick.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { EMPTY_EXTENDED_METRICS_FIXTURE } from "../../backtest/__tests__/backtest-result-fixture";
 import type { BacktestResult, Trade } from "../../types";
 import { quickRobustnessScore } from "../quick";
 
@@ -25,6 +26,7 @@ function mockBacktestResult(overrides: Partial<BacktestResult> = {}): BacktestRe
     winRate: 60,
     maxDrawdown: 10,
     sharpeRatio: 1.5,
+    ...EMPTY_EXTENDED_METRICS_FIXTURE,
     profitFactor: 1.8,
     avgHoldingDays: 5,
     trades: [],

--- a/packages/core/src/robustness/__tests__/robustness.test.ts
+++ b/packages/core/src/robustness/__tests__/robustness.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { EMPTY_EXTENDED_METRICS_FIXTURE } from "../../backtest/__tests__/backtest-result-fixture";
 import type { BacktestResult, DrawdownPeriod, Trade } from "../../types";
 import type { RobustnessGrade } from "../../types/robustness";
 import { scoreToGrade } from "../grade";
@@ -33,6 +34,7 @@ function mockBacktestResult(overrides: Partial<BacktestResult> = {}): BacktestRe
     winRate: 60,
     maxDrawdown: 10,
     sharpeRatio: 1.5,
+    ...EMPTY_EXTENDED_METRICS_FIXTURE,
     profitFactor: 1.8,
     avgHoldingDays: 5,
     trades: [],

--- a/packages/core/src/types/backtest.ts
+++ b/packages/core/src/types/backtest.ts
@@ -321,6 +321,46 @@ export type BacktestResult = {
   maxDrawdown: number;
   /** Sharpe ratio (annualized) */
   sharpeRatio: number;
+  /**
+   * Sortino ratio (annualized). Like Sharpe but divides by *downside*
+   * deviation instead of total return std, so upside volatility no
+   * longer penalizes the score. `0` when no negative returns exist.
+   */
+  sortinoRatio: number;
+  /**
+   * Calmar ratio: annualized return (CAGR) divided by max drawdown.
+   * Standard "return per unit of pain" metric. `0` when `maxDrawdown`
+   * is zero (no drawdown observed yet).
+   */
+  calmarRatio: number;
+  /**
+   * Compound annual growth rate percentage. Computed from the candle
+   * span (first to last bar time), so a backtest covering 1.5 years
+   * with +50% return reports CAGR ≈ +31%. `0` when fewer than 2
+   * candles are passed in.
+   */
+  cagrPercent: number;
+  /**
+   * Per-trade expectancy percentage. Equivalent to the average of
+   * `trade.returnPercent` across all trades. Positive expectancy = the
+   * strategy is profitable per trade on average.
+   */
+  expectancyPercent: number;
+  /**
+   * Market exposure percentage: total holding time divided by the
+   * candle span. A Sharpe of 2 with 10% exposure is very different
+   * from a Sharpe of 2 with 100% exposure; this metric surfaces the
+   * difference. `0` when no candle span is available.
+   */
+  exposurePercent: number;
+  /** Average winning trade return percentage (positive value). `0` when no winning trades. */
+  avgWinPercent: number;
+  /** Average losing trade return percentage (positive value, sign-flipped for display). `0` when no losing trades. */
+  avgLossPercent: number;
+  /** Largest single-trade winning return percentage. `0` when no winning trades. */
+  largestWinPercent: number;
+  /** Largest single-trade losing return percentage (positive value, sign-flipped for display). `0` when no losing trades. */
+  largestLossPercent: number;
   /** Profit factor */
   profitFactor: number;
   /** Average holding days */

--- a/packages/core/src/types/backtest.ts
+++ b/packages/core/src/types/backtest.ts
@@ -361,6 +361,16 @@ export type BacktestResult = {
   largestWinPercent: number;
   /** Largest single-trade losing return percentage (positive value, sign-flipped for display). `0` when no losing trades. */
   largestLossPercent: number;
+  /**
+   * Time of the first candle the backtest ran over (epoch ms). Stored
+   * so derived analyses (equity-curve filter, slicing, post-hoc
+   * annualization) can recompute time-based metrics like `cagrPercent`
+   * and `exposurePercent` without re-supplying the candle window.
+   * `0` when no candle span info was provided to `calculateStats`.
+   */
+  firstBarTime: number;
+  /** Time of the last candle the backtest ran over (epoch ms). See `firstBarTime`. */
+  lastBarTime: number;
   /** Profit factor */
   profitFactor: number;
   /** Average holding days */


### PR DESCRIPTION
## Summary

Adds **11 new fields** to `BacktestResult` so hosts surface what veteran traders expect to see in a backtest summary — matching TradingView Performance Summary, QuantifiedStrategies' checklist, and Van Tharp's metrics framework.

| Field | Purpose |
|---|---|
| `sortinoRatio` | Sharpe but downside-only deviation |
| `calmarRatio` | CAGR / max drawdown |
| `cagrPercent` | Compound annual growth rate from candle span |
| `expectancyPercent` | Mean of `trade.returnPercent` — "is this an edge?" |
| `exposurePercent` | Holding time / candle span, computed via merged `(entry, exit)` intervals so scale-out trades don't double-count |
| `avgWinPercent` / `avgLossPercent` | Per-trade % means (loss reported as positive for natural side-by-side reading) |
| `largestWinPercent` / `largestLossPercent` | Best / worst single trade |
| `firstBarTime` / `lastBarTime` | Candle window the backtest covered (epoch ms), so derived analyses can recompute time-based metrics without re-supplying candles |

## Why

The previous 7-metric set (Total Return / Trades / Win Rate / Max DD / Sharpe / PF / Avg Hold) is missing the metrics veterans expect to read first when evaluating a strategy:

- Sortino splits downside vs upside volatility (Sharpe alone over-penalizes upside).
- Calmar / MAR is the canonical "return per unit of pain".
- Expectancy is Van Tharp's signature "is there an edge per trade" metric.
- Exposure separates a Sharpe-2-at-10%-exposure from a Sharpe-2-at-100%-exposure — very different strategies, identical Sharpe.
- Per-trade aggregates (avg/largest win/loss) are baseline TradingView Performance Summary content.

These come from extending the existing engine; downstream hosts get them automatically.

## Implementation

The metric math lives in a single `computeExtendedMetrics(...)` helper exported from `backtest/engine-utils.ts`, used by every `BacktestResult` construction site:

- `engine-utils.ts:calculateStats` / `emptyResult` — the path `runBacktest` takes.
- `scaled-entry-utils.ts:calculateStats` / `emptyResult` — the scaled-entry engine; imports the helper, no duplicated math.
- `meta-strategy/equity-curve.ts:rebuildResult` — both empty and normal branches rebuilt against the helper so the equity-curve filter recomputes Sortino / Calmar / Exposure / CAGR against the filtered trades.

Exposure uses a merged-interval algorithm on `(entryTime, exitTime)` windows. Scale-out / partial-exit strategies emit several `Trade` records that share an entry time and have increasing exits; a naive `sum(holdingDays)` would multiply the actual exposure by the number of tranches, so the merge collapses overlapping windows into one.

CAGR uses `(finalCapital / initialCapital) ^ (365.25 / spanDays) − 1`. The new `firstBarTime` / `lastBarTime` fields capture the span so the equity-curve filter doesn't have to re-supply candles to recompute against the original window.

## API change

- Type `BacktestResult` gains 11 required fields, all numbers, all defaulted to `0` in `emptyResult`. No existing field semantics change.
- Internal `calculateStats` and `emptyResult` gain an optional `span` parameter (`{ firstTime: number, lastTime: number }`). `runBacktest` and `runScaledEntryBacktest` pass it automatically. External wrappers calling `calculateStats` directly without supplying `span` get `0` for CAGR / exposure / span fields — back-compatible.
- **Note**: because the new fields are required, external code that *constructs* `BacktestResult` (test fixtures, mock results) must supply the new properties. Reading code is unaffected.

## Test plan

- [x] `pnpm test` core: 5995/5995 PASS (14 in `__tests__/extended-metrics.test.ts`, including a scale-out exposure regression and an end-to-end `runBacktest` check that catches an earlier construction-site gap).
- [x] `pnpm test` chart / mcp: 836 + 74 PASS.
- [x] `pnpm build`: all packages green.
- [x] `pnpm lint`: clean.
- [x] `tsc --noEmit --ignoreDeprecations 6.0`: clean for this PR's diff (two pre-existing errors unrelated to this PR remain: `strategy-dna.test.ts` mock for `OptimizationMetric` missing `mar`/`tradeCount`; `always-conditions.test.ts` Candle vs NormalizedCandle).
- [x] Test coverage includes: emptyResult defaults, expectancy = arithmetic mean of `returnPercent`, positive-for-loss aggregate convention, Sortino = 0 when no negative returns, Sortino > Sharpe when upside variance dominates, exposure 100% / 50% / 0% boundary cases, scale-out partial-exit double-count prevention, CAGR matches geometric annualized return, Calmar = CAGR/maxDD, `runBacktest` end-to-end populates every new field, `drawdownPeriods` passthrough unchanged.

## Notes

Nine in-repo test fixtures (`scoring.test.ts`, `equity-curve.test.ts`, `strategy-rotation.test.ts`, `metrics.test.ts`, `monte-carlo.test.ts`, plus the three `robustness/__tests__/*.test.ts` files) now spread a shared `EMPTY_EXTENDED_METRICS_FIXTURE` constant from `__tests__/backtest-result-fixture.ts` instead of inlining eleven zero-valued lines each.

The follow-up commit (`cc12543`) addresses initial review findings: the first version only extended `scaled-entry-utils.ts:calculateStats`, not `engine-utils.ts:calculateStats` (which is what `runBacktest` uses), and exposure double-counted scale-out trades. Both are now fixed and have regression coverage.