### PR TITLE
fix(core): preserve un-deployed capital on volume-constrained partial fills

### DIFF
--- a/packages/core/src/backtest/__tests__/volume-constraint.test.ts
+++ b/packages/core/src/backtest/__tests__/volume-constraint.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { ConditionFn, NormalizedCandle } from "../../types";
+import { runBacktest } from "../engine";
+
+/** Flat market: price never moves, so a backtest's final capital must equal
+ *  the initial capital (minus any fees) regardless of how shares were sized. */
+function flatCandles(count: number, price = 100, volume = 100): NormalizedCandle[] {
+  return Array.from({ length: count }, (_, i) => ({
+    time: 1_700_000_000_000 + i * 86_400_000,
+    open: price,
+    high: price + 1,
+    low: price - 1,
+    close: price,
+    volume,
+  }));
+}
+
+const enterAt =
+  (index: number): ConditionFn =>
+  (_ind, _candle, i) =>
+    i === index;
+const never: ConditionFn = () => false;
+
+describe("backtest volumeConstraint capital conservation", () => {
+  it("a volume-constrained partial fill does not erase un-deployed capital (flat market)", () => {
+    const candles = flatCandles(30);
+    // maxVolumePercent 10 on volume 100 caps the order at 10 shares, far below
+    // the ~10,000 shares the full capital would buy at price 100 — a partial fill.
+    const result = runBacktest(candles, enterAt(2), never, {
+      capital: 1_000_000,
+      volumeConstraint: { maxVolumePercent: 10 },
+    });
+    expect(result.trades.length).toBe(1);
+    // Flat market → final capital must be ~initial (no fees configured here).
+    // Before the fix this returned ~1,000 (a 99.9% phantom loss).
+    expect(result.finalCapital).toBeCloseTo(1_000_000, 6);
+  });
+
+  it("a non-binding volume constraint behaves identically to no constraint", () => {
+    const candles = flatCandles(30);
+    const base = runBacktest(candles, enterAt(2), never, { capital: 1_000_000 });
+    const loose = runBacktest(candles, enterAt(2), never, {
+      capital: 1_000_000,
+      // Huge cap → never shrinks the order → full fill, identical to no constraint.
+      volumeConstraint: { maxVolumePercent: 1_000_000 },
+    });
+    expect(loose.finalCapital).toBe(base.finalCapital);
+    expect(loose.trades.length).toBe(base.trades.length);
+  });
+
+  it("conserves capital across a constrained round-trip (entry + exit on flat market)", () => {
+    const candles = flatCandles(30);
+    const result = runBacktest(candles, enterAt(2), enterAt(20), {
+      capital: 1_000_000,
+      volumeConstraint: { maxVolumePercent: 10 },
+    });
+    expect(result.trades.length).toBe(1);
+    expect(result.finalCapital).toBeCloseTo(1_000_000, 6);
+  });
+
+  it("charges percentage commission only on the filled notional, not the full order", () => {
+    const candles = flatCandles(30);
+    // 10 shares @ 100 = 1,000 filled notional. A 1% rate is ~10 entry + ~10 exit
+    // commission → final ≈ 999,980. The earlier fix erroneously charged 1% of the
+    // full 1,000,000 available capital (~10,000), which would land near 990,000.
+    const result = runBacktest(candles, enterAt(2), enterAt(20), {
+      capital: 1_000_000,
+      commissionRate: 1,
+      volumeConstraint: { maxVolumePercent: 10 },
+    });
+    expect(result.trades.length).toBe(1);
+    // Fees are on the ~1,000 filled notional, so only tens of currency units —
+    // not the ~10,000 the full-capital commission would have removed.
+    expect(result.finalCapital).toBeGreaterThan(999_900);
+    expect(result.finalCapital).toBeLessThanOrEqual(1_000_000);
+  });
+
+  it("FOK (partialFill: false) rejects a volume-constrained entry rather than deploying capital", () => {
+    const candles = flatCandles(30);
+    const result = runBacktest(candles, enterAt(2), never, {
+      capital: 1_000_000,
+      volumeConstraint: { maxVolumePercent: 10, partialFill: false },
+    });
+    // Order can't fully fill within the volume cap → no trade, capital untouched.
+    expect(result.trades.length).toBe(0);
+    expect(result.finalCapital).toBe(1_000_000);
+  });
+});

--- a/packages/core/src/backtest/engine.ts
+++ b/packages/core/src/backtest/engine.ts
@@ -396,6 +396,11 @@ export function runBacktest(
     const entryCommission = commission + availCap * (commissionRate / 100);
     let shares = (availCap - entryCommission) / entryPrice;
 
+    // Whether a volume constraint actually shrank the order below a full fill.
+    // A full fill deploys all available capital (shares * price + commission ==
+    // availCap by construction), so draining the account to 0 is correct. A
+    // partial fill must NOT drain it — only the filled notional leaves.
+    let partiallyFilled = false;
     if (volumeConstraint) {
       const originalShares = shares;
       shares = applyVolumeConstraint(shares, entryPrice, candle, volumeConstraint);
@@ -404,15 +409,38 @@ export function runBacktest(
       if (allowPartialFill === false && shares < originalShares) {
         shares = 0;
       }
+      partiallyFilled = shares > 0 && shares < originalShares;
     }
 
     if (shares <= 0) return null;
 
     const pos = createPosition(entryTime, entryPrice, shares, entryAtr, initialHigh, initialLow);
-    if (marginConfig && marginState) {
-      marginState.borrowedAmount = currentCapital * (marginConfig.leverage - 1);
+    if (partiallyFilled) {
+      // Deduct only the deployed notional + commission; the un-deployed capital
+      // stays as cash. Zeroing currentCapital here (as a full fill does) would
+      // erase it — exit only credits back the deployed shares' value, so the
+      // difference would vanish as a phantom loss on every constrained entry.
+      //
+      // Commission is recomputed on the FILLED notional, not the full-order
+      // `entryCommission` (which is the percentage fee on the whole available
+      // capital): charging the unfilled portion's fee would itself break
+      // capital conservation whenever a percentage commissionRate is set.
+      const filledNotional = shares * entryPrice;
+      const filledCommission = commission + filledNotional * (commissionRate / 100);
+      const deployedCost = filledNotional + filledCommission;
+      if (marginConfig && marginState) {
+        // Fund from cash first; borrow only the remainder of the deployed cost.
+        marginState.borrowedAmount = Math.max(0, deployedCost - currentCapital);
+        currentCapital = Math.max(0, currentCapital - (deployedCost - marginState.borrowedAmount));
+      } else {
+        currentCapital = availCap - deployedCost;
+      }
+    } else {
+      if (marginConfig && marginState) {
+        marginState.borrowedAmount = currentCapital * (marginConfig.leverage - 1);
+      }
+      currentCapital = 0;
     }
-    currentCapital = 0;
     return pos;
   }
 


### PR DESCRIPTION
## Problem

`runBacktest` with a `volumeConstraint` (and the default `partialFill: true`) corrupts equity catastrophically. On a flat market — price 100 throughout, capital 1,000,000, a single entry held to the end — the reported final capital is **1,000** (a ~99.9% phantom loss) instead of ~1,000,000.

Reproduced before the fix:

```
NO constraint     -> finalCapital: 1,000,000
volumeConstraint  -> finalCapital: 1,000   ← phantom loss of 999,000
```

## Root cause

`openPositionFromEntry` (`engine.ts`) sizes shares from the full available capital, optionally shrinks them via `applyVolumeConstraint`, then sets `currentCapital = 0` unconditionally. That zeroing is only valid for a **full** fill, where `shares * price + commission === availableCapital` by construction. For a volume-constrained **partial** fill the position's cost basis is only the deployed notional, so the un-deployed cash is erased — and on exit only `shares * exitPrice` is credited back, so it never returns. Every constrained entry leaks `(availableCapital − deployedCost)` from equity, wrecking totalReturn / drawdown / Sharpe / CAGR.

No test exercised `volumeConstraint`, so the suite stayed green.

## Fix

- On a partial fill, deduct only the **filled notional + commission** and retain the rest as cash. The full-fill path is untouched (still drains to 0), so all existing backtests are bit-for-bit unchanged.
- Recompute the entry commission on the **filled notional** rather than the full-order percentage fee, so capital conservation also holds when a percentage `commissionRate` is configured.
- The margin path borrows only the remainder of the deployed cost beyond cash on hand.

## Tests

New `volume-constraint.test.ts` (5 cases): flat-market capital conservation (the regression), non-binding-constraint == no-constraint parity, a constrained entry→exit round-trip, filled-notional commission, and FOK (`partialFill: false`) rejection.

## Test plan

- New test file: 5 passed
- `pnpm --filter trendcraft test` (backtest suite): 675 passed; full core suite 6067 passed
- `tsc --noEmit`: clean
- `biome check`: clean
