### PR TITLE
feat(strategy-studio): deflated Sharpe headline in the Robustness tab

### DIFF
--- a/packages/chart/examples/strategy-studio/src/lib/__tests__/robustness.test.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/__tests__/robustness.test.ts
@@ -1,0 +1,113 @@
+import type {
+  BacktestResult,
+  GridSearchResult,
+  OptimizationMetric,
+  OptimizationResultEntry,
+} from "trendcraft";
+import { describe, expect, it } from "vitest";
+import { computeDeflatedSharpe } from "../robustness";
+
+/**
+ * Minimal optimization entry — `computeDeflatedSharpe` only reads `score`
+ * (to pick the selected combination) and `backtest.trades[].returnPercent`
+ * (to derive per-return Sharpes), so the rest of the BacktestResult is
+ * stubbed.
+ */
+function entry(score: number, returnPercents: number[]): OptimizationResultEntry {
+  return {
+    params: {},
+    score,
+    metrics: {} as Record<OptimizationMetric, number>,
+    backtest: {
+      trades: returnPercents.map((rp) => ({ returnPercent: rp })),
+    } as unknown as BacktestResult,
+    passedConstraints: true,
+  };
+}
+
+function gridResult(entries: OptimizationResultEntry[]): GridSearchResult {
+  const best = entries.reduce((a, b) => (b.score > a.score ? b : a), entries[0]);
+  return {
+    bestParams: {},
+    bestScore: best ? best.score : null,
+    metric: "sharpe",
+    totalCombinations: entries.length,
+    validCombinations: entries.length,
+    results: entries,
+  };
+}
+
+// A strong, low-variance winner plus three weaker, distinct trials.
+const BEST = entry(3, [5, 4, 6, 5]);
+const A = entry(1, [1, -1, 2, -2]);
+const B = entry(2, [3, -1, 2, 0]);
+const C = entry(0, [-1, -2, 1, 0]);
+
+describe("computeDeflatedSharpe", () => {
+  it("returns empty when there are fewer than two combinations to correct against", () => {
+    const result = computeDeflatedSharpe(gridResult([BEST]));
+    expect(result.kind).toBe("empty");
+  });
+
+  it("returns empty when the selected combination has too few trades for a Sharpe", () => {
+    // Highest score but only one trade — no Sharpe estimate possible.
+    const result = computeDeflatedSharpe(gridResult([entry(9, [4]), A, B]));
+    expect(result).toEqual({
+      kind: "empty",
+      message: "Selected combination has too few trades for a Sharpe estimate",
+    });
+  });
+
+  it("produces a probability in [0, 1] and reports the selected combination's stats", () => {
+    const result = computeDeflatedSharpe(gridResult([A, BEST, B, C]));
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.probability).toBeGreaterThanOrEqual(0);
+    expect(result.probability).toBeLessThanOrEqual(1);
+    // Stats describe the highest-scoring (selected) combination, BEST.
+    expect(result.sampleSize).toBe(4);
+    expect(result.observedSharpe).toBeGreaterThan(0);
+    expect(result.trials).toBe(4);
+  });
+
+  it("selects the highest-scoring combination regardless of array order", () => {
+    const ordered = computeDeflatedSharpe(gridResult([A, B, C, BEST]));
+    const shuffled = computeDeflatedSharpe(gridResult([BEST, C, A, B]));
+    expect(ordered).toEqual(shuffled);
+  });
+
+  it("deflates harder as more trials are searched (selection bias grows with N)", () => {
+    // Duplicating the whole trial set keeps the Sharpe distribution's mean
+    // and variance identical while tripling N, isolating the trial-count
+    // term: a wider search over the same-shaped results must deflate more.
+    const base = [BEST, A, B, C];
+    const few = computeDeflatedSharpe(gridResult(base));
+    const many = computeDeflatedSharpe(gridResult([...base, ...base, ...base]));
+    expect(few.kind).toBe("ok");
+    expect(many.kind).toBe("ok");
+    if (few.kind !== "ok" || many.kind !== "ok") return;
+    expect(many.trials).toBe(12);
+    expect(many.observedSharpe).toBeCloseTo(few.observedSharpe, 10);
+    expect(many.probability).toBeLessThan(few.probability);
+  });
+
+  it("drops combinations with too few trades from the trial set rather than failing", () => {
+    // The single-trade combo can't yield a Sharpe; it must be excluded
+    // from the trial count instead of poisoning the variance.
+    const result = computeDeflatedSharpe(gridResult([BEST, A, B, entry(0, [2])]));
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.trials).toBe(3);
+  });
+
+  it("returns empty when filtering leaves fewer than two trial Sharpes", () => {
+    // Two combinations, but the non-selected one has a single trade and is
+    // filtered out — the lone remaining Sharpe carries no selection-bias
+    // spread, so reporting an OK "best of 1" would be a no-op correction.
+    const result = computeDeflatedSharpe(gridResult([BEST, entry(0, [2])]));
+    expect(result).toEqual({
+      kind: "empty",
+      message: "Need ≥ 2 combinations with enough trades to correct for selection bias",
+    });
+  });
+});

--- a/packages/chart/examples/strategy-studio/src/lib/robustness.ts
+++ b/packages/chart/examples/strategy-studio/src/lib/robustness.ts
@@ -1,4 +1,10 @@
-import { type BacktestResult, type MonteCarloResult, runMonteCarloSimulation } from "trendcraft";
+import {
+  type BacktestResult,
+  deflatedSharpeFromReturns,
+  type GridSearchResult,
+  type MonteCarloResult,
+  runMonteCarloSimulation,
+} from "trendcraft";
 
 /**
  * Default Monte Carlo iteration count. 1000 is the industry-canonical
@@ -57,4 +63,111 @@ export function runMonteCarlo(
   } catch (err) {
     return { kind: "error", message: err instanceof Error ? err.message : String(err) };
   }
+}
+
+/**
+ * Per-return (non-annualized) Sharpe of a trade-return series, using the
+ * population variance (`/N`) that core's Deflated Sharpe math uses. Kept
+ * consistent so the selected strategy's trial Sharpe equals the observed
+ * Sharpe core recomputes internally — a mismatched `/(N-1)` here would
+ * desync the two and bias the correction.
+ */
+function perReturnSharpe(returns: number[]): number {
+  if (returns.length < 2) return Number.NaN;
+  const mu = returns.reduce((s, r) => s + r, 0) / returns.length;
+  const sigma = Math.sqrt(returns.reduce((s, r) => s + (r - mu) ** 2, 0) / returns.length);
+  return sigma === 0 ? Number.NaN : mu / sigma;
+}
+
+/** Per-trade returns as decimals (a trivial read of the public ledger). */
+function tradeReturns(result: BacktestResult): number[] {
+  return result.trades.map((t) => t.returnPercent / 100);
+}
+
+/**
+ * Result of the Deflated Sharpe correction over a grid search. `empty`
+ * mirrors the other robustness computations so the panel can explain why
+ * a probability can't be produced rather than rendering a bare "—".
+ */
+export type DeflatedSharpeComputation =
+  | {
+      kind: "ok";
+      /** P(true Sharpe > 0) after correcting for selection over N trials, in [0, 1]. */
+      probability: number;
+      /** Per-return Sharpe of the selected (highest-scoring) combination. */
+      observedSharpe: number;
+      /** Number of trials whose Sharpe entered the selection-bias correction. */
+      trials: number;
+      /** Trade count of the selected combination (the DSR sample size). */
+      sampleSize: number;
+    }
+  | { kind: "empty"; message: string };
+
+/**
+ * Deflated Sharpe Ratio for the optimization's chosen strategy — the
+ * probability its Sharpe survives correction for selection bias (having
+ * picked the best of N grid combinations), non-normal returns, and the
+ * sample length (Bailey & López de Prado 2014).
+ *
+ * The grid search is exactly the multiple-testing setup the DSR was
+ * designed for: trying many parameter sets inflates the best in-sample
+ * Sharpe purely by chance, and a raw Sharpe headline never shows that. We
+ * feed every grid combination's per-return Sharpe in as the trial set, so
+ * a wide grid that found one lucky peak deflates harder than a narrow grid
+ * that found a broadly-good region.
+ *
+ * The heavy lifting is core's `deflatedSharpeFromReturns`; this wrapper
+ * only shapes the grid result into (selected returns, trial Sharpes) and
+ * adds Studio's empty-state handling. The selected combination is the
+ * highest-scoring one (by whatever metric the grid optimized), picked by
+ * score rather than assuming the array is pre-sorted.
+ */
+export function computeDeflatedSharpe(result: GridSearchResult): DeflatedSharpeComputation {
+  const entries = result.results;
+  if (entries.length < 2) {
+    return {
+      kind: "empty",
+      message: "Need ≥ 2 parameter combinations to correct for selection bias",
+    };
+  }
+  const best = entries.reduce((a, b) => (b.score > a.score ? b : a));
+  const selectedReturns = tradeReturns(best.backtest);
+  if (selectedReturns.length < 2) {
+    return {
+      kind: "empty",
+      message: "Selected combination has too few trades for a Sharpe estimate",
+    };
+  }
+  // Each grid combination contributes one per-return Sharpe; combinations
+  // with too few trades to estimate one (NaN) drop out of the trial set
+  // rather than poisoning its variance.
+  const trialSharpes = entries
+    .map((e) => perReturnSharpe(tradeReturns(e.backtest)))
+    .filter(Number.isFinite);
+  // The grid had ≥ 2 combinations, but if all but one were dropped for
+  // too few trades, the trial set collapses to a single Sharpe — and a
+  // one-element set carries no spread, so `deflatedSharpeFromReturns`
+  // would compute a zero selection-bias benchmark and report an
+  // uncorrected probability as if the grid had not been searched. Reject
+  // it so the "Best of 1 grid combos" no-op never reaches the UI.
+  if (trialSharpes.length < 2) {
+    return {
+      kind: "empty",
+      message: "Need ≥ 2 combinations with enough trades to correct for selection bias",
+    };
+  }
+  const probability = deflatedSharpeFromReturns(selectedReturns, trialSharpes);
+  if (!Number.isFinite(probability)) {
+    return {
+      kind: "empty",
+      message: "Deflated Sharpe is undefined for this grid (zero-variance returns)",
+    };
+  }
+  return {
+    kind: "ok",
+    probability,
+    observedSharpe: perReturnSharpe(selectedReturns),
+    trials: trialSharpes.length,
+    sampleSize: selectedReturns.length,
+  };
 }

--- a/packages/chart/examples/strategy-studio/src/panels/StrategyDnaPanel.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/StrategyDnaPanel.tsx
@@ -8,10 +8,12 @@ import {
 } from "trendcraft";
 import type { OptimizationComputation, WalkForwardComputation } from "../lib/optimization";
 import {
+  computeDeflatedSharpe,
   DEFAULT_MC_ITERATIONS,
   type MonteCarloComputation,
   runMonteCarlo,
 } from "../lib/robustness";
+import { DeflatedSharpeReport } from "./dna/DeflatedSharpeReport";
 import { GenomeVisualization } from "./dna/GenomeVisualization";
 import { MonteCarloReport } from "./dna/MonteCarloReport";
 import { RobustnessReport } from "./dna/RobustnessReport";
@@ -145,6 +147,14 @@ export function StrategyDnaPanel({ optimizationResult, walkForwardResult, lastBa
   const dnaGrade = useMemo(() => {
     return computeDnaGrade(gridSearchResult, walkForward, monteCarloResult);
   }, [gridSearchResult, walkForward, monteCarloResult]);
+
+  // Deflated Sharpe corrects the chosen strategy's Sharpe for having
+  // selected the best of N grid combinations. It needs the full grid
+  // (the trial set), so it stays null on a walk-forward-only run.
+  const deflatedSharpe = useMemo(() => {
+    if (!gridSearchResult) return null;
+    return computeDeflatedSharpe(gridSearchResult);
+  }, [gridSearchResult]);
 
   // Genome and Sensitivity are grid-only views; the Robustness tab also
   // lights up from a standalone walk-forward run (its grade and the
@@ -283,6 +293,14 @@ export function StrategyDnaPanel({ optimizationResult, walkForwardResult, lastBa
         {effectiveTab === "robustness" && (
           <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
             <RobustnessReport grade={dnaGrade} recommendedParams={recommendedParams} />
+            {deflatedSharpe && (
+              <>
+                <div className="meta-strategy-caption" style={{ fontWeight: 600, marginTop: 2 }}>
+                  Deflated Sharpe
+                </div>
+                <DeflatedSharpeReport computation={deflatedSharpe} />
+              </>
+            )}
             <div className="meta-strategy-caption" style={{ fontWeight: 600, marginTop: 2 }}>
               Walk-Forward
             </div>

--- a/packages/chart/examples/strategy-studio/src/panels/dna/DeflatedSharpeReport.tsx
+++ b/packages/chart/examples/strategy-studio/src/panels/dna/DeflatedSharpeReport.tsx
@@ -1,0 +1,82 @@
+import type { DeflatedSharpeComputation } from "../../lib/robustness";
+
+type Props = {
+  /** Deflated Sharpe correction derived from the grid search result. */
+  computation: DeflatedSharpeComputation;
+};
+
+/**
+ * Deflated Sharpe headline for the Robustness tab — the probability that
+ * the optimization's chosen strategy has a genuinely positive Sharpe once
+ * the multiple-testing of the grid search is accounted for.
+ *
+ * Bailey & López de Prado treat ~0.95 as the bar: below it the headline
+ * Sharpe is plausibly a selection-bias artifact, so the chip flips
+ * green → amber → red around it. The subline reports how many grid
+ * combinations fed the correction and the selected combination's raw
+ * per-return Sharpe, so the gap between the raw and deflated views is
+ * visible at a glance.
+ */
+export function DeflatedSharpeReport({ computation }: Props) {
+  if (computation.kind === "empty") {
+    return <div className="meta-strategy-caption">{computation.message}</div>;
+  }
+  const { probability, observedSharpe, trials, sampleSize } = computation;
+  const color = dsrColor(probability);
+  const verdict =
+    probability >= 0.95 ? "credible" : probability >= 0.9 ? "borderline" : "likely overfit";
+
+  return (
+    <div style={{ display: "flex", gap: 6 }}>
+      <DsrStat
+        label={`Deflated Sharpe · ${verdict}`}
+        value={`${(probability * 100).toFixed(0)}%`}
+        color={color}
+      />
+      <DsrStat
+        label="Observed Sharpe (per trade)"
+        value={observedSharpe.toFixed(2)}
+        color="#4a9eff"
+      />
+      <div
+        style={{
+          flex: 1,
+          padding: "6px 8px",
+          fontSize: 9,
+          color: "var(--text-secondary, #888)",
+          lineHeight: 1.4,
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        Best of {trials} grid combos · {sampleSize} trades · P(true Sharpe &gt; 0) after
+        selection-bias correction
+      </div>
+    </div>
+  );
+}
+
+/** ≥ 0.95 credible (green), ≥ 0.90 borderline (amber), below likely overfit (red). */
+function dsrColor(p: number): string {
+  if (p >= 0.95) return "#16a34a";
+  if (p >= 0.9) return "#eab308";
+  return "#dc2626";
+}
+
+/** A single headline stat chip (label + colored value). */
+function DsrStat({ label, value, color }: { label: string; value: string; color: string }) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        padding: "6px 8px",
+        borderRadius: 6,
+        background: "var(--bg-primary, #1a1a1a)",
+        borderLeft: `3px solid ${color}`,
+      }}
+    >
+      <div style={{ fontSize: "var(--font-md)", fontWeight: 700, color }}>{value}</div>
+      <div style={{ fontSize: 9, color: "var(--text-secondary, #888)" }}>{label}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds a Deflated Sharpe headline to the Strategy DNA panel's Robustness tab — the probability that the optimization's chosen strategy has a genuinely positive Sharpe once the multiple-testing of the grid search is accounted for (Bailey & López de Prado 2014).

## Why

A grid search is exactly the selection-bias setup the Deflated Sharpe was designed for: trying many parameter sets inflates the best in-sample Sharpe purely by chance, and a raw Sharpe headline never shows that. Surfacing the deflated probability next to the raw per-return Sharpe makes the overfitting gap visible at a glance.

Every grid combination's per-return Sharpe feeds the trial set, so a wide grid that found one lucky peak deflates harder than a narrow grid that found a broadly-good region. The correction itself is core's `deflatedSharpeFromReturns`; this change only shapes the grid result into (selected returns, trial Sharpes) and adds the UI.

## Behaviour

- The chip flips green / amber / red around the ~0.95 credibility bar, with the selected combination's raw per-return Sharpe alongside.
- Renders only when a grid result exists (a walk-forward-only run leaves it hidden), placed above the Walk-Forward section.
- Falls back to an empty state when there are too few combinations or trades to estimate a Sharpe spread to correct against — including the case where filtering combinations with too few trades collapses the trial set below two.

## Notes

- The per-return Sharpe helper uses population variance (`/N`) to match core's Deflated Sharpe math, so the selected strategy's trial Sharpe equals the observed Sharpe core recomputes internally.
- The selected combination is picked by score (whatever metric the grid optimized) rather than assuming the results array is pre-sorted.

## Test plan

- `tsc -b` — exit 0
- `vitest run` — 108 passed (7 new in `robustness.test.ts`: probability range, highest-scoring selection regardless of array order, selection-bias monotonicity where more trials deflate harder, and the empty-state paths)
- `vite build` — success
- `biome check` — clean
- Manual smoke (headless browser): ran a 64-combo grid search on the Golden Cross / Dead Cross preset over SPY 1D. The Robustness tab rendered "Deflated Sharpe · borderline 91%" (amber), "Observed Sharpe 0.35", and "Best of 64 grid combos · 67 trades" — three-column layout, colors consistent with the credibility band.
