### PR TITLE
feat(core): robustness helpers + Monte Carlo downside-risk summary

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Changed — Monte Carlo resamples with replacement (bootstrap) by default
+### Changed — Monte Carlo: bootstrap resampling by default + downside-risk summary (replaces p-value)
 
 `runMonteCarloSimulation` gains a `method?: "shuffle" | "bootstrap"`
 option and now defaults to **`"bootstrap"`** (was an unconditional
@@ -17,15 +17,43 @@ tooling, where bootstrap (with replacement) is the default for "how
 reliable is this edge?" and order shuffling is the narrower
 sequence-risk test.
 
-`pValue` is redefined as a **downside probability measured directly on
-the resampled outcomes**: `pValue.returns` is the fraction of
-simulations with total return ≤ 0 (probability of loss) and
-`pValue.sharpe` the fraction with Sharpe ≤ 0. It no longer compares the
-resampled distribution to the backtest's own annualized Sharpe — that
-comparison mixed two different Sharpe formulas and overstated
-significance. `assessment.isSignificant` is now true when fewer than
-`1 - confidenceLevel` of simulations lost money. `originalResult` is
-unchanged (still the backtest's reported metrics).
+The result's significance fields are replaced by a **downside-risk
+summary measured directly on the resampled outcomes**. The previous
+`pValue` / `assessment.isSignificant` shape forced a binary
+significance verdict (a permutation-test concept) onto a resampling
+distribution and compared mismatched Sharpe formulas. In its place
+`MonteCarloResult.downside` reports `probProfit`, `probLoss`,
+`riskOfRuin` (the fraction of simulations whose path-dependent max
+drawdown reaches a configurable `ruinThreshold`, default 50%), and the
+`ruinThreshold` used. `runMonteCarloSimulation` accepts a matching
+`ruinThreshold?: number` option. `assessment` keeps a method-aware,
+human-readable `reason` and the `confidenceLevel` but no longer carries
+`isSignificant`. `summarizeMonteCarloResult` returns `{ probProfit,
+probLoss, riskOfRuin, expectedSharpe, sharpe95CI, originalSharpe }`.
+These distribution-based figures are what mainstream backtest Monte
+Carlo tooling reports (StrategyQuant, AmiBroker, BuildAlpha).
+`originalResult` is unchanged (still the backtest's reported metrics).
+
+### Added — Robustness helpers: walk-forward efficiency, stitched OOS equity, Deflated Sharpe
+
+- **`wfeRatio(result)`** — Pardo's Walk-Forward Efficiency: the average
+  per-period ratio of annualized out-of-sample to annualized in-sample
+  return. Both windows are annualized over their calendar span before
+  the ratio, periods with non-positive in-sample return are skipped, and
+  the result is `NaN` when none qualify. Uncapped, so a strategy that
+  beats its optimization out-of-sample scores above 1.0. Pardo treats
+  ≥ 0.5 as the threshold for a robust (rather than curve-fit) strategy.
+- **`stitchOosEquity(result, initialCapital?)`** — stitches every
+  walk-forward period's out-of-sample trades into one continuous equity
+  curve, one point per trade (plus a leading anchor). A finer-grained
+  companion to the period-granularity `getOutOfSampleEquityCurve`.
+- **`deflatedSharpe(params)`** / **`deflatedSharpeFromReturns(returns,
+  trialSharpes)`** — Deflated Sharpe Ratio (Bailey & López de Prado
+  2014): the probability the true Sharpe is positive after correcting
+  for selection bias across `N` trials, non-normality (skew / kurtosis),
+  and sample length. Building blocks `probabilisticSharpe(...)` (PSR) and
+  `expectedMaxSharpe(trials, variance)` (the SR0 selection benchmark) are
+  exported too. All Sharpe inputs are per-return (non-annualized).
 
 ### Added — `listTunables(strategy)` for numeric parameter introspection
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -690,6 +690,7 @@ export {
   // Monte Carlo Simulation
   runMonteCarloSimulation,
   runMonteCarloSimulationSafe,
+  stitchOosEquity,
   summarizeAWFResult,
   summarizeCombinationSearch,
   summarizeGridSearch,
@@ -699,6 +700,7 @@ export {
   // Walk-Forward Analysis
   walkForwardAnalysis,
   walkForwardAnalysisSafe,
+  wfeRatio,
 } from "./optimization";
 // Position Sizing
 export {
@@ -718,6 +720,7 @@ export {
   riskBasedSize,
   riskPerShare,
 } from "./position-sizing";
+export type { DeflatedSharpeParams } from "./scoring";
 // Signal Scoring
 export {
   // Calculator
@@ -740,6 +743,10 @@ export {
   createTrendFollowingPreset,
   createVolumeAnomalyEvaluator,
   createVolumeSpikeEvaluator,
+  // Deflated Sharpe Ratio
+  deflatedSharpe,
+  deflatedSharpeFromReturns,
+  expectedMaxSharpe,
   // Presets
   getPreset,
   isScoreAbove,
@@ -751,6 +758,7 @@ export {
   perfectOrderBearish as poBearishSignal,
   perfectOrderBullish as poBullishSignal,
   poConfirmation,
+  probabilisticSharpe,
   rsiOverbought70,
   // Pre-built signals
   rsiOversold30,

--- a/packages/core/src/optimization/__tests__/monte-carlo.test.ts
+++ b/packages/core/src/optimization/__tests__/monte-carlo.test.ts
@@ -220,7 +220,8 @@ describe("Monte Carlo Simulation", () => {
       });
 
       expect(result1.statistics.sharpe.mean).toBe(result2.statistics.sharpe.mean);
-      expect(result1.pValue.sharpe).toBe(result2.pValue.sharpe);
+      expect(result1.downside.probLoss).toBe(result2.downside.probLoss);
+      expect(result1.downside.riskOfRuin).toBe(result2.downside.riskOfRuin);
     });
 
     it("should produce different max drawdown distributions with different seeds", () => {
@@ -270,16 +271,35 @@ describe("Monte Carlo Simulation", () => {
       expect(mcResult.originalResult.profitFactor).toBe(2.5);
     });
 
-    it("should calculate p-values between 0 and 1", () => {
+    it("should produce downside probabilities between 0 and 1 that sum consistently", () => {
       const trades = createDeterministicTrades();
       const backtest = createMockBacktestResult(trades);
 
       const mcResult = runMonteCarloSimulation(backtest, { simulations: 100 });
 
-      expect(mcResult.pValue.sharpe).toBeGreaterThanOrEqual(0);
-      expect(mcResult.pValue.sharpe).toBeLessThanOrEqual(1);
-      expect(mcResult.pValue.returns).toBeGreaterThanOrEqual(0);
-      expect(mcResult.pValue.returns).toBeLessThanOrEqual(1);
+      const { probProfit, probLoss, riskOfRuin } = mcResult.downside;
+      for (const p of [probProfit, probLoss, riskOfRuin]) {
+        expect(p).toBeGreaterThanOrEqual(0);
+        expect(p).toBeLessThanOrEqual(1);
+      }
+      expect(probProfit + probLoss).toBeCloseTo(1, 10);
+    });
+
+    it("uses the default ruin threshold of 50% and respects an override", () => {
+      const trades = createDeterministicTrades();
+      const backtest = createMockBacktestResult(trades);
+
+      const def = runMonteCarloSimulation(backtest, { simulations: 100, seed: 1 });
+      expect(def.downside.ruinThreshold).toBe(50);
+
+      const strict = runMonteCarloSimulation(backtest, {
+        simulations: 100,
+        seed: 1,
+        ruinThreshold: 5,
+      });
+      expect(strict.downside.ruinThreshold).toBe(5);
+      // A lower (easier-to-hit) ruin threshold can only increase risk of ruin.
+      expect(strict.downside.riskOfRuin).toBeGreaterThanOrEqual(def.downside.riskOfRuin);
     });
 
     it("should calculate confidence intervals", () => {
@@ -304,9 +324,9 @@ describe("Monte Carlo Simulation", () => {
 
       const mcResult = runMonteCarloSimulation(backtest, { simulations: 100 });
 
-      expect(typeof mcResult.assessment.isSignificant).toBe("boolean");
       expect(typeof mcResult.assessment.reason).toBe("string");
       expect(mcResult.assessment.reason.length).toBeGreaterThan(0);
+      expect(mcResult.assessment.confidenceLevel).toBe(0.95);
     });
 
     it("should call progress callback", () => {
@@ -347,14 +367,16 @@ describe("Monte Carlo Simulation", () => {
       expect(formatted).toContain("Assessment:");
     });
 
-    it("should include significance assessment", () => {
+    it("should include the downside-risk summary", () => {
       const trades = createDeterministicTrades();
       const backtest = createMockBacktestResult(trades);
       const mcResult = runMonteCarloSimulation(backtest, { simulations: 100 });
 
       const formatted = formatMonteCarloResult(mcResult);
 
-      expect(formatted).toMatch(/SIGNIFICANT|NOT SIGNIFICANT/);
+      expect(formatted).toContain("Downside risk:");
+      expect(formatted).toContain("P(profit):");
+      expect(formatted).toContain("Risk of ruin");
     });
   });
 
@@ -366,9 +388,9 @@ describe("Monte Carlo Simulation", () => {
 
       const summary = summarizeMonteCarloResult(mcResult);
 
-      expect(typeof summary.isSignificant).toBe("boolean");
-      expect(typeof summary.pValueSharpe).toBe("number");
-      expect(typeof summary.pValueReturns).toBe("number");
+      expect(typeof summary.probProfit).toBe("number");
+      expect(typeof summary.probLoss).toBe("number");
+      expect(typeof summary.riskOfRuin).toBe("number");
       expect(summary.expectedSharpe).toHaveProperty("mean");
       expect(summary.expectedSharpe).toHaveProperty("median");
       expect(summary.sharpe95CI).toHaveProperty("lower");
@@ -474,7 +496,7 @@ describe("Monte Carlo Simulation", () => {
       );
     });
 
-    it("p(loss) is 0 for all-win trades and 1 for all-loss trades", () => {
+    it("P(loss) is 0 for all-win trades and 1 for all-loss trades", () => {
       const allWins: Trade[] = Array.from({ length: 8 }, (_, i) => ({
         entryTime: Date.now() + i * 86400000,
         entryPrice: 100,
@@ -500,18 +522,15 @@ describe("Monte Carlo Simulation", () => {
         seed: 7,
       });
 
-      expect(winMc.pValue.returns).toBe(0);
-      expect(winMc.assessment.isSignificant).toBe(true);
-      expect(lossMc.pValue.returns).toBe(1);
-      expect(lossMc.assessment.isSignificant).toBe(false);
+      expect(winMc.downside.probLoss).toBe(0);
+      expect(winMc.downside.probProfit).toBe(1);
+      expect(lossMc.downside.probLoss).toBe(1);
+      expect(lossMc.downside.probProfit).toBe(0);
 
-      // Identical winners resample to zero-volatility runs (Sharpe 0).
-      // pValue.sharpe must NOT brand them a non-positive outcome, or the
-      // robustness grade would score a flawless strategy as the worst.
-      expect(winMc.pValue.sharpe).toBe(0);
-      // Identical losers (also zero-volatility, Sharpe 0) are still caught
-      // via the non-positive return, so the downside is not hidden.
-      expect(lossMc.pValue.sharpe).toBe(1);
+      // All-win trades never draw down past the ruin threshold; all-loss
+      // trades compound straight down past any sane threshold.
+      expect(winMc.downside.riskOfRuin).toBe(0);
+      expect(lossMc.downside.riskOfRuin).toBe(1);
     });
 
     it("shuffle assessment reflects drawdown sequence risk, not returns", () => {

--- a/packages/core/src/optimization/__tests__/strategy-dna.test.ts
+++ b/packages/core/src/optimization/__tests__/strategy-dna.test.ts
@@ -442,9 +442,9 @@ describe("computeDnaGrade", () => {
     recommendation: { useOptimizedParams: true, suggestedParams: {}, reason: "" },
   };
 
-  const mc: MonteCarloResult = {
-    pValue: { sharpe: 0.005, returns: 0.005 } as never,
-  } as MonteCarloResult;
+  const mc = {
+    downside: { probProfit: 0.995, probLoss: 0.005, riskOfRuin: 0.005, ruinThreshold: 50 },
+  } as unknown as MonteCarloResult;
 
   it("returns overall='F' with all items unavailable when no inputs are provided", () => {
     const out = computeDnaGrade(null, null, null);
@@ -460,9 +460,9 @@ describe("computeDnaGrade", () => {
     expect(wfItem?.grade).toBe("A");
   });
 
-  it("includes MC significance when monteCarlo is provided", () => {
+  it("includes MC robustness when monteCarlo is provided", () => {
     const out = computeDnaGrade(null, null, mc);
-    const mcItem = out.items.find((it) => it.label === "Monte Carlo Significance");
+    const mcItem = out.items.find((it) => it.label === "Monte Carlo Robustness");
     expect(mcItem?.available).toBe(true);
     expect(mcItem?.grade).toBe("A");
   });
@@ -478,7 +478,7 @@ describe("computeDnaGrade", () => {
     // of those two items, not penalize for missing items.
     const out = computeDnaGrade(null, wfStable, mc);
     const wfScore = out.items.find((it) => it.label === "Walk-Forward Stability")?.score ?? 0;
-    const mcScore = out.items.find((it) => it.label === "Monte Carlo Significance")?.score ?? 0;
+    const mcScore = out.items.find((it) => it.label === "Monte Carlo Robustness")?.score ?? 0;
     // weights: WF 0.3, MC 0.3 → renormalized to 0.5 each
     const expected = (wfScore * 0.3 + mcScore * 0.3) / 0.6;
     expect(out.overallScore).toBeCloseTo(expected, 5);

--- a/packages/core/src/optimization/__tests__/walkforward.test.ts
+++ b/packages/core/src/optimization/__tests__/walkforward.test.ts
@@ -1,13 +1,38 @@
 import { describe, expect, it, vi } from "vitest";
 import type { BacktestOptions, NormalizedCandle, PresetCondition } from "../../types";
+import type { WalkForwardPeriod, WalkForwardResult } from "../../types/optimization";
 import { param } from "../grid-search";
 import {
   calculatePeriodCount,
   generatePeriodBoundaries,
   getOutOfSampleEquityCurve,
+  stitchOosEquity,
   summarizeWalkForward,
   walkForwardAnalysis,
+  wfeRatio,
 } from "../walkforward";
+
+const MS_PER_YEAR = 365.25 * 24 * 60 * 60 * 1000;
+
+/** Build a full OptimizationMetric record, defaulting unspecified keys to 0. */
+function metricsRecord(over: { returns?: number; winRate?: number } = {}) {
+  return {
+    sharpe: 0,
+    calmar: 0,
+    mar: 0,
+    profitFactor: 0,
+    recoveryFactor: 0,
+    returns: over.returns ?? 0,
+    winRate: over.winRate ?? 0,
+    tradeCount: 0,
+    maxDrawdown: 0,
+  };
+}
+
+/** Minimal WalkForwardResult carrying only the fields the helpers read. */
+function makeWfResult(periods: Partial<WalkForwardPeriod>[]): WalkForwardResult {
+  return { periods } as unknown as WalkForwardResult;
+}
 
 /**
  * Generate test candles with upward trend
@@ -311,6 +336,162 @@ describe("Walk-Forward Analysis", () => {
         const ratio200k = curve200k[0].equity / 200000;
         expect(ratio100k).toBeCloseTo(ratio200k, 5);
       }
+    });
+  });
+
+  describe("wfeRatio", () => {
+    // Spans of exactly one year make annualization a no-op, so WFE
+    // reduces to the plain out-of-sample / in-sample return ratio.
+    it("equals OOS/IS return ratio when both windows span one year", () => {
+      const result = makeWfResult([
+        {
+          trainStart: 0,
+          trainEnd: MS_PER_YEAR,
+          testStart: MS_PER_YEAR,
+          testEnd: 2 * MS_PER_YEAR,
+          inSampleMetrics: metricsRecord({ returns: 20 }),
+          outOfSampleMetrics: metricsRecord({ returns: 10 }),
+        },
+      ]);
+      expect(wfeRatio(result)).toBeCloseTo(0.5, 10);
+    });
+
+    it("averages per-period WFE", () => {
+      const result = makeWfResult([
+        {
+          trainStart: 0,
+          trainEnd: MS_PER_YEAR,
+          testStart: MS_PER_YEAR,
+          testEnd: 2 * MS_PER_YEAR,
+          inSampleMetrics: metricsRecord({ returns: 20 }),
+          outOfSampleMetrics: metricsRecord({ returns: 10 }), // WFE 0.5
+        },
+        {
+          trainStart: 2 * MS_PER_YEAR,
+          trainEnd: 3 * MS_PER_YEAR,
+          testStart: 3 * MS_PER_YEAR,
+          testEnd: 4 * MS_PER_YEAR,
+          inSampleMetrics: metricsRecord({ returns: 10 }),
+          outOfSampleMetrics: metricsRecord({ returns: 10 }), // WFE 1.0
+        },
+      ]);
+      expect(wfeRatio(result)).toBeCloseTo(0.75, 10);
+    });
+
+    it("skips periods with non-positive in-sample return and is NaN when none qualify", () => {
+      const result = makeWfResult([
+        {
+          trainStart: 0,
+          trainEnd: MS_PER_YEAR,
+          testStart: MS_PER_YEAR,
+          testEnd: 2 * MS_PER_YEAR,
+          inSampleMetrics: metricsRecord({ returns: -5 }),
+          outOfSampleMetrics: metricsRecord({ returns: 10 }),
+        },
+      ]);
+      expect(Number.isNaN(wfeRatio(result))).toBe(true);
+    });
+
+    it("is not capped above 1 when OOS beats IS", () => {
+      const result = makeWfResult([
+        {
+          trainStart: 0,
+          trainEnd: MS_PER_YEAR,
+          testStart: MS_PER_YEAR,
+          testEnd: 2 * MS_PER_YEAR,
+          inSampleMetrics: metricsRecord({ returns: 10 }),
+          outOfSampleMetrics: metricsRecord({ returns: 25 }),
+        },
+      ]);
+      expect(wfeRatio(result)).toBeCloseTo(2.5, 10);
+    });
+  });
+
+  describe("stitchOosEquity", () => {
+    it("compounds each OOS trade onto a leading anchor point", () => {
+      const result = makeWfResult([
+        {
+          testStart: 1000,
+          testBacktest: {
+            trades: [
+              { exitTime: 2000, returnPercent: 10 },
+              { exitTime: 3000, returnPercent: -5 },
+            ],
+          },
+        },
+        {
+          testStart: 4000,
+          testBacktest: {
+            trades: [{ exitTime: 5000, returnPercent: 20 }],
+          },
+        },
+      ] as unknown as Partial<WalkForwardPeriod>[]);
+
+      const curve = stitchOosEquity(result, 100_000);
+
+      // 1 anchor + 3 trades
+      expect(curve.length).toBe(4);
+      expect(curve[0]).toEqual({ time: 1000, equity: 100_000 });
+      expect(curve[1].equity).toBeCloseTo(110_000, 6); // +10%
+      expect(curve[2].equity).toBeCloseTo(104_500, 6); // -5%
+      expect(curve[3].equity).toBeCloseTo(125_400, 6); // +20%
+      // Times are non-decreasing.
+      for (let i = 1; i < curve.length; i++) {
+        expect(curve[i].time).toBeGreaterThanOrEqual(curve[i - 1].time);
+      }
+    });
+
+    it("returns an empty curve for no periods", () => {
+      expect(stitchOosEquity(makeWfResult([]), 100_000)).toEqual([]);
+    });
+
+    it("keeps the curve chronological when test windows overlap", () => {
+      // Overlapping windows (stepSize < testSize): period 2 holds a trade
+      // that exited before period 1's last trade. A global sort must keep
+      // exit times non-decreasing across the whole stitched curve.
+      const result = makeWfResult([
+        {
+          testStart: 1000,
+          testBacktest: {
+            trades: [
+              { exitTime: 2000, returnPercent: 5 },
+              { exitTime: 6000, returnPercent: 5 },
+            ],
+          },
+        },
+        {
+          testStart: 4000,
+          testBacktest: {
+            trades: [{ exitTime: 5000, returnPercent: 5 }],
+          },
+        },
+      ] as unknown as Partial<WalkForwardPeriod>[]);
+
+      const curve = stitchOosEquity(result, 100_000);
+      const times = curve.map((p) => p.time);
+      expect(times).toEqual([1000, 2000, 5000, 6000]);
+      for (let i = 1; i < times.length; i++) {
+        expect(times[i]).toBeGreaterThanOrEqual(times[i - 1]);
+      }
+    });
+
+    it("is finer than the per-period equity curve", () => {
+      const candles = generateUpTrendCandles(300);
+      const createStrategy = (params: Record<string, number>) => ({
+        entry: createEnterCondition(Math.round(params.enterAfter)),
+        exit: createExitCondition(10, Math.round(params.enterAfter)),
+        options: { capital: 100000 } as BacktestOptions,
+      });
+      const result = walkForwardAnalysis(candles, createStrategy, [param("enterAfter", 5, 10, 5)], {
+        windowSize: 100,
+        stepSize: 50,
+        testSize: 50,
+      });
+
+      const perPeriod = getOutOfSampleEquityCurve(result);
+      const stitched = stitchOosEquity(result);
+      // At least as many points as periods (anchor + trades), never fewer.
+      expect(stitched.length).toBeGreaterThanOrEqual(perPeriod.length);
     });
   });
 

--- a/packages/core/src/optimization/index.ts
+++ b/packages/core/src/optimization/index.ts
@@ -131,7 +131,9 @@ export {
   calculatePeriodCount,
   generatePeriodBoundaries,
   getOutOfSampleEquityCurve,
+  stitchOosEquity,
   summarizeWalkForward,
   walkForwardAnalysis,
   walkForwardAnalysisSafe,
+  wfeRatio,
 } from "./walkforward";

--- a/packages/core/src/optimization/monte-carlo.ts
+++ b/packages/core/src/optimization/monte-carlo.ts
@@ -21,6 +21,7 @@ const DEFAULT_OPTIONS = {
   simulations: 1000,
   confidenceLevel: 0.95,
   method: "bootstrap",
+  ruinThreshold: 50,
 } as const;
 
 /**
@@ -194,6 +195,7 @@ export function runMonteCarloSimulation(
   const simulations = options.simulations ?? DEFAULT_OPTIONS.simulations;
   const confidenceLevel = options.confidenceLevel ?? DEFAULT_OPTIONS.confidenceLevel;
   const method = options.method ?? DEFAULT_OPTIONS.method;
+  const ruinThreshold = options.ruinThreshold ?? DEFAULT_OPTIONS.ruinThreshold;
   const { progressCallback } = options;
 
   const trades = result.trades;
@@ -240,30 +242,26 @@ export function runMonteCarloSimulation(
   };
 
   // Original result values — the backtest's own reported metrics, kept
-  // as-is for display. They are NOT used as the p-value baseline: the
-  // resampler recomputes Sharpe with a per-trade formula that differs
-  // from the backtest's candle-aware annualization, so comparing the
-  // two would mix scales and overstate significance.
+  // as-is for display. They are NOT used as a baseline for the downside
+  // figures: the resampler recomputes Sharpe with a per-trade formula
+  // that differs from the backtest's candle-aware annualization, so
+  // comparing the two would mix scales.
   const originalSharpe = result.sharpeRatio;
   const originalReturn = result.totalReturnPercent;
   const originalMaxDD = result.maxDrawdown;
   const originalPF = result.profitFactor;
 
-  // Downside probabilities, measured directly on the resampled outcomes
-  // (no cross-formula comparison): the fraction of simulations that lost
-  // money / produced a non-positive risk-adjusted return. Lower is
-  // better. Under "shuffle" the return multiset is fixed, so pValueReturns
-  // is 0 or 1; it is only informative under "bootstrap".
-  //
-  // `recalculateMetricsFromTrades` returns Sharpe 0 when the resample has
-  // zero volatility (all trades identical) — which happens for a perfect
-  // run of identical *winners* as well as for a flat/losing one. Counting
-  // Sharpe 0 as a downside outright would brand a deterministic winner as
-  // the worst possible outcome (pValue.sharpe = 1), so a zero-Sharpe
-  // resample only counts when its return was also non-positive.
-  const pValueSharpe =
-    sharpeValues.filter((s, i) => s < 0 || (s === 0 && returnValues[i] <= 0)).length / simulations;
-  const pValueReturns = returnValues.filter((v) => v <= 0).length / simulations;
+  // Downside-risk figures, measured directly on the resampled outcomes
+  // (no cross-formula comparison, no permutation-test framing):
+  // - probLoss: fraction of simulations that lost money. Under "shuffle"
+  //   the return multiset is fixed so this collapses to 0 or 1; it is
+  //   only informative under "bootstrap".
+  // - riskOfRuin: fraction whose path-dependent max drawdown reached the
+  //   ruin threshold. Drawdown is path-dependent, so this is meaningful
+  //   under both methods.
+  const probLoss = returnValues.filter((v) => v <= 0).length / simulations;
+  const probProfit = 1 - probLoss;
+  const riskOfRuin = maxDrawdownValues.filter((dd) => dd >= ruinThreshold).length / simulations;
 
   // Calculate confidence intervals
   const alpha = 1 - confidenceLevel;
@@ -289,14 +287,12 @@ export function runMonteCarloSimulation(
     },
   };
 
-  // Assessment is method-specific because the two resamplers answer
-  // different questions. Bootstrap varies the outcome, so significance
-  // is about profitability; shuffle leaves return invariant and only
-  // moves the drawdown path, so significance is about sequence risk.
-  // Sharing one return-based rule would make shuffle trivially
-  // "significant" on any profitable strategy (every reordering stays
-  // profitable), which says nothing.
-  let isSignificant: boolean;
+  // Assessment narrative is method-specific because the two resamplers
+  // answer different questions. Bootstrap varies the outcome, so the
+  // story is about profitability and ruin; shuffle leaves return
+  // invariant and only moves the drawdown path, so the story is about
+  // sequence risk. There is no binary significance flag — the figures
+  // in `downside` are the verdict.
   let reason: string;
   if (method === "shuffle") {
     // How often a different ordering drew down deeper than the one
@@ -305,19 +301,12 @@ export function runMonteCarloSimulation(
     const worseDrawdownProb =
       maxDrawdownValues.filter((v) => v > originalMaxDD).length / simulations;
     const p95MaxDD = getPercentile(sortedMaxDD, 95);
-    isSignificant = worseDrawdownProb <= 1 - confidenceLevel;
     const worsePct = (worseDrawdownProb * 100).toFixed(0);
-    reason = isSignificant
-      ? `Only ${worsePct}% of ${simulations} orderings drew down deeper than the observed ${originalMaxDD.toFixed(1)}% (95th pct ${p95MaxDD.toFixed(1)}%). Drawdown is robust to trade sequence.`
-      : `${worsePct}% of ${simulations} orderings drew down deeper than the observed ${originalMaxDD.toFixed(1)}% (95th pct ${p95MaxDD.toFixed(1)}%). Trade sequence materially affects drawdown risk.`;
+    reason = `${worsePct}% of ${simulations} orderings drew down deeper than the observed ${originalMaxDD.toFixed(1)}% (95th pct ${p95MaxDD.toFixed(1)}%, risk of ${ruinThreshold}%+ ruin ${(riskOfRuin * 100).toFixed(0)}%). Trade sequence ${worseDrawdownProb <= 1 - confidenceLevel ? "barely affects" : "materially affects"} drawdown risk.`;
   } else {
-    // Bootstrap: significance = the downside tail is contained, i.e.
-    // fewer than (1 - confidenceLevel) of resamples lost money.
-    const profitablePct = ((1 - pValueReturns) * 100).toFixed(0);
-    isSignificant = pValueReturns < 1 - confidenceLevel;
-    reason = isSignificant
-      ? `${profitablePct}% of ${simulations} bootstrap resamples were profitable (p(loss)=${pValueReturns.toFixed(3)}). Performance is robust to resampling.`
-      : `Only ${profitablePct}% of ${simulations} bootstrap resamples were profitable (p(loss)=${pValueReturns.toFixed(3)}). Results are sensitive to which trades occur.`;
+    // Bootstrap: report the resampled profitability and ruin tail.
+    const profitablePct = (probProfit * 100).toFixed(0);
+    reason = `${profitablePct}% of ${simulations} bootstrap resamples were profitable (p(loss)=${probLoss.toFixed(3)}, risk of ${ruinThreshold}%+ ruin ${(riskOfRuin * 100).toFixed(0)}%). ${probLoss < 1 - confidenceLevel ? "Downside tail is contained." : "Results are sensitive to which trades occur."}`;
   }
 
   return {
@@ -329,13 +318,14 @@ export function runMonteCarloSimulation(
     },
     statistics,
     simulationCount: simulations,
-    pValue: {
-      sharpe: pValueSharpe,
-      returns: pValueReturns,
+    downside: {
+      probProfit,
+      probLoss,
+      riskOfRuin,
+      ruinThreshold,
     },
     confidenceInterval,
     assessment: {
-      isSignificant,
       reason,
       confidenceLevel,
     },
@@ -346,23 +336,26 @@ export function runMonteCarloSimulation(
  * Format Monte Carlo result for display
  */
 export function formatMonteCarloResult(result: MonteCarloResult): string {
-  const { originalResult, statistics, pValue, confidenceInterval, assessment } = result;
+  const { originalResult, statistics, downside, confidenceInterval, assessment } = result;
 
   const lines = [
     "=== Monte Carlo Simulation Results ===",
     `Simulations: ${result.simulationCount}`,
     "",
     "Original vs Simulated:",
-    `  Sharpe: ${originalResult.sharpe.toFixed(2)} (mean: ${statistics.sharpe.mean.toFixed(2)}, p(≤0)=${pValue.sharpe.toFixed(3)})`,
-    `  Return: ${originalResult.totalReturnPercent.toFixed(2)}% (mean: ${statistics.totalReturnPercent.mean.toFixed(2)}%, p(loss)=${pValue.returns.toFixed(3)})`,
+    `  Sharpe: ${originalResult.sharpe.toFixed(2)} (mean: ${statistics.sharpe.mean.toFixed(2)})`,
+    `  Return: ${originalResult.totalReturnPercent.toFixed(2)}% (mean: ${statistics.totalReturnPercent.mean.toFixed(2)}%)`,
     `  Max DD: ${originalResult.maxDrawdown.toFixed(2)}% (mean: ${statistics.maxDrawdown.mean.toFixed(2)}%)`,
+    "",
+    "Downside risk:",
+    `  P(profit): ${(downside.probProfit * 100).toFixed(1)}%  P(loss): ${(downside.probLoss * 100).toFixed(1)}%`,
+    `  Risk of ruin (${downside.ruinThreshold}%+ drawdown): ${(downside.riskOfRuin * 100).toFixed(1)}%`,
     "",
     `${(assessment.confidenceLevel * 100).toFixed(0)}% Confidence Intervals:`,
     `  Sharpe: [${confidenceInterval.sharpe.lower.toFixed(2)}, ${confidenceInterval.sharpe.upper.toFixed(2)}]`,
     `  Return: [${confidenceInterval.returns.lower.toFixed(2)}%, ${confidenceInterval.returns.upper.toFixed(2)}%]`,
     "",
     "Assessment:",
-    `  ${assessment.isSignificant ? "SIGNIFICANT" : "NOT SIGNIFICANT"}`,
     `  ${assessment.reason}`,
   ];
 
@@ -373,17 +366,17 @@ export function formatMonteCarloResult(result: MonteCarloResult): string {
  * Summarize Monte Carlo result
  */
 export function summarizeMonteCarloResult(result: MonteCarloResult): {
-  isSignificant: boolean;
-  pValueSharpe: number;
-  pValueReturns: number;
+  probProfit: number;
+  probLoss: number;
+  riskOfRuin: number;
   expectedSharpe: { mean: number; median: number };
   sharpe95CI: { lower: number; upper: number };
   originalSharpe: number;
 } {
   return {
-    isSignificant: result.assessment.isSignificant,
-    pValueSharpe: result.pValue.sharpe,
-    pValueReturns: result.pValue.returns,
+    probProfit: result.downside.probProfit,
+    probLoss: result.downside.probLoss,
+    riskOfRuin: result.downside.riskOfRuin,
     expectedSharpe: {
       mean: result.statistics.sharpe.mean,
       median: result.statistics.sharpe.median,

--- a/packages/core/src/optimization/strategy-dna.ts
+++ b/packages/core/src/optimization/strategy-dna.ts
@@ -456,11 +456,18 @@ function wfStabilityScore(stabilityRatio: number): number {
   return 0;
 }
 
-function mcSignificanceScore(pValue: number): number {
-  if (pValue < 0.01) return 100;
-  if (pValue < 0.05) return 75;
-  if (pValue < 0.1) return 50;
-  if (pValue < 0.2) return 25;
+/**
+ * Map Monte Carlo downside risk to a 0–100 robustness score. Driven by
+ * the worse of probability-of-loss and risk-of-ruin (a strategy is only
+ * as robust as its larger downside). Thresholds mirror the color bands
+ * mainstream MC tooling uses for risk of ruin (green < 5%, red > 50%).
+ */
+function mcDownsideScore(probLoss: number, riskOfRuin: number): number {
+  const risk = Math.max(probLoss, riskOfRuin);
+  if (risk < 0.05) return 100;
+  if (risk < 0.1) return 75;
+  if (risk < 0.2) return 50;
+  if (risk < 0.35) return 25;
   return 0;
 }
 
@@ -540,18 +547,18 @@ export function computeDnaGrade(
   }
 
   if (monteCarlo) {
-    const pVal = Math.min(monteCarlo.pValue.sharpe, monteCarlo.pValue.returns);
-    const s = mcSignificanceScore(pVal);
+    const { probLoss, riskOfRuin, ruinThreshold } = monteCarlo.downside;
+    const s = mcDownsideScore(probLoss, riskOfRuin);
     items.push({
-      label: "Monte Carlo Significance",
+      label: "Monte Carlo Robustness",
       grade: scoreToDnaGrade(s),
       score: s,
-      description: `p-value: ${pVal.toFixed(3)}`,
+      description: `P(loss): ${(probLoss * 100).toFixed(0)}%, risk of ${ruinThreshold}%+ ruin: ${(riskOfRuin * 100).toFixed(0)}%`,
       available: true,
     });
   } else {
     items.push({
-      label: "Monte Carlo Significance",
+      label: "Monte Carlo Robustness",
       grade: "F",
       score: 0,
       description: "Run Monte Carlo first",

--- a/packages/core/src/optimization/walkforward.ts
+++ b/packages/core/src/optimization/walkforward.ts
@@ -434,6 +434,136 @@ export function getOutOfSampleEquityCurve(
   return curve;
 }
 
+const MS_PER_YEAR = 365.25 * 24 * 60 * 60 * 1000;
+
+/**
+ * Annualize a total return (in percent) over a calendar span.
+ * Returns `NaN` when the span is non-positive.
+ */
+function annualizeByCalendar(totalReturnPercent: number, startMs: number, endMs: number): number {
+  const years = (endMs - startMs) / MS_PER_YEAR;
+  if (!(years > 0)) return Number.NaN;
+  const total = totalReturnPercent / 100;
+  // A loss beyond -100% is not representable; clamp like `annualizeReturn`.
+  if (total <= -1) return -100;
+  return ((1 + total) ** (1 / years) - 1) * 100;
+}
+
+/**
+ * Walk-Forward Efficiency (WFE) — Pardo's measure of how well a
+ * strategy's in-sample optimization carries to out-of-sample data.
+ *
+ * For each period, WFE = (annualized out-of-sample return) /
+ * (annualized in-sample return). The training and test windows usually
+ * differ in length, so both returns are annualized over their calendar
+ * span before the ratio. The result is the **average per-period WFE**.
+ *
+ * A WFE of 1.0 means out-of-sample matched the optimized in-sample
+ * result; Pardo treats ≥ 0.5 (50–60%) as the threshold for a genuinely
+ * robust strategy rather than a curve-fit one. WFE is not capped — an
+ * out-of-sample result that beats in-sample yields > 1.0. (This is
+ * distinct from `aggregateMetrics.stabilityRatio`, which is capped at 1
+ * and computed on the primary optimization metric rather than on
+ * annualized return.)
+ *
+ * Periods whose in-sample annualized return is ≤ 0 are skipped: walk-
+ * forward efficiency is undefined when the strategy wasn't even
+ * profitable in-sample, since the ratio's sign and magnitude would be
+ * meaningless. Returns `NaN` when no period has a positive in-sample
+ * return, matching the `calculateCalmarRatio` "undefined" convention.
+ *
+ * @param result Walk-forward analysis result
+ * @returns Average per-period walk-forward efficiency, or `NaN` when undefined
+ * @example
+ * ```ts
+ * import { walkForwardAnalysis, wfeRatio } from "trendcraft";
+ *
+ * const wf = walkForwardAnalysis(candles, createStrategy, ranges);
+ * const wfe = wfeRatio(wf);
+ * if (Number.isFinite(wfe) && wfe >= 0.5) {
+ *   console.log(`Robust: WFE ${(wfe * 100).toFixed(0)}%`);
+ * }
+ * ```
+ */
+export function wfeRatio(result: WalkForwardResult): number {
+  const ratios: number[] = [];
+  for (const p of result.periods) {
+    const isAnn = annualizeByCalendar(p.inSampleMetrics.returns, p.trainStart, p.trainEnd);
+    const oosAnn = annualizeByCalendar(p.outOfSampleMetrics.returns, p.testStart, p.testEnd);
+    if (Number.isFinite(isAnn) && isAnn > 0 && Number.isFinite(oosAnn)) {
+      ratios.push(oosAnn / isAnn);
+    }
+  }
+  if (ratios.length === 0) return Number.NaN;
+  return ratios.reduce((s, v) => s + v, 0) / ratios.length;
+}
+
+/**
+ * Stitch the out-of-sample trades from every walk-forward period into a
+ * single continuous equity curve, one point per trade.
+ *
+ * {@link getOutOfSampleEquityCurve} emits one point per *period* (the
+ * compounded period return at each `testEnd`). This finer variant walks
+ * every period's out-of-sample trades in chronological order and
+ * compounds each trade's return, so the curve shows the intra-period
+ * path — the canonical "stitched OOS equity" used to visualize walk-
+ * forward robustness. Points are placed at trade exits, the finest
+ * granularity the walk-forward result carries (per-candle marks are not
+ * retained on the period backtests).
+ *
+ * Each trade is compounded against the running equity
+ * (`equity *= 1 + returnPercent/100`), matching the full-capital
+ * trade-compounding convention used elsewhere in the library (e.g. the
+ * Monte Carlo resampler). A leading anchor point at the first period's
+ * `testStart` with the initial capital starts the curve.
+ *
+ * Trades from every period are merged and sorted globally by exit time
+ * before compounding, so the curve stays chronological even when test
+ * windows overlap (`stepSize < testSize`). Note that overlapping windows
+ * test the same span more than once, so the shared trades are
+ * double-counted — the same caveat that applies to the period-level
+ * {@link getOutOfSampleEquityCurve}. Use non-overlapping windows
+ * (`stepSize === testSize`, the default) for a clean stitched curve.
+ *
+ * @param result Walk-forward analysis result
+ * @param initialCapital Starting capital (default 100000)
+ * @returns Equity curve as `{ time, equity }` — one leading anchor plus one point per out-of-sample trade
+ * @example
+ * ```ts
+ * import { walkForwardAnalysis, stitchOosEquity } from "trendcraft";
+ *
+ * const wf = walkForwardAnalysis(candles, createStrategy, ranges);
+ * const curve = stitchOosEquity(wf, 100_000);
+ * // curve[curve.length - 1].equity → final stitched out-of-sample equity
+ * ```
+ */
+export function stitchOosEquity(
+  result: WalkForwardResult,
+  initialCapital = 100000,
+): Array<{ time: number; equity: number }> {
+  const curve: Array<{ time: number; equity: number }> = [];
+  let equity = initialCapital;
+
+  const firstPeriod = result.periods[0];
+  if (firstPeriod) {
+    curve.push({ time: firstPeriod.testStart, equity });
+  }
+
+  // Merge every period's out-of-sample trades and sort by exit time
+  // globally. Sorting per period would leave the curve non-chronological
+  // when test windows overlap (a later period can hold trades that
+  // exited before the previous period's last trade).
+  const trades = result.periods
+    .flatMap((period) => period.testBacktest.trades)
+    .sort((a, b) => a.exitTime - b.exitTime);
+  for (const trade of trades) {
+    equity += equity * (trade.returnPercent / 100);
+    curve.push({ time: trade.exitTime, equity });
+  }
+
+  return curve;
+}
+
 /**
  * Safe variant of walkForwardAnalysis that returns a Result instead of throwing.
  *

--- a/packages/core/src/robustness/full.ts
+++ b/packages/core/src/robustness/full.ts
@@ -162,7 +162,8 @@ function scoreMonteCarloDimension(
   }
   try {
     const mc = runMonteCarloSimulation(result, { simulations: sims, seed });
-    const pScore = Math.max(0, (1 - mc.pValue.sharpe) * 100);
+    const survivalProb = 1 - Math.max(mc.downside.probLoss, mc.downside.riskOfRuin);
+    const pScore = Math.max(0, survivalProb * 100);
     const worstCase =
       mc.statistics.totalReturnPercent.percentile5 > 0
         ? 100
@@ -174,7 +175,7 @@ function scoreMonteCarloDimension(
       name: "Monte Carlo Survival",
       score: Math.round(Math.max(0, Math.min(100, score)) * 10) / 10,
       weight: 0.25,
-      detail: `p=${mc.pValue.sharpe.toFixed(3)}, 5th%ile=${mc.statistics.totalReturnPercent.percentile5.toFixed(1)}%`,
+      detail: `P(loss)=${(mc.downside.probLoss * 100).toFixed(0)}%, risk of ruin=${(mc.downside.riskOfRuin * 100).toFixed(0)}%, 5th%ile=${mc.statistics.totalReturnPercent.percentile5.toFixed(1)}%`,
     };
   } catch {
     return {

--- a/packages/core/src/robustness/quick.ts
+++ b/packages/core/src/robustness/quick.ts
@@ -84,9 +84,11 @@ function scoreMonteCarlo(
     const mc = runMonteCarloSimulation(result, { simulations, seed });
 
     // Score based on:
-    // - p-value of Sharpe (lower = better)
+    // - survival probability: the chance of neither losing money nor
+    //   suffering a ruin-level drawdown (higher = better)
     // - consistency of returns distribution
-    const pValueScore = Math.max(0, (1 - mc.pValue.sharpe) * 100);
+    const survivalProb = 1 - Math.max(mc.downside.probLoss, mc.downside.riskOfRuin);
+    const pValueScore = Math.max(0, survivalProb * 100);
 
     // Narrow confidence interval -> more consistent
     const ciWidth = mc.confidenceInterval.returns.upper - mc.confidenceInterval.returns.lower;
@@ -110,7 +112,7 @@ function scoreMonteCarlo(
       name: "Monte Carlo Survival",
       score: Math.round(Math.max(0, Math.min(100, score)) * 10) / 10,
       weight: 0.4,
-      detail: `p-value: ${mc.pValue.sharpe.toFixed(3)}, 5th%ile return: ${mc.statistics.totalReturnPercent.percentile5.toFixed(1)}%`,
+      detail: `P(loss): ${(mc.downside.probLoss * 100).toFixed(0)}%, risk of ruin: ${(mc.downside.riskOfRuin * 100).toFixed(0)}%, 5th%ile return: ${mc.statistics.totalReturnPercent.percentile5.toFixed(1)}%`,
     };
   } catch {
     return {

--- a/packages/core/src/scoring/__tests__/deflated-sharpe.test.ts
+++ b/packages/core/src/scoring/__tests__/deflated-sharpe.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  deflatedSharpe,
+  deflatedSharpeFromReturns,
+  expectedMaxSharpe,
+  probabilisticSharpe,
+} from "../deflated-sharpe";
+
+describe("probabilisticSharpe", () => {
+  it("is 0.5 when the observed Sharpe equals the benchmark", () => {
+    // The standard-normal CDF approximation carries |error| < 1.5e-7.
+    expect(probabilisticSharpe(0.1, 0.1, 250)).toBeCloseTo(0.5, 6);
+  });
+
+  it("exceeds 0.5 for a positive edge and drops below for a negative one", () => {
+    expect(probabilisticSharpe(0.1, 0, 250)).toBeGreaterThan(0.5);
+    expect(probabilisticSharpe(-0.1, 0, 250)).toBeLessThan(0.5);
+  });
+
+  it("is monotonically increasing in the observed Sharpe", () => {
+    const lo = probabilisticSharpe(0.05, 0, 250);
+    const mid = probabilisticSharpe(0.1, 0, 250);
+    const hi = probabilisticSharpe(0.2, 0, 250);
+    expect(lo).toBeLessThan(mid);
+    expect(mid).toBeLessThan(hi);
+  });
+
+  it("rises with sample size for a fixed positive edge", () => {
+    expect(probabilisticSharpe(0.1, 0, 1000)).toBeGreaterThan(probabilisticSharpe(0.1, 0, 100));
+  });
+
+  it("matches a hand-computed value for the normal case", () => {
+    // z = 0.1 * sqrt(100) / sqrt(1 + 0.5 * 0.01) = 0.99751 → Φ ≈ 0.8407
+    expect(probabilisticSharpe(0.1, 0, 101, 0, 3)).toBeCloseTo(0.8407, 3);
+  });
+
+  it("returns NaN when the sample is too small or the variance term is non-positive", () => {
+    expect(Number.isNaN(probabilisticSharpe(0.1, 0, 1))).toBe(true);
+    // Large positive skew with a large Sharpe can drive the radicand ≤ 0.
+    expect(Number.isNaN(probabilisticSharpe(5, 0, 250, 10, 3))).toBe(true);
+  });
+});
+
+describe("expectedMaxSharpe", () => {
+  it("is the trial mean when there is no selection (≤ 1 trial or zero variance)", () => {
+    expect(expectedMaxSharpe(1, 0.01)).toBe(0);
+    expect(expectedMaxSharpe(100, 0)).toBe(0);
+    expect(expectedMaxSharpe(1, 0.01, 0.3)).toBe(0.3);
+  });
+
+  it("increases with the number of trials (more trials → higher expected max)", () => {
+    const few = expectedMaxSharpe(5, 0.01);
+    const many = expectedMaxSharpe(500, 0.01);
+    expect(many).toBeGreaterThan(few);
+    expect(few).toBeGreaterThan(0);
+  });
+
+  it("scales with the trial Sharpe standard deviation", () => {
+    expect(expectedMaxSharpe(50, 0.04)).toBeCloseTo(2 * expectedMaxSharpe(50, 0.01), 10);
+  });
+});
+
+describe("deflatedSharpe", () => {
+  it("deflates below the undeflated PSR because the selection benchmark is positive", () => {
+    const params = {
+      observedSharpe: 0.15,
+      sampleSize: 500,
+      trials: 50,
+      trialSharpeVariance: 0.0025,
+    };
+    const dsr = deflatedSharpe(params);
+    const undeflated = probabilisticSharpe(params.observedSharpe, 0, params.sampleSize);
+    expect(dsr).toBeLessThan(undeflated);
+    expect(dsr).toBeGreaterThanOrEqual(0);
+    expect(dsr).toBeLessThanOrEqual(1);
+  });
+
+  it("drops as the number of trials grows (more searching → harder to clear)", () => {
+    const base = {
+      observedSharpe: 0.15,
+      sampleSize: 500,
+      trialSharpeVariance: 0.0025,
+    };
+    const few = deflatedSharpe({ ...base, trials: 5 });
+    const many = deflatedSharpe({ ...base, trials: 1000 });
+    expect(many).toBeLessThan(few);
+  });
+
+  it("equals the undeflated PSR with a single trial", () => {
+    const dsr = deflatedSharpe({
+      observedSharpe: 0.15,
+      sampleSize: 500,
+      trials: 1,
+      trialSharpeVariance: 0.0025,
+    });
+    expect(dsr).toBeCloseTo(probabilisticSharpe(0.15, 0, 500), 10);
+  });
+});
+
+describe("deflatedSharpeFromReturns", () => {
+  it("returns NaN for degenerate input", () => {
+    expect(Number.isNaN(deflatedSharpeFromReturns([0.01], [0.1]))).toBe(true);
+    expect(Number.isNaN(deflatedSharpeFromReturns([0.01, 0.01, 0.01], [0.1]))).toBe(true);
+  });
+
+  it("derives a probability in [0, 1] from raw returns and trial Sharpes", () => {
+    // A steadily positive return series.
+    const returns = Array.from({ length: 300 }, (_, i) => 0.004 + (i % 2 === 0 ? 0.002 : -0.001));
+    const trialSharpes = Array.from({ length: 20 }, (_, i) => 0.05 + i * 0.005);
+    const dsr = deflatedSharpeFromReturns(returns, trialSharpes);
+    expect(dsr).toBeGreaterThanOrEqual(0);
+    expect(dsr).toBeLessThanOrEqual(1);
+  });
+
+  it("is lower when the same edge is framed as the best of many noisy trials", () => {
+    // A modest positive drift buried in genuine volatility, so the
+    // deflated Sharpe is not saturated at 1 and the selection-bias
+    // benchmark can actually move it.
+    const returns = Array.from({ length: 300 }, (_, i) => 0.0008 + ((i % 5) - 2) * 0.01);
+    const fewTrials = [0.08, 0.09, 0.1];
+    const manyTrials = Array.from({ length: 300 }, (_, i) => -0.05 + i * 0.001);
+    expect(deflatedSharpeFromReturns(returns, manyTrials)).toBeLessThan(
+      deflatedSharpeFromReturns(returns, fewTrials),
+    );
+  });
+});

--- a/packages/core/src/scoring/deflated-sharpe.ts
+++ b/packages/core/src/scoring/deflated-sharpe.ts
@@ -1,0 +1,285 @@
+/**
+ * Deflated Sharpe Ratio (DSR)
+ *
+ * Bailey & López de Prado (2014), "The Deflated Sharpe Ratio: Correcting
+ * for Selection Bias, Backtest Overfitting and Non-Normality", Journal
+ * of Portfolio Management.
+ *
+ * The DSR answers: given that this strategy's Sharpe ratio is the *best*
+ * of N trials, and given the return distribution's non-normality and the
+ * sample length, what is the probability that the true Sharpe exceeds
+ * zero? It deflates an observed Sharpe by:
+ * - selection bias: the more configurations you tried (N), the higher a
+ *   Sharpe you expect to find by luck alone (the `expectedMaxSharpe`
+ *   benchmark, SR0);
+ * - non-normality: skew and fat tails inflate the uncertainty of a
+ *   Sharpe estimate;
+ * - sample length: shorter backtests give noisier Sharpe estimates.
+ *
+ * A DSR above ~0.95 is the usual bar for "this edge is unlikely to be a
+ * backtest-overfitting artifact".
+ *
+ * All Sharpe inputs are **per-return (non-annualized)** and must share
+ * the same return frequency as `skewness` / `kurtosis` / `sampleSize`.
+ * Annualized Sharpes (e.g. `× √252`) must be divided back to per-return
+ * units before use, or the `√(T − 1)` scaling is meaningless.
+ *
+ * No external dependencies.
+ */
+
+const EULER_MASCHERONI = 0.5772156649015329;
+const E = Math.E;
+
+/**
+ * CDF of the standard normal distribution. Horner form with
+ * Abramowitz & Stegun 7.1.26 coefficients (|error| < 1.5e-7).
+ */
+function normalCdf(x: number): number {
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const p = 0.3275911;
+  const sign = x < 0 ? -1 : 1;
+  const absX = Math.abs(x) / Math.SQRT2;
+  const t = 1.0 / (1.0 + p * absX);
+  const y = 1.0 - ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-absX * absX);
+  return 0.5 * (1.0 + sign * y);
+}
+
+/**
+ * Inverse CDF (quantile / ppf) of the standard normal distribution.
+ * Acklam's rational approximation (|error| < 1.15e-9 in the central
+ * region). Returns ∓∞ at the boundaries.
+ */
+function normalPpf(p: number): number {
+  if (p <= 0) return Number.NEGATIVE_INFINITY;
+  if (p >= 1) return Number.POSITIVE_INFINITY;
+
+  // Coefficients for the rational approximation.
+  const a = [
+    -3.969683028665376e1, 2.209460984245205e2, -2.759285104469687e2, 1.38357751867269e2,
+    -3.066479806614716e1, 2.506628277459239,
+  ];
+  const b = [
+    -5.447609879822406e1, 1.615858368580409e2, -1.556989798598866e2, 6.680131188771972e1,
+    -1.328068155288572e1,
+  ];
+  const c = [
+    -7.784894002430293e-3, -3.223964580411365e-1, -2.400758277161838, -2.549732539343734,
+    4.374664141464968, 2.938163982698783,
+  ];
+  const d = [7.784695709041462e-3, 3.224671290700398e-1, 2.445134137142996, 3.754408661907416];
+
+  // Define break-points for the central vs. tail regions.
+  const pLow = 0.02425;
+  const pHigh = 1 - pLow;
+
+  let q: number;
+  let r: number;
+  if (p < pLow) {
+    q = Math.sqrt(-2 * Math.log(p));
+    return (
+      (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) /
+      ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1)
+    );
+  }
+  if (p <= pHigh) {
+    q = p - 0.5;
+    r = q * q;
+    return (
+      ((((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * q) /
+      (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1)
+    );
+  }
+  q = Math.sqrt(-2 * Math.log(1 - p));
+  return (
+    -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) /
+    ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1)
+  );
+}
+
+/** Population mean. */
+function mean(xs: number[]): number {
+  return xs.reduce((s, v) => s + v, 0) / xs.length;
+}
+
+/** Population variance. */
+function variance(xs: number[], mu = mean(xs)): number {
+  return xs.reduce((s, v) => s + (v - mu) ** 2, 0) / xs.length;
+}
+
+/**
+ * Sample skewness and **non-excess** kurtosis (3 for a normal
+ * distribution), the moment convention the DSR formula expects.
+ */
+function moments(returns: number[]): { skewness: number; kurtosis: number } {
+  const n = returns.length;
+  const mu = mean(returns);
+  const sigma = Math.sqrt(variance(returns, mu));
+  if (n === 0 || sigma === 0) return { skewness: 0, kurtosis: 3 };
+  let s3 = 0;
+  let s4 = 0;
+  for (const r of returns) {
+    const d = (r - mu) / sigma;
+    s3 += d * d * d;
+    s4 += d * d * d * d;
+  }
+  return { skewness: s3 / n, kurtosis: s4 / n };
+}
+
+/**
+ * Expected maximum Sharpe ratio (SR0) under the null hypothesis of zero
+ * true Sharpe, given `trials` independent backtests whose per-return
+ * Sharpe estimates have variance `trialSharpeVariance`.
+ *
+ * This is the selection-bias benchmark: with more trials you expect a
+ * higher *best* Sharpe purely by chance, so a candidate must clear this
+ * bar to be credible. Uses the extreme-value approximation from Bailey
+ * & López de Prado with the Euler–Mascheroni constant.
+ *
+ * With `trials ≤ 1` there is no selection, so the benchmark is just
+ * `trialSharpeMean` (0 by default).
+ *
+ * @param trials Number of independent strategy configurations evaluated (N)
+ * @param trialSharpeVariance Variance of the per-return Sharpe estimates across trials
+ * @param trialSharpeMean Mean of the trial Sharpe estimates (default 0, the null)
+ * @returns Expected maximum (per-return) Sharpe ratio
+ */
+export function expectedMaxSharpe(
+  trials: number,
+  trialSharpeVariance: number,
+  trialSharpeMean = 0,
+): number {
+  if (trials <= 1 || !(trialSharpeVariance > 0)) return trialSharpeMean;
+  const sd = Math.sqrt(trialSharpeVariance);
+  const maxZ =
+    (1 - EULER_MASCHERONI) * normalPpf(1 - 1 / trials) +
+    EULER_MASCHERONI * normalPpf(1 - 1 / (trials * E));
+  return trialSharpeMean + sd * maxZ;
+}
+
+/**
+ * Probabilistic Sharpe Ratio (PSR) — the probability that the true
+ * (per-return) Sharpe ratio exceeds `benchmarkSharpe`, accounting for
+ * sample length and the non-normality of returns.
+ *
+ * `PSR(SR*) = Φ( (SR̂ − SR*)·√(T − 1) / √(1 − γ₃·SR̂ + ((γ₄ − 1)/4)·SR̂²) )`
+ *
+ * where SR̂ is the observed Sharpe, γ₃ the skewness, and γ₄ the
+ * (non-excess) kurtosis of the return series. The Deflated Sharpe Ratio
+ * is just `PSR` with `benchmarkSharpe = expectedMaxSharpe(...)`.
+ *
+ * @param observedSharpe Observed per-return Sharpe (SR̂)
+ * @param benchmarkSharpe Sharpe threshold to beat (SR*); 0 = "is the edge real at all?"
+ * @param sampleSize Number of return observations (T ≥ 2)
+ * @param skewness Skewness of the return series (default 0 = normal)
+ * @param kurtosis Non-excess kurtosis of the return series (default 3 = normal)
+ * @returns Probability in [0, 1], or `NaN` when undefined (T < 2 or non-positive variance term)
+ */
+export function probabilisticSharpe(
+  observedSharpe: number,
+  benchmarkSharpe: number,
+  sampleSize: number,
+  skewness = 0,
+  kurtosis = 3,
+): number {
+  if (sampleSize < 2) return Number.NaN;
+  const radicand = 1 - skewness * observedSharpe + ((kurtosis - 1) / 4) * observedSharpe ** 2;
+  if (!(radicand > 0)) return Number.NaN;
+  const z = ((observedSharpe - benchmarkSharpe) * Math.sqrt(sampleSize - 1)) / Math.sqrt(radicand);
+  return normalCdf(z);
+}
+
+/** Parameters for {@link deflatedSharpe}. */
+export type DeflatedSharpeParams = {
+  /** Observed per-return (non-annualized) Sharpe ratio of the selected strategy (SR̂). */
+  observedSharpe: number;
+  /** Number of return observations the Sharpe was estimated from (T ≥ 2). */
+  sampleSize: number;
+  /** Number of independent strategy configurations evaluated (N). */
+  trials: number;
+  /** Variance of the per-return Sharpe estimates across the N trials. */
+  trialSharpeVariance: number;
+  /** Skewness of the return series (default 0 = normal). */
+  skewness?: number;
+  /** Non-excess kurtosis of the return series (default 3 = normal). */
+  kurtosis?: number;
+};
+
+/**
+ * Deflated Sharpe Ratio — the probability that the selected strategy's
+ * true Sharpe is positive after correcting for selection bias (N
+ * trials), non-normality, and sample length.
+ *
+ * Equivalent to `probabilisticSharpe(observedSharpe,
+ * expectedMaxSharpe(trials, trialSharpeVariance), sampleSize, skewness,
+ * kurtosis)`.
+ *
+ * Returns a probability in [0, 1]; values above ~0.95 indicate the
+ * Sharpe is unlikely to be a multiple-testing artifact. All Sharpe
+ * inputs must be in per-return (non-annualized) units.
+ *
+ * @example
+ * ```ts
+ * import { deflatedSharpe } from "trendcraft";
+ *
+ * // Best of 50 grid-search configs, per-return Sharpe 0.12 over 500 bars,
+ * // trial Sharpes had variance 0.0025.
+ * const dsr = deflatedSharpe({
+ *   observedSharpe: 0.12,
+ *   sampleSize: 500,
+ *   trials: 50,
+ *   trialSharpeVariance: 0.0025,
+ * });
+ * console.log(dsr < 0.95 ? "likely overfit" : "credible edge");
+ * ```
+ */
+export function deflatedSharpe(params: DeflatedSharpeParams): number {
+  const { observedSharpe, sampleSize, trials, trialSharpeVariance } = params;
+  const skewness = params.skewness ?? 0;
+  const kurtosis = params.kurtosis ?? 3;
+  const sr0 = expectedMaxSharpe(trials, trialSharpeVariance);
+  return probabilisticSharpe(observedSharpe, sr0, sampleSize, skewness, kurtosis);
+}
+
+/**
+ * Convenience wrapper that derives every {@link deflatedSharpe} input
+ * from raw data: the observed Sharpe, sample size, skewness, and
+ * kurtosis from the selected strategy's `returns`, and the trial count
+ * and Sharpe variance from `trialSharpes`.
+ *
+ * Both `returns` and `trialSharpes` must be expressed in the **same
+ * per-return units** — i.e. `trialSharpes[i]` is each trial's
+ * `mean(trialReturns) / stdDev(trialReturns)`, NOT an annualized figure.
+ * The observed Sharpe is computed the same way from `returns`.
+ *
+ * @param returns Per-period return series of the selected strategy (decimals or percents — only the ratio matters)
+ * @param trialSharpes Per-return Sharpe ratio of every trial evaluated (including the selected one)
+ * @returns Deflated Sharpe probability in [0, 1], or `NaN` when undefined
+ * @example
+ * ```ts
+ * import { deflatedSharpeFromReturns, extractTradeReturns } from "trendcraft";
+ *
+ * const returns = extractTradeReturns(bestResult);
+ * const trialSharpes = gridResult.results.map((r) => perReturnSharpe(r));
+ * const dsr = deflatedSharpeFromReturns(returns, trialSharpes);
+ * ```
+ */
+export function deflatedSharpeFromReturns(returns: number[], trialSharpes: number[]): number {
+  if (returns.length < 2) return Number.NaN;
+  const mu = mean(returns);
+  const sigma = Math.sqrt(variance(returns, mu));
+  if (sigma === 0) return Number.NaN;
+  const observedSharpe = mu / sigma;
+  const { skewness, kurtosis } = moments(returns);
+  return deflatedSharpe({
+    observedSharpe,
+    sampleSize: returns.length,
+    trials: trialSharpes.length,
+    trialSharpeVariance: trialSharpes.length > 0 ? variance(trialSharpes) : 0,
+    skewness,
+    kurtosis,
+  });
+}

--- a/packages/core/src/scoring/index.ts
+++ b/packages/core/src/scoring/index.ts
@@ -68,6 +68,14 @@ export {
   scoreStrength,
   scoreWithMinSignals,
 } from "./conditions";
+export type { DeflatedSharpeParams } from "./deflated-sharpe";
+// Deflated Sharpe Ratio (Bailey & López de Prado 2014)
+export {
+  deflatedSharpe,
+  deflatedSharpeFromReturns,
+  expectedMaxSharpe,
+  probabilisticSharpe,
+} from "./deflated-sharpe";
 // Presets
 export {
   createAggressivePreset,

--- a/packages/core/src/types/optimization.ts
+++ b/packages/core/src/types/optimization.ts
@@ -204,6 +204,15 @@ export type MonteCarloOptions = {
    *   risk (clustering of losing trades) specifically.
    */
   method?: "shuffle" | "bootstrap";
+  /**
+   * Drawdown level (as a positive percent) treated as "ruin" for the
+   * {@link MonteCarloResult.downside}.`riskOfRuin` figure. A simulation
+   * counts toward risk of ruin when its path-dependent max drawdown
+   * reaches or exceeds this level. Default `50` (a 50% peak-to-trough
+   * loss), matching the threshold used by mainstream backtest Monte
+   * Carlo tooling (BuildAlpha, AmiBroker).
+   */
+  ruinThreshold?: number;
   /** Progress callback */
   progressCallback?: (current: number, total: number) => void;
 };
@@ -253,24 +262,28 @@ export type MonteCarloResult = {
   /** Number of simulations run */
   simulationCount: number;
   /**
-   * Downside probabilities across the simulated distribution. Lower is
-   * better. Measured directly on the resampled outcomes (no comparison
-   * to the backtest's own annualized figures, which use a different
-   * formula):
-   * - `returns`: fraction of simulations with total return ≤ 0
-   *   (probability of a losing outcome).
-   * - `sharpe`: fraction of simulations with a non-positive risk-adjusted
-   *   return — Sharpe < 0, or Sharpe = 0 only when the return was also
-   *   ≤ 0. A zero-volatility *winning* resample (identical positive
-   *   trades → Sharpe 0) is not counted, so a flawless run is not branded
-   *   the worst outcome.
-   *
-   * Under `"shuffle"`, return is order-invariant so `returns` collapses
-   * to 0 or 1; the figure is only informative under `"bootstrap"`.
+   * Downside-risk summary measured directly on the resampled outcomes —
+   * the headline figures for "how risky is this edge?". These replace
+   * the previous permutation-test `pValue` / `isSignificant` framing,
+   * which forced a binary significance verdict onto a resampling
+   * distribution and compared mismatched Sharpe formulas. The
+   * distribution-based figures below are what mainstream backtest Monte
+   * Carlo tooling reports (StrategyQuant, AmiBroker, BuildAlpha).
    */
-  pValue: {
-    sharpe: number;
-    returns: number;
+  downside: {
+    /** Fraction of simulations that ended profitable (total return > 0). */
+    probProfit: number;
+    /** Fraction of simulations that lost money (total return ≤ 0) = `1 - probProfit`. */
+    probLoss: number;
+    /**
+     * Fraction of simulations whose path-dependent max drawdown reached
+     * or exceeded {@link ruinThreshold}. Meaningful under both methods
+     * (drawdown is path-dependent), unlike `probLoss` which collapses to
+     * 0/1 under `"shuffle"` because the return multiset is fixed.
+     */
+    riskOfRuin: number;
+    /** Drawdown level (positive percent) used as the ruin threshold. */
+    ruinThreshold: number;
   };
   /** Confidence interval for expected performance */
   confidenceInterval: {
@@ -278,9 +291,12 @@ export type MonteCarloResult = {
     returns: { lower: number; upper: number };
     maxDrawdown: { lower: number; upper: number };
   };
-  /** Assessment of whether strategy is statistically significant */
+  /**
+   * Human-readable, method-aware interpretation of the distribution. No
+   * binary significance flag — bootstrap describes outcome uncertainty
+   * (profitability + ruin), shuffle describes sequence risk (drawdown).
+   */
   assessment: {
-    isSignificant: boolean;
     reason: string;
     confidenceLevel: number;
   };


### PR DESCRIPTION
## Summary

Adds three robustness helpers to `trendcraft` core and replaces the Monte Carlo result's permutation-test significance fields with a distribution-based downside-risk summary. All additions are pure, dependency-free math grounded in standard quant references.

### New helpers
- **`wfeRatio(result)`** — Pardo's Walk-Forward Efficiency: the average per-period ratio of annualized out-of-sample to annualized in-sample return. Both windows are annualized over their calendar span before the ratio, periods with non-positive in-sample return are skipped, and the result is `NaN` when none qualify (matching the existing `calculateCalmarRatio` "undefined" convention). Uncapped — a strategy that beats its optimization out-of-sample scores above 1.0. Pardo treats ≥ 0.5 as the threshold for a robust rather than curve-fit strategy.
- **`stitchOosEquity(result, initialCapital?)`** — stitches every walk-forward period's out-of-sample trades into one continuous equity curve, one point per trade (plus a leading anchor). A finer-grained companion to the period-granularity `getOutOfSampleEquityCurve`. Trades are merged and sorted globally by exit time, so the curve stays chronological even when test windows overlap.
- **`deflatedSharpe(params)` / `deflatedSharpeFromReturns(returns, trialSharpes)`** — Deflated Sharpe Ratio (Bailey & López de Prado 2014): the probability the true Sharpe is positive after correcting for selection bias across N trials, non-normality (skew / kurtosis), and sample length. Building blocks `probabilisticSharpe(...)` (PSR) and `expectedMaxSharpe(trials, variance)` (the SR0 selection benchmark) are exported too. All Sharpe inputs are per-return (non-annualized).

### Monte Carlo significance redesign
`MonteCarloResult` previously exposed `pValue` and `assessment.isSignificant`, which forced a binary permutation-test verdict onto a resampling distribution and compared mismatched Sharpe formulas. These are replaced by `MonteCarloResult.downside`:

- `probProfit` / `probLoss` — fraction of simulations that ended profitable / lost money.
- `riskOfRuin` — fraction whose path-dependent max drawdown reached a configurable `ruinThreshold` (default 50%). Meaningful under both `bootstrap` and `shuffle` (drawdown is path-dependent), unlike `probLoss` which collapses to 0/1 under `shuffle`.
- `ruinThreshold` — the threshold used; `runMonteCarloSimulation` accepts a matching `ruinThreshold?` option.

`assessment` keeps a method-aware, human-readable `reason` and `confidenceLevel` but no longer carries `isSignificant`. `summarizeMonteCarloResult` now returns `{ probProfit, probLoss, riskOfRuin, expectedSharpe, sharpe95CI, originalSharpe }`. These distribution-based figures are what mainstream backtest Monte Carlo tooling reports. The prior `pValue` shape had not yet been published to npm, so this is not a breaking change for released consumers.

Downstream consumers updated to the new shape: `computeDnaGrade` (dimension renamed to "Monte Carlo Robustness", scored on probability-of-loss and risk-of-ruin) and the `robustness/` module (scored on a survival probability).

## Testing
- `pnpm test` — 6050+ tests pass, including new coverage for the three helpers and the Monte Carlo migration (downside probabilities, ruin-threshold override, and a chronological-ordering invariant for overlapping walk-forward windows).
- `tsc --noEmit`, `pnpm lint`, `pnpm build` — clean.