### PR TITLE
feat(core): add getIndicatorPresetKey for kind to preset-key resolution

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Added — `getIndicatorPresetKey(kind)` for manifest-kind → preset-key resolution
+
+Forward sibling of `getIndicatorPreset(kind)`: returns the preset's
+short key (`"bb"`) when given either the manifest's canonical long name
+(`"bollingerBands"`) or the short key itself. Returns `undefined` when
+the kind has no preset (regime classifiers, smc events).
+
+Typical use is bridging manifest output to chart-side APIs that key on
+the short name, e.g. `connectIndicators({ presets }).add(key, ...)`.
+Hosts that previously did their own reverse scan over `indicatorPresets`
+can drop that and read directly from the canonical alias table.
+
+Both helpers share the same `KIND_ALIASES` table internally, so they
+cannot drift on which kind maps where.
+
 ### Added — Extended `BacktestResult` metrics (Sortino, Calmar, CAGR, Expectancy, Exposure, per-trade aggregates)
 
 `BacktestResult` gains **eleven** new fields filled in by every call to

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1320,7 +1320,13 @@ export {
 export type { IndicatorCategory, IndicatorPreset, LivePreset, ParamSchema } from "./streaming";
 // Streaming (real-time trading pipeline)
 export * as streaming from "./streaming";
-export { createLiveCandle, getIndicatorPreset, indicatorPresets, livePresets } from "./streaming";
+export {
+  createLiveCandle,
+  getIndicatorPreset,
+  getIndicatorPresetKey,
+  indicatorPresets,
+  livePresets,
+} from "./streaming";
 export type {
   AlphaDecayOptions,
   AlphaDecayResult,

--- a/packages/core/src/streaming/__tests__/indicator-preset-lookup.test.ts
+++ b/packages/core/src/streaming/__tests__/indicator-preset-lookup.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { listManifests } from "../../manifest";
-import { getIndicatorPreset, indicatorPresets } from "../indicator-presets";
+import { getIndicatorPreset, getIndicatorPresetKey, indicatorPresets } from "../indicator-presets";
 
 describe("getIndicatorPreset", () => {
   it("resolves a manifest long-name kind to its preset", () => {
@@ -131,6 +131,70 @@ describe("getIndicatorPreset", () => {
     // produce ~8e-4. Pin the lower bound so any silent revert to 1e4
     // (factor 10000 smaller) trips the assertion.
     expect(Math.abs(lastValue as number)).toBeGreaterThan(0.5);
+  });
+
+  it.each([
+    ["awesomeOscillator", "ao"],
+    ["balanceOfPower", "bop"],
+    ["bollingerBands", "bb"],
+    ["choppinessIndex", "choppiness"],
+    ["coppockCurve", "coppock"],
+    ["donchianChannel", "donchian"],
+    ["easeOfMovement", "emv"],
+    ["ewmaVolatility", "ewmaVol"],
+    ["fairValueGap", "fvg"],
+    ["historicalVolatility", "hv"],
+    ["keltnerChannel", "keltner"],
+    ["openingRange", "orb"],
+    ["ulcerIndex", "ulcer"],
+  ])("getIndicatorPresetKey: alias %s → %s", (long, short) => {
+    expect(getIndicatorPresetKey(long)).toBe(short);
+  });
+
+  it("getIndicatorPresetKey returns the input when it is already a canonical short key", () => {
+    expect(getIndicatorPresetKey("bb")).toBe("bb");
+    expect(getIndicatorPresetKey("rsi")).toBe("rsi");
+  });
+
+  it("getIndicatorPresetKey returns undefined for kinds with no preset", () => {
+    expect(getIndicatorPresetKey("notARealIndicator")).toBeUndefined();
+    expect(getIndicatorPresetKey("hmmRegimes")).toBeUndefined();
+  });
+
+  it("getIndicatorPresetKey ignores inherited Object prototype property names", () => {
+    // `in` would return true for these and produce invalid keys; the
+    // helper must only honor own properties of the presets registry.
+    expect(getIndicatorPresetKey("constructor")).toBeUndefined();
+    expect(getIndicatorPresetKey("toString")).toBeUndefined();
+    expect(getIndicatorPresetKey("hasOwnProperty")).toBeUndefined();
+    expect(getIndicatorPresetKey("__proto__")).toBeUndefined();
+  });
+
+  it("getIndicatorPresetKey agrees with getIndicatorPreset for every kind that resolves", () => {
+    // Drift gate: the two helpers read the same alias map, so for any
+    // input that resolves to a preset, the key returned by *Key must
+    // index the same preset object that getIndicatorPreset returns.
+    // Locks in the "single source of truth" invariant.
+    const aliasInputs = [
+      "bollingerBands",
+      "bb",
+      "awesomeOscillator",
+      "ao",
+      "rsi",
+      "macd",
+      "ewmaVolatility",
+      "ewmaVol",
+    ];
+    for (const kind of aliasInputs) {
+      const preset = getIndicatorPreset(kind);
+      const key = getIndicatorPresetKey(kind);
+      if (preset === undefined) {
+        expect(key).toBeUndefined();
+      } else {
+        expect(key).toBeDefined();
+        expect(indicatorPresets[key as string]).toBe(preset);
+      }
+    }
   });
 
   it("every manifest kind that has a preset can be resolved by long name", () => {

--- a/packages/core/src/streaming/index.ts
+++ b/packages/core/src/streaming/index.ts
@@ -131,7 +131,7 @@ export {
 } from "./guards";
 export type { IndicatorCategory, IndicatorPreset, ParamSchema } from "./indicator-presets";
 // Unified indicator presets (static compute + incremental factory)
-export { getIndicatorPreset, indicatorPresets } from "./indicator-presets";
+export { getIndicatorPreset, getIndicatorPresetKey, indicatorPresets } from "./indicator-presets";
 // LiveCandle (lightweight live candle + indicator manager)
 export { createLiveCandle } from "./live-candle";
 export type { LivePreset } from "./live-presets";

--- a/packages/core/src/streaming/indicator-presets.ts
+++ b/packages/core/src/streaming/indicator-presets.ts
@@ -2170,3 +2170,27 @@ const KIND_ALIASES: Record<string, string> = {
 export function getIndicatorPreset(kind: string): IndicatorPreset | undefined {
   return indicatorPresets[KIND_ALIASES[kind] ?? kind];
 }
+
+/**
+ * Resolve an indicator preset's short key by `kind`, accepting either the
+ * manifest's canonical long name (e.g. `"bollingerBands"`) or the short key
+ * itself (e.g. `"bb"`). Returns `undefined` when the kind has no preset.
+ *
+ * The forward sibling of `getIndicatorPreset`: reach for this when the caller
+ * needs the key string itself — typical use is bridging manifest output to
+ * chart-side APIs that key on the short name (`connectIndicators({ presets })
+ * .add(key, ...)`). Reads from the same `KIND_ALIASES` table that drives
+ * preset resolution, so the two helpers never disagree about which kind maps
+ * where.
+ *
+ * @example
+ * ```ts
+ * getIndicatorPresetKey("bollingerBands"); // "bb" (resolved via alias)
+ * getIndicatorPresetKey("bb");             // "bb" (direct hit)
+ * getIndicatorPresetKey("hmmRegimes");     // undefined (no preset entry)
+ * ```
+ */
+export function getIndicatorPresetKey(kind: string): string | undefined {
+  if (Object.hasOwn(KIND_ALIASES, kind)) return KIND_ALIASES[kind];
+  return Object.hasOwn(indicatorPresets, kind) ? kind : undefined;
+}


### PR DESCRIPTION
## Summary

Adds `getIndicatorPresetKey(kind: string): string | undefined`, the forward sibling of the existing `getIndicatorPreset(kind)`. Given either the manifest's canonical long name (`"bollingerBands"`) or the short key itself (`"bb"`), it returns the canonical short key — or `undefined` for kinds with no preset (regime classifiers, smc events, unknown input).

Hosts that bridge manifest output to chart-side APIs keyed on the short name (e.g. `connectIndicators({ presets }).add(key, ...)`) previously had to maintain their own reverse scan over `indicatorPresets`. With this helper they can drop that and read directly from the canonical alias table.

## Why it matters

There is now exactly **one** source of truth for kind → short-key resolution: the existing `KIND_ALIASES` table in `indicator-presets.ts`. Both `getIndicatorPreset` (returns the preset object) and the new `getIndicatorPresetKey` (returns the key string) read it. By construction they cannot disagree about which kind maps where.

## Surface

| Export | Module | Signature |
|---|---|---|
| `getIndicatorPresetKey` | `trendcraft` / `trendcraft/streaming` | `(kind: string) => string \| undefined` |

The function uses `Object.hasOwn` on both `KIND_ALIASES` and `indicatorPresets` lookups so inherited `Object` prototype property names (`"constructor"`, `"toString"`, `"__proto__"`, `"hasOwnProperty"`) correctly resolve to `undefined` rather than leaking a function or stray string through the API.

## Test plan

- [x] `pnpm test` in `packages/core` — 6012 / 6012 PASS (37 in the touched file)
- [x] `pnpm lint` at repo root — clean
- [x] `pnpm -r build` — all packages build
- [x] New tests cover:
  - All 13 entries in `KIND_ALIASES` resolve to the documented short key
  - Already-canonical keys (`"bb"`, `"rsi"`) are returned unchanged
  - Unknown / preset-less kinds return `undefined`
  - **Drift gate**: for every input that resolves, `indicatorPresets[getIndicatorPresetKey(kind)]` is identity-equal to `getIndicatorPreset(kind)`
  - **Prototype-property regression**: `"constructor"`, `"toString"`, `"hasOwnProperty"`, `"__proto__"` all return `undefined`

## CHANGELOG

Added under `Unreleased`.

## Notes

This is the first PR in a small follow-up that lets Strategy Studio (and any future host) drop its local `resolvePresetKey` helper, which was doing an `O(n)` reverse scan over `indicatorPresets`. That host-side cleanup is a separate PR targeting the Studio epic.