### PR TITLE
fix(chart): per-instance decimation cache, touch-tap double-fire, Vue options reactivity

### DIFF
--- a/packages/chart/src/__tests__/helpers/mock-chart-instance.ts
+++ b/packages/chart/src/__tests__/helpers/mock-chart-instance.ts
@@ -45,6 +45,7 @@ export function createMockChartInstance(): MockChartInstance {
     }),
     setChartType: vi.fn(),
     setLayout: vi.fn(),
+    applyOptions: vi.fn(),
     addIndicator: vi.fn((_data: unknown, _config?: unknown) => {
       const handle = {
         remove: vi.fn(() => {

--- a/packages/chart/src/__tests__/pointer.test.ts
+++ b/packages/chart/src/__tests__/pointer.test.ts
@@ -106,6 +106,41 @@ describe("onTap", () => {
     off();
   });
 
+  it("fires once per touch tap, suppressing the synthesized mouse click", () => {
+    const off = onTap(el, handler);
+    // Real single-finger tap: touchstart → touchend.
+    const start = new Event("touchstart") as unknown as TouchEvent;
+    Object.defineProperty(start, "touches", { value: [{ clientX: 50, clientY: 60 }] });
+    el.dispatchEvent(start);
+    const end = new Event("touchend") as unknown as TouchEvent;
+    Object.defineProperty(end, "changedTouches", { value: [{ clientX: 50, clientY: 60 }] });
+    el.dispatchEvent(end);
+    // Browser then synthesizes a mouse click for the same gesture; it must be
+    // suppressed so the handler fires exactly once (not twice).
+    el.dispatchEvent(new MouseEvent("click", { clientX: 50, clientY: 60 }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0].isTouch).toBe(true);
+    off();
+  });
+
+  it("still fires a genuine mouse click at a different position after a touch tap", () => {
+    const off = onTap(el, handler);
+    const start = new Event("touchstart") as unknown as TouchEvent;
+    Object.defineProperty(start, "touches", { value: [{ clientX: 50, clientY: 60 }] });
+    el.dispatchEvent(start);
+    const end = new Event("touchend") as unknown as TouchEvent;
+    Object.defineProperty(end, "changedTouches", { value: [{ clientX: 50, clientY: 60 }] });
+    el.dispatchEvent(end);
+    // A real mouse click elsewhere (hybrid device) is NOT the synthesized one →
+    // must still fire.
+    el.dispatchEvent(new MouseEvent("click", { clientX: 300, clientY: 300 }));
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[1][0].isTouch).toBe(false);
+    off();
+  });
+
   it("ignores multi-touch starts", () => {
     const off = onTap(el, handler);
     const start = new Event("touchstart") as unknown as TouchEvent;

--- a/packages/chart/src/__tests__/vue-wrapper-lifecycle.test.ts
+++ b/packages/chart/src/__tests__/vue-wrapper-lifecycle.test.ts
@@ -157,4 +157,17 @@ describe("Vue TrendChart lifecycle", () => {
     wrapper.unmount();
     expect(currentMock.__state.destroyCalls).toBe(1);
   });
+
+  it("applies runtime option changes when the options prop is replaced", async () => {
+    const wrapper = mount(TrendChart, {
+      props: { candles: sampleCandles, options: { watermark: "v1" } as never },
+    });
+    // Replacing options with a new object must drive applyOptions. Before the
+    // fix the prop was forwarded by value (not as a getter), so the watcher
+    // never re-fired and runtime option changes were silently dropped.
+    await wrapper.setProps({ options: { watermark: "v2" } as never });
+    expect(currentMock.applyOptions).toHaveBeenCalledWith({ watermark: "v2" });
+
+    wrapper.unmount();
+  });
 });

--- a/packages/chart/src/core/pointer.ts
+++ b/packages/chart/src/core/pointer.ts
@@ -54,6 +54,13 @@ const TAP_THRESHOLD = 25; // 5px squared
 export function onTap(el: HTMLElement, handler: (pos: PointerInfo) => void): () => void {
   let downPos: { x: number; y: number } | null = null;
 
+  // After a real touch tap, mobile browsers synthesize a mouse `click` for the
+  // same gesture (touch→mouse compat). Stamp the touch tap and suppress that
+  // synthesized click so a single tap fires the handler once, not twice
+  // (mirrors the guard onDoubleTap already has for dblclick).
+  let lastTouchTapAt = Number.NEGATIVE_INFINITY;
+  let lastTouchTapPos: { x: number; y: number } | null = null;
+
   const onMouseDown = (e: MouseEvent) => {
     const rect = el.getBoundingClientRect();
     downPos = { x: e.clientX - rect.left, y: e.clientY - rect.top };
@@ -63,6 +70,11 @@ export function onTap(el: HTMLElement, handler: (pos: PointerInfo) => void): () 
     const rect = el.getBoundingClientRect();
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
+    if (lastTouchTapPos && pointerNowMs() - lastTouchTapAt < TOUCH_TO_MOUSE_COMPAT_MS) {
+      const sx = x - lastTouchTapPos.x;
+      const sy = y - lastTouchTapPos.y;
+      if (sx * sx + sy * sy <= TAP_THRESHOLD) return;
+    }
     if (downPos) {
       const dx = x - downPos.x;
       const dy = y - downPos.y;
@@ -95,6 +107,9 @@ export function onTap(el: HTMLElement, handler: (pos: PointerInfo) => void): () 
     const dy = y - touchStartPos.y;
     touchStartPos = null;
     if (dx * dx + dy * dy > TAP_THRESHOLD) return;
+    // Stamp so the synthesized mouse click for this gesture is suppressed.
+    lastTouchTapAt = pointerNowMs();
+    lastTouchTapPos = { x, y };
     handler({ x, y, isTouch: true, ...readModifiers(e) });
   };
 

--- a/packages/chart/src/renderer/render-pipeline.ts
+++ b/packages/chart/src/renderer/render-pipeline.ts
@@ -50,15 +50,25 @@ let _watermarkFont = "";
 const _rightScaleMap = new Map<string, PriceScale>();
 const _seriesByPane = new Map<string, InternalSeries[]>();
 
-/** Candle decimation cache — avoids re-decimating every frame when viewport hasn't changed */
-let _decimCache: {
-  start: number;
-  end: number;
-  target: number;
-  dataVersion: number;
-  candles: readonly CandleData[];
-  originalIndices: Int32Array;
-} | null = null;
+/**
+ * Candle decimation cache — avoids re-decimating every frame when the viewport
+ * hasn't changed. Keyed on the source candle array reference (a WeakMap, like
+ * the LTTB line cache) so each chart instance gets its own entry: a module-level
+ * singleton keyed only on {start,end,target,dataVersion} collided across two
+ * charts sharing those values (e.g. both `fitContent()`'d to the same count and
+ * width), painting one chart's decimated candles onto the other.
+ */
+const _decimCache = new WeakMap<
+  readonly CandleData[],
+  {
+    start: number;
+    end: number;
+    target: number;
+    dataVersion: number;
+    candles: readonly CandleData[];
+    originalIndices: Int32Array;
+  }
+>();
 
 /** Everything the render pipeline needs from CanvasChart */
 export type RenderContext = {
@@ -307,17 +317,20 @@ export function renderFrame(rc: RenderContext): RenderResult {
         let visibleCandles: readonly CandleData[];
         let origIndices: Int32Array | undefined;
         if (decimTarget > 0) {
-          // Use cached decimation result when viewport hasn't changed
+          // Use cached decimation result when viewport hasn't changed. The
+          // cache is keyed on this chart's own candle array, so a sibling
+          // chart with the same start/end/target/version can't read it.
           const dataVer = data.version;
+          const cached = _decimCache.get(candles);
           if (
-            _decimCache &&
-            _decimCache.start === timeScale.startIndex &&
-            _decimCache.end === timeScale.endIndex &&
-            _decimCache.target === decimTarget &&
-            _decimCache.dataVersion === dataVer
+            cached &&
+            cached.start === timeScale.startIndex &&
+            cached.end === timeScale.endIndex &&
+            cached.target === decimTarget &&
+            cached.dataVersion === dataVer
           ) {
-            visibleCandles = _decimCache.candles;
-            origIndices = _decimCache.originalIndices;
+            visibleCandles = cached.candles;
+            origIndices = cached.originalIndices;
           } else {
             const decimated = decimateCandles(
               candles,
@@ -327,14 +340,14 @@ export function renderFrame(rc: RenderContext): RenderResult {
             );
             visibleCandles = decimated.candles;
             origIndices = decimated.originalIndices;
-            _decimCache = {
+            _decimCache.set(candles, {
               start: timeScale.startIndex,
               end: timeScale.endIndex,
               target: decimTarget,
               dataVersion: dataVer,
               candles: visibleCandles,
               originalIndices: origIndices,
-            };
+            });
           }
         } else {
           visibleCandles = candles;

--- a/packages/chart/vue/TrendChart.ts
+++ b/packages/chart/vue/TrendChart.ts
@@ -90,7 +90,11 @@ export const TrendChart = defineComponent({
       chartType: () => props.chartType,
       layout: () => props.layout,
       theme: () => props.theme,
-      options: props.options,
+      // Pass as a getter (like every sibling prop) so `useTrendChart`'s watcher
+      // re-runs applyOptions when the parent replaces `options` with a new
+      // object. Passing `props.options` by value captured the initial reference,
+      // so runtime option changes were silently ignored.
+      options: () => props.options,
       fitOnLoad: () => props.fitOnLoad,
       onCrosshairMove: (data) => emit("crosshairMove", data),
       onSeriesAdded: (data) => emit("seriesAdded", data),


### PR DESCRIPTION
Three `@trendcraft/chart` fixes surfaced by a pre-release audit.

## Decimation cache leaked across chart instances (visual corruption)

The candle decimation cache was a module-level singleton keyed only on `{start, end, target, dataVersion}` — none instance-unique (`dataVersion` is a per-DataLayer counter that starts at 0). Two charts on one page, both zoomed out far enough to decimate and sharing a viewport (e.g. both `fitContent()`'d to the same candle count and canvas width, both at `dataVersion 1`), would have the **second chart read the first's cached candles** and paint one chart's price data onto the other — silent, no error.

**Fix:** key the cache on the source candle array reference via a `WeakMap`, mirroring the existing per-array LTTB line cache, so each instance gets its own entry.

## `onTap` fired twice per touch tap

`onTap` listened to both `touchend` and `click`. On a real single-finger tap mobile browsers synthesize a mouse `click` for the same gesture, so the handler fired **twice** (and a touch-completed drawing emitted a phantom click at its end position). `onDoubleTap` already had a touch→mouse compat guard; `onTap` did not.

**Fix:** stamp the touch tap and suppress the synthesized click within a short position/time window. A genuine mouse click elsewhere still fires.

## Vue `<TrendChart>` ignored runtime `options` changes

Every prop was forwarded to `useTrendChart` as a reactive getter **except** `options`, which was passed by value (`options: props.options`), capturing the initial object. The options watcher (`() => toValue(opts.options)`) therefore never saw a replacement object, so runtime-capable option changes (volume, watermark, formatters, …) were silently dropped. React's wrapper was unaffected.

**Fix:** forward `options` as a getter (`() => props.options`) like every sibling prop.

## Test plan

- `onTap` fires exactly once per touch tap (synthesized click suppressed) and still fires a separate genuine mouse click elsewhere.
- The Vue wrapper drives `applyOptions` when the `options` prop is replaced (mock chart gains an `applyOptions` spy).
- The decimation-cache fix mirrors the proven per-array LTTB cache; covered by the existing decimation / cache-invalidation suites and verified rendering an indicator-showcase example in a headless browser (chart + SMA overlay render, zero console errors).
- Full chart suite: **912 passed**; `tsc --noEmit` clean; `biome check` clean; `size-limit` within all limits (Main 40.35/41 kB).
