### PR TITLE
docs: release-readiness fixes across core, chart, mcp

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 ```bash
 git clone https://github.com/sawapi/trendcraft.git
 cd trendcraft
-pnpm install
+pnpm install --frozen-lockfile
 pnpm test
 ```
 
@@ -36,8 +36,14 @@ pnpm format        # Format code
 Tests are written with [Vitest](https://vitest.dev/).
 
 ```bash
-pnpm test          # Run all tests
-pnpm test:watch    # Run in watch mode
+pnpm test          # Run all tests (all packages)
+```
+
+There is no root watch script. For watch mode, run Vitest in watch mode inside a package, e.g.:
+
+```bash
+cd packages/core
+npx vitest        # Run that package's tests in watch mode
 ```
 
 Add tests for every new feature or bug fix. Place test files in `__tests__/` directories next to the source code they cover.

--- a/README.md
+++ b/README.md
@@ -29,19 +29,19 @@ Release and versioning conventions for the monorepo are documented in [CLAUDE.md
 
 ## Demos
 
-Each demo is a standalone Vite app — `cd` into it, `pnpm install --ignore-workspace`, `pnpm dev`.
+Most demos are standalone Vite apps — `cd` into the directory, then `pnpm install --ignore-workspace` and `pnpm dev`. A couple are plain TypeScript scripts run with `npx tsx`; their run command is noted inline below.
 
-**Charting (`@trendcraft/chart`)**
+**Charting (`@trendcraft/chart`)** — all Vite apps (`pnpm install --ignore-workspace` + `pnpm dev`)
 - [`packages/chart/examples/simple-chart`](./packages/chart/examples/simple-chart) — start here. Vanilla TS, one chart, a handful of indicators.
 - [`packages/chart/examples/simple-react-chart`](./packages/chart/examples/simple-react-chart) / [`simple-vue-chart`](./packages/chart/examples/simple-vue-chart) — framework binding minimal demos.
 - [`packages/chart/examples/indicator-showcase`](./packages/chart/examples/indicator-showcase) — every preset (96+) with live-replay, signal panel, plugin panel.
 - [`packages/chart/examples/sparkline-showcase`](./packages/chart/examples/sparkline-showcase) — the `@trendcraft/chart/sparkline` subpath on a 200-row ticker dashboard.
 
 **Core (`trendcraft`)**
-- [`packages/core/examples/quick-start`](./packages/core/examples/quick-start) — the smallest "import and call an indicator" example.
-- [`packages/core/examples/echarts-viewer`](./packages/core/examples/echarts-viewer) — comprehensive React + ECharts viewer (indicators, signals, backtest, optimization, pattern replay). Demonstrates that the `trendcraft` core works with any chart library, not only `@trendcraft/chart`.
-- [`packages/core/examples/trading-simulator`](./packages/core/examples/trading-simulator) — bar-replay practice tool with order management and end-of-session review.
-- [`packages/core/examples/sp500-showcase`](./packages/core/examples/sp500-showcase) — screening across S&P 500 symbols.
+- [`packages/core/examples/quick-start`](./packages/core/examples/quick-start) — the smallest "import and call an indicator" examples. Plain TS scripts, no dev server: from `packages/core`, run e.g. `npx tsx examples/quick-start/01-basic-indicators.ts`.
+- [`packages/core/examples/echarts-viewer`](./packages/core/examples/echarts-viewer) — comprehensive React + ECharts viewer (indicators, signals, backtest, optimization, pattern replay). Vite app (`pnpm install --ignore-workspace` + `pnpm dev`). Demonstrates that the `trendcraft` core works with any chart library, not only `@trendcraft/chart`.
+- [`packages/core/examples/trading-simulator`](./packages/core/examples/trading-simulator) — bar-replay practice tool with order management and end-of-session review. Vite app (`pnpm install --ignore-workspace` + `pnpm dev`).
+- [`packages/core/examples/sp500-showcase`](./packages/core/examples/sp500-showcase) — screening and backtesting across US ETFs. Plain TS scripts, no dev server: set Alpaca API credentials, then run `npx tsx fetch-data.ts && npx tsx run-showcase.ts`.
 
 ## Disclaimer
 

--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking — `snapshotName` is now a default label, not a uniqueness key
+
+`connectIndicators.add()` previously threw on **any** `snapshotName`
+collision, forcing hosts to pass `{ snapshotName: "..." }` boilerplate
+to keep multiple instances of the same preset — e.g. comparing two
+SMA(20) lines in different colors, or stacking two anchored VWAPs from
+different anchor times.
+
+New behavior:
+
+- A preset's `snapshotName(params)` is treated as a **default label
+  suggestion**, not a uniqueness key.
+- When the derived default collides, the library **auto-suffixes**:
+  `"sma20"` → `"sma20#2"` → `"sma20#3"`, and so on. Identity is
+  guaranteed by `connectIndicators`, not by the preset.
+- When the caller passes an **explicit** `snapshotName` and it
+  collides, the library still throws — an explicit id belongs to the
+  caller and a duplicate is a caller-side bug.
+
+**Migration**: drop the `{ snapshotName }` boilerplate you added solely
+to dedupe same-preset instances; the auto-suffix now handles it. Keep
+explicit `snapshotName` only where you rely on a stable, host-chosen id
+(and ensure those ids are unique — duplicates still throw).
+
 ### Fixed — multiple chart instances no longer cross-contaminate decimated candles
 
 The candle-decimation cache was a module-level singleton keyed only on
@@ -54,6 +78,37 @@ New exports from the package entry:
 `PricePatternsOptions` covers bull/bear/neutral colors (hex + optional
 `r,g,b` triplets for fills), body alpha, neckline / target dash patterns,
 a `minConfidence` floor (default 60), and a `maxPatterns` cap (default 8).
+
+### Added — `connectLivePrimitives` for live-mode plugin support
+
+`connectLivePrimitives(chart, ...)` is a new public export from the
+package entry, returning a `{ remove() }` handle like the other
+`connect*` plugins. It lets the differentiation plugins (SMC, Wyckoff,
+Regime Heatmap, S/R Confluence, Session Zones, etc.) participate in
+live mode by recomputing their primitives as new bars arrive, rather
+than rendering only against a static candle array. The replay subpath's
+`createLiveSimulator` drives it directly (see the `@trendcraft/chart/replay`
+entry below).
+
+### Added / Changed — plugin visual enhancements
+
+- **Volume Profile** now draws the VAH / VAL value-area boundary lines
+  in addition to the POC, so the 70% value area is visible at a glance
+  (#179).
+- **Andrews Pitchfork** gains line labels and the 0.25 / 0.75 half-lines
+  between the median and the outer tines (#180).
+- **Plugin visuals aligned with industry conventions** (#181): TTM
+  Squeeze markers render as circular dots on a zero-line rail (was
+  rectangles, despite the "dots" name); the Regime Heatmap adds a
+  top-left corner pill spelling out the active regime plus confidence
+  ("trending-up · 72%") instead of relying on background tint alone.
+  Pure rendering changes — the data layer is unchanged.
+- **SMC Layer text annotations** label order blocks, fair-value gaps,
+  and liquidity sweeps directly on the chart (#183).
+- **Wyckoff** renders the sub-phase letter as a separate corner chip
+  distinct from the phase label (#184).
+- **Trade analysis** gains a P&L label and magnitude-aware MFE / MAE
+  labels on each trade marker (#185).
 
 ### Added — `liveRecompute` option for batch-only indicator presets
 
@@ -313,11 +368,25 @@ Six new unit tests cover the guard paths.
 
 - **`@trendcraft/chart/sparkline` subpath** — ultra-lightweight mini chart for watchlist-style UIs (200+ instances on a single page). Vanilla `createSparkline` / `createSparklineGroup`, plus `@trendcraft/chart/react/sparkline` and `@trendcraft/chart/vue/sparkline` thin wrappers. Supports both `line` (with optional fill) and `candle` modes, four color presets (`first-vs-last`, `open-vs-close`, `baseline`, `fixed` / per-candle `up`/`down`), and a single-listener delegated hover with a shared tooltip across all sparklines in a group. Vanilla bundle ≈ 2.5 kB brotli; React/Vue ≈ 3 kB. New example at `examples/sparkline-showcase/`.
 
+### Changed
+
+- Bundle size budgets raised (brotli) to absorb the new plugin
+  enhancements and `connectLivePrimitives`. The headless budget is
+  unchanged; per-feature subpaths (`sparkline`, `replay`) carry their
+  own limits.
+
+  | Entry | 0.2.0 limit | Unreleased limit |
+  | --- | --- | --- |
+  | Main (`@trendcraft/chart`) | 36 kB | **41 kB** |
+  | Headless (`@trendcraft/chart/headless`) | 11 kB | 11 kB |
+  | React (`@trendcraft/chart/react`) | 30 kB | **33 kB** |
+  | Vue (`@trendcraft/chart/vue`) | 30 kB | **33 kB** |
+
 ### Not in this release
 
 - Intraday session gap rendering (weekend/overnight visual gaps for minute data) — tracked for v0.3.
 - C1 coverage 90% target — viewport / canvas-chart / drawing-tool DOM integration tests have low ROI; addressed incrementally.
-- Plugin live-mode integration — the six differentiation plugins remain static-only until incrementalization lands.
+- Plugin live-mode integration is now available via `connectLivePrimitives` (see Unreleased above); the differentiation plugins are no longer static-only.
 
 ## [0.2.0] - 2026-04-26
 

--- a/packages/chart/README.md
+++ b/packages/chart/README.md
@@ -48,7 +48,7 @@ Without TrendCraft, pass any `{ time, value }[]` series and a small config: `cha
 - **React & Vue wrappers** — `<TrendChart>` components plus `useTrendChart` hook/composable for imperative access.
 - **Headless API** — DOM-free data layer, scales, layout, and `introspect` for SSR, testing, and custom renderers.
 - **Sparkline & replay subpaths** — compact ~4 kB sparklines and a live-feed replay simulator.
-- **Bundle-size discipline** — zero runtime dependencies; every entry point is brotli size-checked in CI.
+- **Bundle-size discipline** — zero runtime dependencies; every major entry point (main, headless, sparkline, replay, React/Vue wrappers) is brotli size-checked in CI.
 
 ## Framework bindings
 

--- a/packages/chart/RELEASE.md
+++ b/packages/chart/RELEASE.md
@@ -12,7 +12,7 @@ The full cross-package release workflow (including `trendcraft` coordination and
 - [ ] `pnpm --filter @trendcraft/chart build` succeeds
 - [ ] `pnpm --filter @trendcraft/chart test` green
 - [ ] `pnpm --filter @trendcraft/chart verify:publish` green — confirms every `package.json#exports` subpath resolves in both ESM and CJS and exposes its advertised symbols
-- [ ] `pnpm --filter @trendcraft/chart size-check` within limits. The authoritative budget lives in `package.json#size-limit` (currently main ≤ 36 kB, headless ≤ 11 kB, React/Vue ≤ 30 kB, brotli). If a feature warrants a raise, bump it there and call it out in the CHANGELOG `Changed` section.
+- [ ] `pnpm --filter @trendcraft/chart size-check` within limits. The authoritative budget lives in `package.json#size-limit` (currently main ≤ 41 kB, headless ≤ 11 kB, sparkline ≤ 5 kB vanilla / ≤ 7 kB React+Vue, replay ≤ 3 kB, React/Vue ≤ 33 kB, brotli). If a feature warrants a raise, bump it there and call it out in the CHANGELOG `Changed` section.
 - [ ] Docs sanity pass — `README.md`, `docs/*.md`, `llms.txt`, `llms-full.txt` reflect any new public API
 - [ ] Examples still build: `cd packages/chart/examples/simple-chart && pnpm build` (repeat for `simple-react-chart`, `simple-vue-chart`)
 
@@ -28,7 +28,7 @@ git push origin chart-v<x.y.z>
 ## After publish
 
 - [ ] `npm view @trendcraft/chart@<x.y.z> version` returns the new version
-- [ ] Spot-install into a throwaway project and import each entry point (`.`, `/headless`, `/presets`, `/react`, `/vue`) to confirm the published tarball behaves like the local build
+- [ ] Spot-install into a throwaway project and import each entry point (`.`, `/headless`, `/presets`, `/sparkline`, `/replay`, `/react`, `/react/sparkline`, `/vue`, `/vue/sparkline`) to confirm the published tarball behaves like the local build
 - [ ] Open a new `Unreleased` section in `CHANGELOG.md` for the next cycle
 
 ## Rollback

--- a/packages/chart/docs/API.md
+++ b/packages/chart/docs/API.md
@@ -6,11 +6,15 @@ Complete API surface for `@trendcraft/chart`. This is the reference; for concept
 
 | Import from | Contents | Environment |
 |---|---|---|
-| `@trendcraft/chart` | `createChart`, `connectIndicators`, plugin helpers, plugins, all types | Browser only — throws in SSR |
+| `@trendcraft/chart` | `createChart`, `connectIndicators`, `connectLivePrimitives`, plugin helpers, plugins, all types | Browser only — throws in SSR |
 | `@trendcraft/chart/headless` | `DataLayer`, `TimeScale`, `PriceScale`, `LayoutEngine`, `introspect`, `lttb`, formatters | Any (Node / SSR / tests) |
-| `@trendcraft/chart/presets` | Bundled indicator presets | Browser only |
+| `@trendcraft/chart/presets` | `registerTrendCraftPresets` — opt-in introspection rules + visual presets for TrendCraft-specific indicator shapes | Browser only |
+| `@trendcraft/chart/sparkline` | `createSparkline`, `createSparklineGroup`, line/candle mini-chart renderers | Browser only |
+| `@trendcraft/chart/replay` | `createLiveSimulator` — replay historical candles as a live feed | Any (Node / SSR / tests) |
 | `@trendcraft/chart/react` | `TrendChart` component, `useTrendChart` hook | React 19+, browser only |
+| `@trendcraft/chart/react/sparkline` | `Sparkline`, `SparklineList` React components | React 19+, browser only |
 | `@trendcraft/chart/vue` | `TrendChart` component, `useTrendChart` composable | Vue 3.3+, browser only |
+| `@trendcraft/chart/vue/sparkline` | `Sparkline`, `SparklineList` Vue components | Vue 3.3+, browser only |
 
 ## Table of Contents
 
@@ -33,6 +37,7 @@ Complete API surface for `@trendcraft/chart`. This is the reference; for concept
 - [Connection APIs](#connection-apis)
   - [`connectIndicators`](#connectindicatorschart-options)
   - [`defineIndicator`](#defineindicatorpresetid-options)
+  - [`connectLivePrimitives`](#connectliveprimitivessource-specs)
 - [Drawing auto-injection helpers](#drawing-auto-injection-helpers)
 - [Plugin helpers](#plugin-helpers)
 - [Built-in plugins](#built-in-plugins)
@@ -319,9 +324,9 @@ All time values are epoch milliseconds.
 | `paneResize` | `{ paneId: string, height: number }` |
 | `seriesAdded` | `{ id: string, label: string }` |
 | `seriesRemoved` | `{ id: string }` |
-| `dataFiltered` | `{ reason: string, count: number }` |
+| `dataFiltered` | `{ total: number, valid: number, removed: number }` |
 | `drawingComplete` | `Drawing` |
-| `error` | `{ message: string, source?: string }` |
+| `error` | `ChartErrorPayload = { message: string, code?: ChartErrorCode, detail?: unknown }` |
 
 ## Connection APIs
 
@@ -382,6 +387,48 @@ conn.add(sma5);
 ```
 
 Useful when you want to pass indicator configurations around your app without coupling to a specific chart connection.
+
+### `connectLivePrimitives(source, specs)`
+
+```typescript
+function connectLivePrimitives(
+  source: LiveSource,
+  specs: readonly LivePrimitiveSpec<unknown>[],
+): LivePrimitivesConnection
+```
+
+Keep primitive plugins (S/R Zones, SMC, Wyckoff, Kill Zones, Regime Heatmap, etc.) in sync with a live feed. Primitives register via `chart.registerPrimitive()` rather than `addIndicator()`, so they are invisible to `connectIndicators`' live event loop. This helper recomputes each spec on `candleComplete` and pushes the result to the plugin handle's `update()` method (batch recompute — O(N) per completed candle).
+
+```typescript
+import { connectIndicators, connectLivePrimitives, connectSrConfluence } from '@trendcraft/chart';
+import { srZones } from 'trendcraft';
+
+const conn = connectIndicators(chart, { presets, candles, live: source });
+const sr = connectSrConfluence(chart, srZones(source.completedCandles));
+
+const liveSr = connectLivePrimitives(source, [
+  { recompute: (candles) => srZones(candles), handle: sr, name: 'sr' },
+]);
+
+// later
+liveSr.disconnect();
+conn.disconnect();
+```
+
+`LivePrimitiveSpec`:
+
+| Field | Type | Description |
+|---|---|---|
+| `recompute` | `(candles: readonly SourceCandle[]) => T` | Recompute the primitive's data from the current candle history. |
+| `handle` | `LivePrimitiveHandle<T>` | Plugin handle (e.g. from `connectSrConfluence`) whose `update(data)` is called with the recomputed result. |
+| `name` | `string` (optional) | Name used in error logs to identify which spec failed. |
+
+`LivePrimitivesConnection`:
+
+| Method | Description |
+|---|---|
+| `disconnect()` | Unsubscribe from `candleComplete` events. Idempotent. |
+| `recomputeAll()` | Manually trigger a recompute of all specs — useful to seed handles right after construction. No-op once disconnected. |
 
 ## Drawing auto-injection helpers
 
@@ -465,6 +512,9 @@ Tree-shakeable visualization primitives bundled with the library:
 | `createSessionZones` / `connectSessionZones` | Session backgrounds (Asian/London/NY) |
 | `createAndrewsPitchfork` / `connectAndrewsPitchfork` | Andrew's Pitchfork — median line + upper/lower handles from three swing anchors, extending forward |
 | `createVolumeProfile` / `connectVolumeProfile` | Horizontal volume-by-price histogram along the right edge, with highlighted Value Area and dashed POC line |
+| `createMarketProfile` / `connectMarketProfile` | TPO (Time Price Opportunity) market profile — per-price letter/block distribution with Value Area and POC |
+| `createPricePatterns` / `connectPricePatterns` | Chart pattern outlines (double top/bottom, head & shoulders, triangles, etc.). `filterPricePatterns` narrows a `PricePatternSignal[]` set before connecting |
+| `createSqueezeDots` / `connectSqueezeDots` | Bollinger/Keltner squeeze dots along the pane baseline |
 
 Each `create*` returns a `PrimitivePlugin`; each `connect*` registers it and returns an update handle.
 
@@ -620,13 +670,12 @@ The chart uses a three-tier resolution path when deciding how to render a series
 ### Adding custom rules
 
 ```typescript
-import { SeriesRegistry } from '@trendcraft/chart';
-
-SeriesRegistry.addRule({
+chart.addRule({
   name: 'myShape',
-  match: (value) => typeof value === 'object' && value !== null && 'a' in value && 'b' in value,
+  test: (value) => typeof value === 'object' && value !== null && 'a' in value && 'b' in value,
   seriesType: 'line',
-  channels: ['a', 'b'],
+  defaultPane: 'sub',
+  decompose: (value) => ({ a: value.a, b: value.b }),
 });
 ```
 
@@ -641,3 +690,15 @@ chart.addPreset('myShape', {
 ```
 
 Presets override built-ins for the same name. Use this to re-skin built-in indicators without forking.
+
+### TrendCraft preset bundle (`@trendcraft/chart/presets`)
+
+```typescript
+import { registerTrendCraftPresets } from '@trendcraft/chart/presets';
+
+registerTrendCraftPresets(chart);
+```
+
+`registerTrendCraftPresets(chart)` is an opt-in helper that registers introspection rules **and** visual presets for TrendCraft-specific indicator output shapes — e.g. `klinger` `{ kvo, signal, histogram }`, `connorsRsi` `{ crsi, ... }`, `adaptiveRsi` `{ rsi, effectivePeriod, volatilityPercentile }`, `vsa`, `emaRibbon`, `fairValueGap` / `orderBlock` box zones, `fractals`, `heikinAshi`, and more. It also registers the custom renderers those shapes need (FVG / order-block zones, fractal markers, Heikin-Ashi overlay).
+
+Generic shapes (band, MACD-like oscillators, plain numbers, etc.) are handled by the chart core, so this call is only needed when you feed it TrendCraft-specific indicator output. Without it those shapes fall through to generic rendering and may show no visible series. Call it once, right after `createChart`, before adding the affected indicators.

--- a/packages/chart/docs/COOKBOOK.md
+++ b/packages/chart/docs/COOKBOOK.md
@@ -111,10 +111,11 @@ Default hotkeys: `Alt+H` (h-line), `Alt+T` (trendline), `Alt+F` (fib retracement
 
 ```typescript
 import { addAutoFibRetracement } from "@trendcraft/chart";
-import { swingPoints } from "trendcraft";
+import { getAlternatingSwingPoints } from "trendcraft";
 
-const swings = swingPoints(candles, { leftBars: 5, rightBars: 5 });
-addAutoFibRetracement(chart, swings, { lookback: 1 });
+// getAlternatingSwingPoints returns the SwingAnchor shape directly.
+const anchors = getAlternatingSwingPoints(candles, 10, { leftBars: 5, rightBars: 5 });
+addAutoFibRetracement(chart, anchors);
 ```
 
 Companions: `addAutoFibExtension`, `addAutoTrendLine`, `addAutoChannelLine`.
@@ -148,9 +149,11 @@ chart.addBacktest(result);
 
 ```typescript
 import { connectIndicators, createChart } from "@trendcraft/chart";
+import { registerTrendCraftPresets } from "@trendcraft/chart/presets";
 import { createLiveCandle, indicatorPresets } from "trendcraft";
 
 const chart = createChart(container);
+registerTrendCraftPresets(chart);
 chart.setCandles(history);
 
 const live = createLiveCandle({
@@ -208,7 +211,7 @@ export function ChartView({ candles }: { candles: Candle[] }) {
 }
 ```
 
-Need imperative access? Use `useTrendChart()` and read `chartRef.current` once mounted.
+Need imperative access? Use `useTrendChart()`, which returns `{ containerRef, chart }` — spread `containerRef` onto your own `<div ref={containerRef} />` and read `chart` (the `ChartInstance`, `null` until mounted).
 
 ---
 
@@ -289,20 +292,30 @@ Switch modes at runtime via `chart.applyOptions({ crosshair: { mode: "magnet" } 
 ```typescript
 import { definePrimitive } from "@trendcraft/chart";
 
-const zonePlugin = definePrimitive({
-  name: "supportZone",
-  initialState: { lo: 0, hi: 0 },
-  draw(ctx, state, helpers) {
-    const y1 = helpers.priceToY(state.lo);
-    const y2 = helpers.priceToY(state.hi);
-    ctx.fillStyle = "rgba(34,197,94,0.12)";
-    ctx.fillRect(0, Math.min(y1, y2), helpers.width, Math.abs(y2 - y1));
-  },
-});
+type ZoneState = { lo: number; hi: number };
 
-chart.registerPrimitive(zonePlugin);
-chart.setPrimitiveState("supportZone", { lo: 140, hi: 145 });
+function createSupportZone(state: ZoneState) {
+  return definePrimitive<ZoneState>({
+    name: "supportZone",
+    pane: "main",
+    zOrder: "below",
+    defaultState: state,
+    render: ({ ctx, priceScale, pane }, { lo, hi }) => {
+      const y1 = priceScale.priceToY(lo);
+      const y2 = priceScale.priceToY(hi);
+      ctx.fillStyle = "rgba(34,197,94,0.12)";
+      ctx.fillRect(pane.x, Math.min(y1, y2), pane.width, Math.abs(y2 - y1));
+    },
+  });
+}
+
+chart.registerPrimitive(createSupportZone({ lo: 140, hi: 145 }));
+
+// To change the zone, re-register with new state (overwrites by name):
+chart.registerPrimitive(createSupportZone({ lo: 138, hi: 143 }));
 ```
+
+`render(context, state)` receives the live `priceScale` (use `priceScale.priceToY(price)`) and `pane` rect (`pane.x`, `pane.y`, `pane.width`, `pane.height`). State comes from `defaultState`; update it by re-registering the plugin under the same `name`, or via the optional `update(state)` hook called before each frame. Remove with `chart.removePrimitive("supportZone")`.
 
 For series-type plugins (e.g. footprint candles), use `defineSeriesRenderer`. See [PLUGINS.md](./PLUGINS.md).
 

--- a/packages/chart/docs/GUIDE.md
+++ b/packages/chart/docs/GUIDE.md
@@ -30,7 +30,7 @@ A conceptual walkthrough of `@trendcraft/chart`. If you just want to get pixels 
 `@trendcraft/chart` is a Canvas-based charting library built specifically for financial time series. It optimizes for three things:
 
 1. **Zero-config indicator rendering** — pass a `trendcraft` indicator output and the chart figures out where it belongs, what scale it needs, and what reference lines to draw.
-2. **A small, focused runtime** — no runtime dependencies, ~31 kB gzipped main bundle, one canvas per chart, no virtual DOM.
+2. **A small, focused runtime** — no runtime dependencies, ~41 kB main bundle (brotli, size-limit enforced), one canvas per chart, no virtual DOM.
 3. **Extensibility as a plugin system, not a configuration tree** — custom series types and overlays ship as plain functions you register.
 
 What it's **not**:
@@ -172,9 +172,10 @@ import { SeriesRegistry } from '@trendcraft/chart';
 
 SeriesRegistry.addRule({
   name: 'myCustomShape',
-  match: (value) => typeof value === 'object' && value !== null && 'score' in value,
+  test: (value) => typeof value === 'object' && value !== null && 'score' in value,
   seriesType: 'line',
-  channels: ['score'],
+  defaultPane: 'sub',
+  decompose: (value) => ({ score: value.score }),
 });
 ```
 
@@ -312,9 +313,9 @@ Subscribe via `chart.on(event, handler)`. Unsubscribe via `chart.off`. Events ar
 | `paneResize` | `{ paneId, height }` — fires when the user drags a pane divider |
 | `seriesAdded` | `{ id, label }` |
 | `seriesRemoved` | `{ id }` |
-| `dataFiltered` | `{ reason, count }` — warnings about invalid candles dropped |
+| `dataFiltered` | `{ total, valid, removed }` — fires when invalid candles are dropped (`removed` = count) |
 | `drawingComplete` | `Drawing` — fires after a click-to-place drawing finishes |
-| `error` | `{ message, source }` — non-fatal runtime warnings |
+| `error` | `ChartErrorPayload` — `{ message, code?, detail? }`, non-fatal runtime warnings |
 
 ## Live data
 
@@ -324,9 +325,11 @@ At a glance:
 
 ```typescript
 import { createChart, connectIndicators } from '@trendcraft/chart';
+import { registerTrendCraftPresets } from '@trendcraft/chart/presets';
 import { createLiveCandle, indicatorPresets } from 'trendcraft';
 
 const chart = createChart(el, { theme: 'dark' });
+registerTrendCraftPresets(chart); // teaches the chart TrendCraft-specific shapes
 const live = createLiveCandle({ intervalMs: 60_000, history: candles });
 const conn = connectIndicators(chart, {
   presets: indicatorPresets,

--- a/packages/chart/docs/LIVE.md
+++ b/packages/chart/docs/LIVE.md
@@ -49,7 +49,7 @@ The split is intentional: `trendcraft` owns the data math (aggregation, stateful
 |---|---|---|
 | `createLiveCandle` | `trendcraft` | Aggregates ticks into candles, runs incremental indicators, emits events |
 | `livePresets` / `indicatorPresets` | `trendcraft` | Registries of incremental factories + metadata |
-| `incremental.create*` | `trendcraft` | 160+ incremental indicator factories |
+| `incremental.create*` | `trendcraft` | 90+ incremental indicator factories |
 | `connectIndicators` | `@trendcraft/chart` | Wires a preset registry to a chart; handles backfill + live updates |
 | `ChartInstance.updateCandle` | `@trendcraft/chart` | Append or patch the last candle |
 
@@ -61,9 +61,11 @@ If your feed delivers individual trades and you want the chart to aggregate them
 
 ```typescript
 import { createChart, connectIndicators } from '@trendcraft/chart';
+import { registerTrendCraftPresets } from '@trendcraft/chart/presets';
 import { createLiveCandle, indicatorPresets } from 'trendcraft';
 
 const chart = createChart(container, { theme: 'dark' });
+registerTrendCraftPresets(chart);  // required when using indicatorPresets — see "Common pitfalls"
 chart.setCandles(history);  // prime with historical bars
 
 const live = createLiveCandle({
@@ -311,6 +313,20 @@ This is usually what you want. `createLiveCandle` has no network I/O — it just
 For gaps in the feed during a disconnect, request the missing history from your REST API and replay through `live.addCandle(bar)`.
 
 ## Common pitfalls
+
+### Forgetting `registerTrendCraftPresets(chart)`
+
+When you wire `connectIndicators` with `indicatorPresets`, also call `registerTrendCraftPresets(chart)` from `@trendcraft/chart/presets` **before adding indicators**:
+
+```typescript
+import { registerTrendCraftPresets } from '@trendcraft/chart/presets';
+
+const chart = createChart(container, { theme: 'dark' });
+registerTrendCraftPresets(chart);
+const conn = connectIndicators(chart, { presets: indicatorPresets, candles, live });
+```
+
+Without it, TrendCraft-specific shapes (`adaptiveRsi` `{rsi, effectivePeriod, volatilityPercentile}`, `connorsRsi`, `klinger`, `vsa`, etc.) fall through built-in introspection and silently render as generic "Indicator"/"Series" with no visible line. There is no warning — the chart degrades silently.
 
 ### Forgetting to call `conn.disconnect()` in cleanup
 

--- a/packages/chart/docs/PLUGINS.md
+++ b/packages/chart/docs/PLUGINS.md
@@ -411,4 +411,4 @@ export function createMyPlugin(): PrimitivePlugin<MyState> {
 }
 ```
 
-For reference, TrendCraft's own shipped plugins (`regime-heatmap`, `smc-layer`, `wyckoff-phase`, `sr-confluence`, `trade-analysis`, `session-zones`) follow this pattern. They live in `packages/chart/src/plugins/` and export both the factory and connect helper from the main entry.
+For reference, TrendCraft's own shipped plugins (`regime-heatmap`, `smc-layer`, `wyckoff-phase`, `sr-confluence`, `trade-analysis`, `session-zones`, `andrews-pitchfork`, `volume-profile`, `market-profile`, `price-patterns`, `squeeze-dots`) follow this pattern. They live in `packages/chart/src/plugins/` and export both the factory and connect helper from the main entry.

--- a/packages/chart/examples/docs-screenshots/package.json
+++ b/packages/chart/examples/docs-screenshots/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "description": "Internal playground for generating screenshots used in docs/assets/. Not committed to git.",
+  "description": "Internal playground for generating screenshots used in docs/assets/.",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/packages/chart/examples/docs-screenshots/package.json
+++ b/packages/chart/examples/docs-screenshots/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@trendcraft/chart": "link:../..",
-    "trendcraft": "link:../../../../core"
+    "trendcraft": "link:../../../core"
   },
   "devDependencies": {
     "typescript": "^5.7.2",

--- a/packages/chart/examples/docs-screenshots/pnpm-lock.yaml
+++ b/packages/chart/examples/docs-screenshots/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: link:../..
         version: link:../..
       trendcraft:
-        specifier: link:../../../../core
-        version: link:../../../../core
+        specifier: link:../../../core
+        version: link:../../../core
     devDependencies:
       typescript:
         specifier: ^5.7.2

--- a/packages/chart/examples/indicator-showcase/README.md
+++ b/packages/chart/examples/indicator-showcase/README.md
@@ -1,7 +1,7 @@
 # indicator-showcase
 
 Catalog demo for `@trendcraft/chart`. Every preset registered with
-`registerTrendCraftPresets` (96+ entries) is exposed via a categorized sidebar
+`registerTrendCraftPresets` (104+ entries) is exposed via a categorized sidebar
 with parameter controls, live mode, signal panel, and plugin panel.
 
 ## Setup

--- a/packages/chart/examples/indicator-showcase/package.json
+++ b/packages/chart/examples/indicator-showcase/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@trendcraft/chart": "link:../..",
-    "trendcraft": "link:../../../../core"
+    "trendcraft": "link:../../../core"
   },
   "devDependencies": {
     "typescript": "^5.7.2",

--- a/packages/chart/examples/indicator-showcase/pnpm-lock.yaml
+++ b/packages/chart/examples/indicator-showcase/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: link:../..
         version: link:../..
       trendcraft:
-        specifier: link:../../../../core
-        version: link:../../../../core
+        specifier: link:../../../core
+        version: link:../../../core
     devDependencies:
       typescript:
         specifier: ^5.7.2

--- a/packages/chart/examples/indicator-showcase/src/main.ts
+++ b/packages/chart/examples/indicator-showcase/src/main.ts
@@ -1,7 +1,7 @@
 /**
  * Indicator Showcase — Main Entry
  *
- * Demonstrates every preset available in `indicatorPresets` (96 as of 2026-04-18)
+ * Demonstrates every preset available in `indicatorPresets` (104 as of 2026-06-08)
  * with a categorized sidebar UI, search, parameter controls, and active indicator
  * bar. The sidebar is auto-generated from indicatorPresets metadata, so the count
  * stays accurate as the preset registry grows.

--- a/packages/chart/examples/simple-chart/package.json
+++ b/packages/chart/examples/simple-chart/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@trendcraft/chart": "link:../..",
-    "trendcraft": "link:../../../../core"
+    "trendcraft": "link:../../../core"
   },
   "devDependencies": {
     "typescript": "^5.7.2",

--- a/packages/chart/examples/simple-chart/pnpm-lock.yaml
+++ b/packages/chart/examples/simple-chart/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: link:../..
         version: link:../..
       trendcraft:
-        specifier: link:../../../../core
-        version: link:../../../../core
+        specifier: link:../../../core
+        version: link:../../../core
     devDependencies:
       typescript:
         specifier: ^5.7.2

--- a/packages/chart/examples/simple-vue-chart/package.json
+++ b/packages/chart/examples/simple-vue-chart/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -16,7 +16,8 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.0",
     "typescript": "^5.7.2",
-    "vite": "^6.0.3"
+    "vite": "^6.0.3",
+    "vue-tsc": "^2.1.10"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/chart/examples/simple-vue-chart/pnpm-lock.yaml
+++ b/packages/chart/examples/simple-vue-chart/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       vite:
         specifier: ^6.0.3
         version: 6.4.1
+      vue-tsc:
+        specifier: ^2.1.10
+        version: 2.2.12(typescript@5.9.3)
 
 packages:
 
@@ -240,66 +243,79 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -341,6 +357,15 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
 
+  '@volar/language-core@2.4.15':
+    resolution: {integrity: sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==}
+
+  '@volar/source-map@2.4.15':
+    resolution: {integrity: sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==}
+
+  '@volar/typescript@2.4.15':
+    resolution: {integrity: sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==}
+
   '@vue/compiler-core@3.5.31':
     resolution: {integrity: sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ==}
 
@@ -352,6 +377,17 @@ packages:
 
   '@vue/compiler-ssr@3.5.31':
     resolution: {integrity: sha512-h0xIMxrt/LHOvJKMri+vdYT92BrK3HFLtDqq9Pr/lVVfE4IyKZKvWf0vJFW10Yr6nX02OR4MkJwI0c1HDa1hog==}
+
+  '@vue/compiler-vue2@2.7.16':
+    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+
+  '@vue/language-core@2.2.12':
+    resolution: {integrity: sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@vue/reactivity@3.5.31':
     resolution: {integrity: sha512-DtKXxk9E/KuVvt8VxWu+6Luc9I9ETNcqR1T1oW1gf02nXaZ1kuAx58oVu7uX9XxJR0iJCro6fqBLw9oSBELo5g==}
@@ -370,8 +406,20 @@ packages:
   '@vue/shared@3.5.31':
     resolution: {integrity: sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw==}
 
+  alien-signals@1.0.13:
+    resolution: {integrity: sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  de-indent@1.0.2:
+    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
 
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
@@ -399,13 +447,27 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -475,6 +537,15 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-tsc@2.2.12:
+    resolution: {integrity: sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
 
   vue@3.5.31:
     resolution: {integrity: sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==}
@@ -661,6 +732,18 @@ snapshots:
       vite: 6.4.1
       vue: 3.5.31(typescript@5.9.3)
 
+  '@volar/language-core@2.4.15':
+    dependencies:
+      '@volar/source-map': 2.4.15
+
+  '@volar/source-map@2.4.15': {}
+
+  '@volar/typescript@2.4.15':
+    dependencies:
+      '@volar/language-core': 2.4.15
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
   '@vue/compiler-core@3.5.31':
     dependencies:
       '@babel/parser': 7.29.2
@@ -691,6 +774,24 @@ snapshots:
       '@vue/compiler-dom': 3.5.31
       '@vue/shared': 3.5.31
 
+  '@vue/compiler-vue2@2.7.16':
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
+
+  '@vue/language-core@2.2.12(typescript@5.9.3)':
+    dependencies:
+      '@volar/language-core': 2.4.15
+      '@vue/compiler-dom': 3.5.31
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.31
+      alien-signals: 1.0.13
+      minimatch: 9.0.9
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@vue/reactivity@3.5.31':
     dependencies:
       '@vue/shared': 3.5.31
@@ -715,7 +816,17 @@ snapshots:
 
   '@vue/shared@3.5.31': {}
 
+  alien-signals@1.0.13: {}
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@2.1.1:
+    dependencies:
+      balanced-match: 1.0.2
+
   csstype@3.2.3: {}
+
+  de-indent@1.0.2: {}
 
   entities@7.0.1: {}
 
@@ -757,11 +868,21 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  he@1.2.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
+  muggle-string@0.4.1: {}
+
   nanoid@3.3.11: {}
+
+  path-browserify@1.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -823,6 +944,14 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       fsevents: 2.3.3
+
+  vscode-uri@3.1.0: {}
+
+  vue-tsc@2.2.12(typescript@5.9.3):
+    dependencies:
+      '@volar/typescript': 2.4.15
+      '@vue/language-core': 2.2.12(typescript@5.9.3)
+      typescript: 5.9.3
 
   vue@3.5.31(typescript@5.9.3):
     dependencies:

--- a/packages/chart/examples/simple-vue-chart/src/App.vue
+++ b/packages/chart/examples/simple-vue-chart/src/App.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { definePrimitive, defineSeriesRenderer } from "@trendcraft/chart";
+// biome-ignore lint/correctness/noUnusedImports: used as <TrendChart> in the .vue template — Biome can't see template usage.
+import { TrendChart } from "@trendcraft/chart/vue";
 import {
   bollingerBands,
   goldenCrossCondition,
@@ -105,8 +107,15 @@ function computeTrailingStop() {
   });
 }
 
-const _indicators = computed(() => {
-  const list: unknown[] = [];
+// biome-ignore lint/correctness/noUnusedVariables: bound to template via `:indicators` — Biome can't see the .vue template usage.
+const indicators = computed(() => {
+  const list: (
+    | { time: number; value: unknown }[]
+    | {
+        data: { time: number; value: unknown }[];
+        config: import("@trendcraft/chart").SeriesConfig;
+      }
+  )[] = [];
   if (showSma.value) list.push(sma(candles, { period: 20 }));
   if (showBb.value) list.push(bollingerBands(candles));
   if (showRsi.value) list.push(rsi(candles));
@@ -131,13 +140,15 @@ const _indicators = computed(() => {
   return list;
 });
 
-const _backtestResult = computed(() => {
+// biome-ignore lint/correctness/noUnusedVariables: bound to template via `:backtest` — Biome can't see the .vue template usage.
+const backtestResult = computed(() => {
   if (!showBacktest.value) return undefined;
   const normalized = normalizeCandles(candles);
   return runBacktest(normalized, goldenCrossCondition(), rsiBelow(70), { capital: 100000 });
 });
 
-const _plugins = computed(() => {
+// biome-ignore lint/correctness/noUnusedVariables: bound to template via `:plugins` — Biome can't see the .vue template usage.
+const plugins = computed(() => {
   if (!showSrZones.value) return { renderers: [trailRenderer] };
   const recent = candles.slice(-60);
   let high = Number.NEGATIVE_INFINITY;
@@ -156,7 +167,8 @@ const _plugins = computed(() => {
   return { renderers: [trailRenderer], primitives: [srZonePrimitive] };
 });
 
-function _toggleTheme() {
+// biome-ignore lint/correctness/noUnusedVariables: bound to template via `@click="toggleTheme"` — Biome can't see the .vue template usage.
+function toggleTheme() {
   theme.value = theme.value === "dark" ? "light" : "dark";
 }
 </script>

--- a/packages/chart/examples/sparkline-showcase/README.md
+++ b/packages/chart/examples/sparkline-showcase/README.md
@@ -33,10 +33,10 @@ pnpm dev
 - Looking for `createSparklineGroup` usage and per-row `SparklineOptions` — see
   `src/main.ts`.
 - Looking for the smallest possible sparkline call site — see the README of
-  the main [`@trendcraft/chart`](../../README.md#sparkline) package.
+  the main [`@trendcraft/chart`](../../README.md#subpath-entry-points) package.
 
 ## Bundle reference
 
-Sparkline is its own subpath; see `packages/chart/.size-limit.json` for the
-current brotli budget. Importing from `@trendcraft/chart/sparkline` does not
+Sparkline is its own subpath; see the `size-limit` field in
+`packages/chart/package.json` for the current brotli budget. Importing from `@trendcraft/chart/sparkline` does not
 pull in the main chart code.

--- a/packages/chart/examples/strategy-studio/README.md
+++ b/packages/chart/examples/strategy-studio/README.md
@@ -22,7 +22,7 @@ The studio runs **fully offline with no LLM key**. It uses `detectMarketRegime` 
 |---|---|---|
 | PR2 | scaffold + 3-pane layout + regime banner + manifest preset selector | done |
 | PR3 | StrategyBuilder (entry/exit dropdowns) + backtest + trade overlay + JSON I/O | done |
-| PR4 | ParamEditor — paramSchema-driven slider/input UI for the 96 presets | done |
+| PR4 | ParamEditor — paramSchema-driven slider/input UI for the 104 presets | done |
 | PR5 | Replay mode — click-to-anchor, play/pause/step/speed, snapshot backtest | done |
 | PR6 | SignalsPanel — cross/divergence/pattern signal detection + markers | done |
 | PR7 | PluginsPanel — SMC / Pitchfork / Volume Profile / Wyckoff plugin toggles | done |

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -84,6 +84,30 @@ streaming entries now share the same default.
 `optimization` barrel), so the documented `deflatedSharpeFromReturns` example —
 `extractTradeReturns(result)` — no longer throws at runtime.
 
+### Added — incremental price / SMC factories
+
+Five batch indicators gained streaming counterparts, exposed on the
+`incremental` barrel: `createAutoTrendLine`, `createChannelLine`,
+`createFibonacciExtension`, `createFibonacciRetracement` (price), and
+`createLiquiditySweep` (SMC). Each maintains running state across `next()`
+calls instead of recomputing over the full candle history.
+
+### Added — `getIndicatorPreset(kind)` + `alwaysTrue` / `alwaysFalse` conditions
+
+`getIndicatorPreset(kind)` resolves a manifest kind (long name or short
+key) to its `IndicatorPreset`, returning `undefined` when the kind has no
+preset. The `alwaysTrue` / `alwaysFalse` backtest conditions provide
+constant-truth leaves for composing or disabling strategy branches.
+
+### Added — Schaff Trend Cycle `factor` option; T3 `vFactor` exposed in presets
+
+`schaffTrendCycle` gains a `factor` option (default `0.5`, validated to
+`(0, 1]`) controlling the smoothing of both stochastic passes. Separately,
+T3's existing `vFactor` volume-factor option is now surfaced in the
+streaming presets — `livePresets.t3` and `indicatorPresets.t3.paramSchema`
+expose `vFactor` (default `0.7`) so hosts can drive it from the UI, and the
+snapshot name now incorporates it (`t3_<period>_<vFactor>`).
+
 ### Added — optimizer cross-parameter constraints (`validateParams` + `paramFilter`)
 
 The grid-search engine can now reject structurally-invalid parameter
@@ -324,9 +348,9 @@ Resume behaviour is now defined per **state category**:
   DEMA, TEMA, HMA, …) — any state-shaping param change on resume
   throws; the recursive accumulator encodes past params and cannot
   be reconfigured mid-stream.
-- **Event log** (BOS, FVG, Liquidity Sweep, Pivot Points, Order
-  Block, Swing Points, …) — append-only: a params change keeps the
-  recorded events and continues appending.
+- **Event log** (BOS, FVG, Liquidity Sweep, Pivot Points, Swing
+  Points, …) — append-only: a params change keeps the recorded
+  events and continues appending.
 
 A new orthogonal **param-role** axis lets *resume-invariant* params
 change freely on resume regardless of category. These params (e.g.
@@ -372,6 +396,33 @@ The chart introspection rule auto-detects the new shape and
 plots the `short` (orange) and `long` (purple) lines together
 in the sub-pane, so chart consumers don't need any host-side
 changes when the chart picks up the new core.
+
+### Breaking — Roofing Filter / FRAMA align with canonical Ehlers formulas
+
+`roofingFilter` / `createRoofingFilter` and `frama` / `createFrama` now
+match John Ehlers' published reference formulas; both previously used
+variants that diverged from spec.
+
+- **Roofing Filter** (Cybernetic Analysis ch. 13 / Predictive Indicators):
+  the high-pass coefficients switched from a Butterworth-shape form to the
+  canonical critically-damped form (`alpha1 = (cos θ + sin θ − 1) / cos θ`
+  with `θ = √2·π / highPassPeriod`). The `highPassPeriod` minimum was also
+  raised from `1` to `2` — the canonical recurrence is stable for period ≥ 2
+  but diverges at period 1 (Nyquist-degenerate). Output difference is small
+  at default parameters (<1% at period 48).
+- **FRAMA** (Ehlers 2005): the fractal-dimension range calculation now uses
+  each candle's `high` / `low` (`Highest(High, N/2) − Lowest(Low, N/2)`)
+  instead of the smoothing source price. The `source` option still drives
+  the recursive smoothing step; only the period-range slope inputs change.
+  Incremental FRAMA state now stores separate `highBuffer` / `lowBuffer`
+  instead of a single source-price `buffer`.
+
+**Breaking** for callers depending on the prior numeric output (values
+change for every parameter combination) and for `highPassPeriod: 1`
+(now rejected). Because FRAMA is a recursive smoother, `createFrama(opts,
+{ fromState })` refuses to resume with a different `period` / `source`, and
+pre-canonical (close-only `buffer`) snapshots are rejected rather than
+silently migrated — re-warm from candle history instead.
 
 ### Breaking — Ease of Movement default `volumeDivisor`
 

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -50,10 +50,10 @@ console.log(`Return: ${result.totalReturnPercent.toFixed(2)}%  Sharpe: ${result.
 - **最適化** — 制約付きグリッドサーチ、アウトオブサンプル検証のウォークフォワード分析、組み合わせ探索。
 - **シグナルスコアリング** — 重み付きマルチシグナルスコアリング、プリセット、Fluentな`ScoreBuilder`。
 - **ポジションサイジング & リスク** — リスクベース・ATRベース・ケリー・固定比率サイジング、ATRストップとシャンデリアエグジット、VaR/CVaR、リスクパリティ、相関調整サイジング。
-- **ストリーミング** — `createLiveCandle()` がティックやローソク足を集約し、160以上のインクリメンタルなインジケーターファクトリをバーごとに駆動。再開可能なセッションのための状態保存/復元に対応。
+- **ストリーミング** — `createLiveCandle()` がティックやローソク足を集約し、90以上のインクリメンタルなインジケーターファクトリをバーごとに駆動。再開可能なセッションのための状態保存/復元に対応。
 - **高度な分析** — ペアトレード/共和分、クロスアセット相関、アルファ減衰モニタリング、戦略ロバストネススコアリング、シグナル説明可能性。
 
-36個のインジケーターはTA-Libと相互検証済みです — [`cross-validation/`](./cross-validation/) を参照してください。
+48個のインジケーターはTA-Libと相互検証済みです — [`cross-validation/`](./cross-validation/) を参照してください。
 
 ## エントリーポイント
 
@@ -82,7 +82,7 @@ import { ... } from 'trendcraft/manifest';     // インジケーターメタデ
 
 `Candle`の`time`はUnixタイムスタンプ・日付文字列・`Date`を受け付け、すべてのインジケーターは`Series<T> = { time: number, value: T }[]`を返します。
 
-2つのCLIツールが同梱されています: `trendcraft-screen` と `trendcraft-backtest`（`npx`で実行。`--list`で利用可能な条件を確認できます）。
+3つのCLIツールが同梱されています: `trendcraft-screen`、`trendcraft-backtest`、`trendcraft-analyze`（`npx`で実行。screen/backtest は `--list` で利用可能な条件を確認できます）。
 
 ## ドキュメント
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -50,10 +50,10 @@ Runnable scripts live in [`examples/quick-start/`](./examples/quick-start/) (ind
 - **Optimization** — grid search with constraints, walk-forward analysis for out-of-sample validation, and combination search.
 - **Signal scoring** — weighted multi-signal scoring with presets and a fluent `ScoreBuilder`.
 - **Position sizing & risk** — risk-based, ATR-based, Kelly, and fixed-fractional sizing; ATR stops and Chandelier Exit; VaR/CVaR, risk parity, and correlation-adjusted sizing.
-- **Streaming** — `createLiveCandle()` aggregates ticks or candles and drives 160+ incremental indicator factories bar-by-bar, with state save/restore for resumable sessions.
+- **Streaming** — `createLiveCandle()` aggregates ticks or candles and drives 90+ incremental indicator factories bar-by-bar, with state save/restore for resumable sessions.
 - **Advanced analytics** — pairs trading / cointegration, cross-asset correlation, alpha-decay monitoring, strategy robustness scoring, and signal explainability.
 
-36 indicators are cross-validated against TA-Lib — see [`cross-validation/`](./cross-validation/).
+48 indicators are cross-validated against TA-Lib — see [`cross-validation/`](./cross-validation/).
 
 ## Entry points
 
@@ -82,7 +82,7 @@ import { ... } from 'trendcraft/manifest';     // Indicator metadata
 
 A `Candle` accepts `time` as a Unix timestamp, date string, or `Date`; every indicator emits `Series<T> = { time: number, value: T }[]`.
 
-Two CLI tools ship with the package: `trendcraft-screen` and `trendcraft-backtest` (run with `npx`; pass `--list` to see available conditions).
+Three CLI tools ship with the package: `trendcraft-screen`, `trendcraft-backtest`, and `trendcraft-analyze` (run with `npx`; pass `--list` to see available conditions for screen/backtest).
 
 ## Documentation
 

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -2395,12 +2395,12 @@ interface PatternSignal {
 過去データでバックテストを実行。
 
 ```typescript
-import { runBacktest, goldenCross, deadCross } from 'trendcraft';
+import { runBacktest, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
 const result = runBacktest(
   candles,
-  goldenCross(5, 25),  // エントリー: ゴールデンクロス
-  deadCross(5, 25),    // イグジット: デッドクロス
+  goldenCrossCondition(5, 25),  // エントリー: ゴールデンクロス
+  deadCrossCondition(5, 25),    // イグジット: デッドクロス
   {
     capital: 1000000,
     commission: 0,
@@ -2526,8 +2526,8 @@ interface Trade {
 #### 移動平均クロス
 
 ```typescript
-goldenCross(shortPeriod = 5, longPeriod = 25)  // 短期MAが長期MAを上抜け
-deadCross(shortPeriod = 5, longPeriod = 25)    // 短期MAが長期MAを下抜け
+goldenCrossCondition(shortPeriod = 5, longPeriod = 25)  // 短期MAが長期MAを上抜け
+deadCrossCondition(shortPeriod = 5, longPeriod = 25)    // 短期MAが長期MAを下抜け
 ```
 
 #### RSI条件
@@ -2826,20 +2826,20 @@ const cupEntry = patternWithinBars('cup_handle', 5, { confirmedOnly: true });
 論理演算子で複数条件を組み合わせ。
 
 ```typescript
-import { and, or, not, goldenCross, rsiBelow, rsiAbove, deadCross } from 'trendcraft';
+import { and, or, not, goldenCrossCondition, rsiBelow, rsiAbove, deadCrossCondition } from 'trendcraft';
 
 // エントリー: ゴールデンクロス AND RSI < 30
-const entry = and(goldenCross(), rsiBelow(30));
+const entry = and(goldenCrossCondition(), rsiBelow(30));
 
 // イグジット: デッドクロス OR RSI > 70
-const exit = or(deadCross(), rsiAbove(70));
+const exit = or(deadCrossCondition(), rsiAbove(70));
 
 // エントリー: 買われすぎではない
 const notOverbought = not(rsiAbove(70));
 
 // 複雑な条件
 const complexEntry = and(
-  goldenCross(),
+  goldenCrossCondition(),
   rsiBelow(40),
   not(rsiAbove(60))
 );
@@ -2861,7 +2861,7 @@ const customCondition = (
   return candle.volume > 1000000 && candle.close > candle.open;
 };
 
-const result = runBacktest(candles, customCondition, deadCross(), { capital: 1000000 });
+const result = runBacktest(candles, customCondition, deadCrossCondition(), { capital: 1000000 });
 ```
 
 ---
@@ -3184,14 +3184,28 @@ const latest = result[result.length - 1].value;
 ATRからストップと利確レベルを計算。
 
 ```typescript
-import { calculateAtrStops } from 'trendcraft';
+import { atrStops } from 'trendcraft';
 
-const stops = calculateAtrStops(candles, {
-  atrPeriod: 14,
+const stops = atrStops(candles, {
+  period: 14,
   stopMultiplier: 2.5,
   takeProfitMultiplier: 4.0,
 });
+
+const latest = stops[stops.length - 1].value;
+// {
+//   atr, stopDistance, takeProfitDistance,
+//   longStopLevel, longTakeProfitLevel,
+//   shortStopLevel, shortTakeProfitLevel,
+// }
 ```
+
+**オプション:**
+| オプション | 型 | デフォルト | 説明 |
+|--------|------|---------|-------------|
+| `period` | `number` | `14` | ATR期間 |
+| `stopMultiplier` | `number` | `2.0` | ストップ距離のATR倍率 |
+| `takeProfitMultiplier` | `number` | `3.0` | 利確距離のATR倍率 |
 
 **バックテスト連携:**
 
@@ -3274,7 +3288,7 @@ interface VolatilityRegimeValue {
 **使用例:**
 
 ```typescript
-import { regimeIs, regimeNot, atrPercentAbove, and, goldenCross } from 'trendcraft';
+import { regimeIs, regimeNot, atrPercentAbove, and, goldenCrossCondition } from 'trendcraft';
 
 // 低ボラティリティ環境でのみエントリー
 const entry = and(
@@ -3285,7 +3299,7 @@ const entry = and(
 // 極端なボラティリティを避ける
 const entry = and(
   regimeNot('extreme'),
-  goldenCross()
+  goldenCrossCondition()
 );
 
 // トレンドフォロー用にATR%でフィルタ（ボラタイルな銘柄のみ）
@@ -3304,41 +3318,41 @@ const entry = and(
 最適な戦略パラメータのグリッドサーチ。
 
 ```typescript
-import { gridSearch, param, constraint, goldenCross, deadCross } from 'trendcraft';
+import { gridSearch, param, constraint, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
 const result = gridSearch(
   candles,
   (params) => ({
-    entry: goldenCross(params.short, params.long),
-    exit: deadCross(params.short, params.long),
+    entry: goldenCrossCondition(params.short, params.long),
+    exit: deadCrossCondition(params.short, params.long),
   }),
   [
-    param('short', [5, 10, 15, 20]),
-    param('long', [25, 50, 75]),
+    param('short', 5, 20, 5),
+    param('long', 25, 75, 25),
   ],
   {
-    metric: 'sharpeRatio',
+    metric: 'sharpe',
     constraints: [
       constraint('winRate', '>=', 40),
       constraint('maxDrawdown', '<=', 30),
     ],
-    topN: 10,
   }
 );
 
-console.log('最適パラメータ:', result.results[0].parameters);
-console.log('シャープレシオ:', result.results[0].metrics.sharpeRatio);
+// results[] はベスト順にソート済み。上位 10 件は .slice(0, 10) で取得
+const top10 = result.results.slice(0, 10);
+console.log('最適パラメータ:', result.results[0].params);
+console.log('シャープレシオ:', result.results[0].metrics.sharpe);
 ```
 
 **オプション:**
 | オプション | 型 | デフォルト | 説明 |
 |--------|------|---------|-------------|
-| `metric` | `OptimizationMetric` | `'sharpeRatio'` | 最適化対象の指標 |
+| `metric` | `OptimizationMetric` | `'sharpe'` | 最適化対象の指標 |
 | `constraints` | `OptimizationConstraint[]` | `[]` | 結果をフィルタする制約条件 |
-| `topN` | `number` | `10` | 返す上位結果の数 |
-| `capital` | `number` | `1000000` | バックテスト用の初期資金 |
+| `maxCombinations` | `number` | `10000` | テストするパラメータ組み合わせの最大数 |
 
-**指標:** `'sharpeRatio' | 'calmarRatio' | 'recoveryFactor' | 'totalReturn' | 'winRate' | 'profitFactor'`
+**指標:** `'sharpe' | 'calmar' | 'mar' | 'profitFactor' | 'recoveryFactor' | 'returns' | 'winRate' | 'tradeCount' | 'maxDrawdown'`
 
 **戻り値:** `GridSearchResult`
 
@@ -3369,21 +3383,95 @@ const result = walkForwardAnalysis(
   strategyFactory,
   paramRanges,
   {
-    inSampleRatio: 0.7,    // 70%をイン・サンプル、30%をアウト・オブ・サンプル
-    periods: 5,            // 5つのウォークフォワード期間
-    metric: 'sharpeRatio',
+    windowSize: 252,   // 学習ウィンドウ（日足で約1年）
+    stepSize: 63,      // 約1四半期ずつ前進
+    testSize: 63,      // アウト・オブ・サンプル検証期間（約1四半期）
+    metric: 'sharpe',
   }
 );
 
-console.log('アウトオブサンプル結果:', result.outOfSampleResults);
+// aggregateMetrics.avgOutOfSample は指標ごとのレコード。periods[] に各ウィンドウが入る
+console.log('OOS シャープ:', result.aggregateMetrics.avgOutOfSample.sharpe);
+console.log('安定性:', result.aggregateMetrics.stabilityRatio);
 ```
 
 **オプション:**
 | オプション | 型 | デフォルト | 説明 |
 |--------|------|---------|-------------|
-| `inSampleRatio` | `number` | `0.7` | イン・サンプル最適化に使用するデータの割合 |
-| `periods` | `number` | `5` | ウォークフォワード期間の数 |
-| `metric` | `OptimizationMetric` | `'sharpeRatio'` | 最適化する指標 |
+| `windowSize` | `number` | `252` | 学習ウィンドウのサイズ（ローソク足本数） |
+| `stepSize` | `number` | `63` | ウィンドウ間のステップサイズ（ローソク足本数） |
+| `testSize` | `number` | `63` | アウト・オブ・サンプル検証期間のサイズ（ローソク足本数） |
+| `metric` | `OptimizationMetric` | `'sharpe'` | 最適化する指標 |
+
+---
+
+### JSON ファーストの最適化
+
+手書きの `strategyFactory` の代わりに、シリアライズした `StrategyJSON` とパス指定のパラメーター範囲から同じ `gridSearch` / `walkForwardAnalysis` エンジンを駆動します。返される `bestParams` のキーはパス（例: `entry.0.params.period`）なので、そのまま `applyParamOverrides` に渡せます。登録済みのクロスパラメーター制約は param フィルターに AND され、構造的に無効な組み合わせはバックテスト前にスキップされます。
+
+```typescript
+import {
+  gridSearchFromJSON,
+  walkForwardAnalysisFromJSON,
+  backtestRegistry,
+  type PathParameterRange,
+} from 'trendcraft';
+
+const ranges: PathParameterRange[] = [
+  { path: 'entry.0.params.period', min: 10, max: 30, step: 5 },
+];
+
+const grid = gridSearchFromJSON(candles, strategy, ranges, backtestRegistry, {
+  metric: 'sharpe',
+});
+
+const wf = walkForwardAnalysisFromJSON(candles, strategy, ranges, backtestRegistry, {
+  windowSize: 252,
+  stepSize: 63,
+  testSize: 63,
+});
+```
+
+**シグネチャ:**
+
+```typescript
+function gridSearchFromJSON(
+  candles: NormalizedCandle[],
+  strategy: StrategyJSON,
+  ranges: PathParameterRange[],
+  registry: ConditionRegistry<Condition>,
+  options?: GridSearchOptions,
+): GridSearchResult;
+
+function walkForwardAnalysisFromJSON(
+  candles: NormalizedCandle[],
+  strategy: StrategyJSON,
+  ranges: PathParameterRange[],
+  registry: ConditionRegistry<Condition>,
+  options?: WalkForwardOptions,
+): WalkForwardResult;
+```
+
+いずれも範囲パスが解決できない場合（不正な形式、範囲外のリーフ、未知または数値でない param）に throw します。`gridSearchFromJSONSafe` / `walkForwardAnalysisFromJSONSafe` は同じ引数を取り、throw せず `Result<…>` を返します（検証エラー → `INVALID_PARAMETER`、過大なグリッド → `TOO_MANY_COMBINATIONS`、短すぎるスライス → `INSUFFICIENT_DATA`、それ以外 → `OPTIMIZATION_FAILED`）。
+
+---
+
+### ウォークフォワードユーティリティ
+
+```typescript
+import { wfeRatio, stitchOosEquity } from 'trendcraft';
+
+// 期間ごとのウォークフォワード効率（OOS年率 / IS年率）の平均。
+// イン・サンプルのリターンが非正の期間はスキップされ、未定義のときは NaN を返す。
+const wfe = wfeRatio(wf);
+if (Number.isFinite(wfe) && wfe >= 0.5) console.log(`堅牢: WFE ${(wfe * 100).toFixed(0)}%`);
+
+// 各期間のアウトオブサンプルトレードを 1 本の連続エクイティカーブに連結する。
+// トレード 1 件につき 1 点（先頭に最初の期間の testStart のアンカー点を追加）。
+const curve = stitchOosEquity(wf, 100_000); // -> Array<{ time: number; equity: number }>
+```
+
+`wfeRatio(result: WalkForwardResult): number` および `stitchOosEquity(result: WalkForwardResult, initialCapital = 100000)`。
 
 ---
 
@@ -3402,13 +3490,13 @@ const entryPool = createEntryConditionPool();  // デフォルトのエントリ
 const exitPool = createExitConditionPool();    // デフォルトのイグジット条件
 
 const result = combinationSearch(candles, entryPool, exitPool, {
-  metric: 'sharpeRatio',
-  topN: 20,
+  metric: 'sharpe',
 });
 
-result.results.forEach((r) => {
-  console.log(`エントリー: ${r.entryName}, イグジット: ${r.exitName}`);
-  console.log(`シャープ: ${r.metrics.sharpeRatio}`);
+// results[] はベスト順にソート済み。上位 20 件は .slice(0, 20) で取得
+result.results.slice(0, 20).forEach((r) => {
+  console.log(`エントリー: ${r.entryConditions.join(' + ')}, イグジット: ${r.exitConditions.join(' + ')}`);
+  console.log(`シャープ: ${r.metrics.sharpe}`);
 });
 ```
 
@@ -3422,16 +3510,49 @@ import {
   calculateCalmarRatio,
   calculateRecoveryFactor,
   annualizeReturn,
-  calculateAllMetrics
+  calculateAllMetrics,
+  extractTradeReturns
 } from 'trendcraft';
 
 // 個別メトリクスを計算
 const sharpe = calculateSharpeRatio(returns, riskFreeRate);
-const calmar = calculateCalmarRatio(totalReturn, maxDrawdown, years);
-const recovery = calculateRecoveryFactor(totalReturn, maxDrawdown);
+const calmar = calculateCalmarRatio(annualizedReturnPercent, maxDrawdownPercent);
+const recovery = calculateRecoveryFactor(netProfit, maxDrawdown);
 
-// 全メトリクスを一度に計算
-const metrics = calculateAllMetrics(backtestResult);
+// 全メトリクスを一度に計算（年率化のため candles が必須）
+const metrics = calculateAllMetrics(backtestResult, candles);
+
+// バックテスト結果からトレードごとのリターン（小数）を取得
+const tradeReturns = extractTradeReturns(backtestResult); // number[]
+```
+
+`extractTradeReturns(result: BacktestResult): number[]` は各トレードの `returnPercent` を小数に変換します。
+
+---
+
+### `deflatedSharpe(params)` / `deflatedSharpeFromReturns(returns, trialSharpes)`
+
+Deflated Sharpe Ratio —選択バイアス（N 試行）、非正規性、サンプル長を補正した後に、選択された戦略の真の Sharpe が正である確率。`[0, 1]` の確率を返し、~0.95 を超える値は Sharpe が多重検定のアーティファクトである可能性が低いことを示します。すべての Sharpe 入力は per-return（非年率化）単位である必要があります。
+
+```typescript
+import { deflatedSharpe, deflatedSharpeFromReturns, extractTradeReturns } from 'trendcraft';
+
+// パラメーター明示形式
+const dsr = deflatedSharpe({
+  observedSharpe: 0.12,       // 選択された戦略の per-return Sharpe
+  sampleSize: 500,            // リターン観測数（T >= 2）
+  trials: 50,                 // 評価した独立構成の数（N）
+  trialSharpeVariance: 0.0025,// N 試行にわたる per-return Sharpe の分散
+  skewness: 0,                // 任意。デフォルト 0
+  kurtosis: 3,                // 任意。デフォルト 3（非超過）
+});
+console.log(dsr < 0.95 ? 'オーバーフィットの可能性' : '信頼できるエッジ');
+
+// 簡便形式: observedSharpe / sampleSize / skewness / kurtosis を `returns` から、
+// trials / variance を `trialSharpes` から導出します。両配列は同じ per-return
+// 単位である必要があります。未定義のとき（例: リターンが 2 未満）は NaN を返します。
+const returns = extractTradeReturns(bestResult);
+const dsr2 = deflatedSharpeFromReturns(returns, trialSharpes);
 ```
 
 ---
@@ -3440,7 +3561,7 @@ const metrics = calculateAllMetrics(backtestResult);
 
 #### `runMonteCarloSimulation(result, options)`
 
-バックテスト結果の統計的有意性を検証。トレード順序をシャッフルして「運が良かっただけか」を判定します。
+トレードリストをリサンプリングして、バックテスト結果がどれだけ信頼できるかを推定します。
 
 ```typescript
 import { runMonteCarloSimulation, formatMonteCarloResult } from 'trendcraft';
@@ -3449,25 +3570,33 @@ const mcResult = runMonteCarloSimulation(backtestResult, {
   simulations: 1000,
   seed: 42,
   confidenceLevel: 0.95,
+  method: 'bootstrap',   // デフォルト。シーケンスリスクのみ見るなら 'shuffle'
+  ruinThreshold: 50,     // 「破産」とみなすドローダウン（%）
 });
 
 console.log(formatMonteCarloResult(mcResult));
-// => p=0.023, 有意（元のSharpeはランダムより優れている）
 
-// 結果をチェック
-if (mcResult.assessment.isSignificant) {
-  console.log('戦略は統計的に有意です');
-} else {
-  console.log('結果は偶然の可能性があります:', mcResult.assessment.reason);
-}
+// ダウンサイドリスクをチェック
+console.log('利益確率:', mcResult.downside.probProfit);
+console.log('破産リスク:', mcResult.downside.riskOfRuin);
 ```
+
+**仕組み:**
+
+2つのリサンプリング手法があります（`method` オプション）:
+1. `"bootstrap"`（デフォルト）: N件のトレードを復元抽出します。同じトレードが複数回現れたり、まったく現れなかったりするため、トータルリターン・Sharpe・プロフィットファクターがシミュレーションごとに変動します。結果の不確実性推定（リターン分布、損失確率、破産リスク）の基礎となります。
+2. `"shuffle"`: 既存のトレードを並べ替えます（非復元）。リターンの多重集合は変わらないため、リターン・Sharpe・プロフィットファクターはシミュレーション間で同一となり、経路依存の最大ドローダウンのみが変動します。シーケンスリスク（連敗の偏り）の分析に使います。
+
+各シミュレーションはリサンプリングしたトレードからエクイティカーブを再構築し、Sharpe・最大ドローダウン・トータルリターン・プロフィットファクターを再計算します。結果はこれらのメトリクスの分布に加え、`downside` サマリー（利益/損失確率、破産リスク）を返します。二値の有意性フラグはありません — `downside` の数値が判定結果です。
 
 **オプション:**
 | オプション | 型 | デフォルト | 説明 |
 |--------|------|---------|-------------|
-| `simulations` | `number` | `1000` | シャッフルシミュレーション回数 |
+| `simulations` | `number` | `1000` | シミュレーション回数 |
 | `seed` | `number` | `undefined` | 再現性のためのシード値 |
 | `confidenceLevel` | `number` | `0.95` | 信頼区間レベル（0.90, 0.95, 0.99） |
+| `method` | `"bootstrap" \| "shuffle"` | `"bootstrap"` | リサンプリング手法（「仕組み」参照） |
+| `ruinThreshold` | `number` | `50` | `riskOfRuin` で「破産」とみなすドローダウン（正の%） |
 | `progressCallback` | `function` | `undefined` | 進捗コールバック |
 
 **戻り値:** `MonteCarloResult`
@@ -3486,9 +3615,12 @@ interface MonteCarloResult {
     totalReturnPercent: MetricStatistics;
     profitFactor: MetricStatistics;
   };
-  pValue: {
-    sharpe: number;    // Sharpeがランダムで達成される確率
-    returns: number;   // リターンがランダムで達成される確率
+  simulationCount: number;
+  downside: {
+    probProfit: number;    // 利益で終わったシミュレーションの割合
+    probLoss: number;      // 損失で終わった割合 = 1 - probProfit
+    riskOfRuin: number;    // 最大ドローダウンが ruinThreshold に達した割合
+    ruinThreshold: number; // 破産しきい値として使ったドローダウン（%）
   };
   confidenceInterval: {
     sharpe: { lower: number; upper: number };
@@ -3496,11 +3628,9 @@ interface MonteCarloResult {
     maxDrawdown: { lower: number; upper: number };
   };
   assessment: {
-    isSignificant: boolean;  // p < 0.05 なら true
-    reason: string;
+    reason: string;          // 手法別の人間可読な解釈
     confidenceLevel: number;
   };
-  simulationCount: number;
 }
 
 interface MetricStatistics {
@@ -3524,7 +3654,7 @@ const formatted = formatMonteCarloResult(mcResult);
 
 // サマリー取得
 const summary = summarizeMonteCarloResult(mcResult);
-// => { isSignificant, pValueSharpe, pValueReturns, expectedSharpe, sharpe95CI }
+// => { probProfit, probLoss, riskOfRuin, expectedSharpe, sharpe95CI, originalSharpe }
 
 // 統計値の計算（直接使用可能）
 const stats = calculateStatistics([1, 2, 3, 4, 5]);
@@ -3667,9 +3797,9 @@ const equity = getAWFEquityCurve(awfResult, 1000000);
 分割エントリー戦略でのバックテスト。一度に全ポジションを建てる代わりに、資金を複数のトランシェに分割します。
 
 ```typescript
-import { runBacktestScaled, goldenCross, deadCross } from 'trendcraft';
+import { runBacktestScaled, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
-const result = runBacktestScaled(candles, goldenCross(), deadCross(), {
+const result = runBacktestScaled(candles, goldenCrossCondition(), deadCrossCondition(), {
   capital: 1000000,
   scaledEntry: {
     tranches: 3,
@@ -4685,12 +4815,12 @@ TrendCraftはバックテスト・ストリーミング両方でショートポ�
 バックテストオプションに`direction: "short"`を指定。
 
 ```typescript
-import { runBacktest, deadCross, goldenCross } from 'trendcraft';
+import { runBacktest, deadCrossCondition, goldenCrossCondition } from 'trendcraft';
 
 const result = runBacktest(
   candles,
-  deadCross(5, 25),     // エントリー: デッドクロス（ショートイン）
-  goldenCross(5, 25),   // イグジット: ゴールデンクロス（ショートアウト）
+  deadCrossCondition(5, 25),     // エントリー: デッドクロス（ショートイン）
+  goldenCrossCondition(5, 25),   // イグジット: ゴールデンクロス（ショートアウト）
   {
     capital: 1000000,
     direction: 'short',  // ショートセリング有効化
@@ -4749,10 +4879,10 @@ if (result.triggered) {
 `batchBacktest()` と `portfolioBacktest()` も同じ `direction` オプションでショートセリングに対応。
 
 ```typescript
-import { batchBacktest, deadCross, goldenCross } from 'trendcraft';
+import { batchBacktest, deadCrossCondition, goldenCrossCondition } from 'trendcraft';
 
 // バッチバックテスト: direction をオプションに直接指定
-const batchResult = batchBacktest(datasets, deadCross(5, 25), goldenCross(5, 25), {
+const batchResult = batchBacktest(datasets, deadCrossCondition(5, 25), goldenCrossCondition(5, 25), {
   capital: 3_000_000,
   direction: 'short',
   stopLoss: 5,
@@ -4760,7 +4890,7 @@ const batchResult = batchBacktest(datasets, deadCross(5, 25), goldenCross(5, 25)
 });
 
 // ポートフォリオバックテスト: direction は tradeOptions 内に指定
-const portfolioResult = portfolioBacktest(datasets, deadCross(5, 25), goldenCross(5, 25), {
+const portfolioResult = portfolioBacktest(datasets, deadCrossCondition(5, 25), goldenCrossCondition(5, 25), {
   capital: 3_000_000,
   allocation: { type: 'equal' },
   maxPositions: 5,
@@ -4778,7 +4908,7 @@ const portfolioResult = portfolioBacktest(datasets, deadCross(5, 25), goldenCros
 
 ```typescript
 import {
-  and, rsiAbove, rsiBelow, bollingerTouch, deadCross, goldenCross,
+  and, rsiAbove, rsiBelow, bollingerTouch, deadCrossCondition, goldenCrossCondition,
   dmiBearish, anyBearishPattern, stochAbove, stochBelow,
 } from 'trendcraft';
 
@@ -4787,8 +4917,8 @@ const mrEntry = and(rsiAbove(70), bollingerTouch('upper'));
 const mrExit  = rsiBelow(50);
 
 // トレンドフォローショート: 下落トレンド確認
-const tfEntry = and(deadCross(5, 25), dmiBearish());
-const tfExit  = goldenCross(5, 25);
+const tfEntry = and(deadCrossCondition(5, 25), dmiBearish());
+const tfExit  = goldenCrossCondition(5, 25);
 
 // パターンベースショート: 弱気パターン + ストキャスティクス買われすぎ
 const ptEntry = and(anyBearishPattern(), stochAbove(80));
@@ -6057,15 +6187,15 @@ const N = annualizationFactor({ calendar: JPX_CALENDAR }); // 245
 NSGA-II多目的最適化 — 競合する目的関数をバランスするパレート最適なパラメータセットを発見します（例：シャープレシオ最大化とドローダウン最小化の両立）。高速非支配ソートとクラウディングディスタンスで多様性を維持。
 
 ```typescript
-import { paretoOptimization, param, constraint, summarizeParetoResult } from "trendcraft";
+import { paretoOptimization, param, constraint, summarizeParetoResult, goldenCrossCondition, deadCrossCondition } from "trendcraft";
 
 const result = paretoOptimization(
   candles,
   (params) => ({
-    entry: goldenCross(params.short, params.long),
-    exit: deadCross(params.short, params.long),
+    entry: goldenCrossCondition(params.short, params.long),
+    exit: deadCrossCondition(params.short, params.long),
   }),
-  [param("short", [5, 10, 15, 20]), param("long", [25, 50, 75, 100])],
+  [param("short", 5, 20, 5), param("long", 25, 100, 25)],
   {
     objectives: [
       { metric: "sharpe", direction: "maximize" },
@@ -6356,7 +6486,7 @@ type ConditionSpec =
   | { name: string; params?: Record<string, unknown> }
   | { op: "and" | "or" | "not"; conditions: ConditionSpec[] };
 
-// 例: and(goldenCross(5,25), rsiBelow(30))
+// 例: and(goldenCrossCondition(5,25), rsiBelow(30))
 {
   "op": "and",
   "conditions": [

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -2825,12 +2825,12 @@ interface PatternSignal {
 Run a backtest simulation on historical data.
 
 ```typescript
-import { runBacktest, goldenCross, deadCross } from 'trendcraft';
+import { runBacktest, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
 const result = runBacktest(
   candles,
-  goldenCross(5, 25),  // Entry: Golden Cross
-  deadCross(5, 25),    // Exit: Dead Cross
+  goldenCrossCondition(5, 25),  // Entry: Golden Cross
+  deadCrossCondition(5, 25),    // Exit: Dead Cross
   {
     capital: 1000000,
     commission: 0,
@@ -2956,8 +2956,8 @@ interface Trade {
 #### Moving Average Cross
 
 ```typescript
-goldenCross(shortPeriod = 5, longPeriod = 25)  // Short MA crosses above Long MA
-deadCross(shortPeriod = 5, longPeriod = 25)    // Short MA crosses below Long MA
+goldenCrossCondition(shortPeriod = 5, longPeriod = 25)  // Short MA crosses above Long MA
+deadCrossCondition(shortPeriod = 5, longPeriod = 25)    // Short MA crosses below Long MA
 ```
 
 #### RSI Conditions
@@ -3256,20 +3256,20 @@ const cupEntry = patternWithinBars('cup_handle', 5, { confirmedOnly: true });
 Combine multiple conditions with logical operators.
 
 ```typescript
-import { and, or, not, goldenCross, rsiBelow, rsiAbove, deadCross } from 'trendcraft';
+import { and, or, not, goldenCrossCondition, rsiBelow, rsiAbove, deadCrossCondition } from 'trendcraft';
 
 // Entry: Golden Cross AND RSI < 30
-const entry = and(goldenCross(), rsiBelow(30));
+const entry = and(goldenCrossCondition(), rsiBelow(30));
 
 // Exit: Dead Cross OR RSI > 70
-const exit = or(deadCross(), rsiAbove(70));
+const exit = or(deadCrossCondition(), rsiAbove(70));
 
 // Entry: NOT overbought
 const notOverbought = not(rsiAbove(70));
 
 // Complex condition
 const complexEntry = and(
-  goldenCross(),
+  goldenCrossCondition(),
   rsiBelow(40),
   not(rsiAbove(60))
 );
@@ -3291,7 +3291,7 @@ const customCondition = (
   return candle.volume > 1000000 && candle.close > candle.open;
 };
 
-const result = runBacktest(candles, customCondition, deadCross(), { capital: 1000000 });
+const result = runBacktest(candles, customCondition, deadCrossCondition(), { capital: 1000000 });
 ```
 
 ---
@@ -3701,10 +3701,10 @@ const latest = result[result.length - 1].value;
 Calculate stop and take-profit levels from ATR.
 
 ```typescript
-import { calculateAtrStops } from 'trendcraft';
+import { atrStops } from 'trendcraft';
 
-const stops = calculateAtrStops(candles, {
-  atrPeriod: 14,
+const stops = atrStops(candles, {
+  period: 14,
   stopMultiplier: 2.5,
   takeProfitMultiplier: 4.0,
 });
@@ -3712,14 +3712,21 @@ const stops = calculateAtrStops(candles, {
 const latest = stops[stops.length - 1].value;
 // {
 //   atr: 2.5,
-//   stopDistance: 6.25,      // 2.5 * 2.5
-//   takeProfitDistance: 10,  // 2.5 * 4.0
-//   longStop: 93.75,         // close - stopDistance
-//   longTakeProfit: 110,     // close + takeProfitDistance
-//   shortStop: 106.25,       // close + stopDistance
-//   shortTakeProfit: 90,     // close - takeProfitDistance
+//   stopDistance: 6.25,           // 2.5 * 2.5
+//   takeProfitDistance: 10,       // 2.5 * 4.0
+//   longStopLevel: 93.75,         // close - stopDistance
+//   longTakeProfitLevel: 110,     // close + takeProfitDistance
+//   shortStopLevel: 106.25,       // close + stopDistance
+//   shortTakeProfitLevel: 90,     // close - takeProfitDistance
 // }
 ```
+
+**Options:**
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `period` | `number` | `14` | ATR period |
+| `stopMultiplier` | `number` | `2.0` | ATR multiplier for stop distance |
+| `takeProfitMultiplier` | `number` | `3.0` | ATR multiplier for take-profit distance |
 
 **Backtest integration:**
 
@@ -3804,7 +3811,7 @@ Use these conditions to filter trades by market volatility environment.
 **Example:**
 
 ```typescript
-import { regimeIs, regimeNot, atrPercentAbove, and, goldenCross } from 'trendcraft';
+import { regimeIs, regimeNot, atrPercentAbove, and, goldenCrossCondition } from 'trendcraft';
 
 // Only enter trades in low volatility environment
 const entry = and(
@@ -3815,7 +3822,7 @@ const entry = and(
 // Avoid extreme volatility
 const entry = and(
   regimeNot('extreme'),
-  goldenCross()
+  goldenCrossCondition()
 );
 
 // Filter by ATR% for trend-following (volatile stocks only)
@@ -3834,41 +3841,41 @@ const entry = and(
 Grid search for optimal strategy parameters.
 
 ```typescript
-import { gridSearch, param, constraint, goldenCross, deadCross } from 'trendcraft';
+import { gridSearch, param, constraint, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
 const result = gridSearch(
   candles,
   (params) => ({
-    entry: goldenCross(params.short, params.long),
-    exit: deadCross(params.short, params.long),
+    entry: goldenCrossCondition(params.short, params.long),
+    exit: deadCrossCondition(params.short, params.long),
   }),
   [
-    param('short', [5, 10, 15, 20]),
-    param('long', [25, 50, 75]),
+    param('short', 5, 20, 5),
+    param('long', 25, 75, 25),
   ],
   {
-    metric: 'sharpeRatio',
+    metric: 'sharpe',
     constraints: [
       constraint('winRate', '>=', 40),
       constraint('maxDrawdown', '<=', 30),
     ],
-    topN: 10,
   }
 );
 
-console.log('Best parameters:', result.results[0].parameters);
-console.log('Sharpe ratio:', result.results[0].metrics.sharpeRatio);
+// results[] is sorted best-first; take the top 10 with .slice(0, 10)
+const top10 = result.results.slice(0, 10);
+console.log('Best parameters:', result.results[0].params);
+console.log('Sharpe ratio:', result.results[0].metrics.sharpe);
 ```
 
 **Options:**
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `metric` | `OptimizationMetric` | `'sharpeRatio'` | Target metric to optimize |
+| `metric` | `OptimizationMetric` | `'sharpe'` | Target metric to optimize |
 | `constraints` | `OptimizationConstraint[]` | `[]` | Constraints to filter results |
-| `topN` | `number` | `10` | Number of top results to return |
-| `capital` | `number` | `1000000` | Initial capital for backtests |
+| `maxCombinations` | `number` | `10000` | Maximum parameter combinations to test |
 
-**Metrics:** `'sharpeRatio' | 'calmarRatio' | 'recoveryFactor' | 'totalReturn' | 'winRate' | 'profitFactor'`
+**Metrics:** `'sharpe' | 'calmar' | 'mar' | 'profitFactor' | 'recoveryFactor' | 'returns' | 'winRate' | 'tradeCount' | 'maxDrawdown'`
 
 **Returns:** `GridSearchResult`
 
@@ -3899,21 +3906,95 @@ const result = walkForwardAnalysis(
   strategyFactory,
   paramRanges,
   {
-    inSampleRatio: 0.7,    // 70% in-sample, 30% out-of-sample
-    periods: 5,            // 5 walk-forward periods
-    metric: 'sharpeRatio',
+    windowSize: 252,   // training window (~1 year daily)
+    stepSize: 63,      // roll forward ~1 quarter
+    testSize: 63,      // out-of-sample test ~1 quarter
+    metric: 'sharpe',
   }
 );
 
-console.log('Out-of-sample results:', result.outOfSampleResults);
+// aggregateMetrics.avgOutOfSample is a per-metric record; periods[] holds each window
+console.log('OOS Sharpe:', result.aggregateMetrics.avgOutOfSample.sharpe);
+console.log('Stability:', result.aggregateMetrics.stabilityRatio);
 ```
 
 **Options:**
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `inSampleRatio` | `number` | `0.7` | Ratio of data for in-sample optimization |
-| `periods` | `number` | `5` | Number of walk-forward periods |
-| `metric` | `OptimizationMetric` | `'sharpeRatio'` | Metric to optimize |
+| `windowSize` | `number` | `252` | Training window size in candles |
+| `stepSize` | `number` | `63` | Step size in candles between windows |
+| `testSize` | `number` | `63` | Out-of-sample test size in candles |
+| `metric` | `OptimizationMetric` | `'sharpe'` | Metric to optimize |
+
+---
+
+### JSON-first optimization
+
+Drive the same `gridSearch` / `walkForwardAnalysis` engines from a serialized `StrategyJSON` plus path-addressed parameter ranges, instead of a hand-written `strategyFactory`. Returned `bestParams` keys are paths (e.g. `entry.0.params.period`) so they can be plugged straight back into `applyParamOverrides`. Registered cross-parameter constraints are AND'd into the param filter, so structurally-invalid combinations are skipped before backtesting.
+
+```typescript
+import {
+  gridSearchFromJSON,
+  walkForwardAnalysisFromJSON,
+  backtestRegistry,
+  type PathParameterRange,
+} from 'trendcraft';
+
+const ranges: PathParameterRange[] = [
+  { path: 'entry.0.params.period', min: 10, max: 30, step: 5 },
+];
+
+const grid = gridSearchFromJSON(candles, strategy, ranges, backtestRegistry, {
+  metric: 'sharpe',
+});
+
+const wf = walkForwardAnalysisFromJSON(candles, strategy, ranges, backtestRegistry, {
+  windowSize: 252,
+  stepSize: 63,
+  testSize: 63,
+});
+```
+
+**Signatures:**
+
+```typescript
+function gridSearchFromJSON(
+  candles: NormalizedCandle[],
+  strategy: StrategyJSON,
+  ranges: PathParameterRange[],
+  registry: ConditionRegistry<Condition>,
+  options?: GridSearchOptions,
+): GridSearchResult;
+
+function walkForwardAnalysisFromJSON(
+  candles: NormalizedCandle[],
+  strategy: StrategyJSON,
+  ranges: PathParameterRange[],
+  registry: ConditionRegistry<Condition>,
+  options?: WalkForwardOptions,
+): WalkForwardResult;
+```
+
+Both throw if any range path fails to resolve (malformed, out-of-range leaf, unknown or non-numeric param). The `gridSearchFromJSONSafe` / `walkForwardAnalysisFromJSONSafe` variants take the same arguments and return a `Result<…>` instead of throwing (validation → `INVALID_PARAMETER`, over-large grid → `TOO_MANY_COMBINATIONS`, too-short slice → `INSUFFICIENT_DATA`, otherwise `OPTIMIZATION_FAILED`).
+
+---
+
+### Walk-forward utilities
+
+```typescript
+import { wfeRatio, stitchOosEquity } from 'trendcraft';
+
+// Average per-period walk-forward efficiency (OOS annualized / IS annualized).
+// Periods with non-positive in-sample return are skipped; returns NaN when undefined.
+const wfe = wfeRatio(wf);
+if (Number.isFinite(wfe) && wfe >= 0.5) console.log(`Robust: WFE ${(wfe * 100).toFixed(0)}%`);
+
+// Stitch every period's out-of-sample trades into one continuous equity curve,
+// one point per trade (plus a leading anchor at the first period's testStart).
+const curve = stitchOosEquity(wf, 100_000); // -> Array<{ time: number; equity: number }>
+```
+
+`wfeRatio(result: WalkForwardResult): number` and `stitchOosEquity(result: WalkForwardResult, initialCapital = 100000)`.
 
 ---
 
@@ -3932,13 +4013,13 @@ const entryPool = createEntryConditionPool();  // Default entry conditions
 const exitPool = createExitConditionPool();    // Default exit conditions
 
 const result = combinationSearch(candles, entryPool, exitPool, {
-  metric: 'sharpeRatio',
-  topN: 20,
+  metric: 'sharpe',
 });
 
-result.results.forEach((r) => {
-  console.log(`Entry: ${r.entryName}, Exit: ${r.exitName}`);
-  console.log(`Sharpe: ${r.metrics.sharpeRatio}`);
+// results[] is sorted best-first; take the top 20 with .slice(0, 20)
+result.results.slice(0, 20).forEach((r) => {
+  console.log(`Entry: ${r.entryConditions.join(' + ')}, Exit: ${r.exitConditions.join(' + ')}`);
+  console.log(`Sharpe: ${r.metrics.sharpe}`);
 });
 ```
 
@@ -3952,23 +4033,56 @@ import {
   calculateCalmarRatio,
   calculateRecoveryFactor,
   annualizeReturn,
-  calculateAllMetrics
+  calculateAllMetrics,
+  extractTradeReturns
 } from 'trendcraft';
 
 // Calculate individual metrics
 const sharpe = calculateSharpeRatio(returns, riskFreeRate);
-const calmar = calculateCalmarRatio(totalReturn, maxDrawdown, years);
-const recovery = calculateRecoveryFactor(totalReturn, maxDrawdown);
+const calmar = calculateCalmarRatio(annualizedReturnPercent, maxDrawdownPercent);
+const recovery = calculateRecoveryFactor(netProfit, maxDrawdown);
 
-// Calculate all metrics at once
-const metrics = calculateAllMetrics(backtestResult);
+// Calculate all metrics at once (candles required for annualization)
+const metrics = calculateAllMetrics(backtestResult, candles);
+
+// Per-trade returns (decimals) from a backtest result
+const tradeReturns = extractTradeReturns(backtestResult); // number[]
+```
+
+`extractTradeReturns(result: BacktestResult): number[]` maps each trade's `returnPercent` to a decimal.
+
+---
+
+### `deflatedSharpe(params)` / `deflatedSharpeFromReturns(returns, trialSharpes)`
+
+Deflated Sharpe Ratio — the probability that the selected strategy's true Sharpe is positive after correcting for selection bias (N trials), non-normality, and sample length. Returns a probability in `[0, 1]`; values above ~0.95 indicate the Sharpe is unlikely to be a multiple-testing artifact. All Sharpe inputs must be in per-return (non-annualized) units.
+
+```typescript
+import { deflatedSharpe, deflatedSharpeFromReturns, extractTradeReturns } from 'trendcraft';
+
+// Explicit-parameter form
+const dsr = deflatedSharpe({
+  observedSharpe: 0.12,       // per-return Sharpe of the selected strategy
+  sampleSize: 500,            // number of return observations (T >= 2)
+  trials: 50,                 // number of independent configurations evaluated (N)
+  trialSharpeVariance: 0.0025,// variance of per-return Sharpe across the N trials
+  skewness: 0,                // optional, default 0
+  kurtosis: 3,                // optional, default 3 (non-excess)
+});
+console.log(dsr < 0.95 ? 'likely overfit' : 'credible edge');
+
+// Convenience form: derives observedSharpe / sampleSize / skewness / kurtosis
+// from `returns`, and trials / variance from `trialSharpes`. Both arrays must
+// be in the same per-return units. Returns NaN when undefined (e.g. < 2 returns).
+const returns = extractTradeReturns(bestResult);
+const dsr2 = deflatedSharpeFromReturns(returns, trialSharpes);
 ```
 
 ---
 
 ### `runMonteCarloSimulation(result, options)`
 
-Monte Carlo simulation to test if backtest results are statistically significant or just lucky.
+Monte Carlo simulation that resamples the trade list to estimate how reliable a backtest's performance is.
 
 ```typescript
 import { runMonteCarloSimulation, formatMonteCarloResult } from 'trendcraft';
@@ -3977,24 +4091,29 @@ const mcResult = runMonteCarloSimulation(backtestResult, {
   simulations: 1000,
   seed: 42,              // Optional: for reproducibility
   confidenceLevel: 0.95,
+  method: 'bootstrap',   // default; or 'shuffle' for sequence-risk only
+  ruinThreshold: 50,     // drawdown % treated as "ruin"
 });
 
 console.log(formatMonteCarloResult(mcResult));
-// => p=0.023, SIGNIFICANT - Strategy shows statistically significant edge
 ```
 
 **How it works:**
-1. Shuffles the trade sequence 1000 times (configurable)
-2. Recalculates metrics (Sharpe, MaxDrawdown, etc.) for each shuffle
-3. Computes p-value: probability of achieving original result by chance
-4. If p < 0.05, the strategy is statistically significant
+
+Two resampling methods (`method` option):
+1. `"bootstrap"` (default): draws N trades with replacement, so the same trade can repeat or be omitted. Total return, Sharpe, and profit factor all vary across simulations — the basis for outcome-uncertainty estimates (return distribution, probability of loss, risk of ruin).
+2. `"shuffle"`: permutes the existing trades (no replacement). The multiset of returns is unchanged, so return / Sharpe / profit factor are identical across simulations and only the path-dependent max drawdown varies. Use this to study sequence risk specifically.
+
+Each simulation rebuilds the equity curve from the resampled trades and recomputes Sharpe, max drawdown, total return, and profit factor. The result reports the distribution of these metrics plus a `downside` summary (probability of profit/loss, risk of ruin). There is no binary significance flag — the figures in `downside` are the verdict.
 
 **Options:**
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `simulations` | `number` | `1000` | Number of shuffle simulations |
+| `simulations` | `number` | `1000` | Number of simulations |
 | `seed` | `number` | - | Random seed for reproducibility |
 | `confidenceLevel` | `number` | `0.95` | Confidence level for intervals |
+| `method` | `"bootstrap" \| "shuffle"` | `"bootstrap"` | Resampling method (see "How it works") |
+| `ruinThreshold` | `number` | `50` | Drawdown level (positive percent) counted as "ruin" for `riskOfRuin` |
 | `progressCallback` | `function` | - | Progress callback (current, total) |
 
 **Returns:** `MonteCarloResult`
@@ -4014,15 +4133,19 @@ interface MonteCarloResult {
     profitFactor: MetricStatistics;
   };
   simulationCount: number;
-  pValue: { sharpe: number; returns: number };
+  downside: {
+    probProfit: number;    // fraction of simulations that ended profitable
+    probLoss: number;      // fraction that lost money = 1 - probProfit
+    riskOfRuin: number;    // fraction whose max drawdown reached ruinThreshold
+    ruinThreshold: number; // drawdown % used as the ruin threshold
+  };
   confidenceInterval: {
     sharpe: { lower: number; upper: number };
     returns: { lower: number; upper: number };
     maxDrawdown: { lower: number; upper: number };
   };
   assessment: {
-    isSignificant: boolean;
-    reason: string;
+    reason: string;          // method-aware, human-readable interpretation
     confidenceLevel: number;
   };
 }
@@ -4047,8 +4170,9 @@ import { summarizeMonteCarloResult, calculateStatistics } from 'trendcraft';
 
 // Get summary
 const summary = summarizeMonteCarloResult(mcResult);
-console.log(summary.isSignificant);    // true
-console.log(summary.pValueSharpe);     // 0.023
+console.log(summary.probProfit);   // 0.92  (fraction of profitable resamples)
+console.log(summary.riskOfRuin);   // 0.03  (fraction reaching the ruin threshold)
+console.log(summary.sharpe95CI);   // { lower: 0.4, upper: 1.8 }
 
 // Calculate statistics for any array
 const stats = calculateStatistics([1, 2, 3, 4, 5]);
@@ -4192,9 +4316,9 @@ const curve = getAWFEquityCurve(awfResult, 1000000);
 Backtest with split/scaled entry strategies. Instead of entering a full position at once, capital is divided into multiple tranches.
 
 ```typescript
-import { runBacktestScaled, goldenCross, deadCross } from 'trendcraft';
+import { runBacktestScaled, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
-const result = runBacktestScaled(candles, goldenCross(), deadCross(), {
+const result = runBacktestScaled(candles, goldenCrossCondition(), deadCrossCondition(), {
   capital: 1000000,
   scaledEntry: {
     tranches: 3,
@@ -5210,12 +5334,12 @@ TrendCraft supports short selling in both backtest and streaming modes. All shor
 Pass `direction: "short"` in backtest options to simulate short positions.
 
 ```typescript
-import { runBacktest, deadCross, goldenCross } from 'trendcraft';
+import { runBacktest, deadCrossCondition, goldenCrossCondition } from 'trendcraft';
 
 const result = runBacktest(
   candles,
-  deadCross(5, 25),     // Entry: Dead Cross (short entry)
-  goldenCross(5, 25),   // Exit: Golden Cross (short exit)
+  deadCrossCondition(5, 25),     // Entry: Dead Cross (short entry)
+  goldenCrossCondition(5, 25),   // Exit: Golden Cross (short exit)
   {
     capital: 1000000,
     direction: 'short',  // Enable short selling
@@ -5274,10 +5398,10 @@ if (result.triggered) {
 Both `batchBacktest()` and `portfolioBacktest()` support short selling through the same `direction` option.
 
 ```typescript
-import { batchBacktest, deadCross, goldenCross } from 'trendcraft';
+import { batchBacktest, deadCrossCondition, goldenCrossCondition } from 'trendcraft';
 
 // Batch backtest: direction is passed directly in options
-const batchResult = batchBacktest(datasets, deadCross(5, 25), goldenCross(5, 25), {
+const batchResult = batchBacktest(datasets, deadCrossCondition(5, 25), goldenCrossCondition(5, 25), {
   capital: 3_000_000,
   direction: 'short',
   stopLoss: 5,
@@ -5285,7 +5409,7 @@ const batchResult = batchBacktest(datasets, deadCross(5, 25), goldenCross(5, 25)
 });
 
 // Portfolio backtest: direction goes inside tradeOptions
-const portfolioResult = portfolioBacktest(datasets, deadCross(5, 25), goldenCross(5, 25), {
+const portfolioResult = portfolioBacktest(datasets, deadCrossCondition(5, 25), goldenCrossCondition(5, 25), {
   capital: 3_000_000,
   allocation: { type: 'equal' },
   maxPositions: 5,
@@ -5303,7 +5427,7 @@ Common short strategy patterns using built-in conditions:
 
 ```typescript
 import {
-  and, rsiAbove, rsiBelow, bollingerTouch, deadCross, goldenCross,
+  and, rsiAbove, rsiBelow, bollingerTouch, deadCrossCondition, goldenCrossCondition,
   dmiBearish, anyBearishPattern, stochAbove, stochBelow,
 } from 'trendcraft';
 
@@ -5312,8 +5436,8 @@ const mrEntry = and(rsiAbove(70), bollingerTouch('upper'));
 const mrExit  = rsiBelow(50);
 
 // Trend-following short: confirmed downtrend
-const tfEntry = and(deadCross(5, 25), dmiBearish());
-const tfExit  = goldenCross(5, 25);
+const tfEntry = and(deadCrossCondition(5, 25), dmiBearish());
+const tfExit  = goldenCrossCondition(5, 25);
 
 // Pattern-based short: bearish pattern + overbought stochastic
 const ptEntry = and(anyBearishPattern(), stochAbove(80));
@@ -6836,15 +6960,15 @@ The `AnnualizationOptions` bag (`{ calendar?, periodsPerYear? }`) is accepted by
 NSGA-II multi-objective optimization — finds Pareto-optimal parameter sets that balance competing objectives (e.g., maximize Sharpe ratio while minimizing drawdown). Uses fast non-dominated sorting and crowding distance for diversity.
 
 ```typescript
-import { paretoOptimization, param, constraint, summarizeParetoResult } from "trendcraft";
+import { paretoOptimization, param, constraint, summarizeParetoResult, goldenCrossCondition, deadCrossCondition } from "trendcraft";
 
 const result = paretoOptimization(
   candles,
   (params) => ({
-    entry: goldenCross(params.short, params.long),
-    exit: deadCross(params.short, params.long),
+    entry: goldenCrossCondition(params.short, params.long),
+    exit: deadCrossCondition(params.short, params.long),
   }),
-  [param("short", [5, 10, 15, 20]), param("long", [25, 50, 75, 100])],
+  [param("short", 5, 20, 5), param("long", 25, 100, 25)],
   {
     objectives: [
       { metric: "sharpe", direction: "maximize" },
@@ -7137,7 +7261,7 @@ type ConditionSpec =
   | { name: string; params?: Record<string, unknown> }
   | { op: "and" | "or" | "not"; conditions: ConditionSpec[] };
 
-// Example: and(goldenCross(5,25), rsiBelow(30))
+// Example: and(goldenCrossCondition(5,25), rsiBelow(30))
 {
   "op": "and",
   "conditions": [

--- a/packages/core/docs/COOKBOOK.md
+++ b/packages/core/docs/COOKBOOK.md
@@ -57,9 +57,10 @@ import {
 const candles = normalizeCandles(rawCandles);
 
 // Enter: strong bullish trend + volume confirmation
-const entry = and(dmiBullish(20), adxStrong(25), volumeAboveAvg(1.5));
+// dmiBullish()/dmiBearish() default to ADX >= 25 (Wilder's strong-trend level)
+const entry = and(dmiBullish(), adxStrong(25), volumeAboveAvg(1.5));
 // Exit: bearish DMI crossover
-const exit = dmiBearish(20);
+const exit = dmiBearish();
 
 const result = runBacktest(candles, entry, exit, {
   capital: 1_000_000,
@@ -125,7 +126,7 @@ const dailyCandles = normalizeCandles(rawDailyCandles);
 const entry = and(goldenCrossCondition(5, 25), weeklyPriceAboveSma(20));
 const exit = deadCrossCondition(5, 25);
 
-const result = runBacktest(candles, entry, exit, {
+const result = runBacktest(dailyCandles, entry, exit, {
   capital: 1_000_000,
   mtfTimeframes: ["1W"],   // Enable weekly MTF data
   stopLoss: 5,
@@ -199,44 +200,49 @@ import {
 const candles = normalizeCandles(rawCandles);
 
 // Step 1: Grid search for best parameters
+// Signature: gridSearch(candles, createStrategy, parameterRanges[], options)
 const gridResult = gridSearch(
   candles,
-  {
-    shortPeriod: param(3, 10, 1),    // 3 to 10, step 1
-    longPeriod: param(15, 50, 5),    // 15 to 50, step 5
-  },
   (params) => ({
     entry: goldenCrossCondition(params.shortPeriod, params.longPeriod),
     exit: deadCrossCondition(params.shortPeriod, params.longPeriod),
     options: { capital: 1_000_000 },
   }),
+  [
+    param("shortPeriod", 3, 10, 1),    // 3 to 10, step 1
+    param("longPeriod", 15, 50, 5),    // 15 to 50, step 5
+  ],
   { metric: "sharpe" },
 );
 
-console.log(`Best params:`, gridResult.results[0].params);
-console.log(`Best Sharpe: ${gridResult.results[0].metricValue.toFixed(2)}`);
+// results[] is sorted best-first; bestParams/bestScore are also returned directly
+console.log(`Best params:`, gridResult.bestParams);
+console.log(`Best Sharpe: ${gridResult.results[0].score.toFixed(2)}`);
 
 // Step 2: Walk-forward validation
+// Signature: walkForwardAnalysis(candles, createStrategy, parameterRanges[], options)
 const wfResult = walkForwardAnalysis(
   candles,
-  {
-    shortPeriod: param(3, 10, 1),
-    longPeriod: param(15, 50, 5),
-  },
   (params) => ({
     entry: goldenCrossCondition(params.shortPeriod, params.longPeriod),
     exit: deadCrossCondition(params.shortPeriod, params.longPeriod),
     options: { capital: 1_000_000 },
   }),
+  [
+    param("shortPeriod", 3, 10, 1),
+    param("longPeriod", 15, 50, 5),
+  ],
   {
     metric: "sharpe",
-    inSampleRatio: 0.7,
-    periods: 5,
+    windowSize: 252,   // training window (~1 year daily)
+    stepSize: 63,      // roll forward ~1 quarter
+    testSize: 63,      // out-of-sample test ~1 quarter
   },
 );
 
-console.log(`OOS Return: ${wfResult.outOfSampleReturn.toFixed(2)}%`);
-console.log(`Robustness: ${wfResult.robustnessScore.toFixed(2)}`);
+// Aggregate metrics: avgOutOfSample is a per-metric record; stabilityRatio is OOS/IS
+console.log(`OOS Sharpe: ${wfResult.aggregateMetrics.avgOutOfSample.sharpe.toFixed(2)}`);
+console.log(`Stability: ${wfResult.aggregateMetrics.stabilityRatio.toFixed(2)}`);
 ```
 
 ---
@@ -257,12 +263,10 @@ const session = streaming.createTradingSession({
       { name: "rsi", create: () => incremental.createRsi({ period: 14 }) },
       { name: "sma20", create: () => incremental.createSma({ period: 20 }) },
     ],
-    detectors: [
-      {
-        name: "rsiCross30",
-        create: () => streaming.createThresholdDetector({ threshold: 30, direction: "crossBelow" }),
-        indicatorKey: "rsi",
-      },
+    // Named signals are StreamingConditions evaluated against the snapshot.
+    // crossUnder("rsi", 30) fires the bar RSI crosses from >=30 to <30.
+    signals: [
+      { name: "rsiCross30", condition: streaming.crossUnder("rsi", 30) },
     ],
   },
 });
@@ -277,7 +281,7 @@ function onTrade(price: number, volume: number) {
 
   for (const event of events) {
     if (event.type === "signal") {
-      console.log(`Signal: ${event.detectorName} at price ${price}`);
+      console.log(`Signal: ${event.name} at price ${price}`);
     }
     if (event.type === "candle") {
       console.log(`New candle: O=${event.candle.open} H=${event.candle.high}`);

--- a/packages/core/docs/GUIDE.ja.md
+++ b/packages/core/docs/GUIDE.ja.md
@@ -1002,14 +1002,14 @@ rankings.slice(0, 5).forEach((r, i) => {
 ### バックテストでのRS
 
 ```typescript
-import { rsAbove, rsRising, rsRatingAbove, setBenchmark, and } from 'trendcraft';
+import { rsAbove, rsRising, rsRatingAbove, setBenchmark, and, goldenCrossCondition } from 'trendcraft';
 
 // エントリー: 強いRS + トレンド確認
 const entry = and(
   rsAbove(1.0),         // アウトパフォーム
   rsRising(),           // RS改善中
   rsRatingAbove(70),    // 上位30%
-  goldenCross()         // テクニカルエントリー
+  goldenCrossCondition()         // テクニカルエントリー
 );
 
 // ベンチマーク付きバックテスト実行
@@ -1323,24 +1323,24 @@ rangeScore <= 40 → トレンドまたは中立
 | 条件 | 説明 |
 |------|------|
 | `rangeBreakout()` | レンジからのブレイクアウトでエントリー |
-| `notInRange()` | レンジ相場ではない時のみエントリー（フィルター） |
+| `not(inRangeBound())` | レンジ相場ではない時のみエントリー（フィルター） |
 | `rangeForming()` | レンジ形成中にイグジット |
 
 ```typescript
-import { TrendCraft, goldenCross, rangeBreakout, notInRange } from 'trendcraft';
+import { TrendCraft, and, goldenCrossCondition, deadCrossCondition, rangeBreakout, inRangeBound, not } from 'trendcraft';
 
 // ブレイクアウト戦略
 const result1 = TrendCraft.from(candles)
   .strategy()
     .entry(rangeBreakout())
-    .exit(deadCross())
+    .exit(deadCrossCondition())
   .backtest({ capital: 1000000 });
 
 // レンジ相場を避けるフィルター
 const result2 = TrendCraft.from(candles)
   .strategy()
-    .entry(and(goldenCross(), notInRange()))
-    .exit(deadCross())
+    .entry(and(goldenCrossCondition(), not(inRangeBound())))
+    .exit(deadCrossCondition())
   .backtest({ capital: 1000000 });
 ```
 
@@ -1472,12 +1472,12 @@ orb.forEach(({ value }) => {
 ### 基本的な使い方
 
 ```typescript
-import { runBacktest, goldenCross, deadCross } from 'trendcraft';
+import { runBacktest, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
 const result = runBacktest(
   candles,
-  goldenCross(5, 25),  // エントリー条件
-  deadCross(5, 25),    // イグジット条件
+  goldenCrossCondition(5, 25),  // エントリー条件
+  deadCrossCondition(5, 25),    // イグジット条件
   {
     capital: 1000000,    // 初期資金
     stopLoss: 5,         // 5%で損切り
@@ -1490,8 +1490,8 @@ const result = runBacktest(
 
 | 条件 | 説明 |
 |------|------|
-| `goldenCross(short, long)` | 短期MAが長期MAを上抜け |
-| `deadCross(short, long)` | 短期MAが長期MAを下抜け |
+| `goldenCrossCondition(short, long)` | 短期MAが長期MAを上抜け |
+| `deadCrossCondition(short, long)` | 短期MAが長期MAを下抜け |
 | `rsiBelow(threshold)` | RSIが閾値未満 |
 | `rsiAbove(threshold)` | RSIが閾値超え |
 | `macdCrossUp()` | MACDがシグナルを上抜け |
@@ -1503,13 +1503,13 @@ const result = runBacktest(
 ### 条件の組み合わせ
 
 ```typescript
-import { and, or, not } from 'trendcraft';
+import { and, or, not, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
 // ゴールデンクロス AND RSI < 30
-const entry = and(goldenCross(), rsiBelow(30));
+const entry = and(goldenCrossCondition(), rsiBelow(30));
 
 // デッドクロス OR RSI > 70
-const exit = or(deadCross(), rsiAbove(70));
+const exit = or(deadCrossCondition(), rsiAbove(70));
 
 // 買われすぎではない
 const notOverbought = not(rsiAbove(70));
@@ -1626,13 +1626,13 @@ TrendCraftは事前構築されたスコアリング戦略を提供していま�
 | `balanced` | 混合シグナル | 汎用 |
 
 ```typescript
-import { getPreset, scoreAbove } from 'trendcraft';
+import { getPreset, scoreAbove, deadCrossCondition } from 'trendcraft';
 
 // プリセットをバックテストで使用
 const result = TrendCraft.from(candles)
   .strategy()
     .entry(scoreAbove(70, "trendFollowing"))
-    .exit(deadCross())
+    .exit(deadCrossCondition())
   .backtest({ capital: 1000000 });
 ```
 
@@ -1807,31 +1807,30 @@ chandelier.forEach(({ time, value }) => {
 エントリー、ストップ、利確レベルを計算：
 
 ```typescript
-import { calculateAtrStops } from 'trendcraft';
+import { calculateAtrStop, calculateAtrTakeProfit } from 'trendcraft';
 
-const levels = calculateAtrStops({
-  entryPrice: 100,
-  atrValue: 2.5,
-  stopMultiplier: 2,        // 2×ATRでストップ
-  takeProfitMultiplier: 3,  // 3×ATRで利確
-  direction: 'long',
-});
+const entryPrice = 100;
+const atrValue = 2.5;
 
-// 結果:
-// stopPrice: 95 (100 - 2 × 2.5)
-// takeProfitPrice: 107.5 (100 + 3 × 2.5)
-// riskRewardRatio: 1.5
+const stopPrice = calculateAtrStop(entryPrice, atrValue, 2, 'long');
+// 95 (100 - 2 × 2.5)
+const takeProfitPrice = calculateAtrTakeProfit(entryPrice, atrValue, 3, 'long');
+// 107.5 (100 + 3 × 2.5)
+
+const riskRewardRatio =
+  (takeProfitPrice - entryPrice) / (entryPrice - stopPrice);
+// 1.5
 ```
 
 ### バックテストでATRを使用
 
 ```typescript
-import { TrendCraft, goldenCross, deadCross } from 'trendcraft';
+import { TrendCraft, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
 const result = TrendCraft.from(candles)
   .strategy()
-    .entry(goldenCross())
-    .exit(deadCross())
+    .entry(goldenCrossCondition())
+    .exit(deadCrossCondition())
   .backtest({
     capital: 1000000,
     atrRisk: {
@@ -1864,7 +1863,8 @@ const result = TrendCraft.from(candles)
 ```typescript
 import {
   atrBasedSize,
-  calculateAtrStops,
+  calculateAtrStop,
+  calculateAtrTakeProfit,
   atr
 } from 'trendcraft';
 
@@ -1882,18 +1882,16 @@ const position = atrBasedSize({
 });
 
 // ストップと利確を計算
-const levels = calculateAtrStops({
-  entryPrice: 50,
-  atrValue: currentAtr,
-  stopMultiplier: 2,
-  takeProfitMultiplier: 3,
-  direction: 'long',
-});
+const entryPrice = 50;
+const stopPrice = calculateAtrStop(entryPrice, currentAtr, 2, 'long');
+const takeProfitPrice = calculateAtrTakeProfit(entryPrice, currentAtr, 3, 'long');
+const riskRewardRatio =
+  (takeProfitPrice - entryPrice) / (entryPrice - stopPrice);
 
 console.log(`${position.shares}株を50円で購入`);
-console.log(`ストップ: ${levels.stopPrice}`);
-console.log(`ターゲット: ${levels.takeProfitPrice}`);
-console.log(`リスク/リワード: 1:${levels.riskRewardRatio.toFixed(1)}`);
+console.log(`ストップ: ${stopPrice}`);
+console.log(`ターゲット: ${takeProfitPrice}`);
+console.log(`リスク/リワード: 1:${riskRewardRatio.toFixed(1)}`);
 ```
 
 ---
@@ -2003,7 +2001,7 @@ regime = 'extreme'  → 非常に慎重に、様子見も検討
 ### トレードへの応用
 
 ```typescript
-import { regimeIs, regimeNot, atrPercentAbove, and, goldenCross, bollingerTouch } from 'trendcraft';
+import { regimeIs, regimeNot, atrPercentAbove, and, goldenCrossCondition, bollingerTouch } from 'trendcraft';
 
 // 低ボラティリティでのレンジ相場戦略
 const rangeEntry = and(
@@ -2014,7 +2012,7 @@ const rangeEntry = and(
 // トレンド戦略で高ボラティリティを避ける
 const trendEntry = and(
   regimeNot('extreme'),
-  goldenCross()
+  goldenCrossCondition()
 );
 
 // トレンドフォロー用にATR%でフィルタ（ボラタイルな銘柄のみ）
@@ -2055,30 +2053,34 @@ ATR% > 3%     → 非常にボラタイル（テック株、グロース株な�
 グリッドサーチは、パラメータ値のすべての組み合わせをテストして最適な設定を見つけます。
 
 ```typescript
-import { gridSearch, param, constraint, goldenCross, deadCross } from 'trendcraft';
+import { gridSearch, param, constraint, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
 const result = gridSearch(
   candles,
   (params) => ({
-    entry: goldenCross(params.short, params.long),
-    exit: deadCross(params.short, params.long),
+    entry: goldenCrossCondition(params.short, params.long),
+    exit: deadCrossCondition(params.short, params.long),
   }),
   [
-    param('short', [5, 10, 15, 20]),
-    param('long', [25, 50, 75, 100]),
+    param('short', 5, 20, 5),    // 名前, 最小, 最大, ステップ
+    param('long', 25, 100, 25),
   ],
   {
-    metric: 'sharpeRatio',
+    metric: 'sharpe',
     constraints: [
       constraint('winRate', '>=', 40),
       constraint('maxDrawdown', '<=', 30),
     ],
-    topN: 5
   }
 );
 
-console.log('最適パラメータ:', result.results[0].parameters);
-console.log('シャープレシオ:', result.results[0].metrics.sharpeRatio);
+console.log('最適パラメータ:', result.bestParams);
+console.log('シャープレシオ:', result.bestScore);
+
+// 上位5件（スコア降順でソート済み）
+const top5 = result.results.slice(0, 5);
+console.log('最適パラメータ:', top5[0].params);
+console.log('シャープレシオ:', top5[0].metrics.sharpe);
 ```
 
 ### ウォークフォワード分析
@@ -2099,9 +2101,10 @@ const result = walkForwardAnalysis(
   strategyFactory,
   paramRanges,
   {
-    inSampleRatio: 0.7,    // 70%イン・サンプル、30%アウト・オブ・サンプル
-    periods: 5,            // 5つのウォークフォワード期間
-    metric: 'sharpeRatio',
+    windowSize: 252,   // 訓練ウィンドウのローソク足数（日足で約1年）
+    stepSize: 63,      // 前進させるローソク足数（約1四半期）
+    testSize: 63,      // アウト・オブ・サンプル検証ウィンドウ（約1四半期）
+    metric: 'sharpe',
   }
 );
 ```
@@ -2117,8 +2120,11 @@ const result = combinationSearch(
   candles,
   createEntryConditionPool(),
   createExitConditionPool(),
-  { metric: 'sharpeRatio', topN: 20 }
+  { metric: 'sharpe' }
 );
+
+// 上位20件（results はスコア降順でソート済み）
+const top20 = result.results.slice(0, 20);
 ```
 
 ### ヒント
@@ -2154,10 +2160,10 @@ const result = combinationSearch(
 ### 使用例
 
 ```typescript
-import { runBacktestScaled, goldenCross, deadCross } from 'trendcraft';
+import { runBacktestScaled, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
 // 3トランシェでエントリー、2%下落で追加
-const result = runBacktestScaled(candles, goldenCross(), deadCross(), {
+const result = runBacktestScaled(candles, goldenCrossCondition(), deadCrossCondition(), {
   capital: 1000000,
   scaledEntry: {
     tranches: 3,
@@ -2168,7 +2174,7 @@ const result = runBacktestScaled(candles, goldenCross(), deadCross(), {
 });
 
 // シグナルベース: 各ゴールデンクロスで追加
-const result2 = runBacktestScaled(candles, goldenCross(), deadCross(), {
+const result2 = runBacktestScaled(candles, goldenCrossCondition(), deadCrossCondition(), {
   capital: 1000000,
   scaledEntry: {
     tranches: 3,
@@ -2216,7 +2222,7 @@ const snap = rsi.getState();  // 永続化用にシリアライズ
 const resumed = incremental.createRsi({ period: 14 }, { fromState: snap });
 ```
 
-v0.2.0 では moving-average / momentum / trend / volatility / volume / price / Wyckoff 等にわたり 160+ のファクトリを提供しています。
+moving-average / momentum / trend / volatility / volume / price / Wyckoff 等にわたり 90+ のインクリメンタルファクトリを提供しています。
 
 ### `createLiveCandle` — ティック・バー・指標スナップショットを1つにまとめる
 
@@ -2268,7 +2274,7 @@ const smaIndicator = smaFactory(undefined);
 const rsiSeries = indicatorPresets.rsi.compute(candles, { period: 14 });
 ```
 
-`livePresets` はストリーミング向け 76 エントリー、`indicatorPresets` はストリーミング + バッチ両対応の 95 エントリーです。
+`livePresets` はストリーミング向け 84 エントリー、`indicatorPresets` はストリーミング + バッチ両対応の 104 エントリーです。
 
 ### シリーズメタデータ（`SeriesMeta` / `tagSeries`）
 

--- a/packages/core/docs/GUIDE.md
+++ b/packages/core/docs/GUIDE.md
@@ -1008,7 +1008,7 @@ const entry = and(
   rsAbove(1.0),         // Outperforming
   rsRising(),           // RS improving
   rsRatingAbove(70),    // Top 30%
-  goldenCross()         // Technical entry
+  goldenCrossCondition()  // Technical entry
 );
 
 // Run backtest with benchmark
@@ -1331,7 +1331,7 @@ import { rangeBreakout } from 'trendcraft';
 const result = TrendCraft.from(candles)
   .strategy()
     .entry(rangeBreakout())  // Enter when range breaks
-    .exit(deadCross())
+    .exit(deadCrossCondition())
   .backtest({ capital: 1000000 });
 ```
 
@@ -1485,12 +1485,12 @@ Backtesting simulates a trading strategy's performance using historical data. Tr
 ### Basic Usage
 
 ```typescript
-import { runBacktest, goldenCross, deadCross } from 'trendcraft';
+import { runBacktest, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
 const result = runBacktest(
   candles,
-  goldenCross(5, 25),  // Entry condition
-  deadCross(5, 25),    // Exit condition
+  goldenCrossCondition(5, 25),  // Entry condition
+  deadCrossCondition(5, 25),    // Exit condition
   {
     capital: 1000000,    // Initial capital
     stopLoss: 5,         // 5% stop loss
@@ -1503,8 +1503,8 @@ const result = runBacktest(
 
 | Condition | Description |
 |-----------|-------------|
-| `goldenCross(short, long)` | Short MA crosses above Long MA |
-| `deadCross(short, long)` | Short MA crosses below Long MA |
+| `goldenCrossCondition(short, long)` | Short MA crosses above Long MA |
+| `deadCrossCondition(short, long)` | Short MA crosses below Long MA |
 | `rsiBelow(threshold)` | RSI below threshold |
 | `rsiAbove(threshold)` | RSI above threshold |
 | `macdCrossUp()` | MACD crosses above signal |
@@ -1519,10 +1519,10 @@ const result = runBacktest(
 import { and, or, not } from 'trendcraft';
 
 // Golden Cross AND RSI < 30
-const entry = and(goldenCross(), rsiBelow(30));
+const entry = and(goldenCrossCondition(), rsiBelow(30));
 
 // Dead Cross OR RSI > 70
-const exit = or(deadCross(), rsiAbove(70));
+const exit = or(deadCrossCondition(), rsiAbove(70));
 
 // NOT overbought
 const notOverbought = not(rsiAbove(70));
@@ -1645,7 +1645,7 @@ import { getPreset, scoreAbove } from 'trendcraft';
 const result = TrendCraft.from(candles)
   .strategy()
     .entry(scoreAbove(70, "trendFollowing"))
-    .exit(deadCross())
+    .exit(deadCrossCondition())
   .backtest({ capital: 1000000 });
 ```
 
@@ -1820,31 +1820,30 @@ chandelier.forEach(({ time, value }) => {
 Calculate entry, stop, and take-profit levels:
 
 ```typescript
-import { calculateAtrStops } from 'trendcraft';
+import { calculateAtrStop, calculateAtrTakeProfit } from 'trendcraft';
 
-const levels = calculateAtrStops({
-  entryPrice: 100,
-  atrValue: 2.5,
-  stopMultiplier: 2,        // 2x ATR for stop
-  takeProfitMultiplier: 3,  // 3x ATR for take-profit
-  direction: 'long',
-});
+const entryPrice = 100;
+const atrValue = 2.5;
 
-// Result:
-// stopPrice: 95 (100 - 2 × 2.5)
-// takeProfitPrice: 107.5 (100 + 3 × 2.5)
-// riskRewardRatio: 1.5
+const stopPrice = calculateAtrStop(entryPrice, atrValue, 2, 'long');
+// 95 (100 - 2 × 2.5)
+const takeProfitPrice = calculateAtrTakeProfit(entryPrice, atrValue, 3, 'long');
+// 107.5 (100 + 3 × 2.5)
+
+const riskRewardRatio =
+  (takeProfitPrice - entryPrice) / (entryPrice - stopPrice);
+// 1.5
 ```
 
 ### Using ATR in Backtesting
 
 ```typescript
-import { TrendCraft, goldenCross, deadCross } from 'trendcraft';
+import { TrendCraft, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
 const result = TrendCraft.from(candles)
   .strategy()
-    .entry(goldenCross())
-    .exit(deadCross())
+    .entry(goldenCrossCondition())
+    .exit(deadCrossCondition())
   .backtest({
     capital: 1000000,
     atrRisk: {
@@ -1877,7 +1876,8 @@ const result = TrendCraft.from(candles)
 ```typescript
 import {
   atrBasedSize,
-  calculateAtrStops,
+  calculateAtrStop,
+  calculateAtrTakeProfit,
   atr
 } from 'trendcraft';
 
@@ -1895,18 +1895,16 @@ const position = atrBasedSize({
 });
 
 // Calculate stop and take-profit
-const levels = calculateAtrStops({
-  entryPrice: 50,
-  atrValue: currentAtr,
-  stopMultiplier: 2,
-  takeProfitMultiplier: 3,
-  direction: 'long',
-});
+const entryPrice = 50;
+const stopPrice = calculateAtrStop(entryPrice, currentAtr, 2, 'long');
+const takeProfitPrice = calculateAtrTakeProfit(entryPrice, currentAtr, 3, 'long');
+const riskRewardRatio =
+  (takeProfitPrice - entryPrice) / (entryPrice - stopPrice);
 
 console.log(`Buy ${position.shares} shares at $50`);
-console.log(`Stop: ${levels.stopPrice}`);
-console.log(`Target: ${levels.takeProfitPrice}`);
-console.log(`Risk/Reward: 1:${levels.riskRewardRatio.toFixed(1)}`);
+console.log(`Stop: ${stopPrice}`);
+console.log(`Target: ${takeProfitPrice}`);
+console.log(`Risk/Reward: 1:${riskRewardRatio.toFixed(1)}`);
 ```
 
 ---
@@ -2016,7 +2014,7 @@ regime = 'extreme'  → Very cautious, consider sitting out
 ### Trading Applications
 
 ```typescript
-import { regimeIs, regimeNot, atrPercentAbove, and, goldenCross, bollingerTouch } from 'trendcraft';
+import { regimeIs, regimeNot, atrPercentAbove, and, goldenCrossCondition, bollingerTouch } from 'trendcraft';
 
 // Range-bound strategies in low volatility
 const rangeEntry = and(
@@ -2027,7 +2025,7 @@ const rangeEntry = and(
 // Avoid high volatility for trend strategies
 const trendEntry = and(
   regimeNot('extreme'),
-  goldenCross()
+  goldenCrossCondition()
 );
 
 // Filter by ATR% for trend-following (volatile stocks only)
@@ -2068,30 +2066,34 @@ Strategy optimization helps you find the best parameters and conditions for your
 Grid search tests all combinations of parameter values to find optimal settings.
 
 ```typescript
-import { gridSearch, param, constraint, goldenCross, deadCross } from 'trendcraft';
+import { gridSearch, param, constraint, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
 const result = gridSearch(
   candles,
   (params) => ({
-    entry: goldenCross(params.short, params.long),
-    exit: deadCross(params.short, params.long),
+    entry: goldenCrossCondition(params.short, params.long),
+    exit: deadCrossCondition(params.short, params.long),
   }),
   [
-    param('short', [5, 10, 15, 20]),
-    param('long', [25, 50, 75, 100]),
+    param('short', 5, 20, 5),    // name, min, max, step
+    param('long', 25, 100, 25),
   ],
   {
-    metric: 'sharpeRatio',
+    metric: 'sharpe',
     constraints: [
       constraint('winRate', '>=', 40),
       constraint('maxDrawdown', '<=', 30),
     ],
-    topN: 5
   }
 );
 
-console.log('Best parameters:', result.results[0].parameters);
-console.log('Sharpe ratio:', result.results[0].metrics.sharpeRatio);
+console.log('Best parameters:', result.bestParams);
+console.log('Sharpe ratio:', result.bestScore);
+
+// Top 5 results (sorted by score, descending)
+const top5 = result.results.slice(0, 5);
+console.log('Best parameters:', top5[0].params);
+console.log('Sharpe ratio:', top5[0].metrics.sharpe);
 ```
 
 ### Walk-Forward Analysis
@@ -2112,9 +2114,10 @@ const result = walkForwardAnalysis(
   strategyFactory,
   paramRanges,
   {
-    inSampleRatio: 0.7,    // 70% in-sample, 30% out-of-sample
-    periods: 5,            // 5 walk-forward periods
-    metric: 'sharpeRatio',
+    windowSize: 252,   // training window in candles (~1 year daily)
+    stepSize: 63,      // roll forward by this many candles (~1 quarter)
+    testSize: 63,      // out-of-sample test window (~1 quarter)
+    metric: 'sharpe',
   }
 );
 ```
@@ -2130,8 +2133,11 @@ const result = combinationSearch(
   candles,
   createEntryConditionPool(),
   createExitConditionPool(),
-  { metric: 'sharpeRatio', topN: 20 }
+  { metric: 'sharpe' }
 );
+
+// Top 20 combinations (results are sorted by score, descending)
+const top20 = result.results.slice(0, 20);
 ```
 
 ### Tips
@@ -2167,10 +2173,10 @@ Scaled entry (or split entry) divides your capital into multiple tranches instea
 ### Usage Example
 
 ```typescript
-import { runBacktestScaled, goldenCross, deadCross } from 'trendcraft';
+import { runBacktestScaled, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
 // Enter in 3 tranches, adding on 2% dips
-const result = runBacktestScaled(candles, goldenCross(), deadCross(), {
+const result = runBacktestScaled(candles, goldenCrossCondition(), deadCrossCondition(), {
   capital: 1000000,
   scaledEntry: {
     tranches: 3,
@@ -2181,7 +2187,7 @@ const result = runBacktestScaled(candles, goldenCross(), deadCross(), {
 });
 
 // Signal-based: add on each golden cross
-const result2 = runBacktestScaled(candles, goldenCross(), deadCross(), {
+const result2 = runBacktestScaled(candles, goldenCrossCondition(), deadCrossCondition(), {
   capital: 1000000,
   scaledEntry: {
     tranches: 3,
@@ -2229,7 +2235,7 @@ const snap = rsi.getState();  // serialize for persistence
 const resumed = incremental.createRsi({ period: 14 }, { fromState: snap });
 ```
 
-v0.2.0 ships 160+ factories across moving-average, momentum, trend, volatility, volume, price, and Wyckoff categories.
+There are 90+ incremental factories across moving-average, momentum, trend, volatility, volume, price, and Wyckoff categories.
 
 ### `createLiveCandle` — one object for ticks, bars, and indicator snapshots
 
@@ -2281,7 +2287,7 @@ const smaIndicator = smaFactory(undefined);
 const rsiSeries = indicatorPresets.rsi.compute(candles, { period: 14 });
 ```
 
-`livePresets` ships 76 entries (streaming-focused); `indicatorPresets` ships 95 with both streaming and batch paths.
+`livePresets` ships 84 entries (streaming-focused); `indicatorPresets` ships 104 with both streaming and batch paths.
 
 ### Series metadata (`SeriesMeta` / `tagSeries`)
 

--- a/packages/core/docs/migration-0.3-to-0.4.md
+++ b/packages/core/docs/migration-0.3-to-0.4.md
@@ -1,11 +1,15 @@
 # Migrating trendcraft 0.3.x → 0.4.0
 
-The 0.4.0 release lands the **Indicator State Contract**. This is the
-only breaking change that affects incremental-indicator persistence.
+The 0.4.0 release lands the **Indicator State Contract** — the largest
+breaking change, affecting incremental-indicator persistence. It is
+*not* the only breaking change: a second round of work reconciled the
+backtest and streaming condition registries, which renamed a condition
+param and changed several condition defaults (see
+[Condition registry: renamed param + changed defaults](#condition-registry-renamed-param--changed-defaults)).
 This page is the 5-minute upgrade guide: what broke and how to update
 your code.
 
-## What broke
+## What broke: incremental state snapshots
 
 Every incremental indicator's `getState()` / `fromState` now uses a
 versioned envelope instead of a bare state object:
@@ -48,10 +52,12 @@ Session-level state (aggregator state, completed candles) is
 unaffected — only the per-indicator snapshots inside a session blob
 are incompatible.
 
-## What is *not* affected
+## What is *not* affected by the State Contract
 
 - **Strategy JSON** (`serializeStrategy` / `parseStrategy`) describes
-  indicator *configurations*, not runtime state — unchanged.
+  indicator *configurations*, not runtime state — the snapshot envelope
+  does not touch it. (It *is* affected by the separate condition
+  registry change below — see the next section.)
 - **Non-incremental (batch) indicator functions** — `sma(candles)`,
   `ema(candles)`, etc. take candle arrays and have no state to
   persist — unchanged.
@@ -77,3 +83,65 @@ Mixed.
 projection, e.g. a band-width multiplier) may change on resume in any
 category — the saved state is reused verbatim and the new value takes
 effect immediately. `source` is never resume-invariant.
+
+## Condition registry: renamed param + changed defaults
+
+Separately from the State Contract, 0.4.0 reconciled the backtest and
+streaming condition registries so that a portable `StrategyJSON`
+behaves identically on both sides. This changed one **condition param
+name** and several **condition defaults**. Unlike the State Contract,
+this touches persisted `StrategyJSON` (which stores condition params),
+not runtime snapshots.
+
+### Breaking: `dmiBullish` / `dmiBearish` — `minAdx` renamed to `threshold`, default `20` → `25`
+
+The backtest `dmiBullish` / `dmiBearish` conditions renamed their first
+parameter from `minAdx` to `threshold` and raised its default from `20`
+to `25` (Wilder's strong-trend level), aligning them with the streaming
+registry, the shared `adxStrong` condition, and the direct factory
+signatures (`dmiBullish(threshold = 25, period = 14)`).
+
+A persisted `StrategyJSON` leaf using the old `minAdx` key is **not**
+remapped — the unrecognized `minAdx` is silently ignored and the new
+default (`25`) applies, so a strategy that relied on `minAdx: 20`
+silently re-defaults to a stricter `25`. Migrate the JSON param:
+
+```jsonc
+// Before (0.3.x)
+{ "name": "dmiBullish", "params": { "minAdx": 30 } }
+
+// After (0.4.0) — rename the key, keep the value
+{ "name": "dmiBullish", "params": { "threshold": 30 } }
+```
+
+If you relied on the old default behavior (`minAdx` omitted ⇒ `20`),
+make it explicit on upgrade: `{ "params": { "threshold": 20 } }`.
+
+### Behavior change: reconciled condition defaults
+
+These shared conditions had drifted between the two registries and were
+reconciled. Each value below is the new default that applies when the
+param is **omitted** from a `StrategyJSON` leaf (the registry, the
+streaming registry, and the direct factory now agree):
+
+| Condition | Param | Old behavior | New default (0.4.0) |
+| --- | --- | --- | --- |
+| `cmfAbove` / `cmfBelow` | `threshold` | drifted | `0` (the CMF zero-line) |
+| `priceDroppedAtr` | `multiplier` | drifted | `2.0` |
+| `atrPercentAbove` | `threshold` | backtest registry `3.0` | `DEFAULT_ATR_THRESHOLD` (`2.3`) |
+| `atrPercentBelow` | `threshold` | backtest registry: **required** | `1.0` |
+| `bollingerBreakout` / `bollingerTouch` | `band` | streaming registry: **required** | `"lower"` |
+| `rsiBelow` | `threshold` | streaming factory: required | `30` |
+| `rsiAbove` | `threshold` | streaming factory: required | `70` |
+
+Notes:
+
+- `atrPercentBelow` and `bollingerBreakout` / `bollingerTouch` previously
+  **required** the listed param on one registry; a portable JSON that
+  omitted it would fail validation there. They now default instead, so
+  the same JSON validates on both registries — but a strategy that
+  relied on the param being required will no longer error on omission.
+- If you depend on a specific value (rather than the new default), set
+  it explicitly in your `StrategyJSON` after upgrading.
+- A parity test now fails CI on any future shared-param drift between
+  the two registries.

--- a/packages/core/examples/sp500-showcase/run-showcase.ts
+++ b/packages/core/examples/sp500-showcase/run-showcase.ts
@@ -63,7 +63,7 @@ type StrategyDef = {
 
 const STRATEGIES: StrategyDef[] = [
   {
-    name: "Golden Cross (50/200)",
+    name: "Golden Cross (5/25)",
     description: "SMA 5/25 golden cross → dead cross, 5% stop loss",
     entry: goldenCrossCondition(5, 25),
     exit: deadCrossCondition(5, 25),

--- a/packages/core/examples/sp500-showcase/strategies/golden-cross.json
+++ b/packages/core/examples/sp500-showcase/strategies/golden-cross.json
@@ -1,5 +1,5 @@
 {
-  "name": "Golden Cross (50/200 SMA)",
+  "name": "Golden Cross (5/25 SMA)",
   "description": "Classic golden cross / dead cross strategy with 5% stop loss",
   "entry": ["goldenCross"],
   "exit": ["deadCross"],

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -20,7 +20,19 @@ missing volume.
 ### Changed — bumped `zod` to v4
 
 The runtime `zod` dependency moved from v3 to v4. No schema behavior changes for
-callers.
+callers: the validation contract that callers actually observe (non-finite OHLCV
+rejection, candle length, the exactly-one-of `candles` / `candlesArray` /
+`candlesRef` rule) is enforced by explicit `INVALID_INPUT` throws in the
+resolver/handler and surfaced through the canonical error envelope, not by zod's
+own error format — so a major `zod` bump leaves the caller-visible error shape
+unchanged.
+
+### Changed — exclude `.d.ts.map` from the published tarball
+
+`dist/**/*.d.ts.map` is now excluded from the npm package `files` list (alongside
+the already-excluded `.js.map` / `.cjs.map`). The declaration maps shipped no
+consumer value and embedded absolute local source paths; dropping them yields a
+smaller tarball and stops leaking build-machine paths.
 
 ### Added — upfront `params` shape guard for `calc_indicator` / `detect_signal`
 

--- a/packages/mcp/EXAMPLES.md
+++ b/packages/mcp/EXAMPLES.md
@@ -15,6 +15,8 @@ OHLCV candles look like this throughout:
 
 `time` is a unix epoch in milliseconds. `volume` is optional but required for volume-based indicators (`obv`, `mfi`, `cvd`, `volume*` signals, ...).
 
+`detect_signal` also treats a signal as volume-reading whenever you route a price source onto volume with `params: { source: "volume" }`. In that case the dispatcher requires a finite `volume` on *every* bar and rejects the call with `INVALID_INPUT` if any bar omits it — rather than zero-filling, which would feed a synthetic zero into the computation and could fabricate a false trigger. The same rule applies to the intrinsically volume-reading kinds (`obvDivergence`, `volumeBreakout`, `volumeAccumulation`, `volumeMaCross`, `volumeAboveAverage`). Price-only signals ignore volume, so a missing one is tolerated.
+
 ---
 
 ## 1. Discover what fits the situation

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -35,11 +35,17 @@ The same `mcpServers` entry works for Cursor and `~/.claude.json`. For Claude Co
 claude mcp add trendcraft -- npx -y @trendcraft/mcp
 ```
 
-Smoke-test the binary without a client:
+Smoke-test the binary without a client. MCP requires an `initialize` handshake before any other request, so send `initialize`, then the `notifications/initialized` notification, then `tools/list` on the same stdio session:
 
 ```bash
-echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | npx -y @trendcraft/mcp
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  | npx -y @trendcraft/mcp
 ```
+
+The MCP spec requires the `initialize` exchange before any other request, so send the full sequence above rather than a lone `tools/list` — the latter is not guaranteed to be answered across protocol versions and transports.
 
 ## Tools
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@trendcraft/mcp",
   "version": "0.1.0",
-  "description": "Model Context Protocol server for TrendCraft — exposes 96+ indicator manifests (whenToUse / pitfalls / synergy / regime) plus a single calc dispatcher to LLM clients like Claude Desktop and Cursor",
+  "description": "Model Context Protocol server for TrendCraft — exposes 96+ indicator manifests (whenToUse / pitfalls / synergy / regime) plus calc and signal dispatchers to LLM clients like Claude Desktop and Cursor",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary

A documentation/example audit ahead of the next release found that docs and
examples had drifted from the current APIs since the last release: many code
samples would throw or behave unexpectedly if copy-pasted, and one example
shipped runtime-broken. This PR reconciles docs and examples with the actual
source. **No library source changes** — only docs, examples, CHANGELOG,
README, and example config. No version bumps (those happen at release/tag time).

Organized into three per-package commits: `docs(core)`, `docs(chart)`,
`docs(mcp,repo)`.

## Highlights

**core**
- Fixed broken code samples in API.md/ja, GUIDE.md/ja, COOKBOOK.md: ATR stops,
  optimization (`param(name,min,max,step)`, metric `'sharpe'`, `GridSearchResult`
  `.params`/`.metrics.sharpe`, walk-forward `windowSize/stepSize/testSize`,
  `combinationSearch` fields, removed nonexistent `topN`), Monte Carlo (bootstrap
  default + `downside`/`riskOfRuin`), `calculateCalmarRatio` arity,
  `calculateAllMetrics` required `candles` arg.
- Fixed a systemic signal-vs-condition misuse: the bare `goldenCross`/`deadCross`
  exports are the `Series<boolean>` signal helpers, while the backtest conditions
  are `goldenCrossCondition`/`deadCrossCondition`. Corrected 65 condition-usages
  across the four core docs (verified with `tsc`), leaving the signal reference
  sections and the `"goldenCross"` strategy-JSON registry keys unchanged.
- migration-0.3-to-0.4.md now documents the real breaking/behavior changes
  (dmi `minAdx`->`threshold` 20->25; cmf/atrPercent/priceDroppedAtr/bollinger
  `band` default changes).
- CHANGELOG: added missing Unreleased entries. README counts corrected to source.

**chart**
- `simple-vue-chart` was runtime-broken (TrendChart never imported; bindings
  didn't match the template). Fixed, and added `vue-tsc --noEmit` to the build
  so it can't silently regress (the build was vite-only with no type-check).
- COOKBOOK `definePrimitive` and auto-fib recipes rewritten to the real APIs;
  GUIDE/API introspection-rule example, event payload shapes, and the
  `registerTrendCraftPresets` requirement corrected/documented; live examples
  now call `registerTrendCraftPresets(chart)`.
- CHANGELOG/RELEASE: snapshotName collision-policy breaking entry,
  `connectLivePrimitives`, plugin enhancements, refreshed size numbers.

**mcp + repo**
- mcp README smoke-test now performs the required MCP `initialize` handshake
  before `tools/list`; package description corrected (two dispatchers).
- Root README splits the demo run instructions (quick-start / sp500-showcase
  run via `npx tsx`, not Vite); CONTRIBUTING uses `--frozen-lockfile`.

## Test plan

- `pnpm lint` (biome, 1417 files): clean
- core: `pnpm typecheck` (tsc --noEmit) clean, `pnpm build` green, `pnpm test`
  6082 passed
- chart: `pnpm build` + `pnpm typecheck` green
- Corrected condition-factory and signal forms verified by a throwaway `tsc`
  probe; no broken bare-`goldenCross`-as-condition usages remain (grep-verified)
- Examples confirmed already using the correct condition factories