### PR TITLE
fix(chart): resolve react/vue to the real packages in tsconfig (baseUrl shadowing)

### DIFF
--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -68,6 +68,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "biome check .",

--- a/packages/chart/src/__tests__/andrews-pitchfork.test.ts
+++ b/packages/chart/src/__tests__/andrews-pitchfork.test.ts
@@ -40,7 +40,14 @@ const mockTs = () =>
   }) as TimeScale;
 
 const mockPs = () => ({ priceToY: (p: number) => 400 - p * 2 }) as PriceScale;
-const mockPane: PaneRect = { id: "main", x: 0, y: 0, width: 800, height: 400 };
+const mockPane: PaneRect = {
+  id: "main",
+  x: 0,
+  y: 0,
+  width: 800,
+  height: 400,
+  config: { id: "main", flex: 1 },
+};
 const makeCtx = (ctx: CanvasRenderingContext2D) =>
   ({ ctx, pane: mockPane, timeScale: mockTs(), priceScale: mockPs() }) as PrimitiveRenderContext;
 

--- a/packages/chart/src/__tests__/connect-indicators.test.ts
+++ b/packages/chart/src/__tests__/connect-indicators.test.ts
@@ -36,6 +36,7 @@ function createMockChart() {
       handles.push(record);
       return {
         id,
+        config: {},
         update: vi.fn((point: DataPoint) => {
           record.updates.push(point);
         }),

--- a/packages/chart/src/__tests__/interaction-inertia.test.ts
+++ b/packages/chart/src/__tests__/interaction-inertia.test.ts
@@ -8,7 +8,7 @@
  * it terminates.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import { InertiaController } from "../core/interaction/inertia";
 import type { PanInertiaState, ZoomInertiaState } from "../core/interaction/types";
 import { TimeScale } from "../core/scale";
@@ -33,7 +33,7 @@ describe("InertiaController.pan", () => {
   let ts: TimeScale;
   let pan: PanInertiaState;
   let zoom: ZoomInertiaState;
-  let onUpdate: ReturnType<typeof vi.fn>;
+  let onUpdate: Mock<() => void>;
   let inertia: InertiaController;
 
   beforeEach(() => {
@@ -96,7 +96,7 @@ describe("InertiaController.zoom", () => {
   let ts: TimeScale;
   let pan: PanInertiaState;
   let zoom: ZoomInertiaState;
-  let onUpdate: ReturnType<typeof vi.fn>;
+  let onUpdate: Mock<() => void>;
   let inertia: InertiaController;
 
   beforeEach(() => {

--- a/packages/chart/src/__tests__/pointer.test.ts
+++ b/packages/chart/src/__tests__/pointer.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getPointerPos, onDoubleTap, onTap } from "../core/pointer";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { getPointerPos, onDoubleTap, onTap, type PointerInfo } from "../core/pointer";
 
 function makeEl(rect: Partial<DOMRect> = {}): HTMLElement {
   const el = document.createElement("div");
@@ -54,7 +54,7 @@ describe("getPointerPos", () => {
 
 describe("onTap", () => {
   let el: HTMLElement;
-  let handler: ReturnType<typeof vi.fn>;
+  let handler: Mock<(pos: PointerInfo) => void>;
   beforeEach(() => {
     el = makeEl();
     handler = vi.fn();
@@ -166,7 +166,7 @@ describe("onTap", () => {
 
 describe("onDoubleTap", () => {
   let el: HTMLElement;
-  let handler: ReturnType<typeof vi.fn>;
+  let handler: Mock<(pos: PointerInfo) => void>;
   beforeEach(() => {
     el = makeEl();
     handler = vi.fn();

--- a/packages/chart/src/__tests__/viewport-attach.test.ts
+++ b/packages/chart/src/__tests__/viewport-attach.test.ts
@@ -68,8 +68,8 @@ function setup(
   const vp = new Viewport();
   const ts = makeTimeScale(opts.total);
   const panes: PaneRect[] = opts.panes ?? [
-    { id: "main", y: 0, height: 400, flex: 1 },
-    { id: "vol", y: 400, height: 200, flex: 0.5 },
+    { id: "main", x: 0, y: 0, width: 800, height: 400, config: { id: "main", flex: 1 } },
+    { id: "vol", x: 0, y: 400, width: 800, height: 200, config: { id: "vol", flex: 0.5 } },
   ];
   const scrollbar =
     opts.scrollbar !== undefined ? opts.scrollbar : { x: 0, y: 580, width: 800, height: 12 };
@@ -135,7 +135,7 @@ function fireTouch(el: HTMLElement, type: string, touches: Touch[]) {
     ev = new TouchEvent(type, {
       bubbles: true,
       cancelable: true,
-      touches: touches as unknown as TouchList,
+      touches,
     });
   } catch {
     ev = new Event(type, { bubbles: true, cancelable: true });

--- a/packages/chart/src/__tests__/volume-profile.test.ts
+++ b/packages/chart/src/__tests__/volume-profile.test.ts
@@ -33,7 +33,14 @@ const mockTs = () =>
   ({ startIndex: 0, endIndex: 50, barSpacing: 8, indexToX: (i: number) => i * 8 + 4 }) as TimeScale;
 
 const mockPs = () => ({ priceToY: (p: number) => 400 - p * 2 }) as PriceScale;
-const mockPane: PaneRect = { id: "main", x: 0, y: 0, width: 800, height: 400 };
+const mockPane: PaneRect = {
+  id: "main",
+  x: 0,
+  y: 0,
+  width: 800,
+  height: 400,
+  config: { id: "main", flex: 1 },
+};
 const makeCtx = (ctx: CanvasRenderingContext2D) =>
   ({ ctx, pane: mockPane, timeScale: mockTs(), priceScale: mockPs() }) as PrimitiveRenderContext;
 

--- a/packages/chart/tsconfig.json
+++ b/packages/chart/tsconfig.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
     "jsx": "react-jsx",
     "types": ["vitest/globals", "node", "react", "react-dom"]
   },


### PR DESCRIPTION
## Problem

Running `tsc --noEmit` on `@trendcraft/chart` produced ~100 type errors, even though `pnpm build` and CI were green. The bulk were `TS2305 "Module 'react'/'vue' has no exported member ..."` plus an implicit-`any` cascade downstream of them.

## Root cause

`packages/chart/tsconfig.json` set `baseUrl: "."`. With bundler module resolution, a non-relative `import ... from "react"` (or `"vue"`) is resolved against `baseUrl` first — and the package has `react/` and `vue/` wrapper directories. So `react` resolved to the project's own `react/index.ts` (which re-exports `TrendChart`, not `useEffect`), and likewise for `vue`. Every named hook/type import then failed, and the resulting `any` rippled outward.

The Vite build doesn't hit this: Vite resolves and externalizes `react`/`vue` through its own resolver, so the shadowing only bites a direct type-check. (Confirmed via `tsc --traceResolution`, which showed `react` resolving to `packages/chart/react/index.ts`.)

## Fix

- Remove `baseUrl` and the `paths` alias `@/*` (which had **zero** usages) from the chart tsconfig. With bundler resolution neither is needed, and dropping `baseUrl` stops the wrapper directories from shadowing the npm packages. This clears all the react/vue resolution failures and the implicit-`any` cascade — including the long-standing implicit-`any` in `vue/useTrendChart.ts`.
- Fix the genuine stale test fixtures the resolution fix then exposed:
  - `PaneRect` now requires `config: PaneConfig` and `SeriesHandle` requires `config: SeriesConfig`; mocks in andrews-pitchfork / volume-profile / viewport-attach / connect-indicators were missing it. The viewport-attach panes also had a top-level `flex` that belongs inside `config`.
  - `pointer` / `interaction-inertia` typed mock callbacks as `ReturnType<typeof vi.fn>` (broad `Mock<Procedure | Constructable>`), not assignable to the specific handler signatures → typed as `Mock<(pos: PointerInfo) => void>` / `Mock<() => void>`.
  - `viewport-attach` cast `Touch[]` to `TouchList` for a `TouchEventInit.touches` field that wants `Touch[]` → dropped the cast.
- Add a `typecheck` script (`tsc --noEmit`) so the package can be type-checked directly.

No production code changed — only the tsconfig, test fixtures, and a new script.

## Test plan

- `pnpm --filter @trendcraft/chart typecheck` — 0 errors (was ~100)
- `pnpm --filter @trendcraft/chart build` — success
- `pnpm --filter @trendcraft/chart test` — 909 passed
- `pnpm --filter @trendcraft/chart lint` — clean (289 files)
- `pnpm --filter @trendcraft/chart size-check` — all bundles within limits

## Follow-up (separate PR)

`@trendcraft/mcp` has 12 pre-existing type errors in `src/dispatcher/signal-map.ts` (optional vs required `volume`), unrelated to this change. A follow-up will fix those and wire a `typecheck` step into CI and the pre-push hook so type errors are caught before they accumulate — the reason this batch went unnoticed is that nothing ran `tsc --noEmit` in CI or any git hook.
