### PR TITLE
chore: enforce 7-day minimumReleaseAge for supply-chain hardening

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-# Supply chain security: block packages published less than 7 days ago
-minimum-release-age=10080

--- a/packages/chart/examples/docs-screenshots/.npmrc
+++ b/packages/chart/examples/docs-screenshots/.npmrc
@@ -1,0 +1,3 @@
+# Supply chain: refuse package versions published < 7 days ago (10080 min). Set
+# here, not pnpm-workspace.yaml, because this example installs --ignore-workspace.
+minimum-release-age=10080

--- a/packages/chart/examples/indicator-showcase/.npmrc
+++ b/packages/chart/examples/indicator-showcase/.npmrc
@@ -5,3 +5,6 @@
 # --ignore-workspace` skips the repo-root config and does not consistently
 # honor the package.json allowlist across a fresh CI runner.
 only-built-dependencies[]=esbuild
+
+# Supply chain: refuse package versions published < 7 days ago (10080 min).
+minimum-release-age=10080

--- a/packages/chart/examples/simple-chart/.npmrc
+++ b/packages/chart/examples/simple-chart/.npmrc
@@ -5,3 +5,6 @@
 # --ignore-workspace` skips the repo-root config and does not consistently
 # honor the package.json allowlist across a fresh CI runner.
 only-built-dependencies[]=esbuild
+
+# Supply chain: refuse package versions published < 7 days ago (10080 min).
+minimum-release-age=10080

--- a/packages/chart/examples/simple-react-chart/.npmrc
+++ b/packages/chart/examples/simple-react-chart/.npmrc
@@ -5,3 +5,6 @@
 # --ignore-workspace` skips the repo-root config and does not consistently
 # honor the package.json allowlist across a fresh CI runner.
 only-built-dependencies[]=esbuild
+
+# Supply chain: refuse package versions published < 7 days ago (10080 min).
+minimum-release-age=10080

--- a/packages/chart/examples/simple-vue-chart/.npmrc
+++ b/packages/chart/examples/simple-vue-chart/.npmrc
@@ -5,3 +5,6 @@
 # --ignore-workspace` skips the repo-root config and does not consistently
 # honor the package.json allowlist across a fresh CI runner.
 only-built-dependencies[]=esbuild
+
+# Supply chain: refuse package versions published < 7 days ago (10080 min).
+minimum-release-age=10080

--- a/packages/chart/examples/sparkline-showcase/.npmrc
+++ b/packages/chart/examples/sparkline-showcase/.npmrc
@@ -1,0 +1,3 @@
+# Supply chain: refuse package versions published < 7 days ago (10080 min). Set
+# here, not pnpm-workspace.yaml, because this example installs --ignore-workspace.
+minimum-release-age=10080

--- a/packages/chart/examples/strategy-studio/.npmrc
+++ b/packages/chart/examples/strategy-studio/.npmrc
@@ -1,0 +1,3 @@
+# Supply chain: refuse package versions published < 7 days ago (10080 min). Set
+# here, not pnpm-workspace.yaml, because this example installs --ignore-workspace.
+minimum-release-age=10080

--- a/packages/core/examples/echarts-viewer/.npmrc
+++ b/packages/core/examples/echarts-viewer/.npmrc
@@ -1,0 +1,3 @@
+# Supply chain: refuse package versions published < 7 days ago (10080 min). Set
+# here, not pnpm-workspace.yaml, because this example installs --ignore-workspace.
+minimum-release-age=10080

--- a/packages/core/examples/trading-simulator/.npmrc
+++ b/packages/core/examples/trading-simulator/.npmrc
@@ -1,0 +1,3 @@
+# Supply chain: refuse package versions published < 7 days ago (10080 min). Set
+# here, not pnpm-workspace.yaml, because this example installs --ignore-workspace.
+minimum-release-age=10080

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
 packages:
   - "packages/*"
   - "packages/chart/examples/strategy-studio"
+
+# Supply chain security: delay installing newly published versions.
+# 10080 minutes = 7 days. Blocks packages published less than 7 days ago,
+# giving time for compromised releases to be reported and yanked.
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

Harden against supply-chain attacks by refusing to install package versions published less than 7 days ago (`minimumReleaseAge` = 10080 minutes). This gives time for compromised releases to be reported and yanked before they enter the dependency graph.

## Why two locations

pnpm reads this setting from different files depending on how the install runs, and this repo installs in two distinct ways:

| Install path | Reads | Setting location |
|---|---|---|
| Workspace install (`pnpm install`) — published packages `core`, `chart`, plus `strategy-studio` | `pnpm-workspace.yaml` | root `pnpm-workspace.yaml` |
| Standalone examples (`pnpm install --ignore-workspace`) | `.npmrc` only (workspace yaml is ignored under `--ignore-workspace`) | each example `.npmrc` |

A single location cannot cover both: `--ignore-workspace` ignores `pnpm-workspace.yaml` entirely (even one in the same directory), while the workspace install does not read example `.npmrc` files.

## Changes

- **Root `pnpm-workspace.yaml`**: add `minimumReleaseAge: 10080`. Covers the published packages and `strategy-studio` (installed via the workspace).
- **Remove root `.npmrc`**: its only setting moved into `pnpm-workspace.yaml`.
- **Each example `.npmrc`**: add `minimum-release-age=10080`. Required because examples install with `--ignore-workspace`, which only honors `.npmrc`. Existing `.npmrc` files (esbuild build approval) get the line appended; others get a new `.npmrc`.

## Verification

Tested on pnpm 10.33.0 with an isolated `HOME`/`XDG_CONFIG_HOME` to rule out any global config:

- **Control** (no config anywhere): pinning `vite@8.0.16` (published 5 days prior) installs cleanly — no block.
- **`.npmrc` `minimum-release-age=10080`** (incl. under `--ignore-workspace`): the same pin is rejected with `ERR_PNPM_NO_MATURE_MATCHING_VERSION`.
- **`pnpm-workspace.yaml` `minimumReleaseAge: 10080`**: rejects on normal install; ignored under `--ignore-workspace` (hence examples use `.npmrc`).

Config-only change — no source, build, or test logic is affected.

## Follow-up (not in this PR)

pnpm 11 will read only auth/registry settings from `.npmrc`, and replaces `onlyBuiltDependencies` with `allowBuilds`. A later change can migrate examples to per-directory `pnpm-workspace.yaml` (making each example its own workspace root) and drop `--ignore-workspace`, consolidating all settings. That is a separate, larger task requiring CI re-validation.