### PR TITLE
feat(core): cross-parameter constraints in the optimizer (validateParams + paramFilter)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### Added — optimizer cross-parameter constraints (`validateParams` + `paramFilter`)
+
+The grid-search engine can now reject structurally-invalid parameter
+combinations *before* backtesting them, the exhaustive-grid analogue of
+vectorbt's parameter mask. `GridSearchOptions` and `WalkForwardOptions`
+gain a `paramFilter?: (params) => boolean`; combinations it rejects never
+run, never enter `results`, and don't count toward `validCombinations`
+(distinct from metric `constraints`, which filter *after* backtesting on
+realized metrics).
+
+Condition registry entries gain an optional
+`validateParams?: (params) => boolean` for cross-field invariants no
+per-field range can express — `goldenCross` / `deadCross` /
+`validatedGoldenCross` / `validatedDeadCross` now declare
+`shortPeriod < longPeriod`. `gridSearchFromJSON` and
+`walkForwardAnalysisFromJSON` automatically build a `paramFilter` from the
+strategy's leaves and their registered `validateParams` (AND-composed with
+any caller-supplied `paramFilter`), so an inverted-cross combo can neither
+appear in grid results nor be chosen as a walk-forward window's best
+parameters. Walk-forward's no-valid-combination fallback honors the same
+filter rather than defaulting to raw range minima.
+
 ### Added — `walkForwardAnalysisFromJSON` (JSON-first rolling walk-forward)
 
 Sibling of `gridSearchFromJSON` for rolling walk-forward analysis. Drives

--- a/packages/core/src/optimization/__tests__/grid-search-json.test.ts
+++ b/packages/core/src/optimization/__tests__/grid-search-json.test.ts
@@ -359,4 +359,56 @@ describe("gridSearchFromJSONSafe", () => {
       expect(result.error.code).toBe("INVALID_PARAMETER");
     }
   });
+
+  it("applies registered cross-param constraints (goldenCross short < long) from overlapping ranges", () => {
+    const candles = makeUpTrendCandles(80);
+    // Ranges overlap so the grid contains invalid combos where
+    // shortPeriod >= longPeriod (e.g. short=8, long=4). The registered
+    // `validateParams` on goldenCross must keep those out of the results
+    // entirely — no post-filtering by the caller.
+    const result = gridSearchFromJSON(
+      candles,
+      STRATEGY,
+      [
+        { path: "entry.0.shortPeriod", min: 4, max: 8, step: 2 },
+        { path: "entry.0.longPeriod", min: 4, max: 8, step: 2 },
+      ],
+      backtestRegistry,
+      { keepAllResults: true },
+    );
+    for (const entry of result.results) {
+      expect(entry.params["entry.0.shortPeriod"]).toBeLessThan(entry.params["entry.0.longPeriod"]);
+    }
+    // 3 short × 3 long = 9 enumerated; the 6 with short >= long are
+    // skipped, leaving the 3 strictly-increasing pairs (4<6, 4<8, 6<8).
+    expect(result.results.length).toBe(3);
+    if (result.bestParams !== null) {
+      expect(result.bestParams["entry.0.shortPeriod"]).toBeLessThan(
+        result.bestParams["entry.0.longPeriod"],
+      );
+    }
+  });
+
+  it("does not constrain conditions without a validateParams predicate", () => {
+    // A tuned leaf with no cross-param constraint is unaffected: the
+    // param filter is undefined and every combo runs.
+    const rsiStrategy: StrategyJSON = {
+      $schema: "trendcraft/strategy",
+      version: 1,
+      id: "rsi",
+      name: "RSI",
+      entry: { name: "rsiBelow", params: { threshold: 30, period: 14 } },
+      exit: { name: "rsiAbove", params: { threshold: 70, period: 14 } },
+    };
+    const candles = makeUpTrendCandles(80);
+    const result = gridSearchFromJSON(
+      candles,
+      rsiStrategy,
+      [{ path: "entry.0.period", min: 5, max: 9, step: 2 }],
+      backtestRegistry,
+      { keepAllResults: true },
+    );
+    expect(result.totalCombinations).toBe(3);
+    expect(result.results.length).toBe(3);
+  });
 });

--- a/packages/core/src/optimization/__tests__/grid-search.test.ts
+++ b/packages/core/src/optimization/__tests__/grid-search.test.ts
@@ -194,6 +194,38 @@ describe("Grid Search Optimization", () => {
       expect(result.validCombinations).toBeGreaterThanOrEqual(0);
     });
 
+    it("skips combinations rejected by paramFilter before backtesting", () => {
+      const candles = generateUpTrendCandles(50);
+
+      const seen: Array<Record<string, number>> = [];
+      const createStrategy = (params: Record<string, number>) => {
+        seen.push(params);
+        return {
+          entry: createEnterCondition(Math.round(params.enterAt)),
+          exit: createExitCondition(Math.round(params.holdBars)),
+          options: { capital: 100000 } as BacktestOptions,
+        };
+      };
+
+      const result = gridSearch(
+        candles,
+        createStrategy,
+        [param("enterAt", 5, 10, 5), param("holdBars", 10, 15, 5)],
+        // Reject the (enterAt=10, holdBars=10) cell — 1 of 4 combos.
+        { paramFilter: (p) => !(p.enterAt === 10 && p.holdBars === 10) },
+      );
+
+      // The rejected combo never reached the factory (no backtest spent).
+      expect(seen.some((p) => p.enterAt === 10 && p.holdBars === 10)).toBe(false);
+      // …and never appears in the ranked results / best params.
+      for (const entry of result.results) {
+        expect(entry.params.enterAt === 10 && entry.params.holdBars === 10).toBe(false);
+      }
+      if (result.bestParams) {
+        expect(result.bestParams.enterAt === 10 && result.bestParams.holdBars === 10).toBe(false);
+      }
+    });
+
     it("should call progress callback", () => {
       const candles = generateUpTrendCandles(50);
       const progressFn = vi.fn();

--- a/packages/core/src/optimization/__tests__/strategy-dna.test.ts
+++ b/packages/core/src/optimization/__tests__/strategy-dna.test.ts
@@ -29,6 +29,8 @@ const makeEntry = (
     maxDrawdown: -score / 2,
     calmar: score,
     recoveryFactor: score,
+    mar: score,
+    tradeCount: trades,
   },
   // Backtest field is required for OptimizationResultEntry but DNA
   // analytics only read params + metrics + score, so a minimal stub is
@@ -219,6 +221,8 @@ describe("computeRecommendedParams", () => {
             maxDrawdown: -5,
             calmar: 1.5,
             recoveryFactor: 1.5,
+            mar: 1.5,
+            tradeCount: 5,
           },
           outOfSampleMetrics: {
             sharpe: 1.0,
@@ -228,6 +232,8 @@ describe("computeRecommendedParams", () => {
             maxDrawdown: -8,
             calmar: 1.0,
             recoveryFactor: 1.0,
+            mar: 1.0,
+            tradeCount: 5,
           },
           testBacktest: {} as never,
         },

--- a/packages/core/src/optimization/__tests__/walkforward-json.test.ts
+++ b/packages/core/src/optimization/__tests__/walkforward-json.test.ts
@@ -132,4 +132,72 @@ describe("walkForwardAnalysisFromJSONSafe", () => {
       expect(result.error.code).toBe("INSUFFICIENT_DATA");
     }
   });
+
+  it("fast-fails oversized grids as TOO_MANY_COMBINATIONS even with a constraint filter", () => {
+    // The strategy has registered constraints (goldenCross), so a
+    // paramFilter is auto-built. An oversized grid must still be rejected
+    // by the per-window maxCombinations guard rather than eagerly
+    // enumerating the whole Cartesian product first.
+    const candles = makeCandles(200);
+    const result = walkForwardAnalysisFromJSONSafe(
+      candles,
+      SMA_CROSS_STRATEGY,
+      [
+        { path: "entry.0.shortPeriod", min: 1, max: 100, step: 1 },
+        { path: "entry.0.longPeriod", min: 101, max: 300, step: 1 },
+      ],
+      backtestRegistry,
+      WF_OPTS,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("TOO_MANY_COMBINATIONS");
+    }
+  });
+
+  it("rejects a fully-invalid search space as INVALID_PARAMETER (no filtered-out fallback)", () => {
+    // Every combination violates goldenCross's shortPeriod < longPeriod
+    // (short range entirely above long range), so the param filter accepts
+    // nothing. Rather than falling back to a filtered-out combo, the run
+    // must surface that no valid combination exists.
+    const candles = makeCandles(200);
+    const result = walkForwardAnalysisFromJSONSafe(
+      candles,
+      SMA_CROSS_STRATEGY,
+      [
+        { path: "entry.0.shortPeriod", min: 20, max: 24, step: 2 },
+        { path: "entry.0.longPeriod", min: 4, max: 8, step: 2 },
+      ],
+      backtestRegistry,
+      WF_OPTS,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INVALID_PARAMETER");
+    }
+  });
+
+  it("never picks a constraint-violating combo as a window's best params", () => {
+    const candles = makeCandles(200);
+    // Overlapping short/long ranges so the per-window grid contains
+    // invalid combos. Each window's chosen bestParams must still satisfy
+    // goldenCross's shortPeriod < longPeriod — enforced at the optimizer
+    // via the registry's validateParams, not post-hoc.
+    const wf = walkForwardAnalysisFromJSON(
+      candles,
+      SMA_CROSS_STRATEGY,
+      [
+        { path: "entry.0.shortPeriod", min: 4, max: 8, step: 2 },
+        { path: "entry.0.longPeriod", min: 4, max: 8, step: 2 },
+      ],
+      backtestRegistry,
+      WF_OPTS,
+    );
+    expect(wf.periods.length).toBeGreaterThan(0);
+    for (const period of wf.periods) {
+      expect(period.bestParams["entry.0.shortPeriod"]).toBeLessThan(
+        period.bestParams["entry.0.longPeriod"],
+      );
+    }
+  });
 });

--- a/packages/core/src/optimization/grid-search-json.ts
+++ b/packages/core/src/optimization/grid-search-json.ts
@@ -37,6 +37,7 @@ import { err, ok, type Result, tcError } from "../types/result";
 import { gridSearch } from "./grid-search";
 import {
   classifyOptimizationError,
+  composeParamFilter,
   type PathParameterRange,
   pathRangesToParameterRanges,
   strategyFactoryFromJSON,
@@ -59,7 +60,11 @@ export type { PathParameterRange } from "./strategy-json-factory";
  * The `strategy.backtest` block is forwarded into the underlying
  * backtest options, so commission / direction / stops / capital from
  * the strategy JSON are honored. Caller-supplied `options` (e.g.
- * metric, constraints) are passed through to `gridSearch` unchanged.
+ * metric, constraints) are passed through to `gridSearch`; any
+ * registered cross-parameter constraints (`validateParams`, e.g.
+ * `goldenCross` requiring `shortPeriod < longPeriod`) are AND'd into
+ * `paramFilter` so structurally-invalid combinations are skipped before
+ * backtesting rather than ranked as results.
  */
 export function gridSearchFromJSON(
   candles: NormalizedCandle[],
@@ -73,7 +78,10 @@ export function gridSearchFromJSON(
     candles,
     strategyFactoryFromJSON(strategy, registry),
     pathRangesToParameterRanges(ranges),
-    options,
+    {
+      ...options,
+      paramFilter: composeParamFilter(strategy, registry, options?.paramFilter),
+    },
   );
 }
 

--- a/packages/core/src/optimization/grid-search.ts
+++ b/packages/core/src/optimization/grid-search.ts
@@ -137,6 +137,7 @@ export function gridSearch(
     maxCombinations = 10000,
     progressCallback,
     keepAllResults = false,
+    paramFilter,
   } = options;
 
   // Check total combinations
@@ -166,6 +167,15 @@ export function gridSearch(
     // Report progress
     if (progressCallback) {
       progressCallback(i + 1, combinations.length);
+    }
+
+    // Skip structurally-invalid combinations before spending a backtest
+    // on them. Unlike metric `constraints` (which filter on realized
+    // results), this rejects on the parameters themselves — e.g. a
+    // `shortPeriod >= longPeriod` cross — so such a combo never enters
+    // `results` or competes for `bestParams`.
+    if (paramFilter && !paramFilter(params)) {
+      continue;
     }
 
     try {

--- a/packages/core/src/optimization/strategy-json-factory.ts
+++ b/packages/core/src/optimization/strategy-json-factory.ts
@@ -211,6 +211,95 @@ export function strategyFactoryFromJSON(
 }
 
 /**
+ * Build a structural-validity predicate for the optimizer from the
+ * strategy's leaves and their registered `validateParams` constraints
+ * (e.g. `goldenCross` requires `shortPeriod < longPeriod`). Returns
+ * `undefined` when no leaf declares a constraint, so the optimizer pays
+ * nothing for strategies that don't need it.
+ *
+ * The returned predicate receives the engine's name-keyed params, where
+ * each `name` is a range path (`<bucket>.<leafIndex>.<paramName>`). It
+ * regroups them per leaf and merges each leaf's swept values over the
+ * leaf's static params and the registry defaults, so a constraint that
+ * references a sibling param (`longPeriod`) still sees a value even when
+ * only `shortPeriod` is being swept. Both `gridSearchFromJSON` and
+ * `walkForwardAnalysisFromJSON` pass this as `paramFilter`, so the two
+ * entry points enforce the same invariants from one definition.
+ */
+export function buildParamConstraintFilter(
+  strategy: StrategyJSON,
+  registry: ConditionRegistry<Condition>,
+): ((params: Record<string, number>) => boolean) | undefined {
+  const constrained: Array<{
+    address: string;
+    validate: (p: Record<string, number>) => boolean;
+    base: Record<string, number>;
+  }> = [];
+  for (const leaf of flattenStrategyLeaves(strategy)) {
+    const entry = registry.get(leaf.name);
+    if (!entry?.validateParams) continue;
+    // Resolve the leaf's full numeric param set: registry defaults first,
+    // then the strategy's saved overrides. A swept param will layer on
+    // top of this per-combination inside the predicate.
+    const base: Record<string, number> = {};
+    for (const [k, schema] of Object.entries(entry.params)) {
+      if (schema.type === "number" && typeof schema.default === "number") {
+        base[k] = schema.default;
+      }
+    }
+    if (leaf.params) {
+      for (const [k, v] of Object.entries(leaf.params)) {
+        if (typeof v === "number") base[k] = v;
+      }
+    }
+    constrained.push({
+      address: `${leaf.bucket}.${leaf.leafIndex}`,
+      validate: entry.validateParams,
+      base,
+    });
+  }
+  if (constrained.length === 0) return undefined;
+  return (params) => {
+    // Regroup the flat path-keyed combo into per-leaf param maps.
+    const byAddress = new Map<string, Record<string, number>>();
+    for (const [key, value] of Object.entries(params)) {
+      const parsed = parseLeafPath(key);
+      if (parsed.paramName === null) continue;
+      const address = `${parsed.bucket}.${parsed.leafIndex}`;
+      let m = byAddress.get(address);
+      if (!m) {
+        m = {};
+        byAddress.set(address, m);
+      }
+      m[parsed.paramName] = value;
+    }
+    for (const c of constrained) {
+      const merged = { ...c.base, ...(byAddress.get(c.address) ?? {}) };
+      if (!c.validate(merged)) return false;
+    }
+    return true;
+  };
+}
+
+/**
+ * Resolve the `paramFilter` the JSON optimizers hand to the engine:
+ * the registry-derived constraint filter (from {@link buildParamConstraintFilter})
+ * AND'd with any caller-supplied `paramFilter`. Returns `undefined` when
+ * neither exists, so the engine sees no filter and pays nothing. A combo
+ * must satisfy both predicates to be optimized.
+ */
+export function composeParamFilter(
+  strategy: StrategyJSON,
+  registry: ConditionRegistry<Condition>,
+  callerFilter?: (params: Record<string, number>) => boolean,
+): ((params: Record<string, number>) => boolean) | undefined {
+  const constraintFilter = buildParamConstraintFilter(strategy, registry);
+  if (!constraintFilter) return callerFilter;
+  if (!callerFilter) return constraintFilter;
+  return (params) => constraintFilter(params) && callerFilter(params);
+}
+
+/**
  * Convert path-addressed ranges to the engine's `name`-keyed
  * `ParameterRange[]`. The engine doesn't interpret `name`, so the path
  * string is a valid identifier and round-trips through `bestParams` /

--- a/packages/core/src/optimization/walkforward-json.ts
+++ b/packages/core/src/optimization/walkforward-json.ts
@@ -40,6 +40,7 @@ import type { WalkForwardOptions, WalkForwardResult } from "../types/optimizatio
 import { err, ok, type Result, tcError } from "../types/result";
 import {
   classifyOptimizationError,
+  composeParamFilter,
   type PathParameterRange,
   pathRangesToParameterRanges,
   strategyFactoryFromJSON,
@@ -62,7 +63,11 @@ import { walkForwardAnalysis } from "./walkforward";
  * The `strategy.backtest` block is forwarded into each window's backtest
  * options, so commission / direction / stops / capital from the strategy
  * JSON are honored. Caller-supplied `options` (window/step/test sizes,
- * metric, constraints) are passed through unchanged.
+ * metric, constraints) are passed through; any registered cross-parameter
+ * constraints (`validateParams`, e.g. `goldenCross` requiring
+ * `shortPeriod < longPeriod`) are AND'd into `paramFilter` so a
+ * structurally-invalid combination can't be chosen as a window's best
+ * parameters.
  */
 export function walkForwardAnalysisFromJSON(
   candles: NormalizedCandle[],
@@ -76,7 +81,10 @@ export function walkForwardAnalysisFromJSON(
     candles,
     strategyFactoryFromJSON(strategy, registry),
     pathRangesToParameterRanges(ranges),
-    options,
+    {
+      ...options,
+      paramFilter: composeParamFilter(strategy, registry, options?.paramFilter),
+    },
   );
 }
 

--- a/packages/core/src/optimization/walkforward.ts
+++ b/packages/core/src/optimization/walkforward.ts
@@ -16,13 +16,15 @@ import type {
   WalkForwardResult,
 } from "../types/optimization";
 import { err, ok, type Result, tcError } from "../types/result";
-import { gridSearch, type StrategyFactory } from "./grid-search";
+import { generateParameterCombinations, gridSearch, type StrategyFactory } from "./grid-search";
 import { calculateAllMetrics } from "./metrics";
 
 /**
  * Default options for walk-forward analysis
  */
-const DEFAULT_OPTIONS: Required<Omit<WalkForwardOptions, "constraints" | "progressCallback">> = {
+const DEFAULT_OPTIONS: Required<
+  Omit<WalkForwardOptions, "constraints" | "progressCallback" | "paramFilter">
+> = {
   windowSize: 252, // ~1 year of daily data
   stepSize: 63, // ~1 quarter
   testSize: 63, // ~1 quarter
@@ -107,7 +109,7 @@ export function walkForwardAnalysis(
   parameterRanges: ParameterRange[],
   options: WalkForwardOptions = {},
 ): WalkForwardResult {
-  const { windowSize, stepSize, testSize, metric, constraints, progressCallback } = {
+  const { windowSize, stepSize, testSize, metric, constraints, progressCallback, paramFilter } = {
     ...DEFAULT_OPTIONS,
     constraints: [] as OptimizationConstraint[],
     ...options,
@@ -125,6 +127,54 @@ export function walkForwardAnalysis(
       `Insufficient data for walk-forward analysis. Need at least ${windowSize + testSize} candles, got ${candles.length}.`,
     );
   }
+
+  // Fallback params for windows where no combination passed constraints
+  // (none traded / none scored finite in that window), so gridSearch
+  // returned no best params. Without a `paramFilter`, raw range minima
+  // are a fine "nothing optimized here" placeholder. With a `paramFilter`,
+  // minima could themselves be a structurally-invalid combo (e.g.
+  // `shortPeriod === longPeriod` when both ranges start at the same
+  // value) — exactly the kind the optimizer is told to skip — so we use
+  // the first combo the filter accepts instead. If the filter accepts
+  // *no* combination at all (a fully-degenerate search space, e.g. every
+  // goldenCross candidate has `shortPeriod >= longPeriod`), there is no
+  // valid fallback: throwing surfaces the empty search space rather than
+  // silently reporting a filtered-out combo as a window's best params.
+  //
+  // Resolved lazily and memoized: when a `paramFilter` is set this
+  // enumerates the full grid, which must NOT happen before the per-window
+  // `gridSearch` has had a chance to reject an oversized grid via its
+  // `maxCombinations` guard. Because the fallback is only ever needed
+  // *after* a window's `gridSearch` returned (i.e. the grid already
+  // passed that ≤10000 cap), computing it on first use keeps the
+  // fast-fail `TOO_MANY_COMBINATIONS` path intact and bounds the
+  // enumeration.
+  const minimaParams = parameterRanges.reduce(
+    (acc, r) => {
+      acc[r.name] = r.min;
+      return acc;
+    },
+    {} as Record<string, number>,
+  );
+  let resolvedFallback: Record<string, number> | null = null;
+  const fallbackParams = (): Record<string, number> => {
+    if (resolvedFallback === null) {
+      if (!paramFilter) {
+        resolvedFallback = minimaParams;
+      } else {
+        const firstValid = generateParameterCombinations(parameterRanges).find((c) =>
+          paramFilter(c),
+        );
+        if (firstValid === undefined) {
+          throw new Error(
+            "Invalid parameter ranges: every combination in the search space is rejected by a cross-parameter constraint (e.g. shortPeriod < longPeriod)",
+          );
+        }
+        resolvedFallback = firstValid;
+      }
+    }
+    return resolvedFallback;
+  };
 
   const periods: WalkForwardPeriod[] = [];
   const allInSampleMetrics: Record<OptimizationMetric, number>[] = [];
@@ -148,21 +198,17 @@ export function walkForwardAnalysis(
       metric,
       constraints,
       maxCombinations: 10000,
+      paramFilter,
     });
 
-    // Use best parameters or fallback to range minima.
-    // When validCombinations > 0, gridSearch guarantees bestParams is non-null,
-    // but TypeScript can't infer that across the boundary, so assert here.
+    // Use best parameters or fall back to the lazily-resolved fallback (a
+    // filter-valid combo when a paramFilter is set, else range minima).
+    // When validCombinations > 0, gridSearch guarantees bestParams is
+    // non-null, but TypeScript can't infer that across the boundary.
     const bestParams: Record<string, number> =
       gridResult.validCombinations > 0 && gridResult.bestParams !== null
         ? gridResult.bestParams
-        : parameterRanges.reduce(
-            (acc, r) => {
-              acc[r.name] = r.min;
-              return acc;
-            },
-            {} as Record<string, number>,
-          );
+        : fallbackParams();
 
     // Run backtest on training data with best params
     const trainStrategy = createStrategy(bestParams);

--- a/packages/core/src/strategy/__tests__/always-conditions.test.ts
+++ b/packages/core/src/strategy/__tests__/always-conditions.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { runBacktest } from "../../backtest";
 import { alwaysFalse, alwaysTrue } from "../../backtest/conditions/core";
-import type { Candle } from "../../types";
+import type { NormalizedCandle } from "../../types";
 import { loadStrategy } from "../hydrate";
 import { backtestRegistry } from "../registry-backtest";
 import type { StrategyJSON } from "../types";
 
-function makeCandles(n: number): Candle[] {
+function makeCandles(n: number): NormalizedCandle[] {
   return Array.from({ length: n }, (_, i) => ({
     time: 1700000000000 + i * 86400000,
     open: 100 + i,

--- a/packages/core/src/strategy/registry-backtest.ts
+++ b/packages/core/src/strategy/registry-backtest.ts
@@ -186,6 +186,7 @@ backtestRegistry.register({
     },
   },
   create: (p) => goldenCross((p.shortPeriod as number) ?? 5, (p.longPeriod as number) ?? 25),
+  validateParams: (p) => p.shortPeriod < p.longPeriod,
 });
 
 backtestRegistry.register({
@@ -211,6 +212,7 @@ backtestRegistry.register({
     },
   },
   create: (p) => deadCross((p.shortPeriod as number) ?? 5, (p.longPeriod as number) ?? 25),
+  validateParams: (p) => p.shortPeriod < p.longPeriod,
 });
 
 backtestRegistry.register({
@@ -232,6 +234,7 @@ backtestRegistry.register({
       trendPeriod: p.trendPeriod as number,
       minScore: p.minScore as number,
     }),
+  validateParams: (p) => p.shortPeriod < p.longPeriod,
 });
 
 backtestRegistry.register({
@@ -253,6 +256,7 @@ backtestRegistry.register({
       trendPeriod: p.trendPeriod as number,
       minScore: p.minScore as number,
     }),
+  validateParams: (p) => p.shortPeriod < p.longPeriod,
 });
 
 // ============================================

--- a/packages/core/src/strategy/types.ts
+++ b/packages/core/src/strategy/types.ts
@@ -200,6 +200,22 @@ export type ConditionRegistryEntry<T = unknown> = {
   create: (params: Record<string, unknown>) => T;
   /** Whether this is a filter condition (vs. entry/exit signal) */
   isFilter?: boolean;
+  /**
+   * Cross-parameter validity predicate. Returns `false` for a parameter
+   * combination that is structurally invalid for this condition even
+   * though each value passes its own `min`/`max` schema — e.g.
+   * `goldenCross` requires `shortPeriod < longPeriod`, an invariant no
+   * per-field range can express.
+   *
+   * Optimizers (`gridSearch` / `walkForwardAnalysis` via the JSON-first
+   * entry points) skip combinations this rejects *before* backtesting
+   * them, so an inverted-cross combo never enters the results or biases
+   * a walk-forward window's chosen parameters. The predicate receives the
+   * condition's params merged with registry defaults, so it can rely on
+   * siblings being present even when only one param is being swept.
+   * Omit it for conditions with no cross-param constraint.
+   */
+  validateParams?: (params: Record<string, number>) => boolean;
 };
 
 /**

--- a/packages/core/src/types/optimization.ts
+++ b/packages/core/src/types/optimization.ts
@@ -106,6 +106,17 @@ export type GridSearchOptions = {
   progressCallback?: (current: number, total: number) => void;
   /** Whether to keep all results or only valid ones (default: false) */
   keepAllResults?: boolean;
+  /**
+   * Structural validity predicate for a parameter combination. When
+   * provided, combinations it rejects are skipped *before* backtesting —
+   * they never run, never enter `results`, and don't count toward
+   * `validCombinations`. Use it for cross-parameter invariants that no
+   * per-field range can express (e.g. `shortPeriod < longPeriod`), the
+   * exhaustive-grid analogue of vectorbt's parameter mask. The metric
+   * `constraints` above filter *after* backtesting on realized metrics;
+   * this filters *before*, on the parameters themselves.
+   */
+  paramFilter?: (params: Record<string, number>) => boolean;
 };
 
 /**
@@ -172,6 +183,14 @@ export type WalkForwardOptions = {
   constraints?: OptimizationConstraint[];
   /** Progress callback */
   progressCallback?: (period: number, total: number) => void;
+  /**
+   * Structural validity predicate for a parameter combination, forwarded
+   * to each window's internal {@link GridSearchOptions.paramFilter}.
+   * Combinations it rejects are never optimized in any window, so a
+   * structurally-invalid set (e.g. `shortPeriod >= longPeriod`) can't be
+   * chosen as a window's best parameters.
+   */
+  paramFilter?: (params: Record<string, number>) => boolean;
 };
 
 // ============================================


### PR DESCRIPTION
## Summary

Adds cross-parameter constraint enforcement to the optimizer so that
structurally-invalid parameter combinations are skipped **before**
backtesting — the exhaustive-grid analogue of vectorbt's parameter mask.

Motivation: some conditions have a cross-field invariant that no per-field
range can express (e.g. `goldenCross` requires `shortPeriod < longPeriod`).
Until now the only enforcement was a UI-layer post-filter in the example
app, which (a) couldn't apply to walk-forward, where the per-window winners
are chosen inside the engine, and (b) left every other consumer to
reimplement the same check. This moves the knowledge into core's condition
registry and the optimizer, so grid search and walk-forward both honor it
from one definition.

## Changes

- **Engine** — `GridSearchOptions` and `WalkForwardOptions` gain
  `paramFilter?: (params) => boolean`. `gridSearch` skips rejected
  combinations before running a backtest, so they never enter `results`
  or count toward `validCombinations` (distinct from metric `constraints`,
  which filter *after* backtesting on realized metrics).
  `walkForwardAnalysis` threads the filter into each window's grid search.
- **Registry** — `ConditionRegistryEntry` gains
  `validateParams?: (params) => boolean`. `goldenCross` / `deadCross` /
  `validatedGoldenCross` / `validatedDeadCross` declare
  `shortPeriod < longPeriod`.
- **JSON entry points** — `gridSearchFromJSON` and
  `walkForwardAnalysisFromJSON` auto-build a `paramFilter` from the
  strategy's leaves and their registered `validateParams` (AND-composed
  with any caller-supplied filter) via shared `strategy-json-factory`
  helpers (`buildParamConstraintFilter` / `composeParamFilter`), so an
  inverted-cross combo can neither appear in grid results nor be chosen
  as a walk-forward window's best parameters.
- **Walk-forward fallback** — the "no valid combination this window"
  fallback now honors the filter: it uses the first filter-valid
  combination instead of raw range minima, and when the *entire* search
  space is rejected it throws `INVALID_PARAMETER` rather than reporting a
  filtered-out combo. The fallback is resolved lazily so an oversized grid
  still fast-fails as `TOO_MANY_COMBINATIONS` (the cap guard runs before
  any enumeration).
- **Test-fixture type fixes** — corrects two pre-existing `tsc --noEmit`
  errors unrelated to this feature (`strategy-dna` metrics fixtures were
  missing `mar` / `tradeCount`; `always-conditions` used `Candle[]` where
  `NormalizedCandle[]` was required) so the type check is clean.

## Design note

The filter applies to the exhaustive grid by skipping invalid cells, which
matches how vectorbt (parameter mask), backtrader (explicit valid-combo
lists), and scikit-learn (list-of-grids) handle cross-parameter validity
in exhaustive search. Bayesian optimizers (Optuna) instead return a
sentinel for invalid trials; that doesn't apply to an exhaustive grid.

## Test plan

- `pnpm test` (core): 6063 pass, including new cases:
  - `gridSearch` skips `paramFilter`-rejected combos before backtesting.
  - `gridSearchFromJSON` enforces `goldenCross` `short < long` from
    overlapping ranges; leaves without a `validateParams` are unaffected.
  - `walkForwardAnalysisFromJSON` never picks a constraint-violating combo
    as a window's best params; fast-fails oversized grids as
    `TOO_MANY_COMBINATIONS`; rejects a fully-invalid search space as
    `INVALID_PARAMETER`.
- `tsc --noEmit --ignoreDeprecations 6.0`: clean.
- `pnpm build`, `pnpm lint`: clean.

Backward compatible: `paramFilter` and `validateParams` are both optional;
strategies without registered constraints see no behavior change.
