### PR TITLE
fix(core): walk-forward MAR aggregation, short-position equity, missing extractTradeReturns export

### DIFF
--- a/packages/core/src/__tests__/public-exports.test.ts
+++ b/packages/core/src/__tests__/public-exports.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import * as trendcraft from "../index";
+import type { BacktestResult } from "../types";
+
+/**
+ * Guards the package's public barrel (`src/index.ts`). Symbols referenced by a
+ * shipped `@example` must actually be re-exported from the root, or a user
+ * copy-pasting the documented usage hits a runtime TypeError.
+ */
+describe("public root exports", () => {
+  it("re-exports extractTradeReturns (used by the deflatedSharpeFromReturns @example)", () => {
+    expect(typeof trendcraft.extractTradeReturns).toBe("function");
+  });
+
+  it("extractTradeReturns returns per-trade decimal returns from a BacktestResult", () => {
+    const result = {
+      trades: [{ returnPercent: 5 }, { returnPercent: -2 }, { returnPercent: 0 }],
+    } as unknown as BacktestResult;
+    expect(trendcraft.extractTradeReturns(result)).toEqual([0.05, -0.02, 0]);
+  });
+
+  it("the documented Deflated Sharpe pipeline (extractTradeReturns → deflatedSharpeFromReturns) is callable from the root", () => {
+    const best = {
+      trades: Array.from({ length: 30 }, (_, i) => ({ returnPercent: i % 2 === 0 ? 3 : -1 })),
+    } as unknown as BacktestResult;
+    const returns = trendcraft.extractTradeReturns(best);
+    const trialSharpes = [0.1, 0.2, 0.15, 0.05];
+    const dsr = trendcraft.deflatedSharpeFromReturns(returns, trialSharpes);
+    expect(typeof dsr).toBe("number");
+    expect(dsr).toBeGreaterThanOrEqual(0);
+    expect(dsr).toBeLessThanOrEqual(1);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -665,6 +665,7 @@ export {
   createExitConditionPool,
   crowdingDistance,
   extractSensitivityData,
+  extractTradeReturns,
   fastNonDominatedSort,
   formatAWFResult,
   formatCombinationResult,

--- a/packages/core/src/optimization/__tests__/walkforward.test.ts
+++ b/packages/core/src/optimization/__tests__/walkforward.test.ts
@@ -158,6 +158,28 @@ describe("Walk-Forward Analysis", () => {
       expect(result.recommendation).toBeDefined();
     });
 
+    it("aggregates the 'mar' metric (regression: mar was missing from metricKeys)", () => {
+      const candles = generateUpTrendCandles(300);
+      const createStrategy = (params: Record<string, number>) => ({
+        entry: createEnterCondition(Math.round(params.enterAfter)),
+        exit: createExitCondition(10, Math.round(params.enterAfter)),
+        options: { capital: 100000 } as BacktestOptions,
+      });
+
+      const result = walkForwardAnalysis(candles, createStrategy, [param("enterAfter", 5, 15, 5)], {
+        windowSize: 100,
+        stepSize: 50,
+        testSize: 50,
+        metric: "mar",
+      });
+
+      // Before the fix "mar" was absent from metricKeys, so these were
+      // undefined (violating the Record<OptimizationMetric, number> type) and
+      // stabilityRatio silently collapsed to 0 for any mar-optimized run.
+      expect(Number.isFinite(result.aggregateMetrics.avgInSample.mar)).toBe(true);
+      expect(Number.isFinite(result.aggregateMetrics.avgOutOfSample.mar)).toBe(true);
+    });
+
     it("should throw error for insufficient data", () => {
       const candles = generateUpTrendCandles(50);
 

--- a/packages/core/src/optimization/walkforward.ts
+++ b/packages/core/src/optimization/walkforward.ts
@@ -286,9 +286,14 @@ function calculateAggregateMetrics(
   outOfSampleMetrics: Record<OptimizationMetric, number>[],
   primaryMetric: OptimizationMetric,
 ): WalkForwardResult["aggregateMetrics"] {
+  // Must list every OptimizationMetric: a key omitted here is never averaged,
+  // so aggregateMetrics[key] stays undefined and any run optimized on that
+  // metric (e.g. "mar") silently collapses stabilityRatio to 0 and the
+  // recommendation to the pessimistic branch.
   const metricKeys: OptimizationMetric[] = [
     "sharpe",
     "calmar",
+    "mar",
     "profitFactor",
     "recoveryFactor",
     "returns",

--- a/packages/core/src/streaming/position-manager/__tests__/position-tracker.test.ts
+++ b/packages/core/src/streaming/position-manager/__tests__/position-tracker.test.ts
@@ -462,4 +462,32 @@ describe("createPositionTracker", () => {
       expect(pos.id).toBe("pos-2");
     });
   });
+
+  describe("short position open-equity (regression: equity inverted for shorts)", () => {
+    it("moves equity UP when a short's price falls (winning short)", () => {
+      const tracker = createPositionTracker({ capital: 100_000, direction: "short" });
+      tracker.openPosition(100, 100, 1000); // short 100 sh @ 100 → cash 90,000
+      // Price falls to 90 → a +1,000 profit for the short.
+      tracker.updatePrice(makeCandle({ close: 90, high: 91, low: 89 }));
+
+      const account = tracker.getAccount();
+      expect(account.unrealizedPnl).toBe(1000);
+      // Equity must rise to 101,000. The old long-only formula
+      // (cash + currentPrice*shares = 90,000 + 90*100) wrongly gave 99,000,
+      // inverting the equity/drawdown curve against price for every short.
+      expect(account.equity).toBe(101_000);
+      expect(account.peakEquity).toBe(101_000);
+      expect(account.maxDrawdownPercent).toBe(0);
+    });
+
+    it("moves equity DOWN when a short's price rises (losing short)", () => {
+      const tracker = createPositionTracker({ capital: 100_000, direction: "short" });
+      tracker.openPosition(100, 100, 1000);
+      tracker.updatePrice(makeCandle({ close: 110, high: 111, low: 109 }));
+
+      const account = tracker.getAccount();
+      expect(account.unrealizedPnl).toBe(-1000);
+      expect(account.equity).toBe(99_000);
+    });
+  });
 });

--- a/packages/core/src/streaming/position-manager/position-tracker.ts
+++ b/packages/core/src/streaming/position-manager/position-tracker.ts
@@ -175,8 +175,13 @@ export function createPositionTracker(
     } else {
       account.unrealizedPnl =
         directionSign * (currentPrice - position.entryPrice) * position.shares;
-      // Equity = cash + position market value
-      account.equity = account.currentCapital + currentPrice * position.shares;
+      // Equity = cash + entry cost basis + unrealized P&L. This is
+      // direction-agnostic: for a long it equals the old `cash + currentPrice *
+      // shares` (entryPrice*shares + unrealizedPnl == currentPrice*shares), but
+      // for a short the old formula added the position's market value as if the
+      // borrowed shares were an asset, inverting equity/drawdown against price.
+      account.equity =
+        account.currentCapital + position.entryPrice * position.shares + account.unrealizedPnl;
     }
 
     // Track peak equity and drawdown


### PR DESCRIPTION
Three independent core correctness fixes surfaced by a pre-release audit. Each has a focused regression test.

## 1. Walk-forward `mar` metric silently mis-aggregated

`calculateAggregateMetrics` built its per-metric averages from a `metricKeys` list that omitted `"mar"`, although `"mar"` is a valid `OptimizationMetric` and `WalkForwardOptions.metric` accepts it. Running `walkForwardAnalysis(..., { metric: "mar" })` left `aggregateMetrics.avgInSample.mar` / `avgOutOfSample.mar` **undefined** (violating the `Record<OptimizationMetric, number>` type), which collapsed `stabilityRatio` to 0 and forced the pessimistic recommendation regardless of actual out-of-sample MAR — a silent wrong result on a documented, type-valid code path.

**Fix:** add `"mar"` to `metricKeys` (+ a comment that every `OptimizationMetric` must be listed).

## 2. Short-position open equity / drawdown inverted

`PositionTracker.updateUnrealized` computed `equity = cash + currentPrice * shares` — a long-only formula that adds a short's market value as if the borrowed shares were an asset. For a short, equity then moved the **wrong way** with price: a winning short (price falling) showed a *falling* equity curve mid-trade, firing phantom-loss drawdown stops and equity-curve filters. `unrealizedPnl` was already correct, so the two disagreed.

**Fix:** `equity = cash + entryPrice * shares + unrealizedPnl`, which is direction-agnostic — algebraically identical to the old formula for longs (verified against the existing long test) and correct for shorts.

## 3. `extractTradeReturns` documented but not exported

The shipped `@example` on `deflatedSharpeFromReturns` imports `extractTradeReturns` from `"trendcraft"`, but it was never re-exported from the package root (only from the `optimization` barrel), so the documented usage threw `extractTradeReturns is not a function` at runtime.

**Fix:** add `extractTradeReturns` to the root barrel.

## Test plan

- New / extended tests: walk-forward `mar` aggregation yields finite averages; short equity rises on a falling price and falls on a rising one (with peak/drawdown assertions); `public-exports.test.ts` asserts `extractTradeReturns` is on the root export and the documented `extractTradeReturns → deflatedSharpeFromReturns` pipeline runs.
- Full core suite: **6074 passed**
- `tsc --noEmit`: clean
- `biome check`: clean
