### PR TITLE
fix(mcp): require real volume for volume-reading signals; add typecheck gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
 
       - run: pnpm build
 
+      # After build: chart/mcp type-check against `trendcraft`'s published
+      # types (packages/core/dist/*.d.ts), which only exist post-build.
+      - run: pnpm typecheck
+
       - run: pnpm test
 
       - name: Cross-validation (TA-Lib compatibility)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "scripts": {
     "build": "pnpm -r build",
+    "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "biome check .",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
     "types": ["vitest/globals", "node"]
   },
   "include": ["src/**/*", "bin/**/*"],

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "dev": "vite build --watch",
     "build": "vite build",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "start": "node ./dist/bin/trendcraft-mcp.js",

--- a/packages/mcp/src/__tests__/detect-signal.test.ts
+++ b/packages/mcp/src/__tests__/detect-signal.test.ts
@@ -71,6 +71,41 @@ describe("detectSignalHandler", () => {
     );
   });
 
+  it("rejects a volume-based signal when any candle omits volume (INVALID_INPUT)", () => {
+    // Strip volume off the candles — a volume signal must not see fabricated
+    // zeros, so the dispatcher should reject rather than zero-fill.
+    const priceOnly = trendingCandles(40).map(({ volume: _volume, ...c }) => c);
+    expect(() => detectSignalHandler({ kind: "volumeBreakout", candles: priceOnly })).toThrow(
+      /INVALID_INPUT.*reads volume.*40 candle/s,
+    );
+  });
+
+  it("rejects a price-based signal routed onto volume via source:'volume' when volume is omitted", () => {
+    // perfectOrder is price-based, but `source: "volume"` makes it read
+    // candle volume through getPrice — the guard must catch this dynamic
+    // path too, not just the static usesVolume kinds.
+    const priceOnly = trendingCandles(60).map(({ volume: _volume, ...c }) => c);
+    expect(() =>
+      detectSignalHandler({
+        kind: "perfectOrder",
+        candles: priceOnly,
+        params: { source: "volume" },
+      }),
+    ).toThrow(/INVALID_INPUT.*reads volume/s);
+  });
+
+  it("tolerates omitted volume for a price-only signal (zero-filled, no throw)", () => {
+    const priceOnly = trendingCandles(80).map(({ volume: _volume, ...c }) => c);
+    const result = detectSignalHandler({
+      kind: "goldenCross",
+      candles: priceOnly,
+      params: { short: 5, long: 25 },
+      lastN: 0,
+    });
+    expect(result.kind).toBe("goldenCross");
+    expect(result.totalLength).toBe(80);
+  });
+
   it("reclassifies invalid params (short>=long) as INVALID_PARAMETER", () => {
     expect(() =>
       detectSignalHandler({

--- a/packages/mcp/src/dispatcher/signal-map.ts
+++ b/packages/mcp/src/dispatcher/signal-map.ts
@@ -27,6 +27,16 @@ import {
 } from "trendcraft";
 import type { Candle } from "../schemas/candle";
 
+/**
+ * A {@link Candle} whose `volume` has been resolved to a number. The MCP
+ * candle schema accepts `volume` as optional (callers may omit it for
+ * price-only signals), but `trendcraft`'s signal functions take
+ * `Candle[] | NormalizedCandle[]` where `volume` is required. The
+ * dispatcher fills a missing `volume` with `0` before invoking `fn`, so
+ * registry implementations can hand candles straight to `trendcraft`.
+ */
+export type ResolvedCandle = Candle & { volume: number };
+
 export type SignalShape = "series" | "events";
 
 export interface SignalDescriptor {
@@ -42,7 +52,15 @@ export interface SignalDescriptor {
    * `value === true || value.formed === true`.
    */
   firesAt?: (value: unknown) => boolean;
-  fn: (candles: Candle[], options?: Record<string, unknown>) => unknown;
+  /**
+   * True when the signal reads candle `volume`. The dispatcher rejects
+   * input that omits volume on any bar for these kinds rather than
+   * fabricating it — a synthetic zero would distort volume averages and
+   * could fire a false breakout/cross. Price-only signals leave this
+   * unset and tolerate a missing (zero-filled) volume.
+   */
+  usesVolume?: boolean;
+  fn: (candles: ResolvedCandle[], options?: Record<string, unknown>) => unknown;
 }
 
 export function defaultFiresAt(value: unknown): boolean {
@@ -96,12 +114,14 @@ const REGISTRY: Record<string, SignalDescriptor> = {
     shape: "events",
     oneLiner: "Divergence between price and OBV swings.",
     paramsHint: "DivergenceOptions — see trendcraft signals docs.",
+    usesVolume: true,
     fn: (c, o) => obvDivergence(c, o as Parameters<typeof obvDivergence>[1]),
   },
   volumeBreakout: {
     shape: "events",
     oneLiner: "Volume exceeds N-period MA × ratio — breakout volume confirmation.",
     paramsHint: "{ period?: number = 20, minRatio?: number = 1.0 }",
+    usesVolume: true,
     fn: (c, o) => volumeBreakout(c, o as Parameters<typeof volumeBreakout>[1]),
   },
   volumeAccumulation: {
@@ -109,6 +129,7 @@ const REGISTRY: Record<string, SignalDescriptor> = {
     oneLiner: "Sustained positive volume slope (regression-confirmed accumulation).",
     paramsHint:
       "{ period?: number = 10, minSlope?: number = 0.05, minRSquared?: number = 0.3, minConsecutiveDays?: number = 3 }",
+    usesVolume: true,
     fn: (c, o) => volumeAccumulation(c, o as Parameters<typeof volumeAccumulation>[1]),
   },
   volumeMaCross: {
@@ -116,6 +137,7 @@ const REGISTRY: Record<string, SignalDescriptor> = {
     oneLiner: "Volume short-MA crosses volume long-MA — institutional interest signal.",
     paramsHint:
       "{ shortPeriod?: number = 5, longPeriod?: number = 20, minRatio?: number = 1.0, bullishOnly?: boolean = true }",
+    usesVolume: true,
     fn: (c, o) => volumeMaCross(c, o as Parameters<typeof volumeMaCross>[1]),
   },
   volumeAboveAverage: {
@@ -123,6 +145,7 @@ const REGISTRY: Record<string, SignalDescriptor> = {
     oneLiner: "Volume sustained above N-period MA × ratio for K consecutive days.",
     paramsHint:
       "{ period?: number = 20, minRatio?: number = 1.0, minConsecutiveDays?: number = 3 }",
+    usesVolume: true,
     fn: (c, o) => volumeAboveAverage(c, o as Parameters<typeof volumeAboveAverage>[1]),
   },
   candlestickPatterns: {

--- a/packages/mcp/src/tools/detect-signal.ts
+++ b/packages/mcp/src/tools/detect-signal.ts
@@ -71,9 +71,30 @@ export function detectSignalHandler(
   // underlying signal function.
   validateIndicatorParams(input.kind, input.params);
 
+  // `trendcraft`'s signal functions require a numeric `volume`, but the
+  // MCP candle schema allows it to be omitted (price-only callers).
+  //
+  // A signal reads volume either intrinsically (the `usesVolume` kinds) or
+  // dynamically, when the caller routes a price-source option onto volume
+  // (`source: "volume"`, read via `getPrice`). In both cases it must see real
+  // volume on every bar: zero-filling a missing one would feed a synthetic
+  // zero into the computation and could fabricate a signal, so reject the
+  // input instead. Price-only reads ignore volume, so a missing one is
+  // filled with 0 to satisfy `trendcraft`'s numeric-volume contract.
+  const readsVolume = desc.usesVolume === true || input.params?.source === "volume";
+  if (readsVolume) {
+    const missing = candles.filter((c) => c.volume === undefined).length;
+    if (missing > 0) {
+      throw new Error(
+        `INVALID_INPUT: signal "${input.kind}" reads volume, but ${missing} of ${candles.length} candle(s) omit it. Provide volume on every bar, or choose a price-only signal.`,
+      );
+    }
+  }
+  const resolvedCandles = candles.map((c) => ({ ...c, volume: c.volume ?? 0 }));
+
   let raw: unknown;
   try {
-    raw = desc.fn(candles, input.params);
+    raw = desc.fn(resolvedCandles, input.params);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (MISSING_PARAMS_RE.test(message)) {

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist",
-    "baseUrl": ".",
     "lib": ["ES2022"],
     "types": ["vitest/globals", "node"]
   },


### PR DESCRIPTION
Follow-up to the chart tsconfig fix. Closes the remaining type errors (in `@trendcraft/mcp`) and adds a type-check gate so this class of error can't accumulate unseen again — the root reason the recent batch went unnoticed is that nothing ran `tsc --noEmit` in CI or any git hook.

## mcp: require real volume for volume-reading signals

The MCP candle schema accepts `volume` as optional, but `trendcraft`'s signal functions take `Candle[] | NormalizedCandle[]` where `volume` is a required number. `detect_signal` passed the optional-volume candles straight through, which failed `tsc --noEmit` (12 errors) and, at runtime, would feed `undefined` into volume math.

Resolved at the dispatch boundary rather than by fabricating data:

- A signal reads volume either **intrinsically** (the `usesVolume` registry kinds: `obvDivergence`, `volumeBreakout`, `volumeAccumulation`, `volumeMaCross`, `volumeAboveAverage`) or **dynamically**, when the caller routes a price-source option onto volume (`source: "volume"`, read via `getPrice`). For both, reject input that omits volume on any bar with `INVALID_INPUT` — a synthetic zero would distort volume averages and could fabricate a breakout/cross.
- Price-only reads ignore volume, so a missing one is filled with `0` to satisfy `trendcraft`'s numeric-volume contract.
- `SignalDescriptor` gains a `usesVolume` flag and a `ResolvedCandle` (volume-required) type for the registry `fn` signature.
- Tests cover the static reject, the dynamic `source: "volume"` reject, and the price-only tolerated path.

## Type-check gate

- Add a `typecheck` script (`tsc --noEmit`) to core / mcp / chart, and a root `typecheck` that runs them all (`pnpm -r typecheck`).
- Wire `pnpm typecheck` into CI **after** `pnpm build` — chart/mcp resolve `trendcraft` through its published declarations (`packages/core/dist/*.d.ts`), which only exist post-build.
- Pre-push stays lint-only: a local typecheck would need a build first (same dist dependency), so type-checking is enforced authoritatively in CI instead.

## Drop deprecated `baseUrl`

- Remove `baseUrl` (and the unused `@/*` paths) from the core and mcp tsconfigs. `baseUrl` is removed in TypeScript 7.0 and made plain `tsc --noEmit` fail with `TS5101`; neither package uses the alias. (The chart package already dropped it in the preceding fix.)

## Test plan

- `pnpm typecheck` — clean across core / chart / mcp (was: chart ~100 + mcp 12 under raw `tsc`)
- `pnpm build` — success
- `pnpm test` — core 6063 / chart 909 / mcp 77 / strategy-studio 108
- `pnpm lint` — clean (1414 files)
