### PR TITLE
feat(strategy-studio): Kelly sample-size warning and 95% CI

### DIFF
--- a/packages/chart/examples/strategy-studio/src/lib/__tests__/risk.test.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/__tests__/risk.test.ts
@@ -1,0 +1,108 @@
+import type { Trade } from "trendcraft";
+import { describe, expect, it } from "vitest";
+import { classifyKellySample, deriveKellyStats, recommendedKellyFraction } from "../risk";
+
+function tradeAt(returnPercent: number, i = 0): Trade {
+  return {
+    entryTime: i,
+    entryPrice: 100,
+    exitTime: i + 1,
+    exitPrice: 100 + returnPercent,
+    return: returnPercent,
+    returnPercent,
+    holdingDays: 1,
+  };
+}
+
+function manyTrades(wins: number, losses: number, winPct: number, lossPct: number): Trade[] {
+  const out: Trade[] = [];
+  for (let i = 0; i < wins; i++) out.push(tradeAt(winPct, i));
+  for (let i = 0; i < losses; i++) out.push(tradeAt(-lossPct, wins + i));
+  return out;
+}
+
+describe("deriveKellyStats", () => {
+  it("returns null for empty trade list", () => {
+    expect(deriveKellyStats([])).toBeNull();
+  });
+
+  it("returns null when no decided (non-zero) trades exist", () => {
+    expect(deriveKellyStats([tradeAt(0), tradeAt(0)])).toBeNull();
+  });
+
+  it("computes Kelly fraction f* = p - (1-p)/b on a clean 60% / 2:1 sample", () => {
+    // 6 wins of +2%, 4 losses of -1% → p=0.6, b=2 → f* = 0.6 - 0.4/2 = 0.4
+    const stats = deriveKellyStats(manyTrades(6, 4, 2, 1));
+    expect(stats).not.toBeNull();
+    if (!stats) return;
+    expect(stats.winRate).toBeCloseTo(0.6, 6);
+    expect(stats.winLossRatio).toBeCloseTo(2, 6);
+    expect(stats.kellyStar).toBeCloseTo(0.4, 6);
+    expect(stats.sampleSize).toBe(10);
+  });
+
+  it("clips negative Kelly to 0", () => {
+    // 3 wins of +1%, 7 losses of -2% → p=0.3, b=0.5 → f* = 0.3 - 0.7/0.5 = -1.1 → 0
+    const stats = deriveKellyStats(manyTrades(3, 7, 1, 2));
+    if (!stats) throw new Error("expected stats");
+    expect(stats.kellyStar).toBe(0);
+  });
+
+  it("returns null CI when there are fewer than 2 wins or fewer than 2 losses", () => {
+    const stats = deriveKellyStats(manyTrades(1, 5, 2, 1));
+    if (!stats) throw new Error("expected stats");
+    expect(stats.stdError).toBeNull();
+    expect(stats.ci95).toBeNull();
+  });
+
+  it("computes a finite, non-negative 95% CI when both sides have variance", () => {
+    // Introduce dispersion so sample variance is positive
+    const trades: Trade[] = [
+      tradeAt(2.0, 0),
+      tradeAt(3.0, 1),
+      tradeAt(2.5, 2),
+      tradeAt(1.5, 3),
+      tradeAt(2.2, 4),
+      tradeAt(2.8, 5),
+      tradeAt(-1.0, 6),
+      tradeAt(-1.5, 7),
+      tradeAt(-0.8, 8),
+      tradeAt(-1.2, 9),
+    ];
+    const stats = deriveKellyStats(trades);
+    if (!stats) throw new Error("expected stats");
+    if (!stats.stdError || !stats.ci95) throw new Error("expected CI");
+    expect(stats.stdError).toBeGreaterThan(0);
+    expect(stats.ci95.low).toBeLessThanOrEqual(stats.kellyStar);
+    expect(stats.ci95.high).toBeGreaterThanOrEqual(stats.kellyStar);
+    // Sanity: CI half-width is ~1.96 * stdError
+    const halfWidth = (stats.ci95.high - stats.ci95.low) / 2;
+    expect(halfWidth).toBeCloseTo(1.96 * stats.stdError, 6);
+  });
+});
+
+describe("classifyKellySample", () => {
+  it("flags <30 as insufficient", () => {
+    expect(classifyKellySample(0)).toBe("insufficient");
+    expect(classifyKellySample(29)).toBe("insufficient");
+  });
+  it("flags 30..99 as limited", () => {
+    expect(classifyKellySample(30)).toBe("limited");
+    expect(classifyKellySample(99)).toBe("limited");
+  });
+  it("flags ≥100 as acceptable", () => {
+    expect(classifyKellySample(100)).toBe("acceptable");
+    expect(classifyKellySample(500)).toBe("acceptable");
+  });
+});
+
+describe("recommendedKellyFraction", () => {
+  it("returns Quarter Kelly below 100 trades", () => {
+    expect(recommendedKellyFraction(20)).toBe(0.25);
+    expect(recommendedKellyFraction(99)).toBe(0.25);
+  });
+  it("returns Half Kelly at 100+ trades", () => {
+    expect(recommendedKellyFraction(100)).toBe(0.5);
+    expect(recommendedKellyFraction(500)).toBe(0.5);
+  });
+});

--- a/packages/chart/examples/strategy-studio/src/lib/risk.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/risk.ts
@@ -45,43 +45,112 @@ export function latestAtr(candles: StudioCandle[], period: number): number | nul
   return series[series.length - 1]?.value ?? null;
 }
 
+export type KellyStats = {
+  winRate: number;
+  winLossRatio: number;
+  sampleSize: number;
+  /**
+   * Full-Kelly point estimate `f* = p - (1-p)/b` (clipped at 0). The
+   * `kellyFraction` slider scales this down further at the UI layer.
+   */
+  kellyStar: number;
+  /**
+   * Standard error of `kellyStar` via the delta method (Sinclair 2014,
+   * Journal of Investment Strategies). Treats win rate `p` (binomial,
+   * `Var ≈ p(1-p)/n`) and win/loss ratio `b = avg_win / avg_loss` (ratio
+   * of independent sample means) as independent, then propagates through
+   * the partials `df/dp = 1 + 1/b` and `df/db = (1-p)/b^2`. `null` if
+   * either side has fewer than 2 samples (sample variance is undefined).
+   */
+  stdError: number | null;
+  /** 95% confidence interval `kellyStar ± 1.96·stdError`. `null` when `stdError` is. */
+  ci95: { low: number; high: number } | null;
+};
+
 // Use `returnPercent` (size-independent) rather than `return` (dollar P/L) so
 // scaled entries / partial exits / variable position sizing don't let larger
 // notionals dominate the avgWin/avgLoss ratio Kelly depends on. Partial exits
 // are folded in alongside full exits — Kelly is sensitive to the realised
 // payoff distribution, not just fully-closed trades.
-export function deriveKellyStats(trades: readonly Trade[]): {
-  winRate: number;
-  winLossRatio: number;
-  sampleSize: number;
-} | null {
+export function deriveKellyStats(trades: readonly Trade[]): KellyStats | null {
   if (trades.length === 0) return null;
-  let wins = 0;
-  let losses = 0;
-  let winSum = 0;
-  let lossSum = 0;
+  const winReturns: number[] = [];
+  const lossReturns: number[] = [];
   for (const t of trades) {
     const pct = t.returnPercent;
-    if (pct > 0) {
-      wins += 1;
-      winSum += pct;
-    } else if (pct < 0) {
-      losses += 1;
-      lossSum += -pct;
-    }
+    if (pct > 0) winReturns.push(pct);
+    else if (pct < 0) lossReturns.push(-pct);
   }
-  const decided = wins + losses;
+  const decided = winReturns.length + lossReturns.length;
   if (decided === 0) return null;
-  const avgWin = wins > 0 ? winSum / wins : 0;
-  const avgLoss = losses > 0 ? lossSum / losses : 0;
+  const wins = winReturns.length;
+  const losses = lossReturns.length;
+  const avgWin = wins > 0 ? winReturns.reduce((s, v) => s + v, 0) / wins : 0;
+  const avgLoss = losses > 0 ? lossReturns.reduce((s, v) => s + v, 0) / losses : 0;
   // No realised losses → ratio is undefined; fall back to a large but finite
   // proxy so the UI can still surface a Kelly result rather than blank out.
   const winLossRatio = avgLoss > 0 ? avgWin / avgLoss : Math.max(avgWin, 1);
+  const p = wins / decided;
+  const kellyStar = Math.max(0, p - (1 - p) / winLossRatio);
+
+  let stdError: number | null = null;
+  let ci95: { low: number; high: number } | null = null;
+  if (wins >= 2 && losses >= 2 && avgWin > 0 && avgLoss > 0) {
+    const varWin = sampleVariance(winReturns, avgWin);
+    const varLoss = sampleVariance(lossReturns, avgLoss);
+    const varP = (p * (1 - p)) / decided;
+    // delta-method variance of b = avg_win / avg_loss, treating the two
+    // sample means as independent
+    const varB =
+      winLossRatio *
+      winLossRatio *
+      (varWin / (wins * avgWin * avgWin) + varLoss / (losses * avgLoss * avgLoss));
+    const dKdP = 1 + 1 / winLossRatio;
+    const dKdB = (1 - p) / (winLossRatio * winLossRatio);
+    const varK = dKdP * dKdP * varP + dKdB * dKdB * varB;
+    if (Number.isFinite(varK) && varK >= 0) {
+      stdError = Math.sqrt(varK);
+      ci95 = { low: kellyStar - 1.96 * stdError, high: kellyStar + 1.96 * stdError };
+    }
+  }
+
   return {
-    winRate: wins / decided,
+    winRate: p,
     winLossRatio,
     sampleSize: decided,
+    kellyStar,
+    stdError,
+    ci95,
   };
+}
+
+function sampleVariance(xs: number[], mean: number): number {
+  if (xs.length < 2) return 0;
+  let s = 0;
+  for (const x of xs) {
+    const d = x - mean;
+    s += d * d;
+  }
+  return s / (xs.length - 1);
+}
+
+/**
+ * Sample-size driven default Kelly fraction. Industry consensus
+ * (MacLean–Thorp–Ziemba "Good and Bad Properties of Kelly", Van Tharp)
+ * is that Full Kelly is fragile to estimation error and only safe with
+ * a large sample of in-distribution trades; below 100 decided trades
+ * we step down to Quarter Kelly, and never seed Full Kelly automatically.
+ */
+export function recommendedKellyFraction(sampleSize: number): number {
+  return sampleSize >= 100 ? 0.5 : 0.25;
+}
+
+export type KellySampleTier = "insufficient" | "limited" | "acceptable";
+
+export function classifyKellySample(sampleSize: number): KellySampleTier {
+  if (sampleSize < 30) return "insufficient";
+  if (sampleSize < 100) return "limited";
+  return "acceptable";
 }
 
 export function defaultSizingInputs(entryPrice: number): SizingInputs {

--- a/packages/chart/examples/strategy-studio/src/panels/RiskPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/RiskPanel.tsx
@@ -2,11 +2,15 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { BacktestResult } from "trendcraft";
 import { NumInput } from "../components/NumInput";
 import {
+  classifyKellySample,
   computeSizing,
   computeVar,
   DEFAULT_VAR_INPUTS,
   defaultSizingInputs,
   deriveKellyStats,
+  type KellySampleTier,
+  type KellyStats,
+  recommendedKellyFraction,
   type SizingInputs,
   type SizingMethod,
   type VarInputs,
@@ -75,15 +79,22 @@ export function RiskPanel({ candles, lastBacktest }: Props) {
 
   // When a fresh backtest comes in, optionally seed Kelly inputs from its
   // realised win/loss stats. The toggle gives the user an explicit opt-out
-  // in case they want to model a hypothetical strategy.
+  // in case they want to model a hypothetical strategy. The Kelly fraction
+  // is auto-degraded by sample size (`recommendedKellyFraction`) so users
+  // are never silently dropped into Full Kelly with a 20-trade backtest.
   useEffect(() => {
     if (!autoFromBacktest || !kellyStats) return;
     setSizing((prev) => ({
       ...prev,
       winRate: kellyStats.winRate,
       winLossRatio: kellyStats.winLossRatio,
+      kellyFraction: recommendedKellyFraction(kellyStats.sampleSize),
     }));
   }, [autoFromBacktest, kellyStats]);
+
+  const kellyTier: KellySampleTier | null = kellyStats
+    ? classifyKellySample(kellyStats.sampleSize)
+    : null;
 
   const sizingResult = useMemo(() => computeSizing(sizing, candles), [sizing, candles]);
   const varResult = useMemo(() => computeVar(varInputs, candles), [varInputs, candles]);
@@ -204,20 +215,30 @@ export function RiskPanel({ candles, lastBacktest }: Props) {
         </div>
 
         {sizing.method === "kelly" && (
-          <label className="risk-checkbox">
-            <input
-              type="checkbox"
-              checked={autoFromBacktest}
-              onChange={(e) => setAutoFromBacktest(e.target.checked)}
-            />
-            <span>
-              Sync from backtest
-              {kellyStats && (
-                <span className="risk-hint"> ({kellyStats.sampleSize} decided trades)</span>
-              )}
-              {!kellyStats && <span className="risk-hint"> (run backtest to enable)</span>}
-            </span>
-          </label>
+          <>
+            <label className="risk-checkbox">
+              <input
+                type="checkbox"
+                checked={autoFromBacktest}
+                onChange={(e) => setAutoFromBacktest(e.target.checked)}
+              />
+              <span>
+                Sync from backtest
+                {kellyStats && (
+                  <span className="risk-hint"> ({kellyStats.sampleSize} decided trades)</span>
+                )}
+                {!kellyStats && <span className="risk-hint"> (run backtest to enable)</span>}
+              </span>
+            </label>
+            {kellyStats && kellyTier && (
+              <KellyConfidenceBlock
+                stats={kellyStats}
+                tier={kellyTier}
+                fraction={sizing.kellyFraction}
+                appliedPercent={sizingResult.kind === "ok" ? sizingResult.result.riskPercent : null}
+              />
+            )}
+          </>
         )}
 
         <div className="risk-result">
@@ -302,6 +323,110 @@ export function RiskPanel({ candles, lastBacktest }: Props) {
       </section>
     </div>
   );
+}
+
+const TIER_COPY: Record<
+  KellySampleTier,
+  { tone: "bad" | "warn" | "good"; label: string; recommend: string }
+> = {
+  insufficient: {
+    tone: "bad",
+    label: "Insufficient sample",
+    recommend:
+      "Kelly estimates are unreliable below 30 trades. Treat the result as a rough order-of-magnitude, not a target.",
+  },
+  limited: {
+    tone: "warn",
+    label: "Limited sample",
+    recommend:
+      "Quarter Kelly is the safe default below 100 trades — Full Kelly is fragile to estimation error here.",
+  },
+  acceptable: {
+    tone: "good",
+    label: "Acceptable sample",
+    recommend: "Half Kelly is the conventional default at ≥100 decided trades.",
+  },
+};
+
+function KellyConfidenceBlock({
+  stats,
+  tier,
+  fraction,
+  appliedPercent,
+}: {
+  stats: KellyStats;
+  tier: KellySampleTier;
+  fraction: number;
+  /**
+   * Post-cap account % from the live `kellySize` calc (core defaults the
+   * `maxKellyPercent` cap to 25). Passing the engine's actual sized
+   * percentage avoids the "sizing at 40% of account" message above ever
+   * disagreeing with the "Risk 25%" line below for high-edge backtests.
+   * `null` when sizing errored — fall back to the uncapped product.
+   */
+  appliedPercent: number | null;
+}) {
+  const copy = TIER_COPY[tier];
+  const rawScaledPercent = stats.kellyStar * fraction * 100;
+  const displayedPercent = appliedPercent ?? rawScaledPercent;
+  const isCapped = appliedPercent !== null && rawScaledPercent - appliedPercent > 0.01;
+  const isFull = fraction >= 0.95;
+  return (
+    <div className={`kelly-confidence ${copy.tone}`}>
+      <div className="kelly-confidence-headline">
+        {copy.label} — {stats.sampleSize} trades
+      </div>
+      <div className="kelly-confidence-body">
+        Full Kelly {formatPercent01(stats.kellyStar)}
+        {stats.ci95 ? (
+          <>
+            {" "}
+            ± {formatPercent01(stats.ci95.high - stats.kellyStar)} (95% CI{" "}
+            {formatPercent01(Math.max(0, stats.ci95.low))}–{formatPercent01(stats.ci95.high)})
+          </>
+        ) : (
+          <span className="risk-hint"> (CI needs ≥2 wins and ≥2 losses)</span>
+        )}
+      </div>
+      <div className="kelly-confidence-body">
+        Sizing at {formatFractionMultiplier(fraction)} → {formatPercentValue(displayedPercent)} of
+        account per trade
+        {isCapped && (
+          <span className="risk-hint">
+            {" "}
+            (capped from {formatPercentValue(rawScaledPercent)} by kellySize maxKellyPercent)
+          </span>
+        )}
+        .
+        {isFull && tier !== "acceptable" && (
+          <span className="kelly-full-warn">
+            {" "}
+            Full Kelly without 100+ trades risks ruin in drawdowns.
+          </span>
+        )}
+      </div>
+      <div className="kelly-confidence-hint">{copy.recommend}</div>
+    </div>
+  );
+}
+
+/** Format a 0..1 Kelly fraction as a percent string (e.g. 0.234 → "23.4%"). */
+function formatPercent01(v: number): string {
+  if (!Number.isFinite(v)) return "—";
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+/** Format an already-in-percent value (e.g. 23.4 → "23.4%"). */
+function formatPercentValue(v: number): string {
+  if (!Number.isFinite(v)) return "—";
+  return `${v.toFixed(1)}%`;
+}
+
+function formatFractionMultiplier(v: number): string {
+  if (v >= 0.95) return "Full Kelly";
+  if (Math.abs(v - 0.5) < 0.01) return "Half Kelly";
+  if (Math.abs(v - 0.25) < 0.01) return "Quarter Kelly";
+  return `${v.toFixed(2)}× Kelly`;
 }
 
 function RiskMetric({

--- a/packages/chart/examples/strategy-studio/src/styles.css
+++ b/packages/chart/examples/strategy-studio/src/styles.css
@@ -916,6 +916,68 @@ button.ghost.danger:hover {
   border-radius: 4px;
 }
 
+.kelly-confidence {
+  margin-top: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid #2a2e39;
+  background: #0e1320;
+  font-size: 11px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.kelly-confidence.bad {
+  border-color: rgba(239, 83, 80, 0.45);
+  background: rgba(239, 83, 80, 0.06);
+}
+
+.kelly-confidence.warn {
+  border-color: rgba(255, 183, 77, 0.4);
+  background: rgba(255, 183, 77, 0.06);
+}
+
+.kelly-confidence.good {
+  border-color: rgba(38, 166, 154, 0.4);
+  background: rgba(38, 166, 154, 0.06);
+}
+
+.kelly-confidence-headline {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 10px;
+}
+
+.kelly-confidence.bad .kelly-confidence-headline {
+  color: #ef5350;
+}
+
+.kelly-confidence.warn .kelly-confidence-headline {
+  color: #ffb74d;
+}
+
+.kelly-confidence.good .kelly-confidence-headline {
+  color: #26a69a;
+}
+
+.kelly-confidence-body {
+  color: #d1d4dc;
+  font-variant-numeric: tabular-nums;
+}
+
+.kelly-confidence-hint {
+  color: #787b86;
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.kelly-full-warn {
+  color: #ef5350;
+  margin-left: 4px;
+}
+
 /* ============================================
  * Replay Controls (top of chart pane)
  * ============================================ */


### PR DESCRIPTION
## Summary

Treats a small backtest as a first-class limitation when sizing positions with the Kelly criterion, not a footnote. Mirrors industry guidance from MacLean–Thorp–Ziemba *Good and Bad Properties of Kelly*, Van Tharp's tier heuristics, and the Sinclair (2014, *Journal of Investment Strategies*) delta-method CI.

- **Sample-size tier banner** above the Kelly inputs: red `<30` decided trades, yellow `<100`, green `≥100`. Each tier carries a one-line recommendation explaining what the user should do at that sample size.
- **95% confidence interval** for the Kelly fraction `f* = p - (1-p)/b`, propagated through the partials `df/dp = 1 + 1/b` and `df/db = (1-p)/b²` with `Var(p) = p(1-p)/n` and `Var(b)` from independent sample-mean variances on the win / loss return distributions. Reported as `Full Kelly X% ± Y% (95% CI low–high)`. Falls back to "CI needs ≥2 wins and ≥2 losses" when sample variance is undefined.
- **Auto-degrade default fraction**: Quarter Kelly under 100 trades, Half Kelly at ≥100, applied through the existing *Sync from backtest* toggle so the user can opt out. Full Kelly without ≥100 trades carries an inline drawdown-ruin warning.
- **Post-cap sizing line** reads `riskPercent` from the live `kellySize` result, so the "sizing at X% of account" message stays consistent with core's 25% `maxKellyPercent` cap for high-edge backtests.
- **11 unit tests** covering `f*` math (clean 60% / 2:1 sample, negative-Kelly clipping), CI half-width = 1.96·stdError, undefined CI fallback, tier thresholds, and recommended-fraction thresholds.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `pnpm test` (93/93 pass, +11 new in `risk.test.ts`)
- [x] `pnpm lint`
- [x] `pnpm build`