### PR TITLE
fix(core): guard NaN / divide-by-zero in relative-strength, Pareto, and stress-test analytics

### DIFF
--- a/packages/core/src/indicators/relative-strength/__tests__/benchmark-rs.test.ts
+++ b/packages/core/src/indicators/relative-strength/__tests__/benchmark-rs.test.ts
@@ -73,6 +73,20 @@ describe("benchmarkRS", () => {
       expect(latest.rs).toBeCloseTo(1.0, 1);
     });
 
+    it("never emits a NaN rsRating with a degenerate rankingLookback", () => {
+      // rankingLookback 1 lets the ranking gate open at a single sample, where
+      // the percentile divisor (length - 1) is 0. rsRating must stay null
+      // (insufficient data), never NaN.
+      const stock = generateTrendingCandles(100, 100, 0.01);
+      const benchmark = generateFlatCandles(100, 100);
+      const rs = benchmarkRS(stock, benchmark, { period: 20, rankingLookback: 1 });
+
+      expect(rs.length).toBeGreaterThan(0);
+      for (const point of rs) {
+        expect(Number.isNaN(point.value.rsRating as number)).toBe(false);
+      }
+    });
+
     it("should show RS > 1 when stock outperforms benchmark", () => {
       // Stock goes up 1% daily, benchmark flat
       const stock = generateTrendingCandles(100, 100, 0.01);
@@ -361,6 +375,9 @@ describe("Multi-Symbol RS", () => {
       expect(rankings).toHaveLength(1);
       expect(rankings[0].symbol).toBe("ONLY");
       expect(rankings[0].rank).toBe(1);
+      // Single symbol: percentile must be 100 (sole = strongest), not NaN from
+      // dividing by (length - 1) === 0.
+      expect(rankings[0].percentile).toBe(100);
     });
 
     it("should handle all symbols with insufficient data", () => {

--- a/packages/core/src/indicators/relative-strength/benchmark-rs.ts
+++ b/packages/core/src/indicators/relative-strength/benchmark-rs.ts
@@ -131,8 +131,13 @@ export function benchmarkRS(
       const lookback = Math.min(rsValues.length, rankingLookback);
       const recentValues = rsValues.slice(-lookback);
       const sortedValues = [...recentValues].sort((a, b) => a - b);
-      const rank = sortedValues.findIndex((v) => v >= rs);
-      rsRating = Math.round((rank / (sortedValues.length - 1)) * 100);
+      // A percentile rank needs at least two samples; with one the divisor
+      // (length - 1) is 0 → NaN. Leave rsRating null (insufficient data) — only
+      // reachable via a degenerate rankingLookback ≤ 1.
+      if (sortedValues.length >= 2) {
+        const rank = sortedValues.findIndex((v) => v >= rs);
+        rsRating = Math.round((rank / (sortedValues.length - 1)) * 100);
+      }
     }
 
     // Calculate Mansfield RS (deviation from SMA)

--- a/packages/core/src/indicators/relative-strength/multi-rs.ts
+++ b/packages/core/src/indicators/relative-strength/multi-rs.ts
@@ -108,7 +108,12 @@ export function rankByRS(
     symbol: r.symbol,
     rs: r.rs,
     rank: index + 1,
-    percentile: Math.round(((results.length - index - 1) / (results.length - 1)) * 100),
+    // Guard the single-symbol case: (length - 1) would be 0 → NaN. A sole
+    // ranked symbol is by definition the strongest, so its percentile is 100.
+    percentile:
+      results.length > 1
+        ? Math.round(((results.length - index - 1) / (results.length - 1)) * 100)
+        : 100,
     performance: r.performance,
   }));
 

--- a/packages/core/src/optimization/__tests__/pareto.test.ts
+++ b/packages/core/src/optimization/__tests__/pareto.test.ts
@@ -296,6 +296,42 @@ describe("Pareto Optimization", () => {
       }
     });
 
+    it("excludes entries with a non-finite objective metric from the front (NaN calmar on zero-drawdown data)", () => {
+      // Flat market → every trade nets 0 → maxDrawdown 0 → calmar / recoveryFactor
+      // are NaN. NaN breaks non-dominated sorting (never dominated), so such
+      // entries used to pollute the Pareto front. They must be filtered out.
+      const flat: NormalizedCandle[] = Array.from({ length: 100 }, (_, i) => ({
+        time: 1_700_000_000_000 + i * 86_400_000,
+        open: 100,
+        high: 100,
+        low: 100,
+        close: 100,
+        volume: 1000,
+      }));
+      const flatStrategy = (params: Record<string, number>) => ({
+        entry: createEnterCondition(Math.floor(params.enterAt)),
+        exit: createExitCondition(Math.floor(params.enterAt) + 10),
+      });
+
+      const result = paretoOptimization(
+        flat,
+        flatStrategy,
+        [{ name: "enterAt", min: 5, max: 15, step: 5 }],
+        {
+          objectives: [
+            { metric: "calmar", direction: "maximize" },
+            { metric: "returns", direction: "maximize" },
+          ],
+        },
+      );
+
+      // No front member may carry a NaN objective metric (before the fix the
+      // NaN-calmar entries landed in front 0 as spurious "optimal" solutions).
+      for (const entry of result.paretoFront) {
+        expect(Number.isFinite(entry.metrics.calmar)).toBe(true);
+      }
+    });
+
     it("should filter results with constraints", () => {
       const candles = generateUpTrendCandles(100);
 

--- a/packages/core/src/optimization/pareto.ts
+++ b/packages/core/src/optimization/pareto.ts
@@ -265,7 +265,17 @@ export function paretoOptimization(
         checkConstraint(getMetricValue(metrics, c.metric), c.operator, c.value),
       );
 
-      if (passedConstraints) {
+      // Skip entries whose objective metrics are non-finite. calmar / mar /
+      // recoveryFactor return NaN when maxDrawdown <= 0 (flat or never-underwater
+      // equity), and NaN breaks non-dominated sorting: `va < vb` and `va > vb`
+      // are both false for NaN, so such an entry is never dominated and pollutes
+      // the Pareto front as a spurious "optimal" solution (and destabilizes the
+      // crowding-distance sort). Mirror gridSearch's finite-score filter.
+      const objectivesFinite = objectives.every((o) =>
+        Number.isFinite(getMetricValue(metrics, o.metric)),
+      );
+
+      if (passedConstraints && objectivesFinite) {
         // Use first objective's metric value as the "score" for compatibility
         const score = getMetricValue(metrics, objectives[0].metric);
         validEntries.push({

--- a/packages/core/src/risk/__tests__/stress-test.test.ts
+++ b/packages/core/src/risk/__tests__/stress-test.test.ts
@@ -144,6 +144,25 @@ describe("stressTest", () => {
     expect(typeof result.stressedCVaR).toBe("number");
   });
 
+  it("CVaR averages the worst (varIdx + 1) returns, including the VaR observation", () => {
+    // No-shock scenario → stressed === returns, so the tail is fully
+    // deterministic. 20 returns → varIdx = floor(20 * 0.05) = 1, so the 95% CVaR
+    // is the mean of the two worst returns (indices 0 and 1). The earlier
+    // off-by-one (slice(0, max(varIdx,1)) → only index 0) dropped the VaR
+    // observation and averaged just the single worst return.
+    const tail = [-0.1, -0.08];
+    const det = [...tail, ...Array.from({ length: 18 }, () => 0.01)];
+    const noShock = { name: "No shock", description: "identity", shocks: [] };
+    const result = stressTest(det, noShock);
+
+    // VaR observation is the 2nd-worst (index varIdx = 1) → 0.08.
+    expect(result.stressedVaR).toBeCloseTo(0.08, 10);
+    // CVaR = -mean(-0.1, -0.08) = 0.09 (worst two), NOT 0.10 (worst one only).
+    expect(result.stressedCVaR).toBeCloseTo(0.09, 10);
+    // Expected shortfall is at least as deep as VaR.
+    expect(result.stressedCVaR).toBeGreaterThanOrEqual(result.stressedVaR);
+  });
+
   it("drawdown scenario increases max drawdown vs original", () => {
     const scenario = PRESET_SCENARIOS.lehman2008;
     const result = stressTest(returns, scenario);

--- a/packages/core/src/risk/stress-test.ts
+++ b/packages/core/src/risk/stress-test.ts
@@ -326,8 +326,11 @@ export function stressTest(
   const varIdx = Math.floor(sorted.length * 0.05);
   const stressedVaR = -sorted[Math.max(varIdx, 0)];
 
-  // CVaR = mean of returns below VaR threshold
-  const tailReturns = sorted.slice(0, Math.max(varIdx, 1));
+  // CVaR = mean of returns at or below the VaR threshold. slice's end is
+  // exclusive, so include index varIdx (the VaR observation itself) via
+  // varIdx + 1 — matching calculateVaR's `<= threshold` convention. Using
+  // `Math.max(varIdx, 1)` previously dropped the VaR observation from the tail.
+  const tailReturns = sorted.slice(0, varIdx + 1);
   const stressedCVaR =
     tailReturns.length > 0
       ? -(tailReturns.reduce((s, v) => s + v, 0) / tailReturns.length)


### PR DESCRIPTION
Four numerical robustness fixes surfaced by a pre-release audit (NaN / divide-by-zero / off-by-one in analytics). Each has a focused regression test; all are in shipped, publicly-exported code.

## `rankByRS` — NaN percentile for a single symbol

`percentile = round(((n - i - 1) / (n - 1)) * 100)` divides by `(n - 1) === 0` when only one symbol qualifies, yielding `percentile: NaN`. `filterByRSPercentile` then drops it (`NaN >= 80` is false). A sole ranked symbol is by definition the strongest → **percentile 100**.

## `benchmarkRS` — NaN `rsRating` for a degenerate `rankingLookback`

With `rankingLookback <= 1` the ranking gate opens at a single sample, where the percentile divisor `(length - 1)` is 0 → `rsRating: NaN` despite the `number | null` contract. Require **≥ 2 samples**, otherwise leave `rsRating` null. The default `rankingLookback` (252, floor 20) is unaffected.

## `paretoOptimization` — NaN objective metrics pollute the front

`calmar` / `mar` / `recoveryFactor` are NaN when `maxDrawdown <= 0` (flat / never-underwater equity). NaN breaks non-dominated sorting — `a < b` and `a > b` are both false, so a NaN-objective entry is never dominated and lands in front 0 as a spurious "optimal" solution (and destabilizes crowding-distance order). **Skip entries whose objective metrics are non-finite**, mirroring `gridSearch`'s finite-score filter.

## `stress-test` CVaR — off-by-one drops the VaR observation

The expected-shortfall tail used `slice(0, max(varIdx, 1))`, whose exclusive end **excluded the VaR observation at index `varIdx`**. Use `slice(0, varIdx + 1)` to average returns at or below the VaR threshold, matching `calculateVaR`'s `<= threshold` convention.

## Test plan

- New / extended tests: single-symbol percentile 100; no NaN `rsRating` with `rankingLookback: 1`; Pareto front carries no NaN objective metric on zero-drawdown data; CVaR equals the mean of the worst `varIdx + 1` returns (deterministic no-shock scenario).
- Full core suite: **6077 passed**
- `tsc --noEmit`: clean
- `biome check`: clean
