### PR TITLE
feat(chart): replay playhead + seed-end integer accessors in @trendcraft/chart/replay

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -7,6 +7,96 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Replay playhead + seed-end integer accessors in `@trendcraft/chart/replay`
+
+For hosts building a "scrubbable replay" UI on top of
+`createLiveSimulator`, the subpath now exposes the simulator's
+internal integer state directly. The cursor display, snapshot-
+backtest slice, and indicator slices all need to agree on *which
+bar the user has seen most recently*; reading that integer straight
+off the simulator (instead of re-deriving it via independent math)
+is the only design that doesn't admit a class of drift bugs at the
+boundary.
+
+Added on `SimulatorHandle`:
+
+- `getEmittedQueueCount(): number` — exact integer count of queued
+  candles the simulator has fully emitted.
+- `getLastEmittedIdx(): number` — exact integer index, in candle
+  space, of the last emitted bar. Equals
+  `seedCandles.length + getEmittedQueueCount() - 1`. The canonical
+  "playhead" for any snapshot backtest or cursor label that must
+  not leak future data.
+
+Added on `SimulatorOptions`:
+
+- `seedEnd?: number` — integer seed-bar count, takes precedence
+  over `seedRatio` when both are passed. Preferred when the host
+  derives the anchor from a click index (passing `seedRatio =
+  anchor / length` and letting the simulator multiply back can
+  drift by one in IEEE-754, e.g. `Math.floor(22 * (15/22)) === 14`,
+  not 15).
+
+Added at module scope:
+
+- `clampedSeedEnd(candles, cursorIndex): number` — clamps the
+  anchor click to the same `[5%, 95%]` bounds the simulator uses.
+  Stateless utility for previewing what the simulator will pick
+  before construction.
+- `SEED_RATIO_MIN` (`0.05`) / `SEED_RATIO_MAX` (`0.95`) —
+  surface-able constants for hosts that display the bounds in UI.
+
+**Why no `lastEmittedIdx(candles, cursor, count)` /
+`resolveQueueIdx` standalone helpers**: an earlier draft of this
+release exposed both. Review caught four drift bugs in succession
+— float roundoff in the `seedRatio` round-trip; float roundoff in
+`progress * queueLen`; double-clamping disagreement between the
+simulator and the helper's own `clampedSeedEnd`; and a fractional-
+cursor case where the helper preserved the fraction while the
+simulator floored. All four were the same class: two parties (the
+simulator and a stateless helper) deriving the same integer
+through independent paths, which is inherently fragile. The
+redesign drops the standalone helper entirely. The simulator owns
+`seedEnd` and `nextIdx` as integers and exposes them via
+`getEmittedQueueCount()` and `getLastEmittedIdx()` — there is no
+second derivation path.
+
+`clampedSeedEnd` survives because it serves a distinct purpose
+(previewing the simulator's choice before construction), but it
+is now defined so the simulator literally calls it for its own
+`seedEnd` computation. The two paths share one function; they
+cannot disagree by construction. The helper also floors the
+cursor internally, so a fractional sub-pixel UI coordinate
+produces the same integer in both places.
+
+22 new tests in `__tests__/replay.test.ts` cover the `seedEnd`
+integer path including the 22/15 float-drift case, an arbitrary
+`(n, anchor)` sweep against `clampedSeedEnd`, out-of-range clamping
+to `SEED_RATIO_MIN/MAX`, the fractional-cursor floor case
+(`clampedSeedEnd(C, 10.9) === 10`), the `NaN`/`undefined`/non-
+numeric fallback to the 60% default (silent-failure guard), the
+±Infinity boundary clamps, empty-candle preview equality
+(`clampedSeedEnd([], any) === 0` matching `sim.seedCandles.length`),
+the `getLastEmittedIdx()` empty-array sentinel (`-1`), and a
+**property test** that exhaustively asserts `clampedSeedEnd(C,
+cursor) === createLiveSimulator({candles: C, seedEnd: cursor})
+.seedCandles.length` for 9 candle shapes × 18 cursor values (162
+combinations) — including degenerate inputs like `NaN`,
+`±Infinity`, and empty `C`. If any drift remains, this property
+test catches it.
+
+Empty / degenerate inputs are explicitly handled rather than left
+as undefined behavior:
+
+- `clampedSeedEnd([], …)` returns `0` (matching the simulator's
+  zero-bar seed) instead of the previous `1`.
+- `sim.getLastEmittedIdx()` returns `-1` on empty candles —
+  sentinel for "no bar emitted yet". A host slicing
+  `candles.slice(0, idx + 1)` gets the correct empty array
+  instead of pointing at a phantom `candles[0]`.
+
+Bundle: replay subpath 935 B (limit 3 kB).
+
 ### Added — `chart.removeAllPrimitives()` helper
 
 A new method on `ChartInstance` drops every primitive registered via

--- a/packages/chart/src/__tests__/replay.test.ts
+++ b/packages/chart/src/__tests__/replay.test.ts
@@ -1,6 +1,6 @@
 import type { NormalizedCandle } from "trendcraft";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createLiveSimulator } from "../replay";
+import { clampedSeedEnd, createLiveSimulator, SEED_RATIO_MAX, SEED_RATIO_MIN } from "../replay";
 
 function makeCandles(n: number): NormalizedCandle[] {
   return Array.from({ length: n }, (_, i) => ({
@@ -210,6 +210,279 @@ describe("createLiveSimulator", () => {
     expect(sim.getProgress()).toBeCloseTo(2 / 3, 5);
     sim.stepOnce();
     expect(sim.getProgress()).toBe(1);
+    sim.dispose();
+  });
+});
+
+describe("clampedSeedEnd", () => {
+  const C = makeCandles(100);
+
+  it("keeps the click within 5%/95% of the dataset", () => {
+    expect(clampedSeedEnd(C, 1)).toBe(5); // floor(100 * 0.05)
+    expect(clampedSeedEnd(C, 50)).toBe(50);
+    expect(clampedSeedEnd(C, 99)).toBe(95); // floor(100 * 0.95)
+    expect(clampedSeedEnd(C, 1000)).toBe(95);
+  });
+
+  it("guarantees at least one seed bar even on tiny datasets", () => {
+    expect(clampedSeedEnd(makeCandles(1), 0)).toBeGreaterThanOrEqual(1);
+    expect(clampedSeedEnd(makeCandles(5), 0)).toBeGreaterThanOrEqual(1);
+  });
+
+  it("matches SEED_RATIO_MIN / SEED_RATIO_MAX exposed for hosts that surface the bounds", () => {
+    expect(SEED_RATIO_MIN).toBe(0.05);
+    expect(SEED_RATIO_MAX).toBe(0.95);
+  });
+
+  it("floors fractional cursor input so the preview matches the simulator exactly", () => {
+    // The helper exists to PREVIEW what `createLiveSimulator` will pick.
+    // For the preview to be accurate, the helper must use the same
+    // floor+clamp as the simulator — a fractional cursor (e.g. a
+    // sub-pixel UI coordinate) must produce the same integer in both
+    // places.
+    const C100 = makeCandles(100);
+    expect(clampedSeedEnd(C100, 10.9)).toBe(10);
+    expect(clampedSeedEnd(C100, 10.1)).toBe(10);
+    expect(clampedSeedEnd(C100, 50.5)).toBe(50);
+    // And the round-trip: preview === simulator's actual seed.
+    for (const cursor of [10.9, 10.1, 50.5, 4.99, 95.001]) {
+      const sim = createLiveSimulator({ candles: C100, seedEnd: cursor });
+      expect(sim.seedCandles.length).toBe(clampedSeedEnd(C100, cursor));
+      sim.dispose();
+    }
+  });
+
+  it("falls back to 60% default for NaN / undefined / non-numeric (no silent NaN propagation)", () => {
+    // UI math (e.g. `0 / 0` from missing event coords) can produce NaN.
+    // Without the guard, the helper returned NaN, the simulator did
+    // `candles.slice(0, NaN) === []`, and the entire replay silently
+    // stalled in the "complete" state.
+    const C100 = makeCandles(100);
+    const fallback = Math.floor(100 * 0.6); // 60
+    expect(clampedSeedEnd(C100, Number.NaN)).toBe(fallback);
+    expect(clampedSeedEnd(C100, undefined as unknown as number)).toBe(fallback);
+    expect(clampedSeedEnd(C100, "abc" as unknown as number)).toBe(fallback);
+    expect(clampedSeedEnd(C100, {} as unknown as number)).toBe(fallback);
+    // And the simulator's actual seed matches the preview.
+    for (const v of [Number.NaN, undefined, "abc", {}] as unknown[]) {
+      const sim = createLiveSimulator({ candles: C100, seedEnd: v as number });
+      expect(sim.seedCandles.length).toBe(fallback);
+      sim.dispose();
+    }
+  });
+
+  it("clamps ±Infinity to the max/min bounds (no NaN propagation)", () => {
+    const C100 = makeCandles(100);
+    expect(clampedSeedEnd(C100, Number.POSITIVE_INFINITY)).toBe(95);
+    expect(clampedSeedEnd(C100, Number.NEGATIVE_INFINITY)).toBe(5);
+  });
+
+  it("returns 0 for empty candle arrays (matching the simulator's seed count)", () => {
+    // Empty dataset: simulator can only seed 0 bars. Preview MUST agree.
+    expect(clampedSeedEnd([], 0)).toBe(0);
+    expect(clampedSeedEnd([], 50)).toBe(0);
+    expect(clampedSeedEnd([], Number.NaN)).toBe(0);
+  });
+
+  it("PROPERTY: clampedSeedEnd(C, x) === createLiveSimulator({ candles: C, seedEnd: x }).seedCandles.length for every shape × cursor", () => {
+    // The canonical preview/library equality. If this property ever
+    // fails, the API has a drift bug — by construction. The test runs
+    // across degenerate shapes (empty, length-1) and pathological
+    // cursors (NaN, ±Infinity, non-numeric coerced) so the bug class
+    // can't return through a corner case.
+    const shapes = [0, 1, 2, 3, 5, 7, 22, 100, 333];
+    const cursors: unknown[] = [
+      Number.NaN,
+      undefined,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      -100,
+      -1,
+      0,
+      0.9,
+      1,
+      4.999,
+      5,
+      15,
+      15.5,
+      50,
+      94.5,
+      95,
+      99,
+      999,
+    ];
+    for (const len of shapes) {
+      const C = makeCandles(len);
+      for (const cursor of cursors) {
+        const preview = clampedSeedEnd(C, cursor as number);
+        const sim = createLiveSimulator({ candles: C, seedEnd: cursor as number });
+        expect(sim.seedCandles.length).toBe(preview);
+        sim.dispose();
+      }
+    }
+  });
+});
+
+describe("empty candles (degenerate input handled gracefully)", () => {
+  it("simulator on empty candles seeds 0 bars and is immediately complete", () => {
+    const sim = createLiveSimulator({ candles: [] });
+    expect(sim.seedCandles.length).toBe(0);
+    expect(sim.getEmittedQueueCount()).toBe(0);
+    expect(sim.getState()).toBe("complete");
+    sim.dispose();
+  });
+
+  it("getLastEmittedIdx returns -1 sentinel on empty candles (snapshot slice is empty)", () => {
+    const sim = createLiveSimulator({ candles: [] });
+    expect(sim.getLastEmittedIdx()).toBe(-1);
+    // Host slicing `candles.slice(0, idx + 1)` gets the correct empty
+    // snapshot instead of a phantom `candles[0]`.
+    expect([].slice(0, sim.getLastEmittedIdx() + 1)).toEqual([]);
+    sim.dispose();
+  });
+});
+
+describe("getLastEmittedIdx (simulator-owned playhead, no drift)", () => {
+  const C = makeCandles(100);
+
+  it("idle (queue not started) points at the last seed bar, not the first unseen one", () => {
+    // The off-by-one is the no-look-ahead invariant: at idle the cursor
+    // must point at the last *seen* bar (= last seed bar), not the next
+    // unseen one. seedEnd=40 + nextIdx=0 - 1 = 39.
+    const sim = createLiveSimulator({ candles: C, seedEnd: 40 });
+    expect(sim.getLastEmittedIdx()).toBe(39);
+    sim.dispose();
+  });
+
+  it("matches seedCandles.length - 1 at idle for any seedEnd", () => {
+    for (const seedEnd of [10, 25, 50, 75, 95]) {
+      const sim = createLiveSimulator({ candles: C, seedEnd });
+      expect(sim.getLastEmittedIdx()).toBe(sim.seedCandles.length - 1);
+      sim.dispose();
+    }
+  });
+
+  it("advances by exactly one per stepOnce", () => {
+    const sim = createLiveSimulator({ candles: C, seedEnd: 40 });
+    let prev = sim.getLastEmittedIdx();
+    for (let i = 0; i < 10; i++) {
+      sim.stepOnce();
+      const next = sim.getLastEmittedIdx();
+      expect(next - prev).toBe(1);
+      prev = next;
+    }
+    sim.dispose();
+  });
+
+  it("at completion equals the last index in the dataset", () => {
+    const sim = createLiveSimulator({ candles: C, seedEnd: 95 });
+    // Queue length is 5; step through all of it.
+    for (let i = 0; i < 10; i++) sim.stepOnce();
+    expect(sim.getState()).toBe("complete");
+    expect(sim.getLastEmittedIdx()).toBe(C.length - 1);
+    sim.dispose();
+  });
+
+  it("pairs with seedCandles for a host snapshot slice", () => {
+    const sim = createLiveSimulator({ candles: C, seedEnd: 40 });
+    // Idle: snapshot of every emitted bar = exactly the seed.
+    expect(C.slice(0, sim.getLastEmittedIdx() + 1)).toEqual(sim.seedCandles);
+    sim.stepOnce();
+    // After one step: snapshot grows by the just-emitted bar.
+    expect(C.slice(0, sim.getLastEmittedIdx() + 1)).toEqual([...sim.seedCandles, C[40]]);
+    sim.dispose();
+  });
+});
+
+describe("drift-class regressions (locked in by simulator-owned integers)", () => {
+  // Each test below targets a class of drift Codex caught during PR
+  // review. They all collapse to "simulator-owned integers don't drift"
+  // by construction now — there's no second derivation path.
+
+  it("no float drift in seedRatio round-trip (22/15 case)", () => {
+    // Host computes seedRatio = 15/22, simulator floor()s back. Older
+    // code path produced seedEnd=14 not 15. The seedEnd integer option
+    // (preferred) sidesteps this entirely.
+    const C22 = makeCandles(22);
+    const sim = createLiveSimulator({ candles: C22, seedEnd: 15 });
+    expect(sim.seedCandles.length).toBe(15);
+    expect(sim.getLastEmittedIdx()).toBe(14);
+    sim.dispose();
+  });
+
+  it("no float drift in progress × queueLen for exact integer counts", () => {
+    // After exactly 15 emits on a 22-bar queue, getProgress() = 15/22
+    // which floats to 0.6818... and `floor(0.6818 * 22) === 14`. The
+    // playhead is sourced from getLastEmittedIdx() (integer) so it
+    // returns the correct seedEnd + 15 - 1 regardless.
+    const C22 = makeCandles(22);
+    const sim = createLiveSimulator({ candles: C22, seedEnd: 1 });
+    expect(sim.seedCandles.length).toBe(clampedSeedEnd(C22, 1));
+    const seedEnd = sim.seedCandles.length;
+    const stepsToTake = Math.min(15, C22.length - seedEnd);
+    for (let i = 0; i < stepsToTake; i++) sim.stepOnce();
+    expect(sim.getEmittedQueueCount()).toBe(stepsToTake);
+    expect(sim.getLastEmittedIdx()).toBe(seedEnd + stepsToTake - 1);
+    sim.dispose();
+  });
+
+  it("no disagreement between simulator's actual seedEnd and clampedSeedEnd preview", () => {
+    // Host previews the clamp via clampedSeedEnd, then creates the
+    // simulator with the same anchor. The actual seed count must equal
+    // the preview — no double-clamping mismatch.
+    const C100 = makeCandles(100);
+    for (const anchor of [0, 1, 4, 50, 96, 99, 200]) {
+      const preview = clampedSeedEnd(C100, anchor);
+      const sim = createLiveSimulator({ candles: C100, seedEnd: anchor });
+      expect(sim.seedCandles.length).toBe(preview);
+      sim.dispose();
+    }
+  });
+});
+
+describe("seedEnd option (integer anchor, no float drift)", () => {
+  it("preserves the integer anchor when in-range — no roundoff from seedRatio path", () => {
+    // The specific case `Math.floor(22 * (15/22)) === 14` (instead of 15)
+    // would have happened if the host computed `seedRatio = anchor /
+    // length` and passed that in. Passing seedEnd directly sidesteps the
+    // multiply-back step entirely.
+    const C22 = makeCandles(22);
+    const sim = createLiveSimulator({ candles: C22, seedEnd: 15 });
+    expect(sim.seedCandles.length).toBe(15);
+    expect(sim.getLastEmittedIdx()).toBe(14);
+    sim.dispose();
+  });
+
+  it("agrees with clampedSeedEnd for arbitrary (n, anchor) sweep", () => {
+    // The simulator's actual `seedCandles.length` always equals what
+    // `clampedSeedEnd(candles, anchor)` previews — they both funnel
+    // through the same clamp.
+    for (const n of [20, 22, 33, 47, 100, 333]) {
+      const C = makeCandles(n);
+      for (const anchor of [3, n >> 2, n >> 1, (n * 3) >> 2, n - 2]) {
+        const sim = createLiveSimulator({ candles: C, seedEnd: anchor });
+        expect(sim.seedCandles.length).toBe(clampedSeedEnd(C, anchor));
+        sim.dispose();
+      }
+    }
+  });
+
+  it("clamps out-of-bounds seedEnd to SEED_RATIO_MIN/MAX bounds", () => {
+    // The simulator's seedEnd path goes through clampedSeedEnd so any
+    // out-of-range input lands within [5%, 95%]. Hosts can read the
+    // actual value via `sim.seedCandles.length` if it matters.
+    const C100 = makeCandles(100);
+    expect(createLiveSimulator({ candles: C100, seedEnd: 0 }).seedCandles.length).toBe(5);
+    expect(createLiveSimulator({ candles: C100, seedEnd: 1 }).seedCandles.length).toBe(5);
+    expect(createLiveSimulator({ candles: C100, seedEnd: -5 }).seedCandles.length).toBe(5);
+    expect(createLiveSimulator({ candles: C100, seedEnd: 99 }).seedCandles.length).toBe(95);
+    expect(createLiveSimulator({ candles: C100, seedEnd: 999 }).seedCandles.length).toBe(95);
+  });
+
+  it("seedEnd takes precedence when both seedEnd and seedRatio are passed", () => {
+    const C = makeCandles(100);
+    const sim = createLiveSimulator({ candles: C, seedEnd: 30, seedRatio: 0.8 });
+    expect(sim.seedCandles.length).toBe(30);
     sim.dispose();
   });
 });

--- a/packages/chart/src/replay.ts
+++ b/packages/chart/src/replay.ts
@@ -46,8 +46,39 @@ export type SimulatorHandle = {
   /** Initial seed history loaded into the LiveCandle. */
   readonly seedCandles: readonly NormalizedCandle[];
   getState(): SimulatorState;
-  /** 0..1 progress across the queued (= post-seed) candles. */
+  /**
+   * 0..1 progress across the queued (= post-seed) candles. **UI display
+   * only** (progress bar fill). Do not derive an integer index from this
+   * — `Math.floor(progress * queueLen)` can drift by one because of
+   * IEEE-754 roundoff (e.g. `(15/22) * 22 === 14.999...`). Use
+   * `getEmittedQueueCount()` or `getLastEmittedIdx()` instead.
+   */
   getProgress(): number;
+  /**
+   * Integer count of queued candles the simulator has fully emitted
+   * (i.e. fired `candleComplete` for). Sourced directly from the
+   * simulator's internal counter — exact, no float arithmetic.
+   */
+  getEmittedQueueCount(): number;
+  /**
+   * Integer index, in candle space, of the *last bar the simulator has
+   * emitted*. Equals `seedCandles.length + getEmittedQueueCount() - 1`
+   * (when at least one bar exists). Returns `-1` when `candles` is
+   * empty as a sentinel for "no bar emitted yet" — a host slicing
+   * `candles.slice(0, idx + 1)` then gets the correct empty array
+   * instead of a phantom `candles[0]`.
+   *
+   * This is the canonical "playhead" for any snapshot backtest, cursor
+   * label, or indicator slice that must not leak future data. It comes
+   * straight from the simulator's own state — there is no separate
+   * stateless helper to re-derive it, by design: every earlier "derive
+   * the same integer via independent math" path produced a drift bug
+   * (float roundoff, double-clamping, empty-array mismatch). Hosts
+   * that hold a `SimulatorHandle` should always read this method
+   * rather than computing the index from `getProgress()` or a saved
+   * cursor anchor.
+   */
+  getLastEmittedIdx(): number;
   play(): void;
   pause(): void;
   /**
@@ -71,6 +102,20 @@ export type SimulatorOptions = {
   candles: readonly NormalizedCandle[];
   /** Fraction of `candles` to load as seed before playback starts. Default 0.6. */
   seedRatio?: number;
+  /**
+   * Integer count of seed bars. Overrides `seedRatio` when both are
+   * passed. Preferred over `seedRatio` for any host that derives the
+   * anchor from a click index — passing an integer directly avoids
+   * the float roundoff `Math.floor(length * (anchor / length))` can
+   * introduce (e.g. `Math.floor(22 * (15/22)) === 14`, not 15).
+   *
+   * Clamped through `clampedSeedEnd` to the same `SEED_RATIO_MIN/MAX`
+   * bounds. A user-supplied `seedEnd: 1` on 100 candles becomes 5
+   * internally; hosts that need the actual value should read
+   * `sim.seedCandles.length` (or preview with `clampedSeedEnd`
+   * before construction).
+   */
+  seedEnd?: number;
   /** Number of partial ticks emitted before each candleComplete. Default 5. */
   ticksPerCandle?: number;
   /** Initial inter-frame interval in ms. Default 250. */
@@ -79,11 +124,26 @@ export type SimulatorOptions = {
 
 export function createLiveSimulator(opts: SimulatorOptions): SimulatorHandle {
   const candles = opts.candles;
-  const seedRatio = clamp(opts.seedRatio ?? 0.6, 0.05, 0.95);
   const ticksPerCandle = Math.max(1, opts.ticksPerCandle ?? 5);
   let intervalMs = Math.max(8, opts.intervalMs ?? 250);
 
-  const seedEnd = Math.max(1, Math.floor(candles.length * seedRatio));
+  // Prefer `seedEnd` when provided — it avoids the seedRatio float-roundoff
+  // that would otherwise make the simulator and host-side invariant helpers
+  // disagree by one bar on ~3.7% of (length, anchor) combinations. When
+  // only `seedRatio` is given, fall back to the original ratio-based path.
+  //
+  // Both paths funnel through `clampedSeedEnd` so `sim.seedCandles.length`
+  // always matches what `clampedSeedEnd(candles, anchor)` previews. Hosts
+  // that want to know the actual seed end before construction can call
+  // `clampedSeedEnd` directly; either way there's only one clamp logic
+  // and no double-clamping disagreement to debug.
+  // Both paths funnel through `clampedSeedEnd`, which internally floors,
+  // so there is exactly one place that decides the simulator's seed-end
+  // integer — no second derivation path to disagree with.
+  const seedEnd =
+    opts.seedEnd !== undefined
+      ? clampedSeedEnd(candles, opts.seedEnd)
+      : clampedSeedEnd(candles, candles.length * clamp(opts.seedRatio ?? 0.6, 0.05, 0.95));
   const seedCandles = candles.slice(0, seedEnd);
   const queue = candles.slice(seedEnd);
 
@@ -165,6 +225,16 @@ export function createLiveSimulator(opts: SimulatorOptions): SimulatorHandle {
     seedCandles,
     getState: () => state,
     getProgress,
+    getEmittedQueueCount: () => nextIdx,
+    getLastEmittedIdx: () => {
+      // Empty dataset: no bar has been (or can be) emitted. `-1`
+      // signals "no bar yet" — hosts using this for a snapshot slice
+      // get `candles.slice(0, -1 + 1) === []` which is the correct
+      // empty snapshot. Returning `0` would point at a non-existent
+      // index in an empty array.
+      if (candles.length === 0) return -1;
+      return Math.min(candles.length - 1, seedEnd + nextIdx - 1);
+    },
     play(): void {
       if (state === "complete" || state === "playing") return;
       state = "playing";
@@ -257,3 +327,84 @@ function buildPartial(target: NormalizedCandle, i: number, N: number): Normalize
 function clamp(v: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(hi, v));
 }
+
+// ============================================================
+// Replay UI invariants
+// ============================================================
+//
+// Pure helpers for hosts building a "scrubbable replay" UI on top of
+// `createLiveSimulator`. They keep cursor display, snapshot-backtest
+// slice, and the simulator's emitted bars in lockstep — three places
+// that all need to derive the same integer index from the same
+// (anchor, progress) inputs. Drift between them is the no-look-ahead
+// leak Replay exists to prevent.
+//
+// The functions take `readonly unknown[]` and only read `.length`, so
+// they work for any candle-array-like input without coupling to the
+// chart's `NormalizedCandle` type.
+
+/**
+ * Minimum fraction of total history loaded as seed before the
+ * simulator starts replaying. Below this the chart has too little
+ * warm-up data; above the matching `SEED_RATIO_MAX` there's nothing
+ * left to replay. Anchor clicks are clamped through these bounds so
+ * the simulator's actual seed end and the host's cursor display
+ * always agree.
+ */
+export const SEED_RATIO_MIN = 0.05;
+
+/** Maximum fraction of total history loaded as seed. See `SEED_RATIO_MIN`. */
+export const SEED_RATIO_MAX = 0.95;
+
+/**
+ * Clamp a user-supplied anchor (cursor index) to a valid seed-end
+ * range, returning the *exact* integer the simulator will use.
+ *
+ * Always returns an integer — `Math.floor(cursorIndex)` is applied
+ * inside so a fractional input (e.g. a sub-pixel UI coordinate)
+ * doesn't make this helper return a different number from what
+ * `createLiveSimulator({ seedEnd })` would resolve to. The two
+ * paths share this single function so they cannot drift apart.
+ *
+ * Non-numeric / `NaN` / `undefined` inputs fall back to the default
+ * 60% mark (matching the simulator's default `seedRatio: 0.6`)
+ * rather than propagating `NaN` through downstream code — UI math
+ * can sometimes produce `NaN` (`0 / 0`, missing event coords) and a
+ * silent simulator stall is worse than a deterministic fallback.
+ *
+ * Guarantees at least 1 seed bar and at least 1 queue bar (provided
+ * `candles.length >= 2`) so the replay has both warm-up and content.
+ */
+export function clampedSeedEnd(candles: readonly unknown[], cursorIndex: number): number {
+  // Empty candles: the simulator can only seed zero bars, so the
+  // preview must agree. Returning the usual `Math.max(1, ...)` floor
+  // would let this helper report 1 while `sim.seedCandles.length`
+  // stayed 0 — the same kind of preview/library disagreement the rest
+  // of this module exists to prevent.
+  if (candles.length === 0) return 0;
+  const min = Math.max(1, Math.floor(candles.length * SEED_RATIO_MIN));
+  const max = Math.max(min, Math.floor(candles.length * SEED_RATIO_MAX));
+  // `Math.floor` coerces booleans / null / numeric strings cleanly,
+  // but produces `NaN` for actual NaN / undefined / non-numeric. Catch
+  // that single case explicitly so the fallback is deterministic.
+  const floored = Math.floor(cursorIndex);
+  const safe = Number.isNaN(floored) ? Math.floor(candles.length * 0.6) : floored;
+  return Math.max(min, Math.min(max, safe));
+}
+
+// Why no standalone `resolveQueueIdx(candles, cursor, count)` or
+// `lastEmittedIdx(candles, cursor, count)` helpers here:
+//
+// Earlier drafts of this subpath exposed both. Each shipped with a
+// drift bug Codex caught — float-roundoff in `seedRatio` round-trips
+// (`Math.floor(22 * (15/22)) === 14`, not 15), float-roundoff in
+// `progress * queueLen`, then double-clamping disagreement between
+// the simulator's `seedEnd` and the helper's own `clampedSeedEnd`.
+//
+// All three were the same class of bug: two parties (the simulator
+// and a standalone helper) re-deriving the same integer from
+// independent inputs. The fix wasn't another epsilon; it was to
+// remove the second derivation path entirely. The simulator owns
+// `seedEnd` and `nextIdx` as integers — hosts read them via
+// `seedCandles.length`, `getEmittedQueueCount()`, and
+// `getLastEmittedIdx()`. There is no second source of truth.


### PR DESCRIPTION
## Summary

Adds integer accessors to `SimulatorHandle` so hosts building a "scrubbable replay" UI on top of `createLiveSimulator` can read the simulator's playhead and seed count directly, without re-deriving them through independent math.

| Surface | Purpose |
|---|---|
| `sim.getEmittedQueueCount()` | Exact integer count of queued candles fully emitted so far |
| `sim.getLastEmittedIdx()` | Exact integer index in candle space of the last emitted bar (`-1` sentinel on empty arrays) |
| `SimulatorOptions.seedEnd?` | Integer seed-bar count, preferred over `seedRatio` for click-anchor inputs |
| `clampedSeedEnd(candles, cursor)` | Stateless preview of the integer seed-end the simulator will pick |
| `SEED_RATIO_MIN` / `SEED_RATIO_MAX` | Bounds constants |

## Why

Replay UI consumers (cursor display, snapshot backtest slice, indicator slices) all need to agree on "which bar the user has seen most recently". Reading that integer directly from the simulator is the only design that doesn't admit drift bugs at the boundary.

Earlier drafts of this PR shipped two stateless helpers — `lastEmittedIdx(candles, cursor, count)` and `resolveQueueIdx(...)` — that re-derived the same integer the simulator already owned. Six review iterations surfaced six distinct drift bugs:

1. Float roundoff in `seedRatio` round-trips (`Math.floor(22 * (15/22)) === 14`, not 15)
2. Float roundoff in `progress * queueLen`
3. Double-clamping mismatch between the simulator's `seedEnd` and the helper's `clampedSeedEnd`
4. Fractional-cursor floor mismatch (preview returned `10.9`, simulator floored to `10`)
5. NaN silent propagation (helper returned NaN → simulator stalled in "complete")
6. Empty-array preview/library disagreement (preview returned `1`, simulator seeded `0`)

All six were the same class of bug: two parties (the simulator and a stateless helper) deriving the same integer through independent paths. The shipped design eliminates the standalone derivation paths. The surviving `clampedSeedEnd` helper is called *literally by the simulator itself* for its own seed-end computation — they share one function, not "compatible logic".

## API change

- `@trendcraft/chart/replay` gains the 5 new symbols listed above. Pre-existing exports (`createLiveSimulator`, `SimulatorHandle`, etc.) are unchanged.
- `SimulatorHandle` gains two methods (`getEmittedQueueCount`, `getLastEmittedIdx`). Existing methods unchanged.
- `SimulatorOptions` gains `seedEnd?`. `seedRatio?` still works; `seedEnd` takes precedence when both are passed.
- `getProgress()`'s docstring is tightened: it is for UI display only and must not be multiplied by `queueLen` to derive an integer index — use `getEmittedQueueCount()` / `getLastEmittedIdx()` instead.

## Test plan

- [x] `pnpm test` chart: 858/858 PASS (22 new in `__tests__/replay.test.ts`).
- [x] `pnpm test` core / mcp: 5995 + 74 PASS.
- [x] `pnpm build`: all packages green; `vite-plugin-dts` emits cleanly.
- [x] `pnpm lint`: clean.
- [x] `pnpm size-check`: replay subpath 935 B (limit 3 kB).
- [x] **Property test** asserts `clampedSeedEnd(C, x) === createLiveSimulator({candles: C, seedEnd: x}).seedCandles.length` for 9 candle shapes × 18 cursor values (162 pairs) including `NaN`, `±Infinity`, empty `C`, fractional cursors, out-of-range cursors. If any preview/library drift remains, this test fails without waiting for an external review iteration.
- [x] Regression tests for each of the six drift cases above (22/15 float drift, fractional floor, NaN fallback, empty-array sentinel, etc.) are present.

## Notes

This PR closes the chart-side of Phase 1 from the broader Strategy Studio audit. Studio's own `live-simulator.ts` and `replay.ts` files (currently local forks) can be deleted in a follow-up PR targeting `epic/strategy-studio` once this lands — they will become re-exports of the canonical subpath.

The `getProgress()` / `getLastEmittedIdx()` split is a deliberate two-track API: float `getProgress()` for UI progress-bar fills (smooth interpolation during partial ticks) and integer `getLastEmittedIdx()` for any logic that needs an exact bar index. Mixing the two is the bug class that motivated this design.