### PR TITLE
feat(core): walkForwardAnalysisFromJSON (JSON-first rolling walk-forward)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### Added — `walkForwardAnalysisFromJSON` (JSON-first rolling walk-forward)
+
+Sibling of `gridSearchFromJSON` for rolling walk-forward analysis. Drives
+`walkForwardAnalysis` directly from a `StrategyJSON` plus path-addressed
+`PathParameterRange[]`, so callers no longer have to hand-write a
+`StrategyFactory` to walk-forward a JSON strategy. Per-period `bestParams`
+keys are paths (e.g. `"entry.0.shortPeriod"`), matching
+`gridSearchFromJSON`, so a window's optimized params plug straight back
+into `applyParamOverrides`. `walkForwardAnalysisFromJSONSafe` returns a
+`Result` (range-path errors → `INVALID_PARAMETER`, oversized grid →
+`TOO_MANY_COMBINATIONS`, too-short slice → `INSUFFICIENT_DATA`).
+
+Covers rolling walk-forward only; anchored walk-forward runs a
+condition-combination search rather than a parameter sweep and does not
+share this shape.
+
+Internally, the shared JSON→factory translation (path validation, factory
+construction, range conversion, error classification) is now factored into
+`optimization/strategy-json-factory.ts`, which both `gridSearchFromJSON`
+and `walkForwardAnalysisFromJSON` delegate to, so the two entry points
+cannot drift on validation rules.
+
 ### Changed — Monte Carlo: bootstrap resampling by default + downside-risk summary (replaces p-value)
 
 `runMonteCarloSimulation` gains a `method?: "shuffle" | "bootstrap"`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -699,6 +699,8 @@ export {
   summarizeWalkForward,
   // Walk-Forward Analysis
   walkForwardAnalysis,
+  walkForwardAnalysisFromJSON,
+  walkForwardAnalysisFromJSONSafe,
   walkForwardAnalysisSafe,
   wfeRatio,
 } from "./optimization";

--- a/packages/core/src/optimization/__tests__/walkforward-json.test.ts
+++ b/packages/core/src/optimization/__tests__/walkforward-json.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { backtestRegistry } from "../../strategy/registry-backtest";
+import type { StrategyJSON } from "../../strategy/types";
+import type { NormalizedCandle } from "../../types";
+import { walkForwardAnalysisFromJSON, walkForwardAnalysisFromJSONSafe } from "../walkforward-json";
+
+/**
+ * Deterministic sine-on-uptrend series, long enough for several
+ * walk-forward windows of SMA-cross trades.
+ */
+function makeCandles(count: number): NormalizedCandle[] {
+  const candles: NormalizedCandle[] = [];
+  let price = 100;
+  for (let i = 0; i < count; i++) {
+    const noise = Math.sin(i / 5) * 3;
+    const trend = i * 0.2;
+    const close = price + trend + noise;
+    const open = close - 0.5;
+    const high = Math.max(open, close) + 1;
+    const low = Math.min(open, close) - 1;
+    candles.push({
+      time: 1_700_000_000 + i * 86_400,
+      open,
+      high,
+      low,
+      close,
+      volume: 1000 + i,
+    });
+    price = close;
+  }
+  return candles;
+}
+
+const SMA_CROSS_STRATEGY: StrategyJSON = {
+  $schema: "trendcraft/strategy",
+  version: 1,
+  id: "test",
+  name: "Test",
+  entry: { name: "goldenCross", params: { shortPeriod: 5, longPeriod: 20 } },
+  exit: { name: "deadCross", params: { shortPeriod: 5, longPeriod: 20 } },
+};
+
+const RANGES = [{ path: "entry.0.shortPeriod", min: 3, max: 7, step: 2 }];
+const WF_OPTS = { windowSize: 60, stepSize: 30, testSize: 30 };
+
+describe("walkForwardAnalysisFromJSON", () => {
+  it("runs rolling walk-forward and returns path-keyed per-period bestParams", () => {
+    const candles = makeCandles(200);
+    const wf = walkForwardAnalysisFromJSON(
+      candles,
+      SMA_CROSS_STRATEGY,
+      RANGES,
+      backtestRegistry,
+      WF_OPTS,
+    );
+    expect(wf.periods.length).toBeGreaterThan(0);
+    // bestParams keys are paths (not raw param names), matching gridSearchFromJSON.
+    for (const period of wf.periods) {
+      expect(Object.keys(period.bestParams)).toContain("entry.0.shortPeriod");
+    }
+    expect(wf.aggregateMetrics).toHaveProperty("stabilityRatio");
+    expect(wf.recommendation).toHaveProperty("useOptimizedParams");
+  });
+
+  it("throws on an invalid range path (same validation as grid search)", () => {
+    const candles = makeCandles(200);
+    expect(() =>
+      walkForwardAnalysisFromJSON(
+        candles,
+        SMA_CROSS_STRATEGY,
+        [{ path: "entry.0.nonExistentParam", min: 1, max: 3, step: 1 }],
+        backtestRegistry,
+        WF_OPTS,
+      ),
+    ).toThrow(/Invalid range path/);
+  });
+
+  it("throws on insufficient data for even one window", () => {
+    const candles = makeCandles(50);
+    expect(() =>
+      walkForwardAnalysisFromJSON(candles, SMA_CROSS_STRATEGY, RANGES, backtestRegistry, {
+        windowSize: 252,
+        stepSize: 63,
+        testSize: 63,
+      }),
+    ).toThrow(/Insufficient data/);
+  });
+});
+
+describe("walkForwardAnalysisFromJSONSafe", () => {
+  it("returns ok for a valid run", () => {
+    const candles = makeCandles(200);
+    const result = walkForwardAnalysisFromJSONSafe(
+      candles,
+      SMA_CROSS_STRATEGY,
+      RANGES,
+      backtestRegistry,
+      WF_OPTS,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.periods.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("maps an invalid range path to INVALID_PARAMETER", () => {
+    const candles = makeCandles(200);
+    const result = walkForwardAnalysisFromJSONSafe(
+      candles,
+      SMA_CROSS_STRATEGY,
+      [{ path: "entry.0.nonExistentParam", min: 1, max: 3, step: 1 }],
+      backtestRegistry,
+      WF_OPTS,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INVALID_PARAMETER");
+    }
+  });
+
+  it("maps a too-short slice to INSUFFICIENT_DATA", () => {
+    const candles = makeCandles(50);
+    const result = walkForwardAnalysisFromJSONSafe(
+      candles,
+      SMA_CROSS_STRATEGY,
+      RANGES,
+      backtestRegistry,
+      { windowSize: 252, stepSize: 63, testSize: 63 },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INSUFFICIENT_DATA");
+    }
+  });
+});

--- a/packages/core/src/optimization/grid-search-json.ts
+++ b/packages/core/src/optimization/grid-search-json.ts
@@ -5,7 +5,9 @@
  * path-addressed parameter ranges, eliminating the need for callers to
  * write their own strategy-walker / param-injection plumbing. Path
  * syntax is documented on `applyParamOverrides` (see
- * `strategy/walker.ts`).
+ * `strategy/walker.ts`). The shared JSON→factory translation lives in
+ * `strategy-json-factory.ts` so this and `walkForwardAnalysisFromJSON`
+ * can't drift on validation or factory construction.
  *
  * @example
  * ```ts
@@ -27,178 +29,21 @@
  * ```
  */
 
-import { loadStrategy } from "../strategy/hydrate";
 import type { ConditionRegistry } from "../strategy/registry";
 import type { StrategyJSON } from "../strategy/types";
-import { validateConditionSpec } from "../strategy/validate";
-import {
-  applyParamOverrides,
-  flattenStrategyLeaves,
-  type LeafInfo,
-  parseLeafPath,
-} from "../strategy/walker";
-import type { BacktestOptions, Condition, NormalizedCandle } from "../types";
-import type { GridSearchOptions, GridSearchResult, ParameterRange } from "../types/optimization";
+import type { Condition, NormalizedCandle } from "../types";
+import type { GridSearchOptions, GridSearchResult } from "../types/optimization";
 import { err, ok, type Result, tcError } from "../types/result";
 import { gridSearch } from "./grid-search";
+import {
+  classifyOptimizationError,
+  type PathParameterRange,
+  pathRangesToParameterRanges,
+  strategyFactoryFromJSON,
+  validateRangePaths,
+} from "./strategy-json-factory";
 
-/**
- * Path-addressed parameter range. The `path` field uses the syntax
- * documented on `applyParamOverrides`: `<bucket>.<leafIndex>.<paramName>`.
- *
- * Example: `{ path: "entry.0.shortPeriod", min: 3, max: 10, step: 1 }`
- */
-export type PathParameterRange = {
-  path: string;
-  min: number;
-  max: number;
-  step: number;
-};
-
-/**
- * Validate every range path against the provided registry and return
- * the resolved leaf for downstream use. Throws an `Error` (not a
- * `Result`) on invalid input — `gridSearchFromJSONSafe` wraps the
- * throw into a `Result`.
- */
-function validateRangePaths(
-  strategy: StrategyJSON,
-  ranges: PathParameterRange[],
-  registry: ConditionRegistry<Condition>,
-): void {
-  // Empty ranges are passed through to `gridSearch`, which treats them
-  // as a single-combination baseline run. This matches the underlying
-  // engine's behavior so dynamic UIs that end up with no tunable params
-  // selected still get a result instead of an INVALID_PARAMETER throw.
-  const leaves = flattenStrategyLeaves(strategy);
-  const leafByAddress: Map<string, LeafInfo> = new Map();
-  for (const leaf of leaves) {
-    leafByAddress.set(`${leaf.bucket}.${leaf.leafIndex}`, leaf);
-  }
-  // Track seen paths so duplicates are rejected before they double the
-  // grid: two ranges with the same path map to two ParameterRanges
-  // sharing a `name`, and the later assignment in the inner factory
-  // would clobber the earlier one — `bestParams` would silently reflect
-  // only one range while the search space ballooned by the duplicate's
-  // cardinality.
-  const seenPaths = new Set<string>();
-  for (const range of ranges) {
-    if (seenPaths.has(range.path)) {
-      throw new Error(
-        `Invalid range path "${range.path}": duplicate path — each path may appear at most once in ranges`,
-      );
-    }
-    seenPaths.add(range.path);
-    // Reject NaN / ±Infinity early. `gridSearch`'s loop generates
-    // `min + i * step` and `<= max + ε` comparisons that are silently
-    // wrong with non-finite values (NaN comparisons are always false,
-    // Infinity step generates one combination forever). Fail upfront
-    // with a recognizable "Invalid" message so the safe wrapper can
-    // classify it as INVALID_PARAMETER.
-    for (const [field, value] of [
-      ["min", range.min],
-      ["max", range.max],
-      ["step", range.step],
-    ] as const) {
-      if (!Number.isFinite(value)) {
-        throw new Error(
-          `Invalid range path "${range.path}": ${field} must be a finite number, got ${value}`,
-        );
-      }
-    }
-    const parsed = parseLeafPath(range.path);
-    if (parsed.paramName === null) {
-      throw new Error(
-        `Invalid range path "${range.path}": paramName is required for parameter ranges`,
-      );
-    }
-    const leaf = leafByAddress.get(`${parsed.bucket}.${parsed.leafIndex}`);
-    if (!leaf) {
-      throw new Error(
-        `Invalid range path "${range.path}": leaf index ${parsed.leafIndex} is out of range for bucket "${parsed.bucket}"`,
-      );
-    }
-    const entry = registry.get(leaf.name);
-    if (!entry) {
-      throw new Error(
-        `Invalid range path "${range.path}": leaf condition "${leaf.name}" is not registered`,
-      );
-    }
-    const schema = entry.params[parsed.paramName];
-    if (!schema) {
-      throw new Error(
-        `Invalid range path "${range.path}": condition "${leaf.name}" has no param "${parsed.paramName}"`,
-      );
-    }
-    if (schema.type !== "number") {
-      throw new Error(
-        `Invalid range path "${range.path}": param "${parsed.paramName}" on "${leaf.name}" is type "${schema.type}", grid search only supports "number"`,
-      );
-    }
-    // Catch caller-side range shape errors here so the safe variant
-    // can classify them as INVALID_PARAMETER. `gridSearch` itself
-    // throws with a different message ("Parameter ... step must be
-    // positive") that doesn't start with "Invalid", so without this
-    // the safe wrapper would map a user input error to OPTIMIZATION_FAILED.
-    if (range.step <= 0) {
-      throw new Error(
-        `Invalid range path "${range.path}": step must be positive, got ${range.step}`,
-      );
-    }
-    if (range.max < range.min) {
-      throw new Error(
-        `Invalid range path "${range.path}": max (${range.max}) must be >= min (${range.min})`,
-      );
-    }
-    // Per-range schema enforcement. Without these, ranges that
-    // generate impossible values (e.g. step 0.5 on an integer-only
-    // param, or values below schema.min) only fail per-combination
-    // inside the factory, where `gridSearch` swallows the throw and
-    // reports `validCombinations: 0` instead of an actionable error.
-    if (schema.integer === true) {
-      for (const [field, value] of [
-        ["min", range.min],
-        ["max", range.max],
-        ["step", range.step],
-      ] as const) {
-        if (!Number.isInteger(value)) {
-          throw new Error(
-            `Invalid range path "${range.path}": param "${parsed.paramName}" requires integer values (schema.integer=true), but ${field}=${value} is not an integer`,
-          );
-        }
-      }
-    }
-    if (typeof schema.min === "number" && range.min < schema.min) {
-      throw new Error(
-        `Invalid range path "${range.path}": min (${range.min}) is below schema.min (${schema.min}) for "${parsed.paramName}"`,
-      );
-    }
-    if (typeof schema.max === "number" && range.max > schema.max) {
-      throw new Error(
-        `Invalid range path "${range.path}": max (${range.max}) is above schema.max (${schema.max}) for "${parsed.paramName}"`,
-      );
-    }
-  }
-
-  // Validate the whole strategy *after* injecting one sample point per
-  // range (`range.min`). Validating the raw strategy first would reject
-  // legitimate optimization scenarios where the tuned param is missing
-  // or temporarily out of bounds — the entire point of the search space
-  // is to supply those values. Validating the saturated strategy still
-  // catches issues in untuned parts (unregistered leaves elsewhere,
-  // malformed `not` arity, schema violations on params not being tuned).
-  const saturationOverrides: Record<string, number> = {};
-  for (const range of ranges) {
-    saturationOverrides[range.path] = range.min;
-  }
-  const saturated = applyParamOverrides(strategy, saturationOverrides);
-  for (const bucket of ["entry", "exit"] as const) {
-    const result = validateConditionSpec(saturated[bucket], registry);
-    if (!result.valid) {
-      throw new Error(`Invalid strategy: ${bucket} validation failed: ${result.errors.join("; ")}`);
-    }
-  }
-}
+export type { PathParameterRange } from "./strategy-json-factory";
 
 /**
  * JSON-first grid search. Drives the existing `gridSearch` engine from
@@ -224,29 +69,10 @@ export function gridSearchFromJSON(
   options?: GridSearchOptions,
 ): GridSearchResult {
   validateRangePaths(strategy, ranges, registry);
-
-  // Convert path-addressed ranges to the engine's `name`-keyed form.
-  // `gridSearch` doesn't interpret `name`, so the path string is a
-  // valid identifier and round-trips through `bestParams`.
-  const parameterRanges: ParameterRange[] = ranges.map((r) => ({
-    name: r.path,
-    min: r.min,
-    max: r.max,
-    step: r.step,
-  }));
-
   return gridSearch(
     candles,
-    (params) => {
-      const merged = applyParamOverrides(strategy, params);
-      const { entry, exit, backtestOptions } = loadStrategy(merged, registry);
-      const factoryOptions: BacktestOptions = {
-        capital: 100_000,
-        ...backtestOptions,
-      };
-      return { entry, exit, options: factoryOptions };
-    },
-    parameterRanges,
+    strategyFactoryFromJSON(strategy, registry),
+    pathRangesToParameterRanges(ranges),
     options,
   );
 }
@@ -278,14 +104,7 @@ export function gridSearchFromJSONSafe(
     return ok(gridSearchFromJSON(candles, strategy, ranges, registry, options));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    let code: "INVALID_PARAMETER" | "TOO_MANY_COMBINATIONS" | "OPTIMIZATION_FAILED";
-    if (message.includes("Too many parameter combinations")) {
-      code = "TOO_MANY_COMBINATIONS";
-    } else if (message.startsWith("Invalid")) {
-      code = "INVALID_PARAMETER";
-    } else {
-      code = "OPTIMIZATION_FAILED";
-    }
+    const code = classifyOptimizationError(message);
     return err(tcError(code, message, {}, error instanceof Error ? error : undefined));
   }
 }

--- a/packages/core/src/optimization/index.ts
+++ b/packages/core/src/optimization/index.ts
@@ -90,7 +90,6 @@ export {
   extractTradeReturns,
   getMetricValue,
 } from "./metrics";
-
 // Monte Carlo Simulation
 export {
   calculateStatistics,
@@ -118,7 +117,6 @@ export type {
   SensitivityPair,
   SensitivitySingle,
 } from "./strategy-dna";
-
 // Strategy DNA — post-optimization analytics
 export {
   buildGenomeSegments,
@@ -137,3 +135,8 @@ export {
   walkForwardAnalysisSafe,
   wfeRatio,
 } from "./walkforward";
+// Walk-Forward — JSON-first wrapper
+export {
+  walkForwardAnalysisFromJSON,
+  walkForwardAnalysisFromJSONSafe,
+} from "./walkforward-json";

--- a/packages/core/src/optimization/strategy-json-factory.ts
+++ b/packages/core/src/optimization/strategy-json-factory.ts
@@ -1,0 +1,247 @@
+/**
+ * Shared JSON-first optimization plumbing.
+ *
+ * Both `gridSearchFromJSON` and `walkForwardAnalysisFromJSON` drive an
+ * engine (`gridSearch` / `walkForwardAnalysis`) that takes a
+ * `StrategyFactory` plus name-keyed `ParameterRange[]`. The translation
+ * from a `StrategyJSON` + path-addressed `PathParameterRange[]` is
+ * identical for both: validate the paths, build a factory that injects
+ * the swept params via `applyParamOverrides`, and convert the ranges to
+ * the engine's `name`-keyed shape. This module is the single owner of
+ * that translation so the two entry points can't drift on validation
+ * rules or factory construction.
+ */
+
+import { loadStrategy } from "../strategy/hydrate";
+import type { ConditionRegistry } from "../strategy/registry";
+import type { StrategyJSON } from "../strategy/types";
+import { validateConditionSpec } from "../strategy/validate";
+import {
+  applyParamOverrides,
+  flattenStrategyLeaves,
+  type LeafInfo,
+  parseLeafPath,
+} from "../strategy/walker";
+import type { BacktestOptions, Condition } from "../types";
+import type { ParameterRange } from "../types/optimization";
+import type { StrategyFactory } from "./grid-search";
+
+/**
+ * Path-addressed parameter range. The `path` field uses the syntax
+ * documented on `applyParamOverrides`: `<bucket>.<leafIndex>.<paramName>`.
+ *
+ * Example: `{ path: "entry.0.shortPeriod", min: 3, max: 10, step: 1 }`
+ */
+export type PathParameterRange = {
+  path: string;
+  min: number;
+  max: number;
+  step: number;
+};
+
+/**
+ * Validate every range path against the provided registry. Throws an
+ * `Error` (not a `Result`) on invalid input — the `*Safe` wrappers map
+ * the throw into a `Result`. All "Invalid…"-prefixed messages are
+ * classified as `INVALID_PARAMETER` by those wrappers.
+ */
+export function validateRangePaths(
+  strategy: StrategyJSON,
+  ranges: PathParameterRange[],
+  registry: ConditionRegistry<Condition>,
+): void {
+  // Empty ranges are passed through to the engine, which treats them as
+  // a single-combination baseline run. This matches the underlying
+  // engine's behavior so dynamic UIs that end up with no tunable params
+  // selected still get a result instead of an INVALID_PARAMETER throw.
+  const leaves = flattenStrategyLeaves(strategy);
+  const leafByAddress: Map<string, LeafInfo> = new Map();
+  for (const leaf of leaves) {
+    leafByAddress.set(`${leaf.bucket}.${leaf.leafIndex}`, leaf);
+  }
+  // Track seen paths so duplicates are rejected before they double the
+  // grid: two ranges with the same path map to two ParameterRanges
+  // sharing a `name`, and the later assignment in the inner factory
+  // would clobber the earlier one — `bestParams` would silently reflect
+  // only one range while the search space ballooned by the duplicate's
+  // cardinality.
+  const seenPaths = new Set<string>();
+  for (const range of ranges) {
+    if (seenPaths.has(range.path)) {
+      throw new Error(
+        `Invalid range path "${range.path}": duplicate path — each path may appear at most once in ranges`,
+      );
+    }
+    seenPaths.add(range.path);
+    // Reject NaN / ±Infinity early. The engine's loop generates
+    // `min + i * step` and `<= max + ε` comparisons that are silently
+    // wrong with non-finite values (NaN comparisons are always false,
+    // Infinity step generates one combination forever). Fail upfront
+    // with a recognizable "Invalid" message so the safe wrapper can
+    // classify it as INVALID_PARAMETER.
+    for (const [field, value] of [
+      ["min", range.min],
+      ["max", range.max],
+      ["step", range.step],
+    ] as const) {
+      if (!Number.isFinite(value)) {
+        throw new Error(
+          `Invalid range path "${range.path}": ${field} must be a finite number, got ${value}`,
+        );
+      }
+    }
+    const parsed = parseLeafPath(range.path);
+    if (parsed.paramName === null) {
+      throw new Error(
+        `Invalid range path "${range.path}": paramName is required for parameter ranges`,
+      );
+    }
+    const leaf = leafByAddress.get(`${parsed.bucket}.${parsed.leafIndex}`);
+    if (!leaf) {
+      throw new Error(
+        `Invalid range path "${range.path}": leaf index ${parsed.leafIndex} is out of range for bucket "${parsed.bucket}"`,
+      );
+    }
+    const entry = registry.get(leaf.name);
+    if (!entry) {
+      throw new Error(
+        `Invalid range path "${range.path}": leaf condition "${leaf.name}" is not registered`,
+      );
+    }
+    const schema = entry.params[parsed.paramName];
+    if (!schema) {
+      throw new Error(
+        `Invalid range path "${range.path}": condition "${leaf.name}" has no param "${parsed.paramName}"`,
+      );
+    }
+    if (schema.type !== "number") {
+      throw new Error(
+        `Invalid range path "${range.path}": param "${parsed.paramName}" on "${leaf.name}" is type "${schema.type}", optimization only supports "number"`,
+      );
+    }
+    // Catch caller-side range shape errors here so the safe variant can
+    // classify them as INVALID_PARAMETER. The engine itself throws with
+    // a different message ("Parameter ... step must be positive") that
+    // doesn't start with "Invalid", so without this the safe wrapper
+    // would map a user input error to OPTIMIZATION_FAILED.
+    if (range.step <= 0) {
+      throw new Error(
+        `Invalid range path "${range.path}": step must be positive, got ${range.step}`,
+      );
+    }
+    if (range.max < range.min) {
+      throw new Error(
+        `Invalid range path "${range.path}": max (${range.max}) must be >= min (${range.min})`,
+      );
+    }
+    // Per-range schema enforcement. Without these, ranges that generate
+    // impossible values (e.g. step 0.5 on an integer-only param, or
+    // values below schema.min) only fail per-combination inside the
+    // factory, where the engine swallows the throw and reports
+    // `validCombinations: 0` instead of an actionable error.
+    if (schema.integer === true) {
+      for (const [field, value] of [
+        ["min", range.min],
+        ["max", range.max],
+        ["step", range.step],
+      ] as const) {
+        if (!Number.isInteger(value)) {
+          throw new Error(
+            `Invalid range path "${range.path}": param "${parsed.paramName}" requires integer values (schema.integer=true), but ${field}=${value} is not an integer`,
+          );
+        }
+      }
+    }
+    if (typeof schema.min === "number" && range.min < schema.min) {
+      throw new Error(
+        `Invalid range path "${range.path}": min (${range.min}) is below schema.min (${schema.min}) for "${parsed.paramName}"`,
+      );
+    }
+    if (typeof schema.max === "number" && range.max > schema.max) {
+      throw new Error(
+        `Invalid range path "${range.path}": max (${range.max}) is above schema.max (${schema.max}) for "${parsed.paramName}"`,
+      );
+    }
+  }
+
+  // Validate the whole strategy *after* injecting one sample point per
+  // range (`range.min`). Validating the raw strategy first would reject
+  // legitimate optimization scenarios where the tuned param is missing
+  // or temporarily out of bounds — the entire point of the search space
+  // is to supply those values. Validating the saturated strategy still
+  // catches issues in untuned parts (unregistered leaves elsewhere,
+  // malformed `not` arity, schema violations on params not being tuned).
+  const saturationOverrides: Record<string, number> = {};
+  for (const range of ranges) {
+    saturationOverrides[range.path] = range.min;
+  }
+  const saturated = applyParamOverrides(strategy, saturationOverrides);
+  for (const bucket of ["entry", "exit"] as const) {
+    const result = validateConditionSpec(saturated[bucket], registry);
+    if (!result.valid) {
+      throw new Error(`Invalid strategy: ${bucket} validation failed: ${result.errors.join("; ")}`);
+    }
+  }
+}
+
+/**
+ * Build a `StrategyFactory` that injects the swept params into the JSON
+ * strategy via `applyParamOverrides`, then hydrates entry / exit
+ * conditions and backtest options. The `strategy.backtest` block is
+ * forwarded so commission / direction / stops / capital from the
+ * strategy JSON are honored; capital defaults to 100,000 when unset.
+ *
+ * The factory receives the engine's name-keyed params, where each
+ * `name` is a range path string (see {@link pathRangesToParameterRanges}),
+ * so it can pass them straight to `applyParamOverrides`.
+ */
+export function strategyFactoryFromJSON(
+  strategy: StrategyJSON,
+  registry: ConditionRegistry<Condition>,
+): StrategyFactory {
+  return (params) => {
+    const merged = applyParamOverrides(strategy, params);
+    const { entry, exit, backtestOptions } = loadStrategy(merged, registry);
+    const factoryOptions: BacktestOptions = {
+      capital: 100_000,
+      ...backtestOptions,
+    };
+    return { entry, exit, options: factoryOptions };
+  };
+}
+
+/**
+ * Convert path-addressed ranges to the engine's `name`-keyed
+ * `ParameterRange[]`. The engine doesn't interpret `name`, so the path
+ * string is a valid identifier and round-trips through `bestParams` /
+ * `bestEntryConditions` keys.
+ */
+export function pathRangesToParameterRanges(ranges: PathParameterRange[]): ParameterRange[] {
+  return ranges.map((r) => ({
+    name: r.path,
+    min: r.min,
+    max: r.max,
+    step: r.step,
+  }));
+}
+
+/**
+ * Classify a thrown optimization error into the safe-variant error code.
+ * Shared so every `*FromJSONSafe` wrapper maps messages identically.
+ */
+export function classifyOptimizationError(
+  message: string,
+): "INVALID_PARAMETER" | "TOO_MANY_COMBINATIONS" | "INSUFFICIENT_DATA" | "OPTIMIZATION_FAILED" {
+  if (message.includes("Too many parameter combinations")) {
+    return "TOO_MANY_COMBINATIONS";
+  }
+  if (message.startsWith("Invalid")) {
+    return "INVALID_PARAMETER";
+  }
+  // Walk-forward throws "Insufficient data for walk-forward analysis…"
+  // when the slice can't fit even one train+test window.
+  if (message.includes("Insufficient data")) {
+    return "INSUFFICIENT_DATA";
+  }
+  return "OPTIMIZATION_FAILED";
+}

--- a/packages/core/src/optimization/walkforward-json.ts
+++ b/packages/core/src/optimization/walkforward-json.ts
@@ -1,0 +1,114 @@
+/**
+ * walkForwardAnalysisFromJSON — JSON-first wrapper around
+ * `walkForwardAnalysis`.
+ *
+ * The rolling-window walk-forward engine takes a `StrategyFactory` plus
+ * name-keyed `ParameterRange[]`. This wrapper drives it directly from a
+ * `StrategyJSON` plus path-addressed `PathParameterRange[]`, reusing the
+ * exact same validation and factory construction as `gridSearchFromJSON`
+ * (both delegate to `strategy-json-factory.ts`), so the two entry points
+ * can't drift on how a JSON strategy is optimized.
+ *
+ * Only rolling walk-forward is covered here. Anchored walk-forward
+ * (`anchoredWalkForwardAnalysis`) runs a condition-combination search
+ * rather than a parameter sweep, so it does not share this
+ * (strategy, param-range) shape.
+ *
+ * @example
+ * ```ts
+ * import { walkForwardAnalysisFromJSON, backtestRegistry } from "trendcraft";
+ *
+ * const wf = walkForwardAnalysisFromJSON(
+ *   candles,
+ *   strategyJson,
+ *   [
+ *     { path: "entry.0.shortPeriod", min: 3, max: 10, step: 1 },
+ *     { path: "entry.0.longPeriod", min: 15, max: 40, step: 5 },
+ *   ],
+ *   backtestRegistry,
+ *   { windowSize: 252, stepSize: 63, testSize: 63 },
+ * );
+ *
+ * console.log(wf.aggregateMetrics.stabilityRatio);
+ * ```
+ */
+
+import type { ConditionRegistry } from "../strategy/registry";
+import type { StrategyJSON } from "../strategy/types";
+import type { Condition, NormalizedCandle } from "../types";
+import type { WalkForwardOptions, WalkForwardResult } from "../types/optimization";
+import { err, ok, type Result, tcError } from "../types/result";
+import {
+  classifyOptimizationError,
+  type PathParameterRange,
+  pathRangesToParameterRanges,
+  strategyFactoryFromJSON,
+  validateRangePaths,
+} from "./strategy-json-factory";
+import { walkForwardAnalysis } from "./walkforward";
+
+/**
+ * JSON-first rolling walk-forward analysis. Drives `walkForwardAnalysis`
+ * from a `StrategyJSON` plus path-addressed `PathParameterRange[]`. The
+ * per-period `bestParams` keys are paths (not raw param names), matching
+ * `gridSearchFromJSON`, so they can be plugged straight back into
+ * `applyParamOverrides` to apply a window's optimized params.
+ *
+ * Throws on invalid range paths (malformed, out-of-range leaf, unknown
+ * or non-numeric param) and on insufficient data (the slice can't fit
+ * one train+test window). Use `walkForwardAnalysisFromJSONSafe` for a
+ * `Result`-returning variant.
+ *
+ * The `strategy.backtest` block is forwarded into each window's backtest
+ * options, so commission / direction / stops / capital from the strategy
+ * JSON are honored. Caller-supplied `options` (window/step/test sizes,
+ * metric, constraints) are passed through unchanged.
+ */
+export function walkForwardAnalysisFromJSON(
+  candles: NormalizedCandle[],
+  strategy: StrategyJSON,
+  ranges: PathParameterRange[],
+  registry: ConditionRegistry<Condition>,
+  options?: WalkForwardOptions,
+): WalkForwardResult {
+  validateRangePaths(strategy, ranges, registry);
+  return walkForwardAnalysis(
+    candles,
+    strategyFactoryFromJSON(strategy, registry),
+    pathRangesToParameterRanges(ranges),
+    options,
+  );
+}
+
+/**
+ * Safe variant of `walkForwardAnalysisFromJSON` that returns a `Result`
+ * instead of throwing. Range-path validation errors map to
+ * `INVALID_PARAMETER`, an over-large grid to `TOO_MANY_COMBINATIONS`, a
+ * too-short slice to `INSUFFICIENT_DATA`, everything else to
+ * `OPTIMIZATION_FAILED`.
+ *
+ * @example
+ * ```ts
+ * const result = walkForwardAnalysisFromJSONSafe(candles, strategy, ranges, registry);
+ * if (result.ok) {
+ *   console.log(result.value.recommendation);
+ * } else {
+ *   console.error(result.error.code, result.error.message);
+ * }
+ * ```
+ */
+export function walkForwardAnalysisFromJSONSafe(
+  candles: NormalizedCandle[],
+  strategy: StrategyJSON,
+  ranges: PathParameterRange[],
+  registry: ConditionRegistry<Condition>,
+  options?: WalkForwardOptions,
+): Result<WalkForwardResult> {
+  try {
+    return ok(walkForwardAnalysisFromJSON(candles, strategy, ranges, registry, options));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const code = classifyOptimizationError(message);
+    return err(tcError(code, message, {}, error instanceof Error ? error : undefined));
+  }
+}


### PR DESCRIPTION
## Summary

Adds a JSON-first rolling walk-forward wrapper to `trendcraft` core,
filling the gap where `gridSearchFromJSON` existed but walk-forward had no
`StrategyJSON` entry point — callers had to hand-write a `StrategyFactory`
to walk-forward a JSON strategy.

## Changes

- **`walkForwardAnalysisFromJSON` / `walkForwardAnalysisFromJSONSafe`** (new
  `optimization/walkforward-json.ts`) — drives `walkForwardAnalysis` from a
  `StrategyJSON` plus path-addressed `PathParameterRange[]`. Per-period
  `bestParams` keys are paths (e.g. `"entry.0.shortPeriod"`), matching
  `gridSearchFromJSON`, so a window's optimized params plug straight back
  into `applyParamOverrides`. The safe variant maps range-path errors to
  `INVALID_PARAMETER`, an oversized grid to `TOO_MANY_COMBINATIONS`, and a
  too-short slice to `INSUFFICIENT_DATA`.
- **Shared JSON→factory plumbing** (new
  `optimization/strategy-json-factory.ts`) — the path validation, factory
  construction, range conversion, and error classification are factored out
  of `grid-search-json.ts`. Both `gridSearchFromJSON` and
  `walkForwardAnalysisFromJSON` now delegate to it, so the two JSON entry
  points can't drift on validation rules. `grid-search-json.ts` shrinks by
  ~197 lines with no behavior change.
- Exports added to `optimization/index.ts` and the top-level `src/index.ts`.

Covers **rolling** walk-forward only; anchored walk-forward runs a
condition-combination search rather than a parameter sweep and does not
share this shape.

## Testing

- New `walkforward-json.test.ts` (6 cases): valid run returns path-keyed
  per-period `bestParams`; invalid range path throws / maps to
  `INVALID_PARAMETER`; too-short slice throws / maps to `INSUFFICIENT_DATA`.
- `grid-search-json.test.ts` passes unchanged (refactor is behavior-preserving).
- `tsc --noEmit`, `pnpm test` (6057 pass), `pnpm build`, `pnpm lint` — all clean.
