### PR TITLE
fix(mcp): reject non-finite candle OHLCV at the input boundary

### DIFF
--- a/packages/mcp/src/__tests__/candle-input.test.ts
+++ b/packages/mcp/src/__tests__/candle-input.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { CandleStore } from "../dispatcher/candle-store";
-import type { Candle } from "../schemas/candle";
+import { type Candle, candleSchema, candleTupleSchema } from "../schemas/candle";
 import { calcIndicatorHandler } from "../tools/calc";
 import { detectSignalHandler } from "../tools/detect-signal";
 import { loadCandlesHandler } from "../tools/load-candles";
@@ -203,5 +203,24 @@ describe("response envelope additions (v0.2.0+)", () => {
     );
     expect(result.totalLength).toBe(0);
     expect(result.processedBars).toBe(80);
+  });
+});
+
+describe("candle schema finiteness", () => {
+  const base = { time: 1, open: 100, high: 101, low: 99, close: 100, volume: 1000 };
+
+  it("rejects NaN / Infinity OHLCV in the object schema", () => {
+    expect(candleSchema.safeParse(base).success).toBe(true);
+    expect(candleSchema.safeParse({ ...base, close: Number.NaN }).success).toBe(false);
+    expect(candleSchema.safeParse({ ...base, open: Number.POSITIVE_INFINITY }).success).toBe(false);
+    expect(candleSchema.safeParse({ ...base, volume: Number.NaN }).success).toBe(false);
+  });
+
+  it("rejects NaN / Infinity in the tuple schema", () => {
+    expect(candleTupleSchema.safeParse([1, 100, 101, 99, 100, 1000]).success).toBe(true);
+    expect(candleTupleSchema.safeParse([1, 100, 101, 99, Number.NaN]).success).toBe(false);
+    expect(
+      candleTupleSchema.safeParse([1, 100, 101, 99, 100, Number.POSITIVE_INFINITY]).success,
+    ).toBe(false);
   });
 });

--- a/packages/mcp/src/__tests__/detect-signal.test.ts
+++ b/packages/mcp/src/__tests__/detect-signal.test.ts
@@ -80,6 +80,15 @@ describe("detectSignalHandler", () => {
     );
   });
 
+  it("rejects a volume-based signal when a candle supplies a non-finite volume", () => {
+    // A NaN volume would slip past a `=== undefined` check and through `?? 0`,
+    // silently distorting the volume average. The finiteness guard rejects it.
+    const withNaN = trendingCandles(40).map((c, i) => (i === 5 ? { ...c, volume: Number.NaN } : c));
+    expect(() => detectSignalHandler({ kind: "volumeBreakout", candles: withNaN })).toThrow(
+      /INVALID_INPUT.*reads volume.*non-finite/s,
+    );
+  });
+
   it("rejects a price-based signal routed onto volume via source:'volume' when volume is omitted", () => {
     // perfectOrder is price-based, but `source: "volume"` makes it read
     // candle volume through getPrice — the guard must catch this dynamic

--- a/packages/mcp/src/schemas/candle.ts
+++ b/packages/mcp/src/schemas/candle.ts
@@ -1,13 +1,17 @@
 import { z } from "zod";
 import type { CandleStore } from "../dispatcher/candle-store";
 
+// `.finite()` rejects NaN / ±Infinity: a non-finite OHLCV value poisons every
+// downstream indicator/signal with NaN, so it must be refused at the input
+// boundary (the same finiteness contract `validateIndicatorParams` enforces on
+// params) rather than silently producing a NaN-filled result.
 export const candleSchema = z.object({
-  time: z.number(),
-  open: z.number(),
-  high: z.number(),
-  low: z.number(),
-  close: z.number(),
-  volume: z.number().optional(),
+  time: z.number().finite(),
+  open: z.number().finite(),
+  high: z.number().finite(),
+  low: z.number().finite(),
+  close: z.number().finite(),
+  volume: z.number().finite().optional(),
 });
 
 // Length validation is handled by the tool handler so that the surfaced
@@ -24,8 +28,21 @@ export type Candle = z.infer<typeof candleSchema>;
  * `detect_signal` via the `candlesArray` parameter.
  */
 export const candleTupleSchema = z.union([
-  z.tuple([z.number(), z.number(), z.number(), z.number(), z.number()]),
-  z.tuple([z.number(), z.number(), z.number(), z.number(), z.number(), z.number()]),
+  z.tuple([
+    z.number().finite(),
+    z.number().finite(),
+    z.number().finite(),
+    z.number().finite(),
+    z.number().finite(),
+  ]),
+  z.tuple([
+    z.number().finite(),
+    z.number().finite(),
+    z.number().finite(),
+    z.number().finite(),
+    z.number().finite(),
+    z.number().finite(),
+  ]),
 ]);
 
 export const candlesTupleArraySchema = z.array(candleTupleSchema);

--- a/packages/mcp/src/tools/detect-signal.ts
+++ b/packages/mcp/src/tools/detect-signal.ts
@@ -83,14 +83,20 @@ export function detectSignalHandler(
   // filled with 0 to satisfy `trendcraft`'s numeric-volume contract.
   const readsVolume = desc.usesVolume === true || input.params?.source === "volume";
   if (readsVolume) {
-    const missing = candles.filter((c) => c.volume === undefined).length;
+    // Reject a non-finite volume (undefined, or NaN/Infinity if a caller reached
+    // the handler bypassing the schema): a fabricated 0 would distort the volume
+    // average, and a NaN would silently poison the result.
+    const missing = candles.filter((c) => !Number.isFinite(c.volume)).length;
     if (missing > 0) {
       throw new Error(
-        `INVALID_INPUT: signal "${input.kind}" reads volume, but ${missing} of ${candles.length} candle(s) omit it. Provide volume on every bar, or choose a price-only signal.`,
+        `INVALID_INPUT: signal "${input.kind}" reads volume, but ${missing} of ${candles.length} candle(s) omit it or supply a non-finite value. Provide a finite volume on every bar, or choose a price-only signal.`,
       );
     }
   }
-  const resolvedCandles = candles.map((c) => ({ ...c, volume: c.volume ?? 0 }));
+  const resolvedCandles = candles.map((c) => ({
+    ...c,
+    volume: Number.isFinite(c.volume) ? (c.volume as number) : 0,
+  }));
 
   let raw: unknown;
   try {


### PR DESCRIPTION
## Problem

The MCP candle schemas accepted `NaN` / `±Infinity` (bare `z.number()`), unlike params — which `validateIndicatorParams` already guards with `Number.isFinite`. A non-finite OHLCV value flows untouched through `normalizeCandle` into every indicator/signal, so `calc_indicator` / `detect_signal` return a NaN-poisoned series with `ok: true` instead of a clear `INVALID_INPUT`.

The asymmetry also broke the volume-reading guard: `detect_signal` rejected missing volume with `volume === undefined`, but a candle carrying `volume: NaN` is not `undefined`, so it slipped past the guard and through the `?? 0` fill — exactly the silent-distortion the guard was built to prevent.

## Fix

- **`schemas/candle.ts`** — tighten every OHLCV numeric in `candleSchema` and `candleTupleSchema` to `z.number().finite()`, so a non-finite value (including volume) is rejected at the schema boundary, surfacing the canonical `INVALID_INPUT`.
- **`tools/detect-signal.ts`** — for volume-reading signals, reject a **non-finite** volume (`!Number.isFinite(c.volume)` rather than `=== undefined`) and make the zero-fill NaN-safe, as defence-in-depth for any caller that reaches the handler bypassing the schema (e.g. the direct handler API).

## Test plan

- New tests: the object and tuple schemas reject `NaN` / `Infinity` OHLCV (and volume); a volume-based signal with a `NaN` volume raises `INVALID_INPUT`.
- mcp suite: **80 passed**
- `tsc --noEmit`: clean
- `biome check`: clean
