### PR TITLE
fix(chart): harden sparkline device-pixel-ratio guard via shared helper

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -305,6 +305,18 @@ The pinned override path is unchanged — callers that supply
 `pixelRatio` keep full control. Sparkline already re-read DPR each
 frame and is unaffected.
 
+### Fixed — sparkline hardens its device-pixel-ratio guard
+
+The sparkline canvas setup resolved `window.devicePixelRatio` with a
+truthiness check (`dpr ? dpr : 1`), which correctly falls back to `1`
+for `0` / `NaN` / `undefined` but let `±Infinity` and negative values
+through. Multiplying the CSS size by such a ratio yielded a non-finite
+or negative canvas bitmap dimension. The main chart already clamped to
+a finite positive ratio; both paths now share a single
+`safeDevicePixelRatio()` helper, so the sparkline falls back to `1`
+for those degenerate ratios as well. This is a defensive hardening —
+real browsers report a small positive ratio.
+
 ### Fixed — non-finite value guards across render and layout paths
 
 Canvas silently swallows draw calls with `NaN` / `±Infinity`

--- a/packages/chart/src/core/dpr.ts
+++ b/packages/chart/src/core/dpr.ts
@@ -1,0 +1,11 @@
+/**
+ * Read `window.devicePixelRatio` and clamp to a finite positive value.
+ * Falls back to 1 when running outside a browser, when DPR is 0 / NaN /
+ * negative, or when DPR is `±Infinity` (the last is rare in practice
+ * but breaks `canvas.width = w * dpr` if it slips through).
+ */
+export function safeDevicePixelRatio(): number {
+  if (typeof window === "undefined") return 1;
+  const dpr = window.devicePixelRatio;
+  return Number.isFinite(dpr) && dpr > 0 ? dpr : 1;
+}

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -5,6 +5,7 @@
 
 import { ViewTransition } from "../core/animation";
 import { DataLayer } from "../core/data-layer";
+import { safeDevicePixelRatio } from "../core/dpr";
 import type { DrawHelper } from "../core/draw-helper";
 import { autoFormatPrice, setMonthNames } from "../core/format";
 import { type ChartLocale, mergeLocale } from "../core/i18n";
@@ -79,18 +80,6 @@ const DEFAULT_OPTIONS: Required<
   timeAxisHeight: 32,
   fontSize: 11,
 };
-
-/**
- * Read `window.devicePixelRatio` and clamp to a finite positive value.
- * Falls back to 1 when running outside a browser, when DPR is 0 / NaN /
- * negative, or when DPR is `±Infinity` (the last is rare in practice
- * but breaks `canvas.width = w * dpr` if it slips through).
- */
-function safeDevicePixelRatio(): number {
-  if (typeof window === "undefined") return 1;
-  const dpr = window.devicePixelRatio;
-  return Number.isFinite(dpr) && dpr > 0 ? dpr : 1;
-}
 
 // ============================================
 // CanvasChart Class

--- a/packages/chart/src/sparkline/group.ts
+++ b/packages/chart/src/sparkline/group.ts
@@ -1,3 +1,4 @@
+import { safeDevicePixelRatio } from "../core/dpr";
 import { resolveColors } from "./color-resolve";
 import { drawMiniCandles } from "./draw-candle";
 import { drawMiniLine } from "./draw-line";
@@ -62,8 +63,7 @@ function setupCanvas(canvas: HTMLCanvasElement): {
   cssHeight: number;
   ctx: CanvasRenderingContext2D | null;
 } {
-  const dpr =
-    typeof window !== "undefined" && window.devicePixelRatio ? window.devicePixelRatio : 1;
+  const dpr = safeDevicePixelRatio();
   const rect = canvas.getBoundingClientRect();
   const cssWidth = rect.width || canvas.clientWidth || canvas.width || 80;
   const cssHeight = rect.height || canvas.clientHeight || canvas.height || 30;


### PR DESCRIPTION
## Summary

The sparkline canvas setup resolved `window.devicePixelRatio` with a truthiness check (`dpr ? dpr : 1`). That correctly falls back to `1` for `0` / `NaN` / `undefined`, but lets `±Infinity` and negative values through. Multiplying the CSS size by such a ratio yields a non-finite or negative canvas bitmap dimension (`canvas.width = cssWidth * dpr`), which browsers clamp to `0` or reject — the sparkline renders blank.

The main chart already clamped to a finite positive ratio in a local `safeDevicePixelRatio()` helper. This PR extracts that helper into `src/core/dpr.ts` and uses it from both call sites:

- `src/renderer/canvas-chart.ts` — behavior-preserving (same helper, now imported).
- `src/sparkline/group.ts` — gains the clamp, so degenerate ratios fall back to `1`.

This is defensive hardening — real browsers report a small positive ratio, so no user-visible behavior changes in practice.

## Changes

- `src/core/dpr.ts` (new) — `safeDevicePixelRatio()`: returns the DPR only when finite and positive, else `1`.
- `src/renderer/canvas-chart.ts` — drop the local copy, import the shared helper.
- `src/sparkline/group.ts` — replace the truthiness guard with the shared helper.
- `CHANGELOG.md` — Fixed entry.

No public API change.

## Test plan

- `npx tsc --noEmit --ignoreDeprecations 6.0` — clean
- `pnpm build` — passes
- `pnpm test` — 912 passed (78 files)
- `pnpm size-check` — all entries within budget; Sparkline (vanilla) 3.77 kB / 5 kB, Main 40.32 kB / 41 kB