### PR TITLE
docs: sync CLAUDE.md with actual repo state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,11 @@ TrendCraft - Technical analysis library for TypeScript (pnpm workspace monorepo)
 A library for analyzing financial data (stocks, crypto, etc.).
 Provides technical indicators, signal detection, backtesting, and optimization.
 `@trendcraft/chart` provides a Canvas-based charting library with auto-detection of TrendCraft indicator series, framework bindings (React/Vue), and a headless API.
+`@trendcraft/mcp` is a Model Context Protocol server exposing indicator manifests plus calc/signal dispatchers to LLM clients (Claude Desktop, Cursor).
 
 ## Directory Structure
+
+Indicator and example lists below are non-exhaustive (categories grow over time); they name representative members, not the full set.
 
 ```
 packages/
@@ -17,43 +20,46 @@ packages/
 │   │   ├── core/           # Data layer, scales, layout, viewport, plugin types
 │   │   ├── renderer/       # Canvas render pipeline, overlays, axis
 │   │   ├── series/         # Series type renderers (candlestick, line, band, cloud, etc.)
-│   │   └── integration/    # Series introspection, indicator presets, live feed
-│   ├── react/              # React wrapper (TrendChart)
-│   ├── vue/                # Vue wrapper (TrendChart)
-│   └── examples/           # Vanilla, React, Vue examples
-└── core/               # npm package "trendcraft"
-    ├── src/
-    │   ├── core/           # Data normalization, MTF context
-    │   ├── indicators/     # Technical indicators (130+)
-    │   │   ├── moving-average/  # SMA, EMA, WMA, VWMA, KAMA, T3, HMA, McGinley Dynamic, EMA Ribbon
-    │   │   ├── momentum/        # RSI, MACD, Stochastics, DMI/ADX, CCI, ROC, Connors RSI, IMI, ADXR
-    │   │   ├── trend/           # Ichimoku, Supertrend, Parabolic SAR
-    │   │   ├── volatility/      # Bollinger Bands, ATR, Keltner, Donchian, Choppiness Index
-    │   │   ├── volume/          # OBV, MFI, VWAP (Bands), CMF, Volume Profile, Anchored VWAP, Elder Force Index, EMV, Klinger, TWAP, Weis Wave, Market Profile, CVD
-    │   │   ├── price/           # Swing Points, Pivot, FVG, BOS, CHoCH, ORB, Gap Analysis, S/R Zone Clustering
-    │   │   ├── session/         # ICT Kill Zones, Session Analytics, Session Breakout
-    │   │   ├── regime/          # HMM Regime Detection (Baum-Welch, Viterbi)
-    │   │   ├── wyckoff/         # VSA (Volume Spread Analysis), Wyckoff Phase Detection
-    │   │   ├── relative-strength/
-    │   │   └── smc/             # Order Block, Liquidity Sweep
-    │   ├── signals/        # Signal detection (crosses, divergence, patterns)
-    │   ├── backtest/       # Backtest engine
-    │   ├── optimization/   # Grid Search, Walk-Forward, Monte Carlo
-    │   ├── scoring/        # Signal scoring system
-    │   ├── screening/      # Stock screening
-    │   ├── position-sizing/# Position sizing (Kelly, ATR-based, etc.)
-    │   ├── meta-strategy/  # Equity Curve Trading, Strategy Rotation
-    │   ├── strategy/       # Strategy definition, JSON serialization, condition registry
-    │   ├── risk/           # VaR, CVaR, Risk Parity, Correlation-Adjusted Sizing
-    │   └── types/          # Type definitions
-    ├── bin/             # CLI tools
-    ├── docs/            # API docs, guide, cookbook
-    ├── cross-validation/ # TA-Lib cross-validation tests
-    └── examples/
-        ├── echarts-viewer/      # Comprehensive ECharts-based viewer (proves core works with any chart library)
-        ├── trading-simulator/   # React-based trading simulator with backtesting
-        ├── alpaca-demo/         # Multi-agent paper trading system (Alpaca API)
-        └── candle-former-demo/  # CandleFormer demo
+│   │   ├── integration/    # Series introspection, indicator presets, live feed
+│   │   ├── plugins/        # Built-in series/primitive plugins
+│   │   └── sparkline/      # Sparkline subpath (@trendcraft/chart/sparkline)
+│   ├── react/              # React wrapper (TrendChart) + react/sparkline
+│   ├── vue/                # Vue wrapper (TrendChart) + vue/sparkline
+│   └── examples/           # see "## examples/" below
+├── core/               # npm package "trendcraft"
+│   ├── src/
+│   │   ├── core/           # Data normalization, MTF context
+│   │   ├── indicators/     # Technical indicators (130+)
+│   │   │   ├── moving-average/  # SMA, EMA, WMA, VWMA, KAMA, T3, HMA, ALMA, DEMA/TEMA, FRAMA, ZLEMA, McGinley Dynamic, EMA Ribbon
+│   │   │   ├── momentum/        # RSI, MACD, Stochastics, DMI/ADX, CCI, ROC, Connors RSI, IMI, ADXR, TSI, TRIX, KST, PPO, Aroon, …
+│   │   │   ├── trend/           # Ichimoku, Supertrend, Parabolic SAR, Vortex, Schaff Trend Cycle, Linear Regression
+│   │   │   ├── volatility/      # Bollinger Bands, ATR, Keltner, Donchian, GARCH, Garman-Klass, Chandelier Exit, Choppiness Index
+│   │   │   ├── volume/          # OBV, MFI, VWAP (Bands), CMF, Volume Profile, Anchored VWAP, Elder Force Index, EMV, Klinger, TWAP, Weis Wave, Market Profile, CVD
+│   │   │   ├── price/           # Swing Points, Pivot, FVG, BOS, CHoCH, ORB, Gap Analysis, S/R Zone Clustering, Fibonacci, Pitchfork, Zigzag, Fractals
+│   │   │   ├── session/         # ICT Kill Zones, Session Analytics, Session Breakout
+│   │   │   ├── regime/          # HMM Regime Detection (Baum-Welch, Viterbi)
+│   │   │   ├── wyckoff/         # VSA (Volume Spread Analysis), Wyckoff Phase Detection
+│   │   │   ├── relative-strength/
+│   │   │   ├── smc/             # Order Block, Liquidity Sweep
+│   │   │   ├── adaptive/        # Adaptive MA/RSI/Stochastics/Bollinger
+│   │   │   ├── filter/          # Super Smoother, Roofing Filter
+│   │   │   └── incremental/     # Streaming/incremental indicator engine
+│   │   ├── signals/        # Signal detection (crosses, divergence, patterns)
+│   │   ├── backtest/       # Backtest engine
+│   │   ├── optimization/   # Grid Search, Walk-Forward, Monte Carlo
+│   │   ├── scoring/        # Signal scoring system
+│   │   ├── screening/      # Stock screening
+│   │   ├── position-sizing/# Position sizing (Kelly, ATR-based, etc.)
+│   │   ├── meta-strategy/  # Equity Curve Trading, Strategy Rotation
+│   │   ├── strategy/       # Strategy definition, JSON serialization, condition registry
+│   │   ├── risk/           # VaR, CVaR, Risk Parity, Correlation-Adjusted Sizing
+│   │   └── types/          # Type definitions
+│   ├── bin/             # CLI tools
+│   ├── docs/            # API docs, guide, cookbook
+│   ├── cross-validation/ # TA-Lib cross-validation tests
+│   └── examples/        # see "## examples/" below
+└── mcp/                # npm package "@trendcraft/mcp"
+    └── src/             # MCP server: tools/, dispatcher/, schemas/, validation/, bin/
 ```
 
 ## Development Commands
@@ -95,7 +101,7 @@ pnpm size-check   # Check bundle size limits (esbuild, brotli-compressed)
 - All indicators return `Series<T>` type (`{ time: number, value: T }[]`)
 - Uses Wilder's smoothing method (RSI, ATR, etc.)
 - Functions should have JSDoc comments with @example
-- `@trendcraft/chart`: Bundle size limits enforced via `size-limit` + `@size-limit/esbuild` (brotli-compressed). Main ≤ 31 kB, Headless ≤ 11 kB, React/Vue ≤ 27 kB. Zero runtime dependencies; `trendcraft`, `react`, `vue` are optional peer deps
+- `@trendcraft/chart`: Bundle size limits enforced via `size-limit` + `@size-limit/esbuild` (brotli-compressed). Main ≤ 41 kB, Headless ≤ 11 kB, React/Vue wrapper ≤ 33 kB, Sparkline ≤ 5 kB (vanilla) / 7 kB (React/Vue), Replay ≤ 3 kB. Zero runtime dependencies; `trendcraft` (`>=0.3.0`), `react` (`>=19.0.0`), `vue` (`>=3.3.0`) are optional peer deps
 - `@trendcraft/chart` + `indicatorPresets` integration: when wiring a chart to `connectIndicators(chart, { presets: indicatorPresets, ... })`, **also call `registerTrendCraftPresets(chart)` from `@trendcraft/chart/presets`** before adding indicators. Without it, TrendCraft-specific shapes (adaptiveRsi `{rsi, effectivePeriod, volatilityPercentile}`, connorsRsi, klinger, vsa, etc.) fall through built-in introspection rules and silently render as generic "Indicator"/"Series" with no visible line. The chart degrades silently — there is no warning. See `packages/chart/examples/indicator-showcase/src/main.ts:57` for the canonical setup
 
 ## Testing & Validation
@@ -116,7 +122,7 @@ pnpm size-check   # Check bundle size limits (esbuild, brotli-compressed)
 
 ## Release Workflow
 
-This is a pnpm workspace monorepo with two independently published packages. Treat their versions and releases as independent; only the repository is shared.
+This is a pnpm workspace monorepo with three independently published packages: `trendcraft` (core), `@trendcraft/chart`, and `@trendcraft/mcp`. Treat their versions and releases as independent; only the repository is shared. The serial-release steps below cover the core→chart dependency chain; `@trendcraft/mcp` follows the same conventions (tag `mcp-v<x.y.z>`, finalize its own CHANGELOG, publish after core when it consumes newly-added core APIs).
 
 ### Tag naming
 
@@ -124,6 +130,7 @@ Use prefix-dash form so each package's tags are filterable (`git tag -l 'chart-*
 
 - `core-v<major>.<minor>.<patch>` — e.g. `core-v0.2.0`
 - `chart-v<major>.<minor>.<patch>` — e.g. `chart-v0.1.0`
+- `mcp-v<major>.<minor>.<patch>` — e.g. `mcp-v0.1.0`
 
 The legacy tag `v0.1.0` (no prefix) points to the first `trendcraft` release and is kept as-is. Do not reuse the unprefixed `v*` form for new releases.
 
@@ -234,16 +241,16 @@ import { TrendChart } from "@trendcraft/chart/vue";
 
 - `echarts-viewer/` - Comprehensive ECharts-based viewer (proves core works with any chart library)
 - `trading-simulator/` - React-based trading simulator with backtesting
-- `alpaca-demo/` - Multi-agent paper trading system (Alpaca API)
-- `candle-former-demo/` - CandleFormer demo
+- `quick-start/` - Minimal getting-started example
+- `sp500-showcase/` - S&P 500 dataset showcase
 
 ### packages/chart/examples/
 
 - `simple-chart/` - Vanilla TypeScript chart with indicators, drawings, plugins
 - `simple-react-chart/` - React wrapper usage
 - `simple-vue-chart/` - Vue wrapper usage
-
-## Alpaca Demo
-
-- Type check: `cd packages/core/examples/alpaca-demo && npx tsc --noEmit`
-- **pnpm 7+ does NOT need `--` to pass arguments to scripts.** Use `pnpm run dev <command> [options]` directly, not `pnpm run dev -- <command>`. The `--` gets forwarded literally and breaks commander's subcommand parsing.
+- `indicator-showcase/` - Multi-indicator catalog (canonical preset/introspection setup)
+- `sparkline-showcase/` - Sparkline subpath showcase
+- `strategy-studio/` - Strategy backtesting/studio app
+- `docs-screenshots/` - Screenshot generation for docs
+- `webgl-poc/` - WebGL renderer proof-of-concept


### PR DESCRIPTION
## Summary

`CLAUDE.md` had drifted from the actual repository layout. This brings it back in line — documentation only, no code changes.

## Changes

- **Third package**: document `@trendcraft/mcp` alongside `trendcraft` (core) and `@trendcraft/chart` in the overview, directory tree, release workflow ("two" → "three" published packages), and tag naming (`mcp-v<x.y.z>`).
- **Chart bundle budgets**: update `size-limit` figures to match the current config (Main ≤ 41 kB, React/Vue wrapper ≤ 33 kB, add Sparkline ≤ 5/7 kB and Replay ≤ 3 kB subpaths) and record peer dep ranges (`trendcraft >=0.3.0`, `react >=19.0.0`, `vue >=3.3.0`).
- **Indicator/source tree**: add previously-undocumented categories (`adaptive/`, `filter/`, `incremental/`) and chart src dirs (`plugins/`, `sparkline/`); note that the per-category indicator lists are non-exhaustive.
- **examples/**: list only the tracked examples that ship with the repo — add `quick-start`, `sp500-showcase` (core) and `indicator-showcase`, `sparkline-showcase`, `strategy-studio`, `docs-screenshots`, `webgl-poc` (chart). Remove gitignored, local-only examples that a fresh clone would not contain.

## Verification

Documentation-only change; figures and directory entries were cross-checked against `package.json` `size-limit`, peer deps, and the on-disk `packages/*` tree.