### PR TITLE
chore(release): changelog entries for the audit fixes + release hygiene

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — multiple chart instances no longer cross-contaminate decimated candles
+
+The candle-decimation cache was a module-level singleton keyed only on
+`{start, end, target, dataVersion}` — none instance-unique — so two charts on
+one page, both zoomed out enough to decimate and sharing a viewport, could have
+one render with the other's candles. The cache is now keyed on the source candle
+array (a `WeakMap`, like the LTTB line cache), scoping it per instance.
+
+### Fixed — a single touch tap fires the tap handler once, not twice
+
+`onTap` listened to both `touchend` and the mouse `click` that browsers
+synthesize for the same gesture, so each touch tap fired twice (and a
+touch-drawn shape emitted a phantom click). The synthesized click is now
+suppressed, matching the guard `onDoubleTap` already had.
+
+### Fixed — Vue `<TrendChart>` applies runtime `options` changes
+
+The Vue wrapper forwarded the `options` prop by value rather than as a reactive
+getter, so replacing it with a new object never re-ran `applyOptions` and
+runtime option changes (volume, watermark, formatters, …) were silently dropped.
+
 ### Added — Price Patterns plugin (`connectPricePatterns`)
 
 A tree-shakeable visualization plugin for chart-pattern signals — Double

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -60,6 +60,7 @@
     "!dist/**/*.test.*",
     "!dist/**/*.js.map",
     "!dist/**/*.cjs.map",
+    "!dist/**/*.d.ts.map",
     "LICENSE",
     "CHANGELOG.md",
     "llms.txt",
@@ -102,7 +103,7 @@
   },
   "peerDependencies": {
     "react": ">=19.0.0",
-    "trendcraft": ">=0.2.0",
+    "trendcraft": ">=0.3.0",
     "vue": ">=3.3.0"
   },
   "peerDependenciesMeta": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 ## Unreleased
 
+### Fixed — volume-constrained partial fills no longer erase un-deployed capital
+
+`runBacktest` with a `volumeConstraint` (and the default `partialFill: true`)
+zeroed `currentCapital` on entry regardless of how many shares actually filled.
+For a partial fill the cost basis is only the deployed notional, so the
+un-deployed cash was erased from equity and never credited back on exit — on a
+flat market a constrained backtest reported a ~99.9% phantom loss. Only the
+filled notional + commission is now deducted; full (unconstrained) fills are
+unchanged.
+
+### Fixed — walk-forward analysis aggregates the `mar` metric
+
+`calculateAggregateMetrics` omitted `"mar"` from its metric list, so
+`walkForwardAnalysis(..., { metric: "mar" })` left the aggregate `mar`
+undefined, collapsing `stabilityRatio` to 0 and forcing the pessimistic
+recommendation regardless of true out-of-sample performance.
+
+### Fixed — live `PositionTracker` equity/drawdown for short positions
+
+`updateUnrealized` used a long-only equity formula, so an open short's equity
+(and therefore `peakEquity` / `maxDrawdownPercent`) moved the wrong way with
+price — a winning short looked like a losing one mid-trade, firing phantom-loss
+drawdown stops. Equity is now direction-agnostic (`cash + entryPrice·shares +
+unrealizedPnl`).
+
+### Fixed — NaN / divide-by-zero guards in relative-strength, Pareto, and stress-test
+
+`rankByRS` returned `NaN` percentile for a single-symbol input; `benchmarkRS`
+returned `NaN` `rsRating` for a degenerate `rankingLookback`; `paretoOptimization`
+let NaN objective metrics (calmar / mar / recoveryFactor on zero-drawdown data)
+pollute the front; and `stressTest`'s CVaR dropped the VaR observation from its
+tail (off-by-one). All four are now guarded.
+
+### Fixed — sloped Head & Shoulders neckline breakout + RSI registry default drift
+
+`findNecklineBreakIndex` projected a sloped neckline from the wrong anchor, so
+the breakout threshold was mis-placed (false confirmations on down-sloping
+necklines, suppressed breaks on up-sloping ones); flat necklines were
+unaffected. Separately, the streaming registry marked `rsiBelow` / `rsiAbove`
+`threshold` as required while the backtest registry defaulted it, so a portable
+StrategyJSON omitting `threshold` validated differently per registry — the
+streaming entries now share the same default.
+
+### Added — `extractTradeReturns` re-exported from the package root
+
+`extractTradeReturns` is now exported from `trendcraft` (it was only on the
+`optimization` barrel), so the documented `deflatedSharpeFromReturns` example —
+`extractTradeReturns(result)` — no longer throws at runtime.
+
 ### Added — optimizer cross-parameter constraints (`validateParams` + `paramFilter`)
 
 The grid-search engine can now reject structurally-invalid parameter

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,6 +47,7 @@
     "!dist/__benchmarks__",
     "!dist/**/*.js.map",
     "!dist/**/*.cjs.map",
+    "!dist/**/*.d.ts.map",
     "LICENSE"
   ],
   "scripts": {

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+### Fixed — reject non-finite candle OHLCV at the input boundary
+
+The candle schemas accepted `NaN` / `±Infinity` (bare `z.number()`), unlike
+params, so a non-finite OHLCV value flowed into every indicator/signal and
+returned a NaN-poisoned result with `ok: true` instead of a clear
+`INVALID_INPUT`. The schemas now require finite numbers.
+
+### Fixed — volume-reading signals require a real volume on every bar
+
+`detect_signal` checked only `volume === undefined`, so a volume-based signal
+(or one routed onto volume via `source: "volume"`) silently fabricated a `0`
+volume — distorting the volume average — for omitted or `NaN` volumes. Such
+input is now rejected with `INVALID_INPUT`; price-only signals still tolerate a
+missing volume.
+
+### Changed — bumped `zod` to v4
+
+The runtime `zod` dependency moved from v3 to v4. No schema behavior changes for
+callers.
+
 ### Added — upfront `params` shape guard for `calc_indicator` / `detect_signal`
 
 `validateIndicatorParams` rejects structurally broken `params`

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -23,6 +23,7 @@
     "!dist/**/*.test.*",
     "!dist/**/*.js.map",
     "!dist/**/*.cjs.map",
+    "!dist/**/*.d.ts.map",
     "LICENSE",
     "README.md",
     "CHANGELOG.md",


### PR DESCRIPTION
Pre-release prep — no version bump (that lands at release time).

## CHANGELOG
The pre-release audit's bug fixes had merged without being recorded in the per-package CHANGELOGs. Added the missing `### Fixed` / `### Changed` entries, cross-checked against the merged PRs:
- **core**: volume-constraint capital loss, walk-forward MAR aggregation, short-position equity, NaN / divide-by-zero guards (rankByRS / benchmarkRS / Pareto / stress CVaR), sloped H&S neckline + RSI registry drift, and `extractTradeReturns` now exported from the root.
- **chart**: per-instance decimation cache, single-touch-tap double-fire, Vue `options` reactivity.
- **mcp**: non-finite candle rejection, volume-reading signals require a real volume, and the `zod` v3 → v4 bump.

## Release hygiene
- `@trendcraft/chart` `peerDependencies.trendcraft`: `>=0.2.0` → `>=0.3.0`. The new `/replay` subpath runtime-imports `createLiveCandle`, which first exists in core 0.3.0; the old range would let it install against core 0.2.x and crash.
- Exclude `dist/**/*.d.ts.map` from all three `files` whitelists. These were shipping (521 core / 184 chart / 13 mcp) and embed local build-tree paths.

## Test plan
- `npm pack --dry-run` per package: `.d.ts.map` count now **0** (was 521 / 184 / 13).
- All package.json valid; `biome check` clean.
- No code changes — CHANGELOG + package.json metadata only.

## Still required at release time (not in this PR)
- Bump versions (core 0.4.0 / chart 0.3.0 / mcp 0.2.0) and promote each `Unreleased` heading to a dated version.
- mcp `SERVER_VERSION` is already 0.2.0, so bumping mcp's package.json to 0.2.0 resolves the current mismatch.
- Publish serially (core → chart → mcp) so chart/mcp resolve the just-published core.