### PR TITLE
feat(strategy-studio): wire walk-forward analysis into the optimizer + DNA panel

### DIFF
--- a/packages/chart/examples/strategy-studio/src/App.tsx
+++ b/packages/chart/examples/strategy-studio/src/App.tsx
@@ -14,7 +14,7 @@ import { useBacktestRunner } from "./hooks/useBacktestRunner";
 import { useDataSource } from "./hooks/useDataSource";
 import { useRegime } from "./hooks/useRegime";
 import { dataSourceKey } from "./lib/data-sources";
-import type { OptimizationComputation } from "./lib/optimization";
+import type { OptimizationComputation, WalkForwardComputation } from "./lib/optimization";
 import { PLUGIN_BY_KIND, type PluginHandle } from "./lib/plugins";
 import { SIGNAL_BY_KIND } from "./lib/signals";
 import { builderReducer, initialBuilderState, strategyJSONToState } from "./lib/strategy-state";
@@ -583,6 +583,11 @@ export function App() {
   const [optimizationResult, setOptimizationResult] = useState<OptimizationComputation>({
     kind: "idle",
   });
+  // Walk-forward result lifted alongside the grid result so StrategyDnaPanel
+  // can fold it into `computeDnaGrade` and render the per-window breakdown.
+  const [walkForwardResult, setWalkForwardResult] = useState<WalkForwardComputation>({
+    kind: "idle",
+  });
 
   // Backtest snapshot against history up to the current playhead — what the
   // user sees on chart matches what backtest sees.
@@ -822,10 +827,12 @@ export function App() {
           candles={backtestCandles}
           isReplayPlaying={replay.mode === "live" && replay.status === "playing"}
           onResult={setOptimizationResult}
+          onWalkForwardResult={setWalkForwardResult}
         />
         <div className="pane-divider" />
         <StrategyDnaPanel
           optimizationResult={optimizationResult}
+          walkForwardResult={walkForwardResult}
           lastBacktest={runner.state.lastResult?.result}
         />
       </aside>

--- a/packages/chart/examples/strategy-studio/src/lib/__tests__/optimization.test.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/__tests__/optimization.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from "vitest";
 import {
   autoDeriveRange,
   combinationCount,
+  deriveWalkForwardSizing,
   findIntegerRangeViolation,
   listTunables,
   runGridSearch,
+  runWalkForward,
 } from "../optimization";
 import type { StudioCandle } from "../sample-data";
 
@@ -471,5 +473,101 @@ describe("runGridSearch", () => {
     ];
     const out = runGridSearch(makeCandles(100), GOLDEN_CROSS_DEAD_CROSS, ranges, "returns");
     expect(out.kind).toBe("error");
+  });
+});
+
+describe("deriveWalkForwardSizing", () => {
+  it("solves windowSize + windows·testSize = N for non-overlapping windows", () => {
+    // N=1000, 20% OOS, 4 windows → trainPerTest = 4, testSize = 1000/(4+4) = 125.
+    const s = deriveWalkForwardSizing(1000, 20, 4);
+    expect(s.testSize).toBe(125);
+    expect(s.windowSize).toBe(500);
+    expect(s.stepSize).toBe(s.testSize); // non-overlapping OOS
+  });
+
+  it("lands on (approximately) the requested window count", () => {
+    // Sanity-check the derivation against core's period formula:
+    // floor((N - windowSize - testSize)/stepSize) + 1.
+    for (const [n, oos, w] of [
+      [1000, 20, 4],
+      [600, 30, 3],
+      [900, 25, 5],
+      [500, 50, 2],
+    ] as const) {
+      const s = deriveWalkForwardSizing(n, oos, w);
+      const periods = Math.floor((n - s.windowSize - s.testSize) / s.stepSize) + 1;
+      expect(Math.abs(periods - w)).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("clamps OOS% and window count so sizes stay positive", () => {
+    const tiny = deriveWalkForwardSizing(100, 0, 0); // OOS clamps to 5%, windows to 1
+    expect(tiny.testSize).toBeGreaterThanOrEqual(1);
+    expect(tiny.windowSize).toBeGreaterThanOrEqual(1);
+    const huge = deriveWalkForwardSizing(100, 200, 1); // OOS clamps to 90%
+    expect(huge.testSize).toBeGreaterThanOrEqual(1);
+    expect(huge.windowSize).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("runWalkForward", () => {
+  const WF_OPTS = { oosPercent: 20, windows: 3, metric: "returns" as const };
+
+  it("is deterministic — identical inputs produce identical outputs", () => {
+    const candles = makeCandles(400);
+    const ranges = [
+      { name: "entry.0.shortPeriod", min: 3, max: 7, step: 2 },
+      { name: "entry.0.longPeriod", min: 20, max: 30, step: 5 },
+      { name: "exit.0.shortPeriod", min: 3, max: 7, step: 2 },
+      { name: "exit.0.longPeriod", min: 20, max: 30, step: 5 },
+    ];
+    const a = runWalkForward(candles, GOLDEN_CROSS_DEAD_CROSS, ranges, WF_OPTS);
+    const b = runWalkForward(candles, GOLDEN_CROSS_DEAD_CROSS, ranges, WF_OPTS);
+    if (a.kind !== "ok" || b.kind !== "ok") throw new Error("expected ok");
+    expect(a.result.aggregateMetrics.stabilityRatio).toBe(b.result.aggregateMetrics.stabilityRatio);
+    expect(a.windows).toBe(b.windows);
+  });
+
+  it("returns kind:'ok' with at least one analyzed window on a long slice", () => {
+    const ranges = [
+      { name: "entry.0.shortPeriod", min: 3, max: 7, step: 2 },
+      { name: "entry.0.longPeriod", min: 20, max: 30, step: 5 },
+    ];
+    const out = runWalkForward(makeCandles(400), GOLDEN_CROSS_DEAD_CROSS, ranges, WF_OPTS);
+    if (out.kind !== "ok") throw new Error(`expected ok, got ${out.kind}`);
+    expect(out.windows).toBe(out.result.periods.length);
+    expect(out.windows).toBeGreaterThanOrEqual(1);
+    expect(out.oosPercent).toBe(20);
+  });
+
+  it("returns kind:'empty' when 0 tunables (alwaysTrue strategy)", () => {
+    const out = runWalkForward(makeCandles(400), ALWAYS_HOLD, [], WF_OPTS);
+    expect(out.kind).toBe("empty");
+  });
+
+  it("returns kind:'empty' when no window produces an out-of-sample trade", () => {
+    // Periods far longer than the data ever crosses → goldenCross never
+    // fires, so every window has zero trades. Core still returns finite
+    // (zero) metrics, but the wrapper must reject the run rather than feed
+    // an all-zero stability grade into Strategy DNA.
+    const ranges = [
+      { name: "entry.0.shortPeriod", min: 60, max: 64, step: 2 },
+      { name: "entry.0.longPeriod", min: 80, max: 88, step: 4 },
+    ];
+    const out = runWalkForward(makeCandles(400), GOLDEN_CROSS_DEAD_CROSS, ranges, WF_OPTS);
+    expect(out.kind).toBe("empty");
+  });
+
+  it("returns kind:'empty' when the slice is too short for one window", () => {
+    // A low OOS% with few windows derives a long training window: 10% OOS
+    // over 2 windows → windowSize 9, testSize 1, so 8 candles can't fit
+    // even one train+test window (needs ≥ 10).
+    const ranges = [{ name: "entry.0.shortPeriod", min: 3, max: 7, step: 2 }];
+    const out = runWalkForward(makeCandles(8), GOLDEN_CROSS_DEAD_CROSS, ranges, {
+      oosPercent: 10,
+      windows: 2,
+      metric: "returns",
+    });
+    expect(out.kind).toBe("empty");
   });
 });

--- a/packages/chart/examples/strategy-studio/src/lib/optimization.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/optimization.ts
@@ -1,6 +1,7 @@
 import {
   backtestRegistry,
   type Tunable as CoreTunable,
+  calculatePeriodCount,
   listTunables as coreListTunables,
   flattenStrategyLeaves,
   type GridSearchResult,
@@ -11,6 +12,8 @@ import {
   type ParameterRange,
   type PathParameterRange,
   type StrategyJSON,
+  type WalkForwardResult,
+  walkForwardAnalysisFromJSON,
 } from "trendcraft";
 import type { StudioCandle } from "./sample-data";
 
@@ -199,66 +202,6 @@ export function autoDeriveRange(
 
 export type OptimizationMetricUI = "returns" | "sharpe" | "profitFactor" | "winRate";
 
-/**
- * Condition-specific parameter validators. Returns `true` when the params
- * make semantic sense for that condition. Used to drop nonsensical grid
- * cells (e.g. a `goldenCross` row with `shortPeriod=13, longPeriod=12`
- * which mathematically inverts the indicator's design) before the user
- * sees them as "best" in the top-10 table.
- *
- * Core's registry doesn't model cross-param constraints today
- * (`shortPeriod < longPeriod` would need a per-condition predicate), so
- * Studio enforces it at the UI layer. Conditions not listed are treated
- * as always valid.
- */
-const CONDITION_PARAM_CONSTRAINTS: Record<string, (params: Record<string, number>) => boolean> = {
-  goldenCross: (p) => p.shortPeriod < p.longPeriod,
-  deadCross: (p) => p.shortPeriod < p.longPeriod,
-  validatedGoldenCross: (p) => p.shortPeriod < p.longPeriod,
-  validatedDeadCross: (p) => p.shortPeriod < p.longPeriod,
-};
-
-/**
- * Walk a result row's flat param map (`{ "entry.0.shortPeriod": 13,
- * "entry.0.longPeriod": 12, ... }`) and group by leaf path. Returns
- * `false` if any leaf's condition has a registered constraint that the
- * row violates. `leafBaseParams` supplies registry defaults + the
- * strategy's static values so a validator that needs a sibling param
- * the grid isn't varying (e.g. only `shortPeriod` is opened) still has
- * a value to compare against.
- */
-function resultParamsAreValid(
-  params: Record<string, number>,
-  leafConditionByPrefix: Map<string, string>,
-  leafBaseParams: Map<string, Record<string, number>>,
-): boolean {
-  const grouped = new Map<string, Record<string, number>>();
-  for (const prefix of leafConditionByPrefix.keys()) {
-    grouped.set(prefix, { ...(leafBaseParams.get(prefix) ?? {}) });
-  }
-  for (const [key, value] of Object.entries(params)) {
-    const lastDot = key.lastIndexOf(".");
-    if (lastDot <= 0) continue;
-    const prefix = key.slice(0, lastDot);
-    const paramName = key.slice(lastDot + 1);
-    let bucket = grouped.get(prefix);
-    if (!bucket) {
-      bucket = {};
-      grouped.set(prefix, bucket);
-    }
-    bucket[paramName] = value;
-  }
-  for (const [prefix, leafParams] of grouped) {
-    const conditionName = leafConditionByPrefix.get(prefix);
-    if (!conditionName) continue;
-    const validator = CONDITION_PARAM_CONSTRAINTS[conditionName];
-    if (!validator) continue;
-    if (validator(leafParams)) continue;
-    return false;
-  }
-  return true;
-}
-
 export const OPTIMIZATION_METRICS: ReadonlyArray<{ id: OptimizationMetricUI; label: string }> = [
   { id: "returns", label: "Return %" },
   { id: "sharpe", label: "Sharpe" },
@@ -317,6 +260,12 @@ export type OptimizationComputation =
  *    rebuilds `bestScore`/`bestParams`/`validCombinations` from what
  *    remains; if nothing remains, the panel renders an empty-state.
  *
+ * Cross-parameter constraints (e.g. `goldenCross` requiring
+ * `shortPeriod < longPeriod`) are no longer filtered here: core's
+ * `gridSearchFromJSON` builds a `paramFilter` from each condition's
+ * registered `validateParams`, so structurally-invalid combos never
+ * appear in `result.results` in the first place.
+ *
  * Pure: same `(candles, strategy, ranges, metric)` always produces the
  * same output. Replay-aware behavior lives one layer up (the panel
  * disables the Run button while playback is running).
@@ -351,47 +300,14 @@ export function runGridSearch(
       metric: metric === "returns" ? "returns" : metric,
       keepAllResults: false,
     });
-    // Build a `<bucket>.<leafIndex> → conditionName` map + the leaf's
-    // resolved params (registry default merged with user-supplied) so
-    // constraint validators can read params that the grid isn't varying
-    // (e.g. a 1-D sweep of `shortPeriod` still needs `longPeriod` to
-    // check the `short < long` invariant).
-    const leafConditionByPrefix = new Map<string, string>();
-    const leafBaseParams = new Map<string, Record<string, number>>();
-    for (const leaf of flattenStrategyLeaves(strategy)) {
-      const prefix = `${leaf.bucket}.${leaf.leafIndex}`;
-      leafConditionByPrefix.set(prefix, leaf.name);
-      const entry = backtestRegistry.get(leaf.name);
-      const base: Record<string, number> = {};
-      if (entry) {
-        for (const [k, schema] of Object.entries(entry.params)) {
-          if (schema.type === "number" && typeof schema.default === "number") {
-            base[k] = schema.default;
-          }
-        }
-      }
-      if (leaf.params) {
-        for (const [k, v] of Object.entries(leaf.params)) {
-          if (typeof v === "number") base[k] = v;
-        }
-      }
-      leafBaseParams.set(prefix, base);
-    }
     // Studio UX: zero-trade backtests score 0 across every metric, so
     // they'd otherwise tie at the top of a Sharpe / returns ranking
     // when nothing actually traded. Drop them and rebuild the summary
     // fields from the surviving rows. If everything was zero-trade,
     // surface an empty-state instead of a misleading "best 0.00".
-    //
-    // Same dropping happens for combinations that violate a condition's
-    // semantic constraint (e.g. `goldenCross` with `shortPeriod >=
-    // longPeriod` — mathematically valid but the indicator's name
-    // implies the opposite ordering, so presenting these as "best" is
-    // misleading).
-    const usableResults = result.results.filter((r) => {
-      if (r.backtest.trades.length === 0) return false;
-      return resultParamsAreValid(r.params, leafConditionByPrefix, leafBaseParams);
-    });
+    // (Structurally-invalid combos are already excluded upstream by
+    // core's `validateParams`-derived `paramFilter`.)
+    const usableResults = result.results.filter((r) => r.backtest.trades.length > 0);
     if (usableResults.length === 0) {
       return {
         kind: "empty",
@@ -408,6 +324,158 @@ export function runGridSearch(
       validCombinations: usableResults.length,
     };
     return { kind: "ok", result: filtered, metric };
+  } catch (err) {
+    return { kind: "error", message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * The (windowSize, testSize, stepSize) triple core's walk-forward engine
+ * actually consumes, derived from the two dials the panel exposes.
+ */
+export type WalkForwardSizing = {
+  /** Training (in-sample) window length in candles. */
+  windowSize: number;
+  /** Test (out-of-sample) window length in candles. */
+  testSize: number;
+  /** Advance between successive windows. Equals `testSize` here so the
+   * out-of-sample slices tile the data without gaps or overlap. */
+  stepSize: number;
+};
+
+/**
+ * Derive core's `(windowSize, testSize, stepSize)` from the two
+ * user-facing dials the panel exposes: out-of-sample fraction and the
+ * desired number of walk-forward windows.
+ *
+ * Uses non-overlapping out-of-sample windows (`stepSize === testSize`) —
+ * the standard "rolling" walk-forward layout where each period's test
+ * slice picks up exactly where the previous one ended, so the stitched
+ * out-of-sample series has no gaps or double-counting. Under that layout
+ * the engine yields `floor((N − windowSize − testSize) / testSize) + 1`
+ * periods, so solving `windowSize + windows·testSize = N` together with
+ * `windowSize / testSize = (1 − oosFrac) / oosFrac` lands on `windows`
+ * periods (±1 once the sizes are rounded to whole candles).
+ *
+ * `oosPercent` is clamped to `[5, 90]` and `windows` to `≥ 1` so a
+ * mistyped dial can't produce a zero/negative window. Callers should
+ * still check `calculatePeriodCount` against the result before running —
+ * a short slice can leave room for fewer windows than requested.
+ */
+export function deriveWalkForwardSizing(
+  totalCandles: number,
+  oosPercent: number,
+  windows: number,
+): WalkForwardSizing {
+  const oosFrac = Math.min(0.9, Math.max(0.05, oosPercent / 100));
+  const trainPerTest = (1 - oosFrac) / oosFrac;
+  const w = Math.max(1, Math.floor(windows));
+  const testSize = Math.max(1, Math.floor(totalCandles / (trainPerTest + w)));
+  const windowSize = Math.max(1, Math.round(testSize * trainPerTest));
+  return { windowSize, testSize, stepSize: testSize };
+}
+
+export type WalkForwardComputation =
+  | { kind: "idle" }
+  | { kind: "ok"; result: WalkForwardResult; windows: number; oosPercent: number }
+  | { kind: "empty"; message: string }
+  | { kind: "error"; message: string };
+
+export type WalkForwardRunOptions = {
+  /** Out-of-sample fraction per cycle, as a percent (e.g. `20`). */
+  oosPercent: number;
+  /** Requested number of walk-forward windows. */
+  windows: number;
+  /** Metric optimized within each training window. */
+  metric: OptimizationMetricUI;
+};
+
+/**
+ * Run rolling walk-forward analysis via core's
+ * `walkForwardAnalysisFromJSON`, sharing the exact ranges the grid
+ * search uses so the two views describe the same search space.
+ *
+ * Mirrors {@link runGridSearch}'s contract: user-recoverable conditions
+ * (no tunables, no ranges, a slice too short to fit even one window)
+ * short-circuit to `kind:"empty"` with an actionable message rather than
+ * surfacing as errors. The window sizing is derived from the panel's
+ * out-of-sample % and window-count dials by {@link deriveWalkForwardSizing};
+ * because integer rounding can leave room for fewer periods than
+ * requested, the resulting `windows` field reports the count core
+ * actually produced, not the requested one.
+ *
+ * Pure: same `(candles, strategy, ranges, opts)` always produces the
+ * same output. Replay-awareness lives one layer up (the panel disables
+ * Run during playback).
+ *
+ * Cross-parameter constraints (e.g. `goldenCross` requiring
+ * `shortPeriod < longPeriod`) are enforced by core: `walkForwardAnalysisFromJSON`
+ * builds a `paramFilter` from each condition's registered `validateParams`,
+ * so a structurally-invalid combo can't be chosen as any window's best
+ * parameters (and a fully-invalid search space surfaces as an error rather
+ * than a filtered-out fallback). The no-trade half of the grid filter is
+ * mirrored here — a run where no window trades out-of-sample returns
+ * `kind:"empty"` below.
+ */
+export function runWalkForward(
+  candles: StudioCandle[],
+  strategy: StrategyJSON,
+  ranges: ParameterRange[],
+  opts: WalkForwardRunOptions,
+): WalkForwardComputation {
+  const tunables = listTunables(strategy);
+  if (tunables.length === 0) {
+    return { kind: "empty", message: "Strategy has no tunable parameters" };
+  }
+  if (ranges.length === 0) {
+    return { kind: "empty", message: "No parameter ranges configured" };
+  }
+  const sizing = deriveWalkForwardSizing(candles.length, opts.oosPercent, opts.windows);
+  const periodCount = calculatePeriodCount(
+    candles.length,
+    sizing.windowSize,
+    sizing.stepSize,
+    sizing.testSize,
+  );
+  if (periodCount < 1) {
+    return {
+      kind: "empty",
+      message: `Slice too short for ${opts.windows} window(s) at ${opts.oosPercent}% OOS (need ≥ ${sizing.windowSize + sizing.testSize} candles, have ${candles.length})`,
+    };
+  }
+  try {
+    const normalized = normalizeCandles(candles);
+    const pathRanges: PathParameterRange[] = ranges.map((r) => ({
+      path: r.name,
+      min: r.min,
+      max: r.max,
+      step: r.step,
+    }));
+    const result = walkForwardAnalysisFromJSON(normalized, strategy, pathRanges, backtestRegistry, {
+      windowSize: sizing.windowSize,
+      stepSize: sizing.stepSize,
+      testSize: sizing.testSize,
+      metric: opts.metric,
+    });
+    // A window that never trades out-of-sample still yields finite-but-zero
+    // metrics (returns/tradeCount = 0), so a run where *no* window traded
+    // would otherwise report `kind:"ok"` and feed an all-zero stability
+    // grade into Strategy DNA — the same misleading "best 0.00" that
+    // `runGridSearch`'s no-trade filter guards against. Mirror that guard
+    // at the run level: if zero windows produced an out-of-sample trade,
+    // there's nothing to grade, so surface an empty-state. Partial
+    // no-trade windows are kept — core's aggregate already counts a
+    // non-trading window as unstable (`outOfSampleMetrics.returns > 0`)
+    // and `wfeRatio` skips it, so removing periods here would only desync
+    // the aggregate metrics the result already carries.
+    const tradedPeriods = result.periods.filter((p) => p.testBacktest.trades.length > 0).length;
+    if (tradedPeriods === 0) {
+      return {
+        kind: "empty",
+        message: "Walk-forward produced no out-of-sample trades on any window",
+      };
+    }
+    return { kind: "ok", result, windows: result.periods.length, oosPercent: opts.oosPercent };
   } catch (err) {
     return { kind: "error", message: err instanceof Error ? err.message : String(err) };
   }
@@ -451,4 +519,4 @@ export function combinationCount(ranges: ParameterRange[]): number {
   return total;
 }
 
-export type { GridSearchResult, OptimizationMetric, ParameterRange };
+export type { GridSearchResult, OptimizationMetric, ParameterRange, WalkForwardResult };

--- a/packages/chart/examples/strategy-studio/src/panels/OptimizationPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/OptimizationPanel.tsx
@@ -10,11 +10,15 @@ import {
   type OptimizationComputation,
   type OptimizationMetricUI,
   runGridSearch,
+  runWalkForward,
   type Tunable,
+  type WalkForwardComputation,
 } from "../lib/optimization";
 import type { StudioCandle } from "../lib/sample-data";
 
 const MAX_COMBINATIONS = 10_000;
+const WF_DEFAULT_OOS_PERCENT = 20;
+const WF_DEFAULT_WINDOWS = 4;
 
 type Props = {
   /** Last-run strategy JSON (PR10 single source of truth). */
@@ -30,6 +34,13 @@ type Props = {
    * is fire-and-forget broadcast on every change.
    */
   onResult?: (result: OptimizationComputation) => void;
+  /**
+   * Optional notifier for the latest walk-forward result. Same
+   * fire-and-forget contract as `onResult` — StrategyDnaPanel consumes
+   * it to feed `computeDnaGrade` and render the per-window report
+   * without owning the run trigger.
+   */
+  onWalkForwardResult?: (result: WalkForwardComputation) => void;
 };
 
 type RangeMap = Record<string, { min: number; max: number; step: number }>;
@@ -43,12 +54,24 @@ function initRanges(tunables: Tunable[]): RangeMap {
   return out;
 }
 
-export function OptimizationPanel({ strategy, candles, isReplayPlaying, onResult }: Props) {
+export function OptimizationPanel({
+  strategy,
+  candles,
+  isReplayPlaying,
+  onResult,
+  onWalkForwardResult,
+}: Props) {
   const tunables = useMemo<Tunable[]>(() => (strategy ? listTunables(strategy) : []), [strategy]);
 
   const [ranges, setRanges] = useState<RangeMap>(() => initRanges(tunables));
   const [metric, setMetric] = useState<OptimizationMetricUI>("returns");
   const [result, setResult] = useState<OptimizationComputation>({ kind: "idle" });
+
+  // Walk-forward dials. The two user-facing knobs (out-of-sample % and
+  // window count) derive core's window/step/test sizes in `runWalkForward`.
+  const [wfOosPercent, setWfOosPercent] = useState<number>(WF_DEFAULT_OOS_PERCENT);
+  const [wfWindows, setWfWindows] = useState<number>(WF_DEFAULT_WINDOWS);
+  const [wfResult, setWfResult] = useState<WalkForwardComputation>({ kind: "idle" });
 
   // Broadcast every result change so sibling panels (StrategyDnaPanel
   // mounted in App) consume the same data without duplicating the
@@ -58,6 +81,12 @@ export function OptimizationPanel({ strategy, candles, isReplayPlaying, onResult
   useEffect(() => {
     onResult?.(result);
   }, [result]);
+
+  // Same broadcast contract for the walk-forward result.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: onWalkForwardResult is stable in practice; broadcast only when the result itself changes.
+  useEffect(() => {
+    onWalkForwardResult?.(wfResult);
+  }, [wfResult]);
 
   // Anything that changes how `runGridSearch` would evaluate the strategy
   // must invalidate the panel state. Stringify the full entry/exit specs
@@ -76,6 +105,7 @@ export function OptimizationPanel({ strategy, candles, isReplayPlaying, onResult
   useEffect(() => {
     setRanges(initRanges(tunables));
     setResult({ kind: "idle" });
+    setWfResult({ kind: "idle" });
   }, [strategyKey]);
 
   // Any slice change → the prior optimisation was computed against different
@@ -93,6 +123,7 @@ export function OptimizationPanel({ strategy, candles, isReplayPlaying, onResult
   // biome-ignore lint/correctness/useExhaustiveDependencies: keys are content hashes; we don't want to depend on the `candles` reference or the `ranges` object identity.
   useEffect(() => {
     setResult((prev) => (prev.kind === "idle" ? prev : { kind: "idle" }));
+    setWfResult((prev) => (prev.kind === "idle" ? prev : { kind: "idle" }));
   }, [slicedKey, rangesKey]);
 
   const rangeArray = useMemo<ParameterRange[]>(
@@ -138,6 +169,24 @@ export function OptimizationPanel({ strategy, candles, isReplayPlaying, onResult
     setResult(runGridSearch(candles, strategy, rangeArray, metric));
   };
 
+  // Editing the walk-forward dials changes the window sizing, so any
+  // displayed result is from a different analysis. Drop it (idle→idle is
+  // a no-op so we don't re-broadcast on every keystroke) the same way the
+  // metric/range edits invalidate the grid result above.
+  const clearWalkForward = () =>
+    setWfResult((prev) => (prev.kind === "idle" ? prev : { kind: "idle" }));
+
+  const handleRunWalkForward = () => {
+    if (!strategy || runDisabled) return;
+    setWfResult(
+      runWalkForward(candles, strategy, rangeArray, {
+        oosPercent: wfOosPercent,
+        windows: wfWindows,
+        metric,
+      }),
+    );
+  };
+
   if (!strategy) {
     return (
       <div className="risk-panel">
@@ -176,6 +225,7 @@ export function OptimizationPanel({ strategy, candles, isReplayPlaying, onResult
                 // and would be misread as if recomputed for the new one.
                 setMetric(e.target.value as OptimizationMetricUI);
                 setResult({ kind: "idle" });
+                setWfResult({ kind: "idle" });
               }}
             >
               {OPTIMIZATION_METRICS.map((m) => (
@@ -264,7 +314,72 @@ export function OptimizationPanel({ strategy, candles, isReplayPlaying, onResult
         )}
 
         <ResultBody result={result} tunables={tunables} />
+
+        <div className="pane-divider" style={{ margin: "10px 0 8px" }} />
+
+        <div className="optimization-header">
+          <span className="optimization-metric-label" style={{ fontWeight: 600 }}>
+            Walk-Forward
+          </span>
+          <span className="meta-strategy-caption">out-of-sample stability</span>
+        </div>
+        <div className="optimization-header" style={{ gap: 10 }}>
+          <NumInput
+            label="OOS %"
+            value={wfOosPercent}
+            min={5}
+            max={50}
+            step={1}
+            integer
+            onChange={(v) => {
+              setWfOosPercent(v);
+              clearWalkForward();
+            }}
+          />
+          <NumInput
+            label="Windows"
+            value={wfWindows}
+            min={2}
+            max={12}
+            step={1}
+            integer
+            onChange={(v) => {
+              setWfWindows(v);
+              clearWalkForward();
+            }}
+          />
+        </div>
+        <button
+          type="button"
+          className="optimization-run-btn"
+          onClick={handleRunWalkForward}
+          disabled={runDisabled}
+        >
+          {isReplayPlaying ? "Run walk-forward (paused during replay)" : "Run walk-forward"}
+        </button>
+        <WalkForwardStatus result={wfResult} />
       </section>
+    </div>
+  );
+}
+
+/**
+ * One-line walk-forward status shown inside the Optimization panel. The
+ * full per-window report renders in StrategyDnaPanel's Robustness tab;
+ * this is just enough to confirm the run landed and point the user there.
+ */
+function WalkForwardStatus({ result }: { result: WalkForwardComputation }) {
+  if (result.kind === "idle") return null;
+  if (result.kind === "empty") {
+    return <div className="meta-strategy-caption">{result.message}</div>;
+  }
+  if (result.kind === "error") {
+    return <div className="risk-error">{result.message}</div>;
+  }
+  return (
+    <div className="meta-strategy-caption">
+      {result.windows} window(s) analyzed at {result.oosPercent}% OOS — see Strategy DNA →
+      Robustness for the breakdown.
     </div>
   );
 }

--- a/packages/chart/examples/strategy-studio/src/panels/StrategyDnaPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/StrategyDnaPanel.tsx
@@ -6,7 +6,7 @@ import {
   computeRecommendedParams,
   extractSensitivityData,
 } from "trendcraft";
-import type { OptimizationComputation } from "../lib/optimization";
+import type { OptimizationComputation, WalkForwardComputation } from "../lib/optimization";
 import {
   DEFAULT_MC_ITERATIONS,
   type MonteCarloComputation,
@@ -16,6 +16,7 @@ import { GenomeVisualization } from "./dna/GenomeVisualization";
 import { MonteCarloReport } from "./dna/MonteCarloReport";
 import { RobustnessReport } from "./dna/RobustnessReport";
 import { SensitivityHeatmap } from "./dna/SensitivityHeatmap";
+import { WalkForwardReport } from "./dna/WalkForwardReport";
 
 type DnaTab = "genome" | "sensitivity" | "robustness";
 
@@ -35,6 +36,12 @@ type Props = {
    */
   optimizationResult: OptimizationComputation;
   /**
+   * Walk-forward computation from the sibling OptimizationPanel. Feeds
+   * the "Walk-Forward Stability" dimensions of the grade and the
+   * per-window report. Stays `idle` until the user runs walk-forward.
+   */
+  walkForwardResult: WalkForwardComputation;
+  /**
    * Last backtest result, used as the Monte Carlo resampling input.
    * `undefined` until the user runs a backtest; the MC section then
    * renders its own "run a backtest first" empty state.
@@ -48,12 +55,14 @@ type Props = {
  * Genome and Sensitivity tabs are display-only (builder state is never
  * mutated from this panel, matching PR12's OptimizationPanel
  * philosophy). The Robustness tab adds a run-on-demand Monte Carlo
- * simulation over the last backtest, which lights up the "Monte Carlo
- * Significance" dimension of the grade. The Walk-Forward dimensions
- * stay `available: false` until that workflow is wired.
+ * simulation over the last backtest (lighting up the "Monte Carlo
+ * Significance" dimension) and surfaces the walk-forward result run from
+ * the sibling Optimization panel (lighting up the "Walk-Forward
+ * Stability" dimensions and rendering the per-window report).
  */
-export function StrategyDnaPanel({ optimizationResult, lastBacktest }: Props) {
+export function StrategyDnaPanel({ optimizationResult, walkForwardResult, lastBacktest }: Props) {
   const gridSearchResult = optimizationResult.kind === "ok" ? optimizationResult.result : null;
+  const walkForward = walkForwardResult.kind === "ok" ? walkForwardResult.result : null;
 
   const [activeTab, setActiveTab] = useState<DnaTab>("genome");
   const [selectedParam, setSelectedParam] = useState<string | null>(null);
@@ -124,20 +133,29 @@ export function StrategyDnaPanel({ optimizationResult, lastBacktest }: Props) {
 
   const recommendedParams = useMemo(() => {
     if (!gridSearchResult) return null;
-    return computeRecommendedParams(gridSearchResult, null, sensitivityData);
-  }, [gridSearchResult, sensitivityData]);
+    return computeRecommendedParams(gridSearchResult, walkForward, sensitivityData);
+  }, [gridSearchResult, walkForward, sensitivityData]);
 
   const monteCarloResult = mcComputation.kind === "ok" ? mcComputation.result : null;
 
-  // Feed the Monte Carlo result into the grade so the "Monte Carlo
-  // Significance" dimension lights up (and the overall grade reweights)
-  // as soon as the user runs it. Walk-Forward stays `null` until that
-  // workflow is wired.
+  // Feed the walk-forward and Monte Carlo results into the grade so the
+  // "Walk-Forward Stability" and "Monte Carlo Significance" dimensions
+  // light up (and the overall grade reweights) as soon as the user runs
+  // each. Both stay `null` until their respective workflow runs.
   const dnaGrade = useMemo(() => {
-    return computeDnaGrade(gridSearchResult, null, monteCarloResult);
-  }, [gridSearchResult, monteCarloResult]);
+    return computeDnaGrade(gridSearchResult, walkForward, monteCarloResult);
+  }, [gridSearchResult, walkForward, monteCarloResult]);
 
-  if (gridSearchResult === null) {
+  // Genome and Sensitivity are grid-only views; the Robustness tab also
+  // lights up from a standalone walk-forward run (its grade and the
+  // per-window report don't need a grid result). So the panel is
+  // reachable whenever *either* workflow has data — gating it on the
+  // grid alone would strand a walk-forward run the user was just told to
+  // open here.
+  const hasGrid = gridSearchResult !== null;
+  const hasWalkForward = walkForward !== null;
+
+  if (!hasGrid && !hasWalkForward) {
     // Distinguish the three non-`ok` states. For `idle` (no run yet)
     // we deliberately don't tell the user "Run a grid search" — the
     // sibling Optimization panel may be unable to run (no strategy,
@@ -160,37 +178,52 @@ export function StrategyDnaPanel({ optimizationResult, lastBacktest }: Props) {
     );
   }
 
+  // Genome/Sensitivity need a grid result; when only walk-forward has
+  // run, force the Robustness tab (where the WF report lives) so the
+  // user lands on the data they just computed instead of an empty
+  // grid-only tab.
+  const effectiveTab: DnaTab = hasGrid ? activeTab : "robustness";
+
   return (
     <div className="risk-panel">
       <div className="pane-header">Strategy DNA</div>
       <section className="risk-section">
         <div style={{ display: "flex", gap: 0, marginBottom: 8 }}>
-          {TABS.map((tab, idx) => (
-            <button
-              key={tab.key}
-              type="button"
-              onClick={() => setActiveTab(tab.key)}
-              style={{
-                flex: 1,
-                padding: "5px 4px",
-                fontSize: 10,
-                borderWidth: 1,
-                borderStyle: "solid",
-                borderColor: "var(--border, #333)",
-                background:
-                  activeTab === tab.key ? "var(--accent, #4a9eff)" : "var(--bg-tertiary, #222)",
-                color: activeTab === tab.key ? "#fff" : "var(--text-secondary, #888)",
-                cursor: "pointer",
-                borderRadius:
-                  idx === 0 ? "4px 0 0 4px" : idx === TABS.length - 1 ? "0 4px 4px 0" : "0",
-              }}
-            >
-              {tab.label}
-            </button>
-          ))}
+          {TABS.map((tab, idx) => {
+            // Genome/Sensitivity are meaningless without a grid result, so
+            // disable them when only walk-forward has run.
+            const tabDisabled = !hasGrid && tab.key !== "robustness";
+            return (
+              <button
+                key={tab.key}
+                type="button"
+                disabled={tabDisabled}
+                onClick={() => setActiveTab(tab.key)}
+                style={{
+                  flex: 1,
+                  padding: "5px 4px",
+                  fontSize: 10,
+                  borderWidth: 1,
+                  borderStyle: "solid",
+                  borderColor: "var(--border, #333)",
+                  background:
+                    effectiveTab === tab.key
+                      ? "var(--accent, #4a9eff)"
+                      : "var(--bg-tertiary, #222)",
+                  color: effectiveTab === tab.key ? "#fff" : "var(--text-secondary, #888)",
+                  cursor: tabDisabled ? "not-allowed" : "pointer",
+                  opacity: tabDisabled ? 0.4 : 1,
+                  borderRadius:
+                    idx === 0 ? "4px 0 0 4px" : idx === TABS.length - 1 ? "0 4px 4px 0" : "0",
+                }}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
         </div>
 
-        {activeTab === "genome" &&
+        {effectiveTab === "genome" &&
           (genomeSegments && genomeSegments.length > 0 ? (
             <>
               <div className="meta-strategy-caption" style={{ marginBottom: 6 }}>
@@ -232,7 +265,7 @@ export function StrategyDnaPanel({ optimizationResult, lastBacktest }: Props) {
             <div className="meta-strategy-caption">No tunable parameters in this grid search.</div>
           ))}
 
-        {activeTab === "sensitivity" &&
+        {effectiveTab === "sensitivity" &&
           (sensitivityData && sensitivityData.singleParams.length > 0 ? (
             <SensitivityHeatmap
               data={sensitivityData}
@@ -247,9 +280,13 @@ export function StrategyDnaPanel({ optimizationResult, lastBacktest }: Props) {
             </div>
           ))}
 
-        {activeTab === "robustness" && (
+        {effectiveTab === "robustness" && (
           <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
             <RobustnessReport grade={dnaGrade} recommendedParams={recommendedParams} />
+            <div className="meta-strategy-caption" style={{ fontWeight: 600, marginTop: 2 }}>
+              Walk-Forward
+            </div>
+            <WalkForwardReport computation={walkForwardResult} />
             <div className="meta-strategy-caption" style={{ fontWeight: 600, marginTop: 2 }}>
               Monte Carlo
             </div>

--- a/packages/chart/examples/strategy-studio/src/panels/dna/WalkForwardReport.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/dna/WalkForwardReport.tsx
@@ -1,0 +1,140 @@
+import { type WalkForwardResult, wfeRatio } from "trendcraft";
+import type { WalkForwardComputation } from "../../lib/optimization";
+
+type Props = {
+  /** Latest walk-forward computation lifted from the Optimization panel. */
+  computation: WalkForwardComputation;
+};
+
+/**
+ * Walk-Forward section of the Robustness tab — read-only view of the
+ * rolling analysis run from the sibling Optimization panel (the run
+ * trigger and window dials live there, matching how Grid Search and
+ * Strategy DNA already share one run).
+ *
+ * The headline is Pardo's Walk-Forward Efficiency (`wfeRatio`): the
+ * average of each window's calendar-annualized out-of-sample / in-sample
+ * return. Pardo treats ≥ 50% as the bar for a genuinely robust strategy
+ * rather than a curve-fit one, so the badge flips pass/fail at 0.5. The
+ * per-window table below shows the raw in/out-of-sample returns each
+ * window contributed, so a single bad window that drags the average down
+ * is visible rather than hidden inside the aggregate.
+ */
+export function WalkForwardReport({ computation }: Props) {
+  if (computation.kind === "idle") {
+    return (
+      <div className="meta-strategy-caption">
+        Run a walk-forward analysis from the Optimization panel to grade out-of-sample stability.
+      </div>
+    );
+  }
+  if (computation.kind === "empty") {
+    return <div className="meta-strategy-caption">{computation.message}</div>;
+  }
+  if (computation.kind === "error") {
+    return <div className="risk-error">{computation.message}</div>;
+  }
+  return (
+    <WalkForwardBody
+      result={computation.result}
+      windows={computation.windows}
+      oosPercent={computation.oosPercent}
+    />
+  );
+}
+
+/** WFE pass ≥ 0.5 (Pardo), borderline ≥ 0.3, fail below. */
+function wfeColor(wfe: number): string {
+  if (!Number.isFinite(wfe)) return "#6b7280";
+  if (wfe >= 0.5) return "#16a34a";
+  if (wfe >= 0.3) return "#eab308";
+  return "#dc2626";
+}
+
+function WalkForwardBody({
+  result,
+  windows,
+  oosPercent,
+}: {
+  result: WalkForwardResult;
+  windows: number;
+  oosPercent: number;
+}) {
+  const wfe = wfeRatio(result);
+  const wfeFinite = Number.isFinite(wfe);
+  const color = wfeColor(wfe);
+  const { stabilityRatio } = result.aggregateMetrics;
+  const verdict = !wfeFinite
+    ? "n/a"
+    : wfe >= 0.5
+      ? "robust"
+      : wfe >= 0.3
+        ? "borderline"
+        : "overfit";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {/* Headline: WFE badge + stability ratio */}
+      <div style={{ display: "flex", gap: 6 }}>
+        <WfStat
+          label={`Avg WFE · ${verdict}`}
+          value={wfeFinite ? `${(wfe * 100).toFixed(0)}%` : "—"}
+          color={color}
+        />
+        <WfStat
+          label="Stability ratio"
+          value={`${(stabilityRatio * 100).toFixed(0)}%`}
+          color="#4a9eff"
+        />
+      </div>
+      <div style={{ fontSize: 9, color: "var(--text-secondary, #888)", lineHeight: 1.4 }}>
+        {windows} window(s) · {oosPercent}% out-of-sample · {result.recommendation.reason}
+      </div>
+
+      {/* Per-window in/out-of-sample breakdown */}
+      <table className="optimization-result-table">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th className="num">IS Ret %</th>
+            <th className="num">OOS Ret %</th>
+            <th className="num">OOS Sharpe</th>
+          </tr>
+        </thead>
+        <tbody>
+          {result.periods.map((p, i) => (
+            <tr key={`${p.trainStart}-${p.testStart}`}>
+              <td>{i + 1}</td>
+              <td className="num">{p.inSampleMetrics.returns.toFixed(1)}</td>
+              <td
+                className="num"
+                style={{ color: p.outOfSampleMetrics.returns > 0 ? "#16a34a" : "#dc2626" }}
+              >
+                {p.outOfSampleMetrics.returns.toFixed(1)}
+              </td>
+              <td className="num">{p.outOfSampleMetrics.sharpe.toFixed(2)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/** A single headline stat chip (label + colored value). */
+function WfStat({ label, value, color }: { label: string; value: string; color: string }) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        padding: "6px 8px",
+        borderRadius: 6,
+        background: "var(--bg-primary, #1a1a1a)",
+        borderLeft: `3px solid ${color}`,
+      }}
+    >
+      <div style={{ fontSize: "var(--font-md)", fontWeight: 700, color }}>{value}</div>
+      <div style={{ fontSize: 9, color: "var(--text-secondary, #888)" }}>{label}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a rolling **walk-forward** workflow to Strategy Studio alongside the
existing grid search, surfacing out-of-sample stability in the Strategy
DNA panel. Builds on the core walk-forward JSON entry point and the
optimizer cross-parameter constraints recently merged to `main`
(`walkForwardAnalysisFromJSON`, `validateParams` / `paramFilter`).

## Changes

- **`lib/optimization.ts`** — `runWalkForward` + `deriveWalkForwardSizing`
  + `WalkForwardComputation`. The panel exposes two dials (out-of-sample %
  and window count); `deriveWalkForwardSizing` solves them into core's
  `windowSize` / `stepSize` / `testSize` using non-overlapping
  out-of-sample windows (`stepSize === testSize`). A run where no window
  trades out-of-sample returns `kind:"empty"` (mirrors grid search's
  no-trade guard). Drives core's `walkForwardAnalysisFromJSON`.
- **`OptimizationPanel`** — OOS%/window dials + a Run walk-forward button,
  broadcasting the result via `onWalkForwardResult` (mirrors the grid
  `onResult` lift). Editing a dial, the strategy, the slice, the ranges, or
  the metric invalidates a stale walk-forward result.
- **`App`** — lifts the walk-forward result to `StrategyDnaPanel`.
- **`StrategyDnaPanel`** — feeds the result into
  `computeDnaGrade(grid, wf, mc)` and `computeRecommendedParams`, and
  renders it in the Robustness tab. The panel is now reachable from a
  standalone walk-forward run (no grid-search result required); the
  grid-only Genome/Sensitivity tabs disable themselves in that case.
- **`panels/dna/WalkForwardReport.tsx`** (new) — Pardo Walk-Forward
  Efficiency badge (`wfeRatio`, >= 0.5 = robust), stability ratio, the
  recommendation reason, and a per-window in/out-of-sample returns + Sharpe
  table.

### Removed local constraint filter

Deletes the example's `CONDITION_PARAM_CONSTRAINTS` / `resultParamsAreValid`
post-filter. Core now enforces cross-parameter constraints in the optimizer
itself (`gridSearchFromJSON` / `walkForwardAnalysisFromJSON` build a
`paramFilter` from each condition's registered `validateParams`), so
structurally-invalid combinations (e.g. `goldenCross` with
`shortPeriod >= longPeriod`) never reach the example and both grid search
and walk-forward enforce the same invariant from one definition.
`runGridSearch` keeps only its zero-trade UX filter.

## Test plan

- `pnpm test` (strategy-studio): 101 pass, including `deriveWalkForwardSizing`
  (window-count / OOS% derivation, clamping) and `runWalkForward`
  (determinism, empty on no tunables / too-short slice / no out-of-sample
  trades).
- `tsc --noEmit`: clean. `pnpm build`, `pnpm lint`: clean.
- Manual smoke (dev server): backtest -> grid search -> walk-forward ->
  Strategy DNA Robustness shows the WFE badge (101% robust), stability
  ratio, and a 4-window IS/OOS/Sharpe breakdown; the grade's Walk-Forward
  Stability and Win Rate Stability dimensions and the recommended params
  ("4/4 stable WF periods") light up. Grid search still returns only
  `shortPeriod < longPeriod` combinations (now enforced upstream).

Targets `epic/strategy-studio`, which has been brought up to `main`
beforehand so the core APIs this PR calls are present.
