### PR TITLE
chore(deps): bump actions/dependency-review-action from 4.9.0 to 5.0.0

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate


### PR DESCRIPTION
Applies dependabot #207's bump directly (it couldn't auto-rebase — conflicted with the checkout bump #256 in the same workflow file). Pinned to the same SHA dependabot proposed (`a1d282b` = v5.0.0). Closes #207.