### PR TITLE
feat(strategy-studio): stitched out-of-sample equity chart in the Walk-Forward report

### DIFF
--- a/packages/chart/examples/strategy-studio/src/panels/dna/WalkForwardReport.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/dna/WalkForwardReport.tsx
@@ -1,4 +1,6 @@
-import { type WalkForwardResult, wfeRatio } from "trendcraft";
+import { Sparkline } from "@trendcraft/chart/react/sparkline";
+import { useMemo } from "react";
+import { stitchOosEquity, type WalkForwardResult, wfeRatio } from "trendcraft";
 import type { WalkForwardComputation } from "../../lib/optimization";
 
 type Props = {
@@ -15,10 +17,17 @@ type Props = {
  * The headline is Pardo's Walk-Forward Efficiency (`wfeRatio`): the
  * average of each window's calendar-annualized out-of-sample / in-sample
  * return. Pardo treats ≥ 50% as the bar for a genuinely robust strategy
- * rather than a curve-fit one, so the badge flips pass/fail at 0.5. The
- * per-window table below shows the raw in/out-of-sample returns each
- * window contributed, so a single bad window that drags the average down
- * is visible rather than hidden inside the aggregate.
+ * rather than a curve-fit one, so the badge flips pass/fail at 0.5.
+ *
+ * Below the headline is the stitched out-of-sample equity curve
+ * (`stitchOosEquity`) — every window's out-of-sample trades compounded
+ * into one continuous path. This is the canonical walk-forward visual:
+ * it shows what an account that only ever traded unseen data would have
+ * done, so curve-fit strategies that look great in-sample but stall
+ * out-of-sample show up as a flat or sinking line even when the average
+ * WFE rounds up. The per-window table then breaks the same path back into
+ * its raw in/out-of-sample returns so a single bad window that drags the
+ * average down is visible rather than hidden inside the aggregate.
  */
 export function WalkForwardReport({ computation }: Props) {
   if (computation.kind === "idle") {
@@ -72,6 +81,14 @@ function WalkForwardBody({
         ? "borderline"
         : "overfit";
 
+  // Stitched out-of-sample equity: every window's OOS trades compounded
+  // into one continuous path. The absolute capital only scales the curve
+  // (the chart auto-fits), so the core default is fine — the endpoint
+  // relative to the start is the total compounded OOS return.
+  const curve = useMemo(() => stitchOosEquity(result).map((p) => p.equity), [result]);
+  const oosReturn = curve.length > 1 ? (curve[curve.length - 1] / curve[0] - 1) * 100 : Number.NaN;
+  const oosUp = oosReturn >= 0;
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
       {/* Headline: WFE badge + stability ratio */}
@@ -90,6 +107,31 @@ function WalkForwardBody({
       <div style={{ fontSize: 9, color: "var(--text-secondary, #888)", lineHeight: 1.4 }}>
         {windows} window(s) · {oosPercent}% out-of-sample · {result.recommendation.reason}
       </div>
+
+      {/* Stitched out-of-sample equity curve (canonical walk-forward visual) */}
+      {curve.length > 1 && (
+        <div className="results-chart-block">
+          <div
+            className="results-chart-label"
+            style={{ display: "flex", justifyContent: "space-between" }}
+          >
+            <span>Stitched OOS equity</span>
+            <span style={{ color: oosUp ? "#16a34a" : "#dc2626", fontWeight: 700 }}>
+              {oosUp ? "+" : ""}
+              {oosReturn.toFixed(1)}%
+            </span>
+          </div>
+          <Sparkline
+            type="line"
+            data={curve}
+            width={320}
+            height={56}
+            color={{ fixed: oosUp ? "#26a69a" : "#ef5350" }}
+            fill
+            style={{ width: "100%" }}
+          />
+        </div>
+      )}
 
       {/* Per-window in/out-of-sample breakdown */}
       <table className="optimization-result-table">


### PR DESCRIPTION
## What

Adds the stitched out-of-sample equity curve to the Walk-Forward section of the Strategy DNA panel's Robustness tab.

Every walk-forward window's out-of-sample trades are compounded into one continuous equity path via core's `stitchOosEquity`, rendered with the same `Sparkline` the results panel already uses. The chart sits between the WFE headline badge and the per-window breakdown table.

## Why

The headline WFE ratio shows the average and the per-window table shows the spread, but neither shows the *shape* of what an account that only ever traded unseen data would have done. A strategy that looks great in-sample but stalls out-of-sample reads as a flat or sinking line even when the average WFE rounds up — so the stitched curve is the canonical walk-forward visual that those numbers can't convey.

The section label also surfaces the total compounded out-of-sample return (endpoint relative to start), colored by sign (teal positive / red negative).

## Notes

- The absolute starting capital only scales the curve (the Sparkline auto-fits), so the core default capital is used; the endpoint-relative return is what carries meaning.
- UI-only change: the computation is delegated to core's already-tested `stitchOosEquity`. No new business logic, so no new unit tests were added.

## Test plan

- `tsc -b` — exit 0
- `vitest run` — 101 passed
- `vite build` — success
- `biome check` (changed file) — clean
- Manual smoke (headless browser): ran a 16-combo / 4-window walk-forward on the Golden Cross / Dead Cross preset over SPY 1D. The Walk-Forward report rendered Avg WFE 229% (robust), a stitched OOS equity curve at +49.3% (rising teal line + fill, canvas 318×56), and a 4-window IS/OOS table — no layout overlap, colors consistent with the return sign.
