### PR TITLE
fix(core): sloped H&S neckline breakout anchor + RSI registry default drift

### DIFF
--- a/packages/core/src/signals/patterns/__tests__/head-shoulders.test.ts
+++ b/packages/core/src/signals/patterns/__tests__/head-shoulders.test.ts
@@ -83,6 +83,38 @@ describe("headAndShoulders", () => {
     }
   });
 
+  it("detects and confirms a sloped-neckline pattern (breakout projected from the right-shoulder anchor)", () => {
+    const candles: NormalizedCandle[] = [];
+    let day = 1;
+    for (let i = 0; i < 10; i++) candles.push(createCandle(day++, 100 + i * 2));
+    // Left shoulder
+    for (let i = 0; i < 5; i++)
+      candles.push(createCandle(day++, 120 + (i < 3 ? i * 2 : (4 - i) * 2)));
+    // Left trough ~108
+    for (let i = 0; i < 8; i++)
+      candles.push(createCandle(day++, i < 4 ? 118 - i * 3 : 108 + (i - 4) * 3));
+    // Head
+    for (let i = 0; i < 7; i++)
+      candles.push(createCandle(day++, i < 4 ? 118 + i * 5 : 133 - (i - 3) * 5));
+    // Right trough ~100 — lower than the left trough, so the neckline slopes down.
+    for (let i = 0; i < 8; i++)
+      candles.push(createCandle(day++, i < 4 ? 115 - i * 3 : 100 + (i - 4) * 3));
+    // Right shoulder
+    for (let i = 0; i < 5; i++)
+      candles.push(createCandle(day++, 118 + (i < 3 ? i * 2 : (4 - i) * 2)));
+    // Strong break below the (down-sloping) neckline
+    for (let i = 0; i < 15; i++) candles.push(createCandle(day++, 112 - i * 4));
+
+    const patterns = headAndShoulders(candles, { swingLookback: 3 });
+    // The sloped neckline must still project a confirmable breakout. The
+    // breakout level is anchored at the right shoulder (currentPrice), not the
+    // left trough (startPrice) — the latter would mis-place the threshold.
+    expect(patterns.length).toBeGreaterThanOrEqual(1);
+    expect(patterns[0].confirmed).toBe(true);
+    expect(patterns[0].confidence).toBeGreaterThanOrEqual(0);
+    expect(patterns[0].confidence).toBeLessThanOrEqual(100);
+  });
+
   it("should respect shoulderTolerance parameter", () => {
     const candles: NormalizedCandle[] = [];
     let day = 1;

--- a/packages/core/src/signals/patterns/head-shoulders.ts
+++ b/packages/core/src/signals/patterns/head-shoulders.ts
@@ -421,8 +421,12 @@ function findNecklineBreakIndex(
 ): number | null {
   const endIndex = Math.min(fromIndex + maxBars, candles.length);
   for (let i = fromIndex + 1; i < endIndex; i++) {
-    // Calculate neckline price at this index (accounting for slope)
-    const necklinePrice = neckline.startPrice + neckline.slope * (i - fromIndex);
+    // Project the neckline at bar i from its value at `fromIndex`. The base must
+    // be `currentPrice` (the neckline value at fromIndex = rightShoulder.index),
+    // NOT `startPrice` (its value at the left trough/peak): with a sloped
+    // neckline the two differ by slope·(rightShoulder − leftTrough), which would
+    // mis-place the breakout threshold and flip confirmation on/off.
+    const necklinePrice = neckline.currentPrice + neckline.slope * (i - fromIndex);
 
     if (direction === "down" && candles[i].close < necklinePrice) {
       return i;

--- a/packages/core/src/strategy/__tests__/registry.test.ts
+++ b/packages/core/src/strategy/__tests__/registry.test.ts
@@ -174,3 +174,23 @@ describe("streamingRegistry", () => {
     expect(streamingRegistry.has("crossOver")).toBe(true);
   });
 });
+
+describe("cross-registry param consistency", () => {
+  it("rsiBelow/rsiAbove threshold is optional-with-default in both registries", () => {
+    // A StrategyJSON that omits `threshold` must validate identically against
+    // either registry. Previously the streaming registry marked threshold
+    // `required` (no default) while backtest defaulted it, so `{ name: "rsiBelow" }`
+    // passed backtest validation but failed streaming validation.
+    for (const [name, expectedDefault] of [
+      ["rsiBelow", 30],
+      ["rsiAbove", 70],
+    ] as const) {
+      const bt = backtestRegistry.get(name)?.params.threshold;
+      const st = streamingRegistry.get(name)?.params.threshold;
+      expect(bt?.default).toBe(expectedDefault);
+      expect(st?.default).toBe(expectedDefault);
+      expect(bt?.required).toBeFalsy();
+      expect(st?.required).toBeFalsy();
+    }
+  });
+});

--- a/packages/core/src/strategy/registry-streaming.ts
+++ b/packages/core/src/strategy/registry-streaming.ts
@@ -103,10 +103,12 @@ streamingRegistry.register({
   displayName: "RSI Below",
   category: "momentum",
   params: {
-    threshold: { type: "number", required: true, min: 0, max: 100 },
+    // Default matches the backtest registry so a portable StrategyJSON that
+    // omits `threshold` validates identically against either registry.
+    threshold: { type: "number", default: 30, min: 0, max: 100, description: "RSI threshold" },
     key: { type: "string", default: "rsi" },
   },
-  create: (p) => rsiBelow(p.threshold as number, (p.key as string) ?? "rsi"),
+  create: (p) => rsiBelow((p.threshold as number) ?? 30, (p.key as string) ?? "rsi"),
 });
 
 streamingRegistry.register({
@@ -114,10 +116,10 @@ streamingRegistry.register({
   displayName: "RSI Above",
   category: "momentum",
   params: {
-    threshold: { type: "number", required: true, min: 0, max: 100 },
+    threshold: { type: "number", default: 70, min: 0, max: 100, description: "RSI threshold" },
     key: { type: "string", default: "rsi" },
   },
-  create: (p) => rsiAbove(p.threshold as number, (p.key as string) ?? "rsi"),
+  create: (p) => rsiAbove((p.threshold as number) ?? 70, (p.key as string) ?? "rsi"),
 });
 
 // ============================================


### PR DESCRIPTION
Two fixes surfaced by a pre-release audit.

## Head & Shoulders: sloped-neckline breakout anchored to the wrong index

`findNecklineBreakIndex` projected the neckline at bar `i` as `startPrice + slope * (i - fromIndex)`, but `startPrice` is the neckline's value at the **left trough/peak** while `fromIndex` is the **right shoulder**. For a sloped neckline the two differ by `slope·(rightShoulder − leftTrough)` — the neckline's entire rise across the right half of the pattern — so the breakout threshold was mis-placed: a down-sloping neckline made "break below" trigger too easily (false confirmations), and an up-sloping one suppressed real breaks. `currentPrice` is already the neckline value at the right shoulder (= `fromIndex`), and `neckline.currentPrice` was used correctly everywhere else (height/target), only the break test diverged.

**Fix:** project from `currentPrice` (`currentPrice + slope * (i - fromIndex)`). Flat necklines (`startPrice == currentPrice`) are unchanged, so existing detection/confirmation tests are unaffected. Affects `headAndShoulders` and `inverseHeadAndShoulders`.

## RSI registry default drift

The streaming registry registered `rsiBelow` / `rsiAbove` `threshold` as **required** (no default) while the backtest registry **defaulted** it (30 / 70). Because both registries share the same `ConditionSpec` / `StrategyJSON` contract and are marketed for cross-runtime portability, a strategy JSON omitting `threshold` (e.g. `{ name: "rsiBelow" }`) validated against the backtest registry but failed the streaming one.

**Fix:** give the streaming entries the same default `threshold`, so a portable StrategyJSON validates identically against either registry. (The `period` vs `key` param-name difference is an intentional runtime divergence and is left as-is.)

## Test plan

- A sloped-neckline (down-sloping) H&S pattern is detected and `confirmed`; `rsiBelow` / `rsiAbove` `threshold` is optional-with-matching-default (30 / 70, not `required`) across both registries.
- Full core suite: **6079 passed**
- `tsc --noEmit`: clean
- `biome check`: clean
