### PR TITLE
feat(core): listTunables for strategy parameter introspection

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+### Added — `listTunables(strategy)` for numeric parameter introspection
+
+Walks a `StrategyJSON`'s entry / exit conditions and emits one `Tunable`
+per numeric registry-declared parameter. Mirrors the strategy-parameter
+introspection surface exposed by other TA frameworks (TA-Lib's
+`TA_GetOptInputParameterInfo`, backtrader's `self.params`, freqtrade's
+`IntParameter` / `DecimalParameter`, Pine Script's `input.int` /
+`input.float`).
+
+Each `Tunable.key` follows the canonical `<bucket>.<leafIndex>.<paramName>`
+path syntax so the result feeds `gridSearchFromJSON` without
+translation. The full registry `ParamDef` is attached as `schema` so
+callers can read `min` / `max` / `default` / `integer` / `precision` /
+`suggestedMin` / `suggestedMax` directly. There is **no** heuristic on
+top — integer / continuous typing is read from the explicit
+`schema.integer` annotation, in line with the industry pattern of
+making this typing explicit at the schema level (TA-Lib enum,
+freqtrade class hierarchy, Pine Script function pair).
+
+Conditions whose registry entry is missing or whose params are all
+non-numeric are silently skipped, so a strategy with `alwaysTrue` /
+`alwaysFalse` returns `[]`. Defaults to `backtestRegistry`.
+
+Also adds `ParamDef.tunable?: boolean` so registry entries can opt out
+of enumeration when they declare `type: "number"` for compactness but
+the runtime value is non-scalar — applied internally to the Perfect
+Order `periods` param (consumed as `number[]`).
+
 ### Added — `getIndicatorPresetKey(kind)` for manifest-kind → preset-key resolution
 
 Forward sibling of `getIndicatorPreset(kind)`: returns the preset's

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1297,6 +1297,7 @@ export type {
   SessionOverrides,
   StrategyDefinition,
   StrategyJSON,
+  Tunable,
   ValidationResult as StrategyValidationResult,
 } from "./strategy";
 // Strategy Definition
@@ -1308,6 +1309,7 @@ export {
   createSessionFromStrategy,
   flattenStrategyLeaves,
   hydrateCondition,
+  listTunables,
   loadStrategy,
   parseLeafPath,
   parseStrategy,

--- a/packages/core/src/strategy/__tests__/tunables.test.ts
+++ b/packages/core/src/strategy/__tests__/tunables.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import { gridSearchFromJSON } from "../../optimization/grid-search-json";
+import type { NormalizedCandle } from "../../types";
+import { backtestRegistry } from "../registry-backtest";
+import { streamingRegistry } from "../registry-streaming";
+import { listTunables } from "../tunables";
+import type { StrategyJSON } from "../types";
+
+function makeCandles(count: number, startPrice = 100): NormalizedCandle[] {
+  const out: NormalizedCandle[] = [];
+  const baseTime = Date.now() - count * 86_400_000;
+  for (let i = 0; i < count; i++) {
+    const close = startPrice + i * 0.5 + Math.sin(i / 5) * 2;
+    out.push({
+      time: baseTime + i * 86_400_000,
+      open: close - 0.2,
+      high: close + 0.4,
+      low: close - 0.4,
+      close,
+      volume: 1000 + i,
+    });
+  }
+  return out;
+}
+
+const GOLDEN_CROSS: StrategyJSON = {
+  $schema: "trendcraft/strategy",
+  version: 1,
+  id: "gc",
+  name: "Golden Cross",
+  entry: { name: "goldenCross", params: { shortPeriod: 5, longPeriod: 25 } },
+  exit: { name: "deadCross", params: { shortPeriod: 5, longPeriod: 25 } },
+};
+
+const BUY_AND_HOLD: StrategyJSON = {
+  $schema: "trendcraft/strategy",
+  version: 1,
+  id: "bh",
+  name: "Buy and Hold",
+  entry: { name: "alwaysTrue" },
+  exit: { name: "alwaysFalse" },
+};
+
+describe("listTunables", () => {
+  it("emits one Tunable per numeric registry-declared param", () => {
+    const tunables = listTunables(GOLDEN_CROSS);
+    const keys = tunables.map((t) => t.key).sort();
+    expect(keys).toEqual([
+      "entry.0.longPeriod",
+      "entry.0.shortPeriod",
+      "exit.0.longPeriod",
+      "exit.0.shortPeriod",
+    ]);
+  });
+
+  it("attaches the full registry ParamDef as `schema`", () => {
+    const tunables = listTunables(GOLDEN_CROSS);
+    const short = tunables.find((t) => t.key === "entry.0.shortPeriod");
+    expect(short).toBeDefined();
+    if (!short) return;
+    // Caller reads typing / bounds / hints directly via schema — no
+    // heuristic wrapper.
+    expect(short.schema.type).toBe("number");
+    expect(short.schema.integer).toBe(true);
+    expect(typeof short.schema.default).toBe("number");
+    expect(typeof short.schema.min).toBe("number");
+  });
+
+  it("identifies each Tunable with bucket, leafIndex, conditionName, paramName", () => {
+    const tunables = listTunables(GOLDEN_CROSS);
+    const short = tunables.find((t) => t.key === "entry.0.shortPeriod");
+    expect(short).toBeDefined();
+    if (!short) return;
+    expect(short.bucket).toBe("entry");
+    expect(short.leafIndex).toBe(0);
+    expect(short.conditionName).toBe("goldenCross");
+    expect(short.paramName).toBe("shortPeriod");
+  });
+
+  it("returns [] for strategies whose conditions take no numeric params", () => {
+    expect(listTunables(BUY_AND_HOLD)).toEqual([]);
+  });
+
+  it("walks nested AND / OR combinators in depth-first order", () => {
+    const strategy: StrategyJSON = {
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "nested",
+      name: "Nested",
+      entry: {
+        op: "and",
+        conditions: [
+          { name: "goldenCross", params: { shortPeriod: 5, longPeriod: 25 } },
+          {
+            op: "or",
+            conditions: [
+              { name: "rsiBelow", params: { threshold: 30, period: 14 } },
+              { name: "rsiAbove", params: { threshold: 70, period: 14 } },
+            ],
+          },
+        ],
+      },
+      exit: { name: "alwaysFalse" },
+    };
+    const buckets = listTunables(strategy).map(
+      (t) => `${t.bucket}.${t.leafIndex}.${t.conditionName}`,
+    );
+    expect(buckets).toContain("entry.0.goldenCross");
+    expect(buckets).toContain("entry.1.rsiBelow");
+    expect(buckets).toContain("entry.2.rsiAbove");
+  });
+
+  it("skips registry params marked `tunable: false`", () => {
+    // perfectOrder* declares `periods` with `type: "number"` for schema
+    // compactness, but the runtime value is `number[]` (the factory
+    // calls `periods.join(...)`). listTunables must honor the
+    // `tunable: false` opt-out so a UI doesn't seed a scalar grid range
+    // for a vector-typed param.
+    const strategy: StrategyJSON = {
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "po",
+      name: "Perfect Order",
+      entry: { name: "perfectOrderBullish" },
+      exit: { name: "alwaysFalse" },
+    };
+    const tunables = listTunables(strategy);
+    expect(tunables.find((t) => t.paramName === "periods")).toBeUndefined();
+  });
+
+  it("skips leaves whose condition is not in the registry", () => {
+    const strategy: StrategyJSON = {
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "partial",
+      name: "Partial",
+      entry: { name: "goldenCross", params: { shortPeriod: 5, longPeriod: 25 } },
+      exit: { name: "neverRegistered" as string },
+    };
+    const tunables = listTunables(strategy);
+    expect(tunables.every((t) => t.bucket === "entry")).toBe(true);
+  });
+
+  it("accepts a ConditionRegistry parametrised over any condition type", () => {
+    // Compile-time check: listTunables only reads `entry.params` and
+    // must accept any registry, not just ConditionRegistry<Condition>.
+    // The function call below would not type-check if the registry
+    // parameter were pinned to the backtest condition type.
+    expect(() => listTunables(BUY_AND_HOLD, streamingRegistry)).not.toThrow();
+  });
+
+  it("defaults to `backtestRegistry` when no registry is provided", () => {
+    // Both call shapes must produce the same result for the common
+    // case — the default exists so non-MTF callers don't have to import
+    // and pass the registry every time.
+    const withDefault = listTunables(GOLDEN_CROSS);
+    const withExplicit = listTunables(GOLDEN_CROSS, backtestRegistry);
+    expect(withDefault).toEqual(withExplicit);
+  });
+
+  it("PROPERTY: every emitted Tunable.key is accepted as a path by gridSearchFromJSON", () => {
+    // Drift gate: the keys listTunables emits must round-trip through
+    // gridSearchFromJSON's path validator. If the format ever changes
+    // on either side without the other updating, this catches it
+    // structurally for every demo + a synthetic nested strategy.
+    const syntheticNested: StrategyJSON = {
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "synth",
+      name: "Synth",
+      entry: {
+        op: "and",
+        conditions: [
+          { name: "rsiBelow", params: { threshold: 30, period: 14 } },
+          { name: "goldenCross", params: { shortPeriod: 5, longPeriod: 25 } },
+        ],
+      },
+      exit: { name: "alwaysFalse" },
+    };
+    const candles = makeCandles(60);
+    for (const strategy of [GOLDEN_CROSS, syntheticNested]) {
+      for (const tunable of listTunables(strategy)) {
+        const minVal = typeof tunable.schema.min === "number" ? tunable.schema.min : 0;
+        const range = { path: tunable.key, min: minVal, max: minVal + 1, step: 1 };
+        try {
+          gridSearchFromJSON(candles, strategy, [range], backtestRegistry, { metric: "returns" });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          expect(
+            msg,
+            `tunable ${tunable.key}: gridSearchFromJSON rejected path with "${msg}"`,
+          ).not.toMatch(/^Invalid range path/);
+        }
+      }
+    }
+  });
+});

--- a/packages/core/src/strategy/index.ts
+++ b/packages/core/src/strategy/index.ts
@@ -20,6 +20,11 @@ export { backtestRegistry } from "./registry-backtest";
 export { streamingRegistry } from "./registry-streaming";
 // New: Serialization
 export { parseStrategy, parseStrategySafe, serializeStrategy } from "./serialize";
+export type { Tunable } from "./tunables";
+// Strategy tunables — enumerate numeric registry-declared params for
+// optimization / range editors. Mirrors the introspection surface
+// exposed by TA-Lib / freqtrade / Pine Script.
+export { listTunables } from "./tunables";
 // Existing exports
 // New: Strategy JSON Serialization types
 export type {

--- a/packages/core/src/strategy/registry-backtest.ts
+++ b/packages/core/src/strategy/registry-backtest.ts
@@ -405,7 +405,11 @@ backtestRegistry.register({
 // ============================================
 
 const poParams = {
-  periods: { type: "number" as const, description: "MA periods (array via JSON)" },
+  periods: {
+    type: "number" as const,
+    tunable: false,
+    description: "MA periods (array via JSON)",
+  },
 };
 
 backtestRegistry.register({

--- a/packages/core/src/strategy/tunables.ts
+++ b/packages/core/src/strategy/tunables.ts
@@ -1,0 +1,105 @@
+/**
+ * Strategy Tunables
+ *
+ * Walk a `StrategyJSON` to enumerate the numeric parameters that an
+ * optimizer or UI can vary. Mirrors the introspection surface every
+ * mainstream TA framework exposes — TA-Lib's
+ * `TA_GetOptInputParameterInfo`, backtrader's `self.params`, freqtrade's
+ * `IntParameter` / `DecimalParameter`, Pine Script's `input.int` /
+ * `input.float`.
+ *
+ * Each emitted `Tunable.key` follows the canonical path syntax
+ * (`<bucket>.<leafIndex>.<paramName>`, see `parseLeafPath` /
+ * `applyParamOverrides`) so the result feeds `gridSearchFromJSON`
+ * without translation.
+ */
+
+import type { Condition } from "../types";
+import type { ConditionRegistry } from "./registry";
+import { backtestRegistry } from "./registry-backtest";
+import type { ParamDef, StrategyJSON } from "./types";
+import { flattenStrategyLeaves } from "./walker";
+
+/**
+ * One tunable parameter discovered by walking a strategy's ConditionSpec.
+ *
+ * Numeric params only — `string` / `boolean` schema entries are filtered
+ * out at enumeration time (they aren't tunable on a numeric grid).
+ * Params marked `schema.tunable === false` are also skipped (used by the
+ * registry to opt out of enumeration when `type: "number"` is declared
+ * for compactness but the runtime value is non-scalar — e.g. MA period
+ * vectors).
+ *
+ * The full registry `ParamDef` is attached as `schema` so callers can read
+ * `schema.min` / `max` / `default` / `integer` / `precision` /
+ * `suggestedMin` / `suggestedMax` directly. There is deliberately **no**
+ * heuristic on top — the industry standard (TA-Lib's
+ * `TA_OptInput_IntegerRange` vs `TA_OptInput_RealRange`, freqtrade's
+ * `IntParameter` vs `DecimalParameter`, Pine Script's `input.int` vs
+ * `input.float`) is to make integer / continuous typing explicit at the
+ * schema level, not infer it.
+ */
+export type Tunable = {
+  /** Canonical path: `<bucket>.<leafIndex>.<paramName>`. */
+  key: string;
+  bucket: "entry" | "exit";
+  leafIndex: number;
+  conditionName: string;
+  paramName: string;
+  /** Full registry `ParamDef`. Read `.min` / `.max` / `.integer` / etc. directly. */
+  schema: ParamDef;
+};
+
+/**
+ * Walk a strategy JSON's `entry` / `exit` and emit one `Tunable` per
+ * numeric registry-declared parameter. Wrapper around
+ * `flattenStrategyLeaves` that joins each leaf against `registry`.
+ *
+ * Conditions whose registry entry is missing or whose params are all
+ * non-numeric are silently skipped, so a strategy with `alwaysTrue` /
+ * `alwaysFalse` returns `[]`. For partially-registered strategies
+ * (one valid + one unknown), only the valid leaves are surfaced —
+ * `gridSearchFromJSON` will reject the unknown leaf upfront when
+ * actually run.
+ *
+ * Defaults to `backtestRegistry` so the common case is parameter-less.
+ * The function reads `entry.params` only (no `.create` / `.hydrate`),
+ * so any `ConditionRegistry<T>` — including the bundled
+ * `streamingRegistry` or a user-defined one — is acceptable.
+ *
+ * @example
+ * ```ts
+ * const tunables = listTunables(strategy);
+ * for (const t of tunables) {
+ *   console.log(t.key, t.paramName, t.schema.default);
+ * }
+ * ```
+ */
+export function listTunables<T = Condition>(
+  strategy: StrategyJSON,
+  registry: ConditionRegistry<T> = backtestRegistry as unknown as ConditionRegistry<T>,
+): Tunable[] {
+  const out: Tunable[] = [];
+  for (const leaf of flattenStrategyLeaves(strategy)) {
+    const entry = registry.get(leaf.name);
+    if (!entry) continue;
+    for (const [paramName, schema] of Object.entries(entry.params)) {
+      if (schema.type !== "number") continue;
+      // `tunable: false` is an explicit opt-out for params whose JSON
+      // value is not a scalar number — registry entries that declare
+      // `type: "number"` for compactness but actually consume the value
+      // as an array (e.g. Perfect Order MA periods). These would not
+      // survive a scalar grid sweep.
+      if (schema.tunable === false) continue;
+      out.push({
+        key: `${leaf.bucket}.${leaf.leafIndex}.${paramName}`,
+        bucket: leaf.bucket,
+        leafIndex: leaf.leafIndex,
+        conditionName: leaf.name,
+        paramName,
+        schema,
+      });
+    }
+  }
+  return out;
+}

--- a/packages/core/src/strategy/types.ts
+++ b/packages/core/src/strategy/types.ts
@@ -155,6 +155,15 @@ export type ParamDef = {
    * persisted strategy JSON, whereas tightening `max` would.
    */
   suggestedMax?: number;
+  /**
+   * `false` opts the parameter out of generic numeric introspection
+   * (e.g. `listTunables`). Use this for params whose JSON value is *not*
+   * a scalar number — for instance MA period vectors declared with
+   * `type: "number"` for compactness but actually consumed as
+   * `number[]`. Defaults to `true` (the param participates in
+   * enumeration).
+   */
+  tunable?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds `listTunables(strategy, registry?)` and the `Tunable` type — a focused introspection helper that walks a `StrategyJSON`'s entry / exit conditions and emits one entry per numeric registry-declared parameter.

The shape mirrors the strategy-parameter introspection surface that other technical-analysis frameworks already expose:

| Framework | Equivalent |
|---|---|
| TA-Lib | `TA_GetOptInputParameterInfo` |
| backtrader | `self.params` / `self.p` |
| freqtrade | `IntParameter` / `DecimalParameter` class hierarchy |
| Pine Script | `input.int` / `input.float` |
| lumibot | `self.get_parameters()` |

## Design notes

- **`Tunable.key`** follows the canonical `<bucket>.<leafIndex>.<paramName>` path syntax, so the output feeds `gridSearchFromJSON` without translation. Path acceptance is locked in by a property test that walks demo + nested-synthetic strategies and verifies every emitted key is accepted by `gridSearchFromJSON`'s validator.
- **No heuristic on integer / continuous typing.** Callers read `tunable.schema.integer` / `precision` / `suggestedMin` / `suggestedMax` directly. This matches the universal industry pattern: every major library makes this typing explicit at the schema level (TA-Lib enum, freqtrade class hierarchy, Pine Script function pair). Attempting to infer integer-ness from a `Number.isInteger`-style heuristic creates structural false positives for continuous params with integer-typed defaults (e.g. RSI threshold `default: 30, min: 0, max: 100, integer omitted` — the value `29.5` is valid).
- **Generic `<T = Condition>`.** The function reads `entry.params` only (no `.create` / `.hydrate`), so any `ConditionRegistry<T>` — including the bundled `streamingRegistry` or a user-defined one — is acceptable. Default `backtestRegistry` keeps the common call site parameter-less.
- **`ParamDef.tunable?: boolean`** is added so registry entries can opt out of enumeration. Applied internally to the Perfect Order `periods` param, which declares `type: "number"` for schema compactness but is consumed as `number[]` at runtime. Without the opt-out, an introspection caller would surface a vector-valued param as a scalar tunable and a downstream grid sweep would skip every combination.

## Surface

| Export | Module | Signature |
|---|---|---|
| `Tunable` | `trendcraft` / `trendcraft/strategy` | type |
| `listTunables` | `trendcraft` / `trendcraft/strategy` | `(strategy, registry?) => Tunable[]` |
| `ParamDef.tunable` | (existing type) | new optional field |

## What's intentionally NOT included

The Studio app that motivated this audit also defines `autoDeriveRange(schema, currentValue)`, `findIntegerRangeViolation(tunables, ranges)`, and `DEMO_STRATEGIES`. After surveying mainstream TA frameworks, those three helpers do not have clear precedent in the industry (no major library auto-derives optimization ranges; demo strategies are typically kept out of the core package). They remain Studio-local for now and can be promoted independently if a second consumer needs them.

## Test plan

- [x] `pnpm test` in `packages/core` — 6021 / 6021 PASS (10 in the new file)
- [x] `npx tsc --noEmit --ignoreDeprecations 6.0` — no new errors (5 pre-existing on `main` unchanged)
- [x] `pnpm lint` — clean
- [x] `pnpm -r build` — all packages build
- [x] New tests cover:
  - Emission shape per leaf / per numeric param
  - Nested AND / OR walking in depth-first order
  - Skipping unregistered conditions
  - `tunable: false` opt-out (regression for Perfect Order periods)
  - Defaulting to `backtestRegistry`
  - Accepting `streamingRegistry` (generic registry typing)
  - **Property test**: every emitted `Tunable.key` is accepted by `gridSearchFromJSON`

## CHANGELOG

Added under `Unreleased`.