### PR TITLE
fix(core): reconcile backtest/streaming condition registry defaults

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## Unreleased
 
+### Breaking — `dmiBullish` / `dmiBearish` ADX param renamed `minAdx` → `threshold`
+
+The backtest `dmiBullish(threshold, period)` / `dmiBearish(threshold, period)`
+conditions renamed their first parameter from `minAdx` to `threshold` and
+raised its default from `20` to `25` (Wilder's strong-trend level). This aligns
+them with the streaming registry, the shared `adxStrong` condition, and the
+direct factory signatures — the ADX threshold now has one name and one default
+everywhere. A persisted StrategyJSON leaf `{ "name": "dmiBullish", "params": {
+"minAdx": 30 } }` must be updated to `{ "params": { "threshold": 30 } }`; an
+unrecognized `minAdx` is otherwise ignored and the new default (25) applies.
+
+### Fixed — backtest ↔ streaming registry parity for shared condition params
+
+Conditions registered under the same name in both registries had drifted on
+portability-relevant param schema, so a portable StrategyJSON behaved
+differently per registry. Reconciled: `cmfAbove` / `cmfBelow` `threshold`
+default (now `0`, the CMF zero-line, on both), `priceDroppedAtr` `multiplier`
+default (now `2.0` on both), `atrPercentAbove` `threshold` default (now the
+shared `DEFAULT_ATR_THRESHOLD` constant on both), `atrPercentBelow` `threshold`
+(backtest now defaults it to `1.0` instead of requiring it), and
+`bollingerBreakout` / `bollingerTouch` `band` (streaming now defaults to
+`"lower"` instead of requiring it). A new parity test fails CI on any future
+shared-param drift between the two registries.
+
+The condition factories behind these entries were aligned with the reconciled
+defaults so a directly-constructed condition and a registry-hydrated one behave
+identically when a param is omitted: the streaming `cmfAbove` / `cmfBelow`
+(`0`), `priceDroppedAtr` (`2.0`), `atrPercentAbove` (`DEFAULT_ATR_THRESHOLD`),
+`rsiBelow` (`30`) / `rsiAbove` (`70`) factories now carry those defaults; the
+backtest `atrPercentBelow` factory defaults `threshold` to `1.0` instead of
+requiring it; and the streaming and backtest `bollingerBreakout` /
+`bollingerTouch` factories default `band` to `"lower"` instead of requiring it.
+
 ### Fixed — volume-constrained partial fills no longer erase un-deployed capital
 
 `runBacktest` with a `volumeConstraint` (and the default `partialFill: true`)

--- a/packages/core/src/backtest/conditions/bollinger.ts
+++ b/packages/core/src/backtest/conditions/bollinger.ts
@@ -51,7 +51,7 @@ function getBBData(
  * ```
  */
 export function bollingerBreakout(
-  band: "upper" | "lower",
+  band: "upper" | "lower" = "lower",
   period = 20,
   stdDev = 2,
 ): PresetCondition {
@@ -82,7 +82,11 @@ export function bollingerBreakout(
  * const result = runBacktest(candles, entry, bollingerTouch("upper"), { capital: 1_000_000 });
  * ```
  */
-export function bollingerTouch(band: "upper" | "lower", period = 20, stdDev = 2): PresetCondition {
+export function bollingerTouch(
+  band: "upper" | "lower" = "lower",
+  period = 20,
+  stdDev = 2,
+): PresetCondition {
   return {
     type: "preset",
     name: `bollingerTouch('${band}')`,

--- a/packages/core/src/backtest/conditions/dmi.ts
+++ b/packages/core/src/backtest/conditions/dmi.ts
@@ -11,7 +11,7 @@ import type { PresetCondition } from "../../types";
 
 /**
  * DMI Bullish: +DI > -DI with optional ADX filter
- * @param minAdx Minimum ADX for trend strength (default: 20)
+ * @param threshold Minimum ADX for trend strength (default: 25, Wilder's strong-trend level)
  * @example
  * ```ts
  * import { runBacktest, dmiBullish, dmiBearish } from "trendcraft";
@@ -21,12 +21,12 @@ import type { PresetCondition } from "../../types";
  * });
  * ```
  */
-export function dmiBullish(minAdx = 20, period = 14): PresetCondition {
+export function dmiBullish(threshold = 25, period = 14): PresetCondition {
   const cacheKey = `dmi_${period}`;
 
   return {
     type: "preset",
-    name: `dmiBullish(ADX>${minAdx})`,
+    name: `dmiBullish(ADX>=${threshold})`,
     evaluate: (indicators, _candle, index, candles) => {
       let dmiData = indicators[cacheKey] as
         | {
@@ -43,14 +43,14 @@ export function dmiBullish(minAdx = 20, period = 14): PresetCondition {
       const d = dmiData[index]?.value;
       if (!d || d.plusDi === null || d.minusDi === null || d.adx === null) return false;
 
-      return d.plusDi > d.minusDi && d.adx >= minAdx;
+      return d.plusDi > d.minusDi && d.adx >= threshold;
     },
   };
 }
 
 /**
  * DMI Bearish: -DI > +DI with optional ADX filter
- * @param minAdx Minimum ADX for trend strength (default: 20)
+ * @param threshold Minimum ADX for trend strength (default: 25, Wilder's strong-trend level)
  * @example
  * ```ts
  * import { runBacktest, dmiBullish, dmiBearish, and, adxStrong } from "trendcraft";
@@ -60,12 +60,12 @@ export function dmiBullish(minAdx = 20, period = 14): PresetCondition {
  * const result = runBacktest(candles, entry, dmiBearish(), { capital: 1_000_000 });
  * ```
  */
-export function dmiBearish(minAdx = 20, period = 14): PresetCondition {
+export function dmiBearish(threshold = 25, period = 14): PresetCondition {
   const cacheKey = `dmi_${period}`;
 
   return {
     type: "preset",
-    name: `dmiBearish(ADX>${minAdx})`,
+    name: `dmiBearish(ADX>=${threshold})`,
     evaluate: (indicators, _candle, index, candles) => {
       let dmiData = indicators[cacheKey] as
         | {
@@ -82,7 +82,7 @@ export function dmiBearish(minAdx = 20, period = 14): PresetCondition {
       const d = dmiData[index]?.value;
       if (!d || d.plusDi === null || d.minusDi === null || d.adx === null) return false;
 
-      return d.minusDi > d.plusDi && d.adx >= minAdx;
+      return d.minusDi > d.plusDi && d.adx >= threshold;
     },
   };
 }

--- a/packages/core/src/backtest/conditions/volatility.ts
+++ b/packages/core/src/backtest/conditions/volatility.ts
@@ -415,7 +415,7 @@ export function atrPercentAbove(
  * ```
  */
 export function atrPercentBelow(
-  threshold: number,
+  threshold = 1.0,
   options?: Pick<AtrFilterOptions, "atrPeriod">,
 ): PresetCondition {
   return {

--- a/packages/core/src/strategy/__tests__/registry-parity.test.ts
+++ b/packages/core/src/strategy/__tests__/registry-parity.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { backtestRegistry } from "../registry-backtest";
+import { streamingRegistry } from "../registry-streaming";
+import type { ParamDef } from "../types";
+
+/**
+ * Registry parity contract (backtest ↔ streaming).
+ *
+ * `backtestRegistry` and `streamingRegistry` are two independently hand-
+ * maintained tables. A StrategyJSON leaf `{ name, params }` is meant to be
+ * portable: validating or hydrating it against either registry should behave
+ * the same. That only holds when conditions registered under the SAME name
+ * agree on the params they share.
+ *
+ * The two sides use deliberately different execution models:
+ *   - streaming conditions read a pre-computed snapshot via a `key` param
+ *   - backtest conditions compute the indicator inline from `period`/`fast`…
+ * So params that exist in only ONE registry (streaming `key`, backtest
+ * `period`, …) are an intentional paradigm difference and are NOT compared.
+ *
+ * What this guards: for a condition present in both registries, every param
+ * key common to both must have an identical portability-relevant schema, and
+ * `isFilter`/`category` must match. This catches silent drift — e.g. a shared
+ * `threshold` whose default diverged so a portable JSON omitting it behaves
+ * differently per side. (See the 2026-06 reconciliation that aligned cmf/atr/
+ * priceDroppedAtr defaults and the dmi `minAdx`→`threshold` rename.)
+ */
+
+// Portability-relevant schema fields. UI-only hints (suggestedMin/suggestedMax,
+// precision, integer, tunable, description) are intentionally excluded — they
+// don't affect validateConditionSpec / hydrate behavior, so they may differ
+// between a UI-facing backtest entry and a leaner streaming entry.
+const COMPARED_FIELDS: (keyof ParamDef)[] = ["type", "default", "min", "max", "required", "enum"];
+
+function paramFingerprint(def: ParamDef): string {
+  const picked: Record<string, unknown> = {};
+  for (const f of COMPARED_FIELDS) picked[f] = def[f];
+  return JSON.stringify(picked);
+}
+
+/**
+ * Documented, intentional shared-param differences. Each key is
+ * `${condition}.${param}`; the value explains why the divergence is allowed.
+ *
+ * Empty by design: every known shared-param drift has been reconciled. Adding
+ * an entry here is the explicit, reviewable escape hatch for a difference that
+ * genuinely cannot be unified. The test below also fails if an entry here no
+ * longer drifts, forcing stale exceptions to be removed.
+ */
+const KNOWN_DRIFTS: Record<string, string> = {};
+
+describe("registry parity (backtest ↔ streaming)", () => {
+  const sharedNames = backtestRegistry
+    .names()
+    .filter((name) => streamingRegistry.has(name))
+    .sort();
+
+  it("has a non-trivial overlap to guard", () => {
+    // Sanity floor: if this drops, an import or registration regressed.
+    expect(sharedNames.length).toBeGreaterThan(20);
+  });
+
+  it("shared params agree on portability-relevant schema", () => {
+    const observedDrifts = new Set<string>();
+    const unexpected: string[] = [];
+
+    for (const name of sharedNames) {
+      const bt = backtestRegistry.get(name)!;
+      const st = streamingRegistry.get(name)!;
+      for (const param of Object.keys(bt.params)) {
+        if (!(param in st.params)) continue; // param unique to backtest — paradigm difference
+        const key = `${name}.${param}`;
+        const btFp = paramFingerprint(bt.params[param]);
+        const stFp = paramFingerprint(st.params[param]);
+        if (btFp !== stFp) {
+          observedDrifts.add(key);
+          if (!(key in KNOWN_DRIFTS)) {
+            unexpected.push(`  ${key}: backtest=${btFp} streaming=${stFp}`);
+          }
+        }
+      }
+    }
+
+    expect(
+      unexpected,
+      `Shared-param drift between registries (align them, or add to KNOWN_DRIFTS with a reason):\n${unexpected.join("\n")}`,
+    ).toEqual([]);
+
+    // Stale-allowlist guard: every KNOWN_DRIFTS entry must still drift.
+    const stale = Object.keys(KNOWN_DRIFTS).filter((key) => !observedDrifts.has(key));
+    expect(
+      stale,
+      `KNOWN_DRIFTS entries no longer drift — remove them:\n${stale.map((s) => `  ${s}`).join("\n")}`,
+    ).toEqual([]);
+  });
+
+  it("shared conditions agree on isFilter and category", () => {
+    const mismatches: string[] = [];
+    for (const name of sharedNames) {
+      const bt = backtestRegistry.get(name)!;
+      const st = streamingRegistry.get(name)!;
+      if (Boolean(bt.isFilter) !== Boolean(st.isFilter)) {
+        mismatches.push(
+          `  ${name}.isFilter: backtest=${Boolean(bt.isFilter)} streaming=${Boolean(st.isFilter)}`,
+        );
+      }
+      if (bt.category !== st.category) {
+        mismatches.push(`  ${name}.category: backtest=${bt.category} streaming=${st.category}`);
+      }
+    }
+    expect(mismatches, `Metadata drift between registries:\n${mismatches.join("\n")}`).toEqual([]);
+  });
+});

--- a/packages/core/src/strategy/registry-backtest.ts
+++ b/packages/core/src/strategy/registry-backtest.ts
@@ -150,6 +150,7 @@ import {
   volumeRatioAbove,
   volumeTrendConfidence,
 } from "../backtest/conditions/volume-advanced";
+import { DEFAULT_ATR_THRESHOLD } from "../indicators/volatility/atr-filter";
 import type { PatternType } from "../signals/patterns/types";
 import type { Condition } from "../types";
 import { ConditionRegistry } from "./registry";
@@ -629,22 +630,26 @@ backtestRegistry.register({
   name: "dmiBullish",
   displayName: "DMI Bullish",
   category: "trend",
+  // `threshold` (name + default 25) matches the streaming registry and the
+  // shared `adxStrong` condition. 25 is Wilder's original strong-trend level.
   params: {
-    minAdx: { type: "number", default: 20, min: 0 },
+    threshold: { type: "number", default: 25, min: 0 },
     period: { type: "number", default: 14, min: 1 },
   },
-  create: (p) => dmiBullish((p.minAdx as number) ?? 20, (p.period as number) ?? 14),
+  create: (p) => dmiBullish((p.threshold as number) ?? 25, (p.period as number) ?? 14),
 });
 
 backtestRegistry.register({
   name: "dmiBearish",
   displayName: "DMI Bearish",
   category: "trend",
+  // `threshold` (name + default 25) matches the streaming registry and the
+  // shared `adxStrong` condition. 25 is Wilder's original strong-trend level.
   params: {
-    minAdx: { type: "number", default: 20, min: 0 },
+    threshold: { type: "number", default: 25, min: 0 },
     period: { type: "number", default: 14, min: 1 },
   },
-  create: (p) => dmiBearish((p.minAdx as number) ?? 20, (p.period as number) ?? 14),
+  create: (p) => dmiBearish((p.threshold as number) ?? 25, (p.period as number) ?? 14),
 });
 
 backtestRegistry.register({
@@ -997,22 +1002,27 @@ backtestRegistry.register({
   name: "atrPercentAbove",
   displayName: "ATR% Above",
   category: "volatility",
+  // Default references the shared DEFAULT_ATR_THRESHOLD constant so the
+  // registry, the streaming registry, and the factory can't drift apart.
   params: {
-    threshold: { type: "number", default: 3.0, min: 0 },
+    threshold: { type: "number", default: DEFAULT_ATR_THRESHOLD, min: 0 },
   },
   isFilter: true,
-  create: (p) => atrPercentAbove((p.threshold as number) ?? 3.0),
+  create: (p) => atrPercentAbove((p.threshold as number) ?? DEFAULT_ATR_THRESHOLD),
 });
 
 backtestRegistry.register({
   name: "atrPercentBelow",
   displayName: "ATR% Below",
   category: "volatility",
+  // Default matches the streaming registry (1% ≈ low daily volatility). A
+  // sensible default keeps a portable JSON that omits `threshold` valid on
+  // both sides instead of failing validation here.
   params: {
-    threshold: { type: "number", required: true, min: 0 },
+    threshold: { type: "number", default: 1.0, min: 0 },
   },
   isFilter: true,
-  create: (p) => atrPercentBelow(p.threshold as number),
+  create: (p) => atrPercentBelow((p.threshold as number) ?? 1.0),
 });
 
 // ============================================

--- a/packages/core/src/strategy/registry-streaming.ts
+++ b/packages/core/src/strategy/registry-streaming.ts
@@ -16,6 +16,7 @@
  * ```
  */
 
+import { DEFAULT_ATR_THRESHOLD } from "../indicators/volatility/atr-filter";
 import {
   bollingerBreakout,
   bollingerExpansion,
@@ -318,25 +319,29 @@ streamingRegistry.register({
   name: "bollingerBreakout",
   displayName: "Bollinger Breakout",
   category: "volatility",
+  // `band` defaults to "lower" to match the backtest registry (a portable
+  // JSON omitting `band` resolves identically on either side).
   params: {
-    band: { type: "string", required: true, enum: ["upper", "lower"] },
+    band: { type: "string", default: "lower", enum: ["upper", "lower"] },
     key: { type: "string", default: "bb" },
   },
-  create: (p) => bollingerBreakout(p.band as "upper" | "lower", (p.key as string) ?? "bb"),
+  create: (p) =>
+    bollingerBreakout((p.band as "upper" | "lower") ?? "lower", (p.key as string) ?? "bb"),
 });
 
 streamingRegistry.register({
   name: "bollingerTouch",
   displayName: "Bollinger Touch",
   category: "volatility",
+  // `band` defaults to "lower" to match the backtest registry (see bollingerBreakout).
   params: {
-    band: { type: "string", required: true, enum: ["upper", "lower"] },
+    band: { type: "string", default: "lower", enum: ["upper", "lower"] },
     tolerance: { type: "number", default: 0.1, min: 0 },
     key: { type: "string", default: "bb" },
   },
   create: (p) =>
     bollingerTouch(
-      p.band as "upper" | "lower",
+      (p.band as "upper" | "lower") ?? "lower",
       (p.tolerance as number) ?? 0.1,
       (p.key as string) ?? "bb",
     ),
@@ -427,18 +432,21 @@ streamingRegistry.register({
   name: "cmfAbove",
   displayName: "CMF Above",
   category: "volume",
-  params: { threshold: { type: "number", default: 0.05 }, key: { type: "string", default: "cmf" } },
-  create: (p) => cmfAbove((p.threshold as number) ?? 0.05, (p.key as string) ?? "cmf"),
+  // Default matches the backtest registry. 0 is the canonical CMF zero-line
+  // reference (the ±0.05 buffer is an optional whipsaw filter, not the default).
+  params: { threshold: { type: "number", default: 0 }, key: { type: "string", default: "cmf" } },
+  create: (p) => cmfAbove((p.threshold as number) ?? 0, (p.key as string) ?? "cmf"),
 });
 streamingRegistry.register({
   name: "cmfBelow",
   displayName: "CMF Below",
   category: "volume",
+  // Default matches the backtest registry (CMF zero-line; see cmfAbove).
   params: {
-    threshold: { type: "number", default: -0.05 },
+    threshold: { type: "number", default: 0 },
     key: { type: "string", default: "cmf" },
   },
-  create: (p) => cmfBelow((p.threshold as number) ?? -0.05, (p.key as string) ?? "cmf"),
+  create: (p) => cmfBelow((p.threshold as number) ?? 0, (p.key as string) ?? "cmf"),
 });
 streamingRegistry.register({
   name: "obvRising",
@@ -483,12 +491,15 @@ streamingRegistry.register({
   name: "atrPercentAbove",
   displayName: "ATR% Above",
   category: "volatility",
+  // Default references the shared DEFAULT_ATR_THRESHOLD constant (matches the
+  // backtest registry and the factory; single source of truth).
   params: {
-    threshold: { type: "number", default: 2.0, min: 0 },
+    threshold: { type: "number", default: DEFAULT_ATR_THRESHOLD, min: 0 },
     key: { type: "string", default: "atr" },
   },
   isFilter: true,
-  create: (p) => atrPercentAbove((p.threshold as number) ?? 2.0, (p.key as string) ?? "atr"),
+  create: (p) =>
+    atrPercentAbove((p.threshold as number) ?? DEFAULT_ATR_THRESHOLD, (p.key as string) ?? "atr"),
 });
 
 streamingRegistry.register({
@@ -575,11 +586,13 @@ streamingRegistry.register({
   name: "priceDroppedAtr",
   displayName: "Price Dropped ATR",
   category: "volatility",
+  // Default matches the backtest registry. 2× ATR is the conventional range
+  // (2–3) for a meaningful move; 1× is too tight to register as a "drop".
   params: {
-    multiplier: { type: "number", default: 1.0, min: 0.1 },
+    multiplier: { type: "number", default: 2.0, min: 0.1 },
     key: { type: "string", default: "atr" },
   },
-  create: (p) => priceDroppedAtr((p.multiplier as number) ?? 1.0, (p.key as string) ?? "atr"),
+  create: (p) => priceDroppedAtr((p.multiplier as number) ?? 2.0, (p.key as string) ?? "atr"),
 });
 
 streamingRegistry.register({

--- a/packages/core/src/streaming/conditions/bollinger.ts
+++ b/packages/core/src/streaming/conditions/bollinger.ts
@@ -8,10 +8,13 @@ import type { StreamingPresetCondition } from "./types";
 /**
  * Condition: Price breaks above/below Bollinger Band
  *
- * @param band - Which band to check ("upper" or "lower")
+ * @param band - Which band to check ("upper" or "lower", default: "lower")
  * @param key - Snapshot key for Bollinger Bands (default: "bb")
  */
-export function bollingerBreakout(band: "upper" | "lower", key = "bb"): StreamingPresetCondition {
+export function bollingerBreakout(
+  band: "upper" | "lower" = "lower",
+  key = "bb",
+): StreamingPresetCondition {
   return {
     type: "preset",
     name: `bollingerBreakout(${band})`,
@@ -26,12 +29,12 @@ export function bollingerBreakout(band: "upper" | "lower", key = "bb"): Streamin
 /**
  * Condition: Price touches/is near a Bollinger Band
  *
- * @param band - Which band to check ("upper" or "lower")
+ * @param band - Which band to check ("upper" or "lower", default: "lower")
  * @param tolerance - Percentage tolerance (default: 0.1 = 0.1%)
  * @param key - Snapshot key for Bollinger Bands (default: "bb")
  */
 export function bollingerTouch(
-  band: "upper" | "lower",
+  band: "upper" | "lower" = "lower",
   tolerance = 0.1,
   key = "bb",
 ): StreamingPresetCondition {

--- a/packages/core/src/streaming/conditions/presets.ts
+++ b/packages/core/src/streaming/conditions/presets.ts
@@ -44,7 +44,7 @@ export type RegimeFilterOptions = {
  * const oversold = rsiBelow(30);
  * ```
  */
-export function rsiBelow(threshold: number, key = "rsi"): StreamingPresetCondition {
+export function rsiBelow(threshold = 30, key = "rsi"): StreamingPresetCondition {
   return {
     type: "preset",
     name: `rsiBelow(${threshold})`,
@@ -66,7 +66,7 @@ export function rsiBelow(threshold: number, key = "rsi"): StreamingPresetConditi
  * const overbought = rsiAbove(70);
  * ```
  */
-export function rsiAbove(threshold: number, key = "rsi"): StreamingPresetCondition {
+export function rsiAbove(threshold = 70, key = "rsi"): StreamingPresetCondition {
   return {
     type: "preset",
     name: `rsiAbove(${threshold})`,

--- a/packages/core/src/streaming/conditions/price.ts
+++ b/packages/core/src/streaming/conditions/price.ts
@@ -10,10 +10,10 @@ import type { StreamingPresetCondition } from "./types";
 /**
  * Condition: Price dropped by more than N ATRs from previous close
  *
- * @param multiplier - ATR multiplier (default: 1.0)
+ * @param multiplier - ATR multiplier (default: 2.0)
  * @param key - Snapshot key for ATR (default: "atr")
  */
-export function priceDroppedAtr(multiplier = 1.0, key = "atr"): StreamingPresetCondition {
+export function priceDroppedAtr(multiplier = 2.0, key = "atr"): StreamingPresetCondition {
   let prevClose: number | null = null;
 
   return {

--- a/packages/core/src/streaming/conditions/volatility.ts
+++ b/packages/core/src/streaming/conditions/volatility.ts
@@ -2,16 +2,20 @@
  * Volatility Streaming Conditions
  */
 
+import { DEFAULT_ATR_THRESHOLD } from "../../indicators/volatility/atr-filter";
 import { getNumber } from "../snapshot-utils";
 import type { StreamingPresetCondition } from "./types";
 
 /**
  * Condition: ATR as percentage of close is above threshold
  *
- * @param threshold - ATR% threshold (default: 2.0 = 2%)
+ * @param threshold - ATR% threshold (default: {@link DEFAULT_ATR_THRESHOLD})
  * @param key - Snapshot key for ATR (default: "atr")
  */
-export function atrPercentAbove(threshold = 2.0, key = "atr"): StreamingPresetCondition {
+export function atrPercentAbove(
+  threshold = DEFAULT_ATR_THRESHOLD,
+  key = "atr",
+): StreamingPresetCondition {
   return {
     type: "preset",
     name: `atrPercentAbove(${threshold}%)`,

--- a/packages/core/src/streaming/conditions/volume.ts
+++ b/packages/core/src/streaming/conditions/volume.ts
@@ -26,10 +26,10 @@ export function volumeAboveAvg(multiplier = 1.5, key = "volumeAnomaly"): Streami
 /**
  * Condition: Chaikin Money Flow above threshold
  *
- * @param threshold - CMF threshold (default: 0.05)
+ * @param threshold - CMF threshold (default: 0, the CMF zero-line)
  * @param key - Snapshot key (default: "cmf")
  */
-export function cmfAbove(threshold = 0.05, key = "cmf"): StreamingPresetCondition {
+export function cmfAbove(threshold = 0, key = "cmf"): StreamingPresetCondition {
   return {
     type: "preset",
     name: `cmfAbove(${threshold})`,
@@ -43,10 +43,10 @@ export function cmfAbove(threshold = 0.05, key = "cmf"): StreamingPresetConditio
 /**
  * Condition: Chaikin Money Flow below threshold
  *
- * @param threshold - CMF threshold (default: -0.05)
+ * @param threshold - CMF threshold (default: 0, the CMF zero-line)
  * @param key - Snapshot key (default: "cmf")
  */
-export function cmfBelow(threshold = -0.05, key = "cmf"): StreamingPresetCondition {
+export function cmfBelow(threshold = 0, key = "cmf"): StreamingPresetCondition {
   return {
     type: "preset",
     name: `cmfBelow(${threshold})`,


### PR DESCRIPTION
## Summary

The backtest and streaming condition registries are two independently
hand-maintained tables. A portable `StrategyJSON` leaf (`{ name, params }`) is
meant to behave the same whichever registry validates or hydrates it — but
conditions registered under the **same name** had silently drifted on
portability-relevant param schema, so a JSON that omits a param could resolve
differently per registry. The factories behind those entries had also drifted
from the registry defaults, so a registry-hydrated condition and a directly
constructed one could produce different signals for an omitted param.

This PR reconciles the shared params, aligns the factories with the reconciled
defaults, and adds a parity test that fails CI on any future shared-param drift
between the two registries.

## Reconciled shared params

Registry + factory now agree, so an omitted param behaves identically whether
the condition is hydrated from JSON or constructed directly:

| Condition | Param | Default | Notes |
|---|---|---|---|
| `cmfAbove` / `cmfBelow` | `threshold` | `0` | CMF zero-line (the ±0.05 buffer is an optional filter, not the default) |
| `priceDroppedAtr` | `multiplier` | `2.0` | conventional 2–3× ATR range; 1× is too tight |
| `atrPercentAbove` | `threshold` | `DEFAULT_ATR_THRESHOLD` | both registries + the factory now reference the one shared constant |
| `atrPercentBelow` | `threshold` | `1.0` | backtest no longer requires it |
| `bollingerBreakout` / `bollingerTouch` | `band` | `"lower"` | streaming no longer requires it |
| `rsiBelow` / `rsiAbove` | `threshold` | `30` / `70` | streaming factories now carry the standard defaults |

## Breaking change

The backtest `dmiBullish` / `dmiBearish` conditions renamed their first
parameter from `minAdx` to `threshold` and raised its default from `20` to `25`
(Wilder's strong-trend level). This unifies the ADX threshold's name and default
across the streaming registry, the shared `adxStrong` condition, and the direct
factory signatures — previously `25` in three of four places, with backtest
`dmi` the lone outlier at `20`.

Migration: a persisted `StrategyJSON` leaf using
`{ "params": { "minAdx": N } }` must be updated to
`{ "params": { "threshold": N } }`. An unrecognized `minAdx` is ignored and the
new default (`25`) applies.

## Parity guard

`packages/core/src/strategy/__tests__/registry-parity.test.ts` asserts that, for
any condition present in both registries, every param key common to both has an
identical portability-relevant schema (`type`/`default`/`min`/`max`/`required`/
`enum`) and matching `isFilter` / `category`. Params unique to one registry
(streaming `key`, backtest `period`, …) are an intentional execution-model
difference and are excluded. The test also fails if a documented exception no
longer drifts, forcing stale exceptions to be removed.

Note: registry↔factory default consistency (the source of the second class of
drift fixed here) cannot be guarded automatically — a function's default
parameter values aren't introspectable at runtime — so that axis remains a
review concern.

## Test plan

- `pnpm test` (core): 6082 passed
- `pnpm lint`: clean
- `pnpm build` (core): green
- `pnpm typecheck` (core, `tsc --noEmit`): clean
- No remaining `minAdx` references in source after the rename (verified by grep)