### PR TITLE
feat(strategy-studio): wire Monte Carlo into Strategy DNA robustness grade

### DIFF
--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -824,7 +824,10 @@ export function App() {
           onResult={setOptimizationResult}
         />
         <div className="pane-divider" />
-        <StrategyDnaPanel optimizationResult={optimizationResult} />
+        <StrategyDnaPanel
+          optimizationResult={optimizationResult}
+          lastBacktest={runner.state.lastResult?.result}
+        />
       </aside>
 
       {popoverState && popoverInstance && (

--- a/packages/chart/examples/strategy-studio/src/lib/robustness.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/robustness.ts
@@ -1,0 +1,60 @@
+import { type BacktestResult, type MonteCarloResult, runMonteCarloSimulation } from "trendcraft";
+
+/**
+ * Default Monte Carlo iteration count. 1000 is the industry-canonical
+ * baseline (AmiBroker / StrategyQuant / BuildAlpha all default here):
+ * enough for stable 5th/95th percentile estimates without a perceptible
+ * pause on a few-hundred-trade backtest.
+ */
+export const DEFAULT_MC_ITERATIONS = 1000;
+
+/**
+ * Discriminated result of a Monte Carlo run, mirroring
+ * `OptimizationComputation` so the panel can render `empty` / `error`
+ * states with their own messages instead of collapsing to a generic
+ * "no data" caption.
+ */
+export type MonteCarloComputation =
+  | { kind: "idle" }
+  | { kind: "ok"; result: MonteCarloResult; iterations: number }
+  | { kind: "empty"; message: string }
+  | { kind: "error"; message: string };
+
+/**
+ * Run trade-shuffle Monte Carlo over the last backtest's trades via
+ * core's `runMonteCarloSimulation`.
+ *
+ * The wrapper exists for Studio-specific empty-state handling: core
+ * throws when there are fewer than 2 trades, but Studio treats "no
+ * backtest yet" and "too few trades" as user-recoverable conditions
+ * (`kind: "empty"`), not errors.
+ *
+ * A `seed` is always supplied so a given backtest + iteration count
+ * reproduces the same distribution across re-runs — clicking Run twice
+ * on an unchanged strategy should not shuffle the verdict. Users who
+ * want to observe sampling variance can vary the iteration count.
+ */
+export function runMonteCarlo(
+  lastBacktest: BacktestResult | undefined,
+  options: { iterations?: number; seed?: number } = {},
+): MonteCarloComputation {
+  if (!lastBacktest) {
+    return { kind: "empty", message: "Run a backtest first to enable Monte Carlo" };
+  }
+  if (lastBacktest.trades.length < 2) {
+    return {
+      kind: "empty",
+      message: "Need at least 2 trades for Monte Carlo simulation",
+    };
+  }
+  const iterations = options.iterations ?? DEFAULT_MC_ITERATIONS;
+  try {
+    const result = runMonteCarloSimulation(lastBacktest, {
+      simulations: iterations,
+      seed: options.seed ?? 42,
+    });
+    return { kind: "ok", result, iterations };
+  } catch (err) {
+    return { kind: "error", message: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/packages/chart/examples/strategy-studio/src/panels/StrategyDnaPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/StrategyDnaPanel.tsx
@@ -1,12 +1,19 @@
 import { useEffect, useMemo, useState } from "react";
 import {
+  type BacktestResult,
   buildGenomeSegments,
   computeDnaGrade,
   computeRecommendedParams,
   extractSensitivityData,
 } from "trendcraft";
 import type { OptimizationComputation } from "../lib/optimization";
+import {
+  DEFAULT_MC_ITERATIONS,
+  type MonteCarloComputation,
+  runMonteCarlo,
+} from "../lib/robustness";
 import { GenomeVisualization } from "./dna/GenomeVisualization";
+import { MonteCarloReport } from "./dna/MonteCarloReport";
 import { RobustnessReport } from "./dna/RobustnessReport";
 import { SensitivityHeatmap } from "./dna/SensitivityHeatmap";
 
@@ -27,23 +34,49 @@ type Props = {
    * actually completed but produced no usable result.
    */
   optimizationResult: OptimizationComputation;
+  /**
+   * Last backtest result, used as the Monte Carlo resampling input.
+   * `undefined` until the user runs a backtest; the MC section then
+   * renders its own "run a backtest first" empty state.
+   */
+  lastBacktest: BacktestResult | undefined;
 };
 
 /**
- * Strategy DNA panel — three-tab read-only visualization of an
- * optimization run's genome, parameter sensitivity, and robustness
- * grade. Display-only by design (no Apply button, no Compute Monte
- * Carlo trigger): builder state is never mutated from this panel,
- * matching PR12's OptimizationPanel philosophy. Walk-Forward and
- * Monte Carlo dimensions on the grade card surface as
- * `available: false` until Studio adds those workflows.
+ * Strategy DNA panel — three-tab visualization of an optimization
+ * run's genome, parameter sensitivity, and robustness grade. The
+ * Genome and Sensitivity tabs are display-only (builder state is never
+ * mutated from this panel, matching PR12's OptimizationPanel
+ * philosophy). The Robustness tab adds a run-on-demand Monte Carlo
+ * simulation over the last backtest, which lights up the "Monte Carlo
+ * Significance" dimension of the grade. The Walk-Forward dimensions
+ * stay `available: false` until that workflow is wired.
  */
-export function StrategyDnaPanel({ optimizationResult }: Props) {
+export function StrategyDnaPanel({ optimizationResult, lastBacktest }: Props) {
   const gridSearchResult = optimizationResult.kind === "ok" ? optimizationResult.result : null;
 
   const [activeTab, setActiveTab] = useState<DnaTab>("genome");
   const [selectedParam, setSelectedParam] = useState<string | null>(null);
   const [selectedParamPair, setSelectedParamPair] = useState<[string, string] | null>(null);
+
+  // Monte Carlo runs on demand (expensive + stochastic), so its result
+  // is button-triggered state rather than a derived useMemo. Iteration
+  // count is user-selectable; the result carries the count it was run
+  // with so a stale display can't mislabel itself.
+  const [mcIterations, setMcIterations] = useState<number>(DEFAULT_MC_ITERATIONS);
+  const [mcComputation, setMcComputation] = useState<MonteCarloComputation>({ kind: "idle" });
+
+  // A new backtest invalidates any prior Monte Carlo result — it was
+  // resampled from a different trade set. Key on the result object
+  // reference: the runner produces a fresh `BacktestResult` on every
+  // run, so the effect fires exactly when the underlying trades change.
+  // A scalar proxy (trade count + total return) would collide when a
+  // modified strategy happens to produce the same aggregate, leaving a
+  // stale MC verdict and DNA grade on screen.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: lastBacktest is the intended change trigger, not read inside the effect — clearing MC on each new result object is the point.
+  useEffect(() => {
+    setMcComputation({ kind: "idle" });
+  }, [lastBacktest]);
 
   // Reset sensitivity selections when the grid result changes.
   // Otherwise a second run with a different tunable set would leave
@@ -94,9 +127,15 @@ export function StrategyDnaPanel({ optimizationResult }: Props) {
     return computeRecommendedParams(gridSearchResult, null, sensitivityData);
   }, [gridSearchResult, sensitivityData]);
 
+  const monteCarloResult = mcComputation.kind === "ok" ? mcComputation.result : null;
+
+  // Feed the Monte Carlo result into the grade so the "Monte Carlo
+  // Significance" dimension lights up (and the overall grade reweights)
+  // as soon as the user runs it. Walk-Forward stays `null` until that
+  // workflow is wired.
   const dnaGrade = useMemo(() => {
-    return computeDnaGrade(gridSearchResult, null, null);
-  }, [gridSearchResult]);
+    return computeDnaGrade(gridSearchResult, null, monteCarloResult);
+  }, [gridSearchResult, monteCarloResult]);
 
   if (gridSearchResult === null) {
     // Distinguish the three non-`ok` states. For `idle` (no run yet)
@@ -209,7 +248,28 @@ export function StrategyDnaPanel({ optimizationResult }: Props) {
           ))}
 
         {activeTab === "robustness" && (
-          <RobustnessReport grade={dnaGrade} recommendedParams={recommendedParams} />
+          <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+            <RobustnessReport grade={dnaGrade} recommendedParams={recommendedParams} />
+            <div className="meta-strategy-caption" style={{ fontWeight: 600, marginTop: 2 }}>
+              Monte Carlo
+            </div>
+            <MonteCarloReport
+              computation={mcComputation}
+              iterations={mcIterations}
+              onIterationsChange={setMcIterations}
+              onRun={() =>
+                setMcComputation(runMonteCarlo(lastBacktest, { iterations: mcIterations }))
+              }
+              disabled={!lastBacktest || lastBacktest.trades.length < 2}
+              disabledReason={
+                !lastBacktest
+                  ? "Run a backtest first to enable Monte Carlo."
+                  : lastBacktest.trades.length < 2
+                    ? "Need at least 2 trades for Monte Carlo simulation."
+                    : undefined
+              }
+            />
+          </div>
         )}
       </section>
     </div>

--- a/packages/chart/examples/strategy-studio/src/panels/dna/MonteCarloReport.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/dna/MonteCarloReport.tsx
@@ -1,0 +1,174 @@
+import type { MetricStatistics, MonteCarloResult } from "trendcraft";
+import type { MonteCarloComputation } from "../../lib/robustness";
+
+type Props = {
+  computation: MonteCarloComputation;
+  iterations: number;
+  onIterationsChange: (n: number) => void;
+  onRun: () => void;
+  /** Disabled while there is no usable backtest to resample. */
+  disabled: boolean;
+  /** Reason the run is disabled, shown as a caption when `disabled`. */
+  disabledReason?: string;
+};
+
+const ITERATION_OPTIONS = [500, 1000, 5000];
+
+/**
+ * Monte Carlo section of the Robustness tab — trade-shuffle resampling
+ * of the last backtest. Run-on-demand (not auto-computed): the
+ * simulation is O(iterations · trades) and stochastic, so it stays
+ * behind an explicit button like the sibling Grid Search.
+ *
+ * Surfaces the significance verdict, both p-values, and a 5th/median/
+ * 95th percentile table for Sharpe / Return / Max DD — the resampled
+ * spread is the headline a single backtest number can't show. Richer
+ * visuals (equity fan chart, Max DD histogram, P(ruin)) land in a
+ * later pass once core exposes the per-path equity bands.
+ */
+export function MonteCarloReport({
+  computation,
+  iterations,
+  onIterationsChange,
+  onRun,
+  disabled,
+  disabledReason,
+}: Props) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <label
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+            fontSize: "var(--font-xs)",
+            color: "var(--text-secondary, #888)",
+          }}
+        >
+          <span>Iterations</span>
+          <select
+            value={iterations}
+            disabled={disabled}
+            onChange={(e) => onIterationsChange(Number(e.target.value))}
+            style={{ fontSize: "var(--font-xs)" }}
+          >
+            {ITERATION_OPTIONS.map((n) => (
+              <option key={n} value={n}>
+                {n.toLocaleString()}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          className="optimization-run-btn"
+          onClick={onRun}
+          disabled={disabled}
+          style={{ flex: 1 }}
+        >
+          Run Monte Carlo
+        </button>
+      </div>
+
+      {disabled && disabledReason && <div className="meta-strategy-caption">{disabledReason}</div>}
+
+      {computation.kind === "empty" && (
+        <div className="meta-strategy-caption">{computation.message}</div>
+      )}
+      {computation.kind === "error" && <div className="risk-error">{computation.message}</div>}
+      {computation.kind === "ok" && (
+        <McResultBody result={computation.result} iterations={computation.iterations} />
+      )}
+    </div>
+  );
+}
+
+function McResultBody({ result, iterations }: { result: MonteCarloResult; iterations: number }) {
+  const { assessment, pValue, statistics, originalResult } = result;
+  return (
+    <>
+      {/* Significance verdict */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "6px 10px",
+          borderRadius: 6,
+          background: "var(--bg-primary, #1a1a1a)",
+          borderLeft: `3px solid ${assessment.isSignificant ? "#16a34a" : "#ea580c"}`,
+        }}
+      >
+        <span
+          style={{
+            fontSize: "var(--font-sm)",
+            fontWeight: 600,
+            color: assessment.isSignificant ? "#16a34a" : "#ea580c",
+          }}
+        >
+          {assessment.isSignificant ? "Significant" : "Not significant"}
+        </span>
+        <span style={{ fontSize: 9, color: "var(--text-secondary, #888)" }}>
+          {iterations.toLocaleString()} shuffles · p(Sharpe) {pValue.sharpe.toFixed(3)} · p(Return){" "}
+          {pValue.returns.toFixed(3)}
+        </span>
+      </div>
+
+      {/* Percentile spread table */}
+      <table className="optimization-result-table">
+        <thead>
+          <tr>
+            <th>Metric</th>
+            <th className="num">Actual</th>
+            <th className="num">5th</th>
+            <th className="num">Median</th>
+            <th className="num">95th</th>
+          </tr>
+        </thead>
+        <tbody>
+          <McRow
+            label="Sharpe"
+            actual={originalResult.sharpe}
+            stats={statistics.sharpe}
+            digits={2}
+          />
+          <McRow
+            label="Return %"
+            actual={originalResult.totalReturnPercent}
+            stats={statistics.totalReturnPercent}
+            digits={1}
+          />
+          <McRow
+            label="Max DD %"
+            actual={originalResult.maxDrawdown}
+            stats={statistics.maxDrawdown}
+            digits={1}
+          />
+        </tbody>
+      </table>
+    </>
+  );
+}
+
+function McRow({
+  label,
+  actual,
+  stats,
+  digits,
+}: {
+  label: string;
+  actual: number;
+  stats: MetricStatistics;
+  digits: number;
+}) {
+  return (
+    <tr>
+      <td>{label}</td>
+      <td className="num">{actual.toFixed(digits)}</td>
+      <td className="num">{stats.percentile5.toFixed(digits)}</td>
+      <td className="num">{stats.median.toFixed(digits)}</td>
+      <td className="num">{stats.percentile95.toFixed(digits)}</td>
+    </tr>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a run-on-demand **Monte Carlo** simulation to the Strategy DNA panel's **Robustness** tab. It resamples the last backtest's trades via core's `runMonteCarloSimulation` and feeds the result into `computeDnaGrade`, so the "Monte Carlo Significance" dimension lights up and the overall A–F grade reweights as soon as the user runs it.

Previously the DNA grade only ever received the grid-search result; the Walk-Forward and Monte Carlo dimensions were permanently `available: false`. This is the first of the Phase 2 "Robustness" wiring steps — Studio now actually *runs* one of the two analyses the grade was already designed to consume.

## Changes

- **`lib/robustness.ts`** (new): `runMonteCarlo(lastBacktest, { iterations })` wrapper returning a discriminated union (`idle` / `ok` / `empty` / `error`), mirroring the existing `runGridSearch` style. "No backtest yet" and "fewer than 2 trades" are treated as user-recoverable `empty` states rather than errors. A fixed seed keeps a given backtest + iteration count reproducible across re-runs.
- **`panels/dna/MonteCarloReport.tsx`** (new): iteration selector (500 / 1000 / 5000), Run button, significance verdict, both p-values, and a 5th / median / 95th percentile table for Sharpe / Return / Max DD.
- **`panels/StrategyDnaPanel.tsx`**: new `lastBacktest` prop and button-triggered MC state fed into `computeDnaGrade(grid, null, mcResult)`. The prior MC result is cleared whenever a new `BacktestResult` arrives — keyed on object-reference identity so a re-run that happens to yield the same aggregate return cannot leave a stale verdict on screen.
- **`App.tsx`**: threads the last backtest result into `StrategyDnaPanel`.

## Scope

Studio-only; **no core changes**. Walk-Forward wiring and richer MC visuals (equity fan chart, Max DD histogram, P(ruin)) follow in later passes.

## Known follow-ups (not in this PR)

- The Robustness tab currently requires a grid search to have run (the panel early-returns without one), even though Monte Carlo only needs a backtest. Making the tab usable from a backtest alone is a separate cleanup.
- The trade-shuffle Monte Carlo in core leaves total Return and Sharpe order-invariant (only Max DD varies across shuffles), and its recalculated Sharpe uses a different formula than the backtest's reported Sharpe, which inflates the significance verdict. Both are core concerns to be addressed alongside the upcoming core robustness helpers (bootstrap resampling + Sharpe-formula alignment).

## Verification

- `tsc --noEmit` clean
- `biome check` clean
- `vite build` succeeds
- Manual browser smoke: Run backtest → Run grid search → DNA → Robustness → Run Monte Carlo; the overall grade reweighted (D → B on the default SPY golden/dead-cross strategy), the Monte Carlo Significance dimension lit up, and the percentile table rendered without layout breaks.