### PR TITLE
feat(core): Monte Carlo bootstrap resampling with method-aware significance

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+### Changed — Monte Carlo resamples with replacement (bootstrap) by default
+
+`runMonteCarloSimulation` gains a `method?: "shuffle" | "bootstrap"`
+option and now defaults to **`"bootstrap"`** (was an unconditional
+order shuffle). Bootstrap draws N trades with replacement, so total
+return, Sharpe, and profit factor vary across simulations — the basis
+for outcome-uncertainty and probability-of-loss estimates. The previous
+behaviour is still available as `method: "shuffle"` for sequence-risk
+analysis, where only the path-dependent max drawdown varies.
+
+This matches the resampling distinction drawn by mainstream backtest MC
+tooling, where bootstrap (with replacement) is the default for "how
+reliable is this edge?" and order shuffling is the narrower
+sequence-risk test.
+
+`pValue` is redefined as a **downside probability measured directly on
+the resampled outcomes**: `pValue.returns` is the fraction of
+simulations with total return ≤ 0 (probability of loss) and
+`pValue.sharpe` the fraction with Sharpe ≤ 0. It no longer compares the
+resampled distribution to the backtest's own annualized Sharpe — that
+comparison mixed two different Sharpe formulas and overstated
+significance. `assessment.isSignificant` is now true when fewer than
+`1 - confidenceLevel` of simulations lost money. `originalResult` is
+unchanged (still the backtest's reported metrics).
+
 ### Added — `listTunables(strategy)` for numeric parameter introspection
 
 Walks a `StrategyJSON`'s entry / exit conditions and emits one `Tunable`

--- a/packages/core/src/optimization/__tests__/monte-carlo.test.ts
+++ b/packages/core/src/optimization/__tests__/monte-carlo.test.ts
@@ -421,4 +421,118 @@ describe("Monte Carlo Simulation", () => {
       expect(mcResult.simulationCount).toBe(100);
     });
   });
+
+  describe("resampling method", () => {
+    // A clearly mixed win/loss set so bootstrap draws differ from each other.
+    const mixedTrades: Trade[] = Array.from({ length: 20 }, (_, i) => ({
+      entryTime: Date.now() + i * 86400000,
+      entryPrice: 100,
+      exitTime: Date.now() + (i + 1) * 86400000,
+      exitPrice: i % 3 === 0 ? 92 : 108,
+      return: i % 3 === 0 ? -80 : 80,
+      returnPercent: i % 3 === 0 ? -8 : 8,
+      holdingDays: 1,
+    }));
+
+    it("shuffle leaves total return invariant across simulations", () => {
+      const backtest = createMockBacktestResult(mixedTrades);
+      const mc = runMonteCarloSimulation(backtest, {
+        simulations: 200,
+        seed: 42,
+        method: "shuffle",
+      });
+      // Permuting trade order cannot change the compounded total return
+      // (multiplication is commutative); only float rounding wiggles it.
+      expect(mc.statistics.totalReturnPercent.stdDev).toBeLessThan(1e-6);
+    });
+
+    it("bootstrap varies total return across simulations", () => {
+      const backtest = createMockBacktestResult(mixedTrades);
+      const mc = runMonteCarloSimulation(backtest, {
+        simulations: 200,
+        seed: 42,
+        method: "bootstrap",
+      });
+      // Resampling with replacement changes the multiset of returns, so
+      // total return genuinely varies — the whole point of the mode.
+      expect(mc.statistics.totalReturnPercent.stdDev).toBeGreaterThan(0);
+      expect(mc.statistics.totalReturnPercent.percentile5).toBeLessThan(
+        mc.statistics.totalReturnPercent.percentile95,
+      );
+    });
+
+    it("defaults to bootstrap", () => {
+      const backtest = createMockBacktestResult(mixedTrades);
+      const explicit = runMonteCarloSimulation(backtest, {
+        simulations: 200,
+        seed: 42,
+        method: "bootstrap",
+      });
+      const defaulted = runMonteCarloSimulation(backtest, { simulations: 200, seed: 42 });
+      expect(defaulted.statistics.totalReturnPercent.stdDev).toBe(
+        explicit.statistics.totalReturnPercent.stdDev,
+      );
+    });
+
+    it("p(loss) is 0 for all-win trades and 1 for all-loss trades", () => {
+      const allWins: Trade[] = Array.from({ length: 8 }, (_, i) => ({
+        entryTime: Date.now() + i * 86400000,
+        entryPrice: 100,
+        exitTime: Date.now() + (i + 1) * 86400000,
+        exitPrice: 110,
+        return: 100,
+        returnPercent: 10,
+        holdingDays: 1,
+      }));
+      const allLosses: Trade[] = allWins.map((t) => ({
+        ...t,
+        exitPrice: 90,
+        return: -100,
+        returnPercent: -10,
+      }));
+
+      const winMc = runMonteCarloSimulation(createMockBacktestResult(allWins), {
+        simulations: 100,
+        seed: 7,
+      });
+      const lossMc = runMonteCarloSimulation(createMockBacktestResult(allLosses), {
+        simulations: 100,
+        seed: 7,
+      });
+
+      expect(winMc.pValue.returns).toBe(0);
+      expect(winMc.assessment.isSignificant).toBe(true);
+      expect(lossMc.pValue.returns).toBe(1);
+      expect(lossMc.assessment.isSignificant).toBe(false);
+
+      // Identical winners resample to zero-volatility runs (Sharpe 0).
+      // pValue.sharpe must NOT brand them a non-positive outcome, or the
+      // robustness grade would score a flawless strategy as the worst.
+      expect(winMc.pValue.sharpe).toBe(0);
+      // Identical losers (also zero-volatility, Sharpe 0) are still caught
+      // via the non-positive return, so the downside is not hidden.
+      expect(lossMc.pValue.sharpe).toBe(1);
+    });
+
+    it("shuffle assessment reflects drawdown sequence risk, not returns", () => {
+      const backtest = createMockBacktestResult(mixedTrades);
+      const shuffle = runMonteCarloSimulation(backtest, {
+        simulations: 200,
+        seed: 42,
+        method: "shuffle",
+      });
+      const bootstrap = runMonteCarloSimulation(backtest, {
+        simulations: 200,
+        seed: 42,
+        method: "bootstrap",
+      });
+      // Returns are invariant under shuffle, so significance must come
+      // from the drawdown distribution — never the misleading "all
+      // resamples profitable" claim that a shared return rule produced.
+      expect(shuffle.assessment.reason).toMatch(/ordering|drawdown/i);
+      expect(shuffle.assessment.reason).not.toMatch(/profitable/i);
+      // Bootstrap keeps the profitability framing.
+      expect(bootstrap.assessment.reason).toMatch(/profitable/i);
+    });
+  });
 });

--- a/packages/core/src/optimization/monte-carlo.ts
+++ b/packages/core/src/optimization/monte-carlo.ts
@@ -1,8 +1,13 @@
 /**
  * Monte Carlo Simulation
  *
- * Shuffles trade sequence to test robustness of backtest results.
- * Determines if performance is statistically significant vs random chance.
+ * Resamples the trade list to estimate how reliable a backtest's
+ * performance is. Two methods (see {@link MonteCarloOptions.method}):
+ * - `"bootstrap"` (default): sample N trades with replacement, so total
+ *   return / Sharpe / profit factor vary — used for outcome-uncertainty
+ *   and probability-of-loss estimates.
+ * - `"shuffle"`: permute the trade order, so only the path-dependent max
+ *   drawdown varies — used for sequence-risk analysis.
  */
 
 import type { BacktestResult, Trade } from "../types";
@@ -15,16 +20,34 @@ import { err, ok, type Result, tcError } from "../types/result";
 const DEFAULT_OPTIONS = {
   simulations: 1000,
   confidenceLevel: 0.95,
+  method: "bootstrap",
 } as const;
 
 /**
- * Fisher-Yates shuffle algorithm
+ * Fisher-Yates shuffle algorithm — permutes the array (no replacement).
+ * The multiset of elements is preserved, so only order changes.
  */
 function shuffleArray<T>(array: T[], random: () => number): T[] {
   const result = [...array];
   for (let i = result.length - 1; i > 0; i--) {
     const j = Math.floor(random() * (i + 1));
     [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+/**
+ * Bootstrap resample — draw `array.length` elements with replacement.
+ * Unlike {@link shuffleArray}, the same element can be drawn multiple
+ * times and others omitted, so the multiset of returns changes per
+ * draw. This is what makes total return / Sharpe / profit factor vary
+ * across simulations rather than staying pinned to the original.
+ */
+function bootstrapSample<T>(array: T[], random: () => number): T[] {
+  const n = array.length;
+  const result: T[] = new Array(n);
+  for (let i = 0; i < n; i++) {
+    result[i] = array[Math.floor(random() * n)];
   }
   return result;
 }
@@ -170,6 +193,7 @@ export function runMonteCarloSimulation(
 ): MonteCarloResult {
   const simulations = options.simulations ?? DEFAULT_OPTIONS.simulations;
   const confidenceLevel = options.confidenceLevel ?? DEFAULT_OPTIONS.confidenceLevel;
+  const method = options.method ?? DEFAULT_OPTIONS.method;
   const { progressCallback } = options;
 
   const trades = result.trades;
@@ -181,6 +205,7 @@ export function runMonteCarloSimulation(
 
   // Create random generator
   const random = options.seed !== undefined ? createSeededRandom(options.seed) : Math.random;
+  const resample = method === "shuffle" ? shuffleArray : bootstrapSample;
 
   // Collect simulation results
   const sharpeValues: number[] = [];
@@ -194,11 +219,11 @@ export function runMonteCarloSimulation(
       progressCallback(i + 1, simulations);
     }
 
-    // Shuffle trades
-    const shuffledTrades = shuffleArray(trades, random);
+    // Resample trades (bootstrap with replacement, or order shuffle)
+    const resampledTrades = resample(trades, random);
 
     // Recalculate metrics
-    const metrics = recalculateMetricsFromTrades(shuffledTrades, initialCapital);
+    const metrics = recalculateMetricsFromTrades(resampledTrades, initialCapital);
 
     sharpeValues.push(metrics.sharpe);
     maxDrawdownValues.push(metrics.maxDrawdown);
@@ -214,15 +239,31 @@ export function runMonteCarloSimulation(
     profitFactor: calculateStatistics(profitFactorValues),
   };
 
-  // Original result values
+  // Original result values — the backtest's own reported metrics, kept
+  // as-is for display. They are NOT used as the p-value baseline: the
+  // resampler recomputes Sharpe with a per-trade formula that differs
+  // from the backtest's candle-aware annualization, so comparing the
+  // two would mix scales and overstate significance.
   const originalSharpe = result.sharpeRatio;
   const originalReturn = result.totalReturnPercent;
   const originalMaxDD = result.maxDrawdown;
   const originalPF = result.profitFactor;
 
-  // Calculate p-values (probability of achieving >= original by chance)
-  const pValueSharpe = sharpeValues.filter((v) => v >= originalSharpe).length / simulations;
-  const pValueReturns = returnValues.filter((v) => v >= originalReturn).length / simulations;
+  // Downside probabilities, measured directly on the resampled outcomes
+  // (no cross-formula comparison): the fraction of simulations that lost
+  // money / produced a non-positive risk-adjusted return. Lower is
+  // better. Under "shuffle" the return multiset is fixed, so pValueReturns
+  // is 0 or 1; it is only informative under "bootstrap".
+  //
+  // `recalculateMetricsFromTrades` returns Sharpe 0 when the resample has
+  // zero volatility (all trades identical) — which happens for a perfect
+  // run of identical *winners* as well as for a flat/losing one. Counting
+  // Sharpe 0 as a downside outright would brand a deterministic winner as
+  // the worst possible outcome (pValue.sharpe = 1), so a zero-Sharpe
+  // resample only counts when its return was also non-positive.
+  const pValueSharpe =
+    sharpeValues.filter((s, i) => s < 0 || (s === 0 && returnValues[i] <= 0)).length / simulations;
+  const pValueReturns = returnValues.filter((v) => v <= 0).length / simulations;
 
   // Calculate confidence intervals
   const alpha = 1 - confidenceLevel;
@@ -248,13 +289,35 @@ export function runMonteCarloSimulation(
     },
   };
 
-  // Assessment
-  const isSignificant = pValueSharpe < 1 - confidenceLevel;
+  // Assessment is method-specific because the two resamplers answer
+  // different questions. Bootstrap varies the outcome, so significance
+  // is about profitability; shuffle leaves return invariant and only
+  // moves the drawdown path, so significance is about sequence risk.
+  // Sharing one return-based rule would make shuffle trivially
+  // "significant" on any profitable strategy (every reordering stays
+  // profitable), which says nothing.
+  let isSignificant: boolean;
   let reason: string;
-  if (isSignificant) {
-    reason = `Original Sharpe (${originalSharpe.toFixed(2)}) exceeds ${(confidenceLevel * 100).toFixed(0)}% of random permutations (p=${pValueSharpe.toFixed(3)}). Strategy shows statistically significant edge.`;
+  if (method === "shuffle") {
+    // How often a different ordering drew down deeper than the one
+    // actually observed. Low = the observed path was already near the
+    // worst case, so little drawdown is hidden by trade sequence.
+    const worseDrawdownProb =
+      maxDrawdownValues.filter((v) => v > originalMaxDD).length / simulations;
+    const p95MaxDD = getPercentile(sortedMaxDD, 95);
+    isSignificant = worseDrawdownProb <= 1 - confidenceLevel;
+    const worsePct = (worseDrawdownProb * 100).toFixed(0);
+    reason = isSignificant
+      ? `Only ${worsePct}% of ${simulations} orderings drew down deeper than the observed ${originalMaxDD.toFixed(1)}% (95th pct ${p95MaxDD.toFixed(1)}%). Drawdown is robust to trade sequence.`
+      : `${worsePct}% of ${simulations} orderings drew down deeper than the observed ${originalMaxDD.toFixed(1)}% (95th pct ${p95MaxDD.toFixed(1)}%). Trade sequence materially affects drawdown risk.`;
   } else {
-    reason = `Original Sharpe (${originalSharpe.toFixed(2)}) is within random distribution (p=${pValueSharpe.toFixed(3)}). Results may be due to lucky trade sequence.`;
+    // Bootstrap: significance = the downside tail is contained, i.e.
+    // fewer than (1 - confidenceLevel) of resamples lost money.
+    const profitablePct = ((1 - pValueReturns) * 100).toFixed(0);
+    isSignificant = pValueReturns < 1 - confidenceLevel;
+    reason = isSignificant
+      ? `${profitablePct}% of ${simulations} bootstrap resamples were profitable (p(loss)=${pValueReturns.toFixed(3)}). Performance is robust to resampling.`
+      : `Only ${profitablePct}% of ${simulations} bootstrap resamples were profitable (p(loss)=${pValueReturns.toFixed(3)}). Results are sensitive to which trades occur.`;
   }
 
   return {
@@ -290,8 +353,8 @@ export function formatMonteCarloResult(result: MonteCarloResult): string {
     `Simulations: ${result.simulationCount}`,
     "",
     "Original vs Simulated:",
-    `  Sharpe: ${originalResult.sharpe.toFixed(2)} (mean: ${statistics.sharpe.mean.toFixed(2)}, p=${pValue.sharpe.toFixed(3)})`,
-    `  Return: ${originalResult.totalReturnPercent.toFixed(2)}% (mean: ${statistics.totalReturnPercent.mean.toFixed(2)}%)`,
+    `  Sharpe: ${originalResult.sharpe.toFixed(2)} (mean: ${statistics.sharpe.mean.toFixed(2)}, p(≤0)=${pValue.sharpe.toFixed(3)})`,
+    `  Return: ${originalResult.totalReturnPercent.toFixed(2)}% (mean: ${statistics.totalReturnPercent.mean.toFixed(2)}%, p(loss)=${pValue.returns.toFixed(3)})`,
     `  Max DD: ${originalResult.maxDrawdown.toFixed(2)}% (mean: ${statistics.maxDrawdown.mean.toFixed(2)}%)`,
     "",
     `${(assessment.confidenceLevel * 100).toFixed(0)}% Confidence Intervals:`,

--- a/packages/core/src/types/optimization.ts
+++ b/packages/core/src/types/optimization.ts
@@ -188,6 +188,22 @@ export type MonteCarloOptions = {
   seed?: number;
   /** Confidence level for percentile calculations (default: 0.95) */
   confidenceLevel?: number;
+  /**
+   * Resampling method (default: `"bootstrap"`).
+   *
+   * - `"bootstrap"`: draw N trades with replacement. The same trade can
+   *   appear multiple times or not at all, so total return, Sharpe, and
+   *   profit factor all vary across simulations — the basis for
+   *   outcome-uncertainty estimates (return distribution, probability of
+   *   loss). This is the canonical method for "how reliable is this
+   *   edge?".
+   * - `"shuffle"`: permute the existing trades (no replacement). The
+   *   multiset of returns is unchanged, so total return / Sharpe /
+   *   profit factor are identical across simulations and only the
+   *   path-dependent max drawdown varies. Use this to study sequence
+   *   risk (clustering of losing trades) specifically.
+   */
+  method?: "shuffle" | "bootstrap";
   /** Progress callback */
   progressCallback?: (current: number, total: number) => void;
 };
@@ -236,7 +252,22 @@ export type MonteCarloResult = {
   };
   /** Number of simulations run */
   simulationCount: number;
-  /** P-value: probability of achieving original result by chance */
+  /**
+   * Downside probabilities across the simulated distribution. Lower is
+   * better. Measured directly on the resampled outcomes (no comparison
+   * to the backtest's own annualized figures, which use a different
+   * formula):
+   * - `returns`: fraction of simulations with total return ≤ 0
+   *   (probability of a losing outcome).
+   * - `sharpe`: fraction of simulations with a non-positive risk-adjusted
+   *   return — Sharpe < 0, or Sharpe = 0 only when the return was also
+   *   ≤ 0. A zero-volatility *winning* resample (identical positive
+   *   trades → Sharpe 0) is not counted, so a flawless run is not branded
+   *   the worst outcome.
+   *
+   * Under `"shuffle"`, return is order-invariant so `returns` collapses
+   * to 0 or 1; the figure is only informative under `"bootstrap"`.
+   */
   pValue: {
     sharpe: number;
     returns: number;


### PR DESCRIPTION
## Summary

`runMonteCarloSimulation` previously only shuffled trade order. Because a permutation leaves the multiset of returns unchanged, total return / Sharpe / profit factor were identical across every simulation — only the path-dependent max drawdown varied. That made the return/Sharpe percentile bands degenerate and the significance verdict unreliable.

This adds a `method` option and switches the default to **bootstrap** (resample with replacement), which is the canonical method for estimating outcome uncertainty.

## Changes

- **`MonteCarloOptions.method?: "shuffle" | "bootstrap"`**, default `"bootstrap"`.
  - `bootstrap`: draw N trades with replacement. The same trade can repeat or be skipped, so return / Sharpe / profit factor vary — the basis for outcome-uncertainty and probability-of-loss estimates.
  - `shuffle`: the previous order permutation, preserved for sequence-risk (drawdown) analysis.
- **`pValue` redefined** as a downside probability measured directly on the resampled outcomes, rather than comparing the resampled distribution against the backtest's own annualized Sharpe (which used a different formula and overstated significance):
  - `pValue.returns` = fraction of simulations with total return ≤ 0.
  - `pValue.sharpe` = fraction with a non-positive risk-adjusted return (Sharpe < 0, or Sharpe = 0 only when the return was also ≤ 0, so a zero-volatility *winning* resample is not branded the worst outcome).
- **`assessment` is method-aware**: bootstrap reports profitability robustness (downside tail contained), shuffle reports drawdown sequence risk (how often a different ordering draws down deeper than observed). `originalResult` is unchanged (still the backtest's reported metrics).
- Tests for both methods (return invariance under shuffle vs variation under bootstrap, default selection, probability-of-loss bounds, method-aware assessment text, zero-volatility winner/loser handling).
- CHANGELOG entry under Unreleased documenting the default behaviour change.

## Behaviour change

This changes the default output of a published function. Existing consumers that read `pValue` (the robustness scoring in `robustness/full.ts` and `robustness/quick.ts`, and the DNA grade) now reflect probability-of-loss rather than exceed-random-permutation; the direction (lower = more robust) is unchanged and all their tests pass. Documented under the CHANGELOG "Changed" subsection (allowed in a 0.x minor).

## Verification

- Full core suite: 6027 passing.
- `tsc --noEmit --ignoreDeprecations 6.0`: no new errors (pre-existing test-fixture type errors confirmed identical on the base branch).
- `biome check`: clean.
- `vite build` (core): succeeds.