### PR TITLE
refactor(chart): consolidate duplicated rendering helpers

### DIFF
--- a/packages/chart/react/sparkline.tsx
+++ b/packages/chart/react/sparkline.tsx
@@ -95,22 +95,22 @@ export function Sparkline({ width = 80, height = 30, style, className, ...opts }
     };
   }, [group]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: granular opts deps; full opts ref would over-trigger.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: granular opts deps; a full opts ref would over-trigger. React requires an array literal here, so keep this list in sync with SPARKLINE_OPTION_KEYS.
   useEffect(() => {
     handleRef.current?.update(opts as Partial<SparklineOptions>);
   }, [
-    opts.data,
     opts.type,
+    opts.data,
+    opts.color,
     opts.fill,
     opts.baseline,
     opts.maxCandles,
     opts.totalSlots,
-    opts.color,
     opts.session,
     opts.breakGap,
     opts.densityFallback,
-    opts.hover,
     opts.colors,
+    opts.hover,
   ]);
 
   return (

--- a/packages/chart/src/core/draw-helper.ts
+++ b/packages/chart/src/core/draw-helper.ts
@@ -300,3 +300,30 @@ export function withPaneClip(
     ctx.restore();
   }
 }
+
+/**
+ * Trace a rounded-rectangle path (`beginPath` → `closePath`) with corner
+ * radius `r`. Leaves filling/stroking to the caller, so a caller can fill the
+ * pill and then start a fresh path for an attached tail. Uses `quadraticCurveTo`
+ * corners rather than the native `ctx.roundRect` for broad canvas-mock support.
+ */
+export function roundRectPath(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): void {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}

--- a/packages/chart/src/core/validation.ts
+++ b/packages/chart/src/core/validation.ts
@@ -24,6 +24,26 @@ const isObject = (v: unknown): v is Record<string, unknown> => typeof v === "obj
 const isFiniteNumber = (v: unknown): v is number => typeof v === "number" && Number.isFinite(v);
 
 /**
+ * True when all four OHLC fields are finite. Canvas silently swallows draw
+ * calls with `NaN` / `±Infinity` coordinates, so renderers skip any bar that
+ * fails this check rather than leaving an invisible gap with no error. Used by
+ * the candlestick and overlay-candle renderers, which share the exact guard.
+ */
+export function isFiniteOHLC(c: {
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}): boolean {
+  return (
+    Number.isFinite(c.open) &&
+    Number.isFinite(c.high) &&
+    Number.isFinite(c.low) &&
+    Number.isFinite(c.close)
+  );
+}
+
+/**
  * Validate `addSignals` input. Each entry must have a finite epoch-ms `time`
  * and `type` of `'buy'` or `'sell'`.
  */

--- a/packages/chart/src/plugins/price-patterns.ts
+++ b/packages/chart/src/plugins/price-patterns.ts
@@ -22,7 +22,7 @@
  * ```
  */
 
-import { withPaneClip } from "../core/draw-helper";
+import { roundRectPath, withPaneClip } from "../core/draw-helper";
 import { definePrimitive } from "../core/plugin-types";
 import type { ChartInstance } from "../core/types";
 
@@ -223,17 +223,7 @@ function drawAnchoredLabel(
   const r = 3;
 
   ctx.fillStyle = bg;
-  ctx.beginPath();
-  ctx.moveTo(labelX + r, labelY);
-  ctx.lineTo(labelX + w - r, labelY);
-  ctx.quadraticCurveTo(labelX + w, labelY, labelX + w, labelY + r);
-  ctx.lineTo(labelX + w, labelY + h - r);
-  ctx.quadraticCurveTo(labelX + w, labelY + h, labelX + w - r, labelY + h);
-  ctx.lineTo(labelX + r, labelY + h);
-  ctx.quadraticCurveTo(labelX, labelY + h, labelX, labelY + h - r);
-  ctx.lineTo(labelX, labelY + r);
-  ctx.quadraticCurveTo(labelX, labelY, labelX + r, labelY);
-  ctx.closePath();
+  roundRectPath(ctx, labelX, labelY, w, h, r);
   ctx.fill();
 
   // Tail

--- a/packages/chart/src/plugins/regime-heatmap.ts
+++ b/packages/chart/src/plugins/regime-heatmap.ts
@@ -21,7 +21,7 @@
  * ```
  */
 
-import { withPaneClip } from "../core/draw-helper";
+import { roundRectPath, withPaneClip } from "../core/draw-helper";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import { definePrimitive } from "../core/plugin-types";
 import type { ChartInstance, DataPoint } from "../core/types";
@@ -149,19 +149,8 @@ function renderRegimeBadge(
   const pillH = textH + padY * 2;
 
   // Pill background — saturated regime tint with rounded corners.
-  const r = pillH / 2;
   ctx.fillStyle = `rgba(${rgb},0.85)`;
-  ctx.beginPath();
-  ctx.moveTo(pillX + r, pillY);
-  ctx.lineTo(pillX + pillW - r, pillY);
-  ctx.quadraticCurveTo(pillX + pillW, pillY, pillX + pillW, pillY + r);
-  ctx.lineTo(pillX + pillW, pillY + pillH - r);
-  ctx.quadraticCurveTo(pillX + pillW, pillY + pillH, pillX + pillW - r, pillY + pillH);
-  ctx.lineTo(pillX + r, pillY + pillH);
-  ctx.quadraticCurveTo(pillX, pillY + pillH, pillX, pillY + pillH - r);
-  ctx.lineTo(pillX, pillY + r);
-  ctx.quadraticCurveTo(pillX, pillY, pillX + r, pillY);
-  ctx.closePath();
+  roundRectPath(ctx, pillX, pillY, pillW, pillH, pillH / 2);
   ctx.fill();
 
   // White text — high contrast against the saturated pill regardless of

--- a/packages/chart/src/renderer/drawing-renderer.ts
+++ b/packages/chart/src/renderer/drawing-renderer.ts
@@ -189,15 +189,22 @@ function renderTrendLine(
   ctx.fill();
 }
 
-function renderFibRetracement(
+/**
+ * Shared renderer for Fibonacci retracement and extension drawings. Both draw
+ * the same idiom — a horizontal line per level, light shading between adjacent
+ * levels, and a `pct% (price)` label — and differ only in how a level maps to
+ * a price (`priceAt`) and in the color table. Solid line for the 0 and 1
+ * anchors, dashed for the rest.
+ */
+function renderFibLevels(
   ctx: CanvasRenderingContext2D,
-  drawing: FibRetracementDrawing,
   c: DrawCtx,
   fontSize: number,
+  levels: readonly number[],
+  colors: readonly string[],
+  priceAt: (level: number) => number,
 ): void {
   const { pane } = c;
-  const levels = drawing.levels ?? DEFAULT_FIB_LEVELS;
-  const priceRange = drawing.endPrice - drawing.startPrice;
 
   ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
   ctx.textAlign = "left";
@@ -205,9 +212,9 @@ function renderFibRetracement(
 
   for (let i = 0; i < levels.length; i++) {
     const level = levels[i];
-    const price = drawing.endPrice - priceRange * level;
+    const price = priceAt(level);
     const y = toScreenY(price, c);
-    const color = FIB_COLORS[i % FIB_COLORS.length];
+    const color = colors[i % colors.length];
 
     // Horizontal line
     ctx.strokeStyle = color;
@@ -221,8 +228,7 @@ function renderFibRetracement(
 
     // Fill between levels
     if (i < levels.length - 1) {
-      const nextPrice = drawing.endPrice - priceRange * levels[i + 1];
-      const nextY = toScreenY(nextPrice, c);
+      const nextY = toScreenY(priceAt(levels[i + 1]), c);
       ctx.fillStyle = color;
       ctx.globalAlpha = 0.04;
       ctx.fillRect(pane.x, Math.min(y, nextY), pane.width, Math.abs(nextY - y));
@@ -237,6 +243,23 @@ function renderFibRetracement(
     ctx.fillStyle = color;
     ctx.fillText(label, pane.x + 4, y);
   }
+}
+
+function renderFibRetracement(
+  ctx: CanvasRenderingContext2D,
+  drawing: FibRetracementDrawing,
+  c: DrawCtx,
+  fontSize: number,
+): void {
+  const priceRange = drawing.endPrice - drawing.startPrice;
+  renderFibLevels(
+    ctx,
+    c,
+    fontSize,
+    drawing.levels ?? DEFAULT_FIB_LEVELS,
+    FIB_COLORS,
+    (level) => drawing.endPrice - priceRange * level,
+  );
 }
 
 function renderRay(ctx: CanvasRenderingContext2D, drawing: RayDrawing, c: DrawCtx): void {
@@ -413,48 +436,15 @@ function renderFibExtension(
   c: DrawCtx,
   fontSize: number,
 ): void {
-  const { pane } = c;
-  const levels = drawing.levels ?? DEFAULT_FIB_EXT_LEVELS;
   const priceRange = drawing.endPrice - drawing.startPrice;
-
-  ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
-  ctx.textAlign = "left";
-  ctx.textBaseline = "middle";
-
-  for (let i = 0; i < levels.length; i++) {
-    const level = levels[i];
-    const price = drawing.startPrice + priceRange * level;
-    const y = toScreenY(price, c);
-    const color = FIB_EXT_COLORS[i % FIB_EXT_COLORS.length];
-
-    // Horizontal line
-    ctx.strokeStyle = color;
-    ctx.lineWidth = 1;
-    ctx.setLineDash(level === 0 || level === 1 ? [] : [4, 3]);
-    ctx.globalAlpha = 0.7;
-    ctx.beginPath();
-    ctx.moveTo(pane.x, Math.round(y) + 0.5);
-    ctx.lineTo(pane.x + pane.width, Math.round(y) + 0.5);
-    ctx.stroke();
-
-    // Fill between levels
-    if (i < levels.length - 1) {
-      const nextPrice = drawing.startPrice + priceRange * levels[i + 1];
-      const nextY = toScreenY(nextPrice, c);
-      ctx.fillStyle = color;
-      ctx.globalAlpha = 0.04;
-      ctx.fillRect(pane.x, Math.min(y, nextY), pane.width, Math.abs(nextY - y));
-    }
-
-    ctx.globalAlpha = 1;
-    ctx.setLineDash([]);
-
-    // Label
-    const pct = (level * 100).toFixed(1);
-    const label = `${pct}% (${autoFormatPrice(price)})`;
-    ctx.fillStyle = color;
-    ctx.fillText(label, pane.x + 4, y);
-  }
+  renderFibLevels(
+    ctx,
+    c,
+    fontSize,
+    drawing.levels ?? DEFAULT_FIB_EXT_LEVELS,
+    FIB_EXT_COLORS,
+    (level) => drawing.startPrice + priceRange * level,
+  );
 }
 
 function renderTextLabel(

--- a/packages/chart/src/renderer/overlay-renderer.ts
+++ b/packages/chart/src/renderer/overlay-renderer.ts
@@ -16,6 +16,7 @@ import type {
   TimeframeOverlay,
   TradeMarker,
 } from "../core/types";
+import { isFiniteOHLC } from "../core/validation";
 import type { AxisExcludeRange } from "./axis-renderer";
 
 /**
@@ -222,17 +223,10 @@ export function renderTimeframeOverlays(
     ctx.globalAlpha = opacity;
 
     for (const candle of overlay.candles) {
-      // Skip candles with non-finite OHLC. Same rationale as the
-      // primary candlestick renderer: canvas silently swallows draw
-      // calls with NaN coords, leaving an invisible bar with no error.
-      if (
-        !Number.isFinite(candle.open) ||
-        !Number.isFinite(candle.high) ||
-        !Number.isFinite(candle.low) ||
-        !Number.isFinite(candle.close)
-      ) {
-        continue;
-      }
+      // Skip candles with non-finite OHLC. Same rationale as the primary
+      // candlestick renderer: canvas silently swallows draw calls with NaN
+      // coords, leaving an invisible bar with no error.
+      if (!isFiniteOHLC(candle)) continue;
 
       const startIdx = dataLayer.indexAtTime(candle.time);
       const nextIdx = overlay.candles.indexOf(candle) + 1;

--- a/packages/chart/src/series/candlestick.ts
+++ b/packages/chart/src/series/candlestick.ts
@@ -5,6 +5,7 @@
 
 import type { PriceScale, TimeScale } from "../core/scale";
 import type { CandleData, ThemeColors } from "../core/types";
+import { isFiniteOHLC } from "../core/validation";
 
 export function renderCandlesticks(
   ctx: CanvasRenderingContext2D,
@@ -29,17 +30,10 @@ export function renderCandlesticks(
   for (let i = start; i < end && i < candles.length; i++) {
     const candle = candles[i];
     if (!candle) continue;
-    // Skip candles with non-finite OHLC. Canvas silently swallows
-    // draw calls with NaN / Infinity coordinates, so a contaminated
-    // bar would otherwise produce an invisible gap with no error.
-    if (
-      !Number.isFinite(candle.open) ||
-      !Number.isFinite(candle.high) ||
-      !Number.isFinite(candle.low) ||
-      !Number.isFinite(candle.close)
-    ) {
-      continue;
-    }
+    // Skip candles with non-finite OHLC — canvas silently swallows draw
+    // calls with NaN / Infinity coordinates, so a contaminated bar would
+    // otherwise produce an invisible gap with no error.
+    if (!isFiniteOHLC(candle)) continue;
 
     const x = timeScale.indexToX(originalIndices ? originalIndices[i] : i);
     const sx = Math.round(x) + 0.5; // snap to pixel grid for crisp 1px lines

--- a/packages/chart/src/sparkline/draw-candle.ts
+++ b/packages/chart/src/sparkline/draw-candle.ts
@@ -1,4 +1,5 @@
 import type { StrokeAndFill } from "./color-resolve";
+import { computeYScale, drawSparkBaseline } from "./scale";
 import type { SessionLayout } from "./session";
 import type { ResolvedColors, SparklineCandle } from "./types";
 
@@ -42,15 +43,8 @@ export function drawMiniCandles(args: CandleDrawArgs): void {
     if (c.low < min) min = c.low;
     if (c.high > max) max = c.high;
   }
-  if (baselineValue != null) {
-    if (baselineValue < min) min = baselineValue;
-    if (baselineValue > max) max = baselineValue;
-  }
 
-  const padY = 1;
-  const innerH = Math.max(1, height - padY * 2);
-  const range = max - min || 1;
-  const yOf = (v: number) => padY + innerH - ((v - min) / range) * innerH;
+  const { yOf } = computeYScale(min, max, baselineValue, height);
 
   // Compute slot/body width. Session mode bases the slot on the median bar
   // interval mapped to pixels via the layout's pxPerMs; slot mode uses simple
@@ -79,18 +73,7 @@ export function drawMiniCandles(args: CandleDrawArgs): void {
   const bodyW = Math.max(1, Math.floor(slot * 0.7));
 
   // Baseline (under candles)
-  if (baselineValue != null) {
-    ctx.save();
-    ctx.strokeStyle = themeColors.baseline;
-    ctx.lineWidth = 1;
-    ctx.setLineDash([2, 2]);
-    ctx.beginPath();
-    const by = yOf(baselineValue);
-    ctx.moveTo(0, by);
-    ctx.lineTo(width, by);
-    ctx.stroke();
-    ctx.restore();
-  }
+  drawSparkBaseline(ctx, yOf, baselineValue, width, themeColors.baseline);
 
   for (let i = 0; i < data.length; i++) {
     const c = data[i];

--- a/packages/chart/src/sparkline/draw-line.ts
+++ b/packages/chart/src/sparkline/draw-line.ts
@@ -1,4 +1,5 @@
 import type { StrokeAndFill } from "./color-resolve";
+import { computeYScale, drawSparkBaseline } from "./scale";
 import type { SessionLayout } from "./session";
 import type { ResolvedColors, SparklineCandle } from "./types";
 
@@ -61,16 +62,8 @@ export function drawMiniLine(args: LineDrawArgs): void {
     if (v < min) min = v;
     if (v > max) max = v;
   }
-  if (baselineValue != null) {
-    if (baselineValue < min) min = baselineValue;
-    if (baselineValue > max) max = baselineValue;
-  }
 
-  const padY = 1;
-  const innerH = Math.max(1, height - padY * 2);
-  const range = max - min || 1;
-
-  const yOf = (v: number) => padY + innerH - ((v - min) / range) * innerH;
+  const { yOf } = computeYScale(min, max, baselineValue, height);
 
   // Compute x positions per point. Session mode maps by time and emits
   // separate path segments per break; slot mode places points at evenly
@@ -139,18 +132,7 @@ export function drawMiniLine(args: LineDrawArgs): void {
   }
 
   // Baseline (drawn under stroke).
-  if (baselineValue != null) {
-    ctx.save();
-    ctx.strokeStyle = themeColors.baseline;
-    ctx.lineWidth = 1;
-    ctx.setLineDash([2, 2]);
-    ctx.beginPath();
-    const by = yOf(baselineValue);
-    ctx.moveTo(0, by);
-    ctx.lineTo(width, by);
-    ctx.stroke();
-    ctx.restore();
-  }
+  drawSparkBaseline(ctx, yOf, baselineValue, width, themeColors.baseline);
 
   // Stroke — one polyline per segment, so the line breaks at each gap.
   ctx.strokeStyle = colors.stroke;

--- a/packages/chart/src/sparkline/index.ts
+++ b/packages/chart/src/sparkline/index.ts
@@ -47,7 +47,7 @@ export type {
   SparklineOptions,
   SparklineSession,
 } from "./types";
-export { DEFAULT_COLORS } from "./types";
+export { DEFAULT_COLORS, SPARKLINE_OPTION_KEYS } from "./types";
 
 /**
  * Create a single sparkline. For multiple instances on the same page, prefer

--- a/packages/chart/src/sparkline/scale.ts
+++ b/packages/chart/src/sparkline/scale.ts
@@ -1,0 +1,59 @@
+export type YScale = {
+  /** Map a data value to a CSS-pixel y coordinate. */
+  yOf: (v: number) => number;
+  /** Extent actually used (raw extent widened to include the baseline). */
+  min: number;
+  max: number;
+};
+
+/**
+ * Build the vertical scale shared by the line and candle sparkline renderers.
+ * `min`/`max` are the raw data extent the caller scanned (line: close range;
+ * candle: low/high range). When `baselineValue` is set it is folded into the
+ * extent so the dashed baseline stays on-canvas. A 1px vertical pad keeps the
+ * extremes off the edge, and a zero-height range collapses to `1` to avoid a
+ * divide-by-zero.
+ */
+export function computeYScale(
+  min: number,
+  max: number,
+  baselineValue: number | null,
+  height: number,
+): YScale {
+  if (baselineValue != null) {
+    if (baselineValue < min) min = baselineValue;
+    if (baselineValue > max) max = baselineValue;
+  }
+  const padY = 1;
+  const innerH = Math.max(1, height - padY * 2);
+  const range = max - min || 1;
+  return {
+    min,
+    max,
+    yOf: (v: number) => padY + innerH - ((v - min) / range) * innerH,
+  };
+}
+
+/**
+ * Draw the dashed sparkline baseline at `baselineValue`. No-op when the
+ * baseline is null. Saves/restores ctx so the dash pattern doesn't leak.
+ */
+export function drawSparkBaseline(
+  ctx: CanvasRenderingContext2D,
+  yOf: (v: number) => number,
+  baselineValue: number | null,
+  width: number,
+  baselineColor: string,
+): void {
+  if (baselineValue == null) return;
+  ctx.save();
+  ctx.strokeStyle = baselineColor;
+  ctx.lineWidth = 1;
+  ctx.setLineDash([2, 2]);
+  ctx.beginPath();
+  const by = yOf(baselineValue);
+  ctx.moveTo(0, by);
+  ctx.lineTo(width, by);
+  ctx.stroke();
+  ctx.restore();
+}

--- a/packages/chart/src/sparkline/types.ts
+++ b/packages/chart/src/sparkline/types.ts
@@ -129,6 +129,29 @@ export type SparklineOptions = {
   hover?: boolean;
 };
 
+/**
+ * The `SparklineOptions` keys a live `update()` must react to — the single
+ * source of truth the React effect-deps, the Vue watch sources, and the Vue
+ * prop→options builder all derive from. Add a new live-updatable option here
+ * and every wrapper picks it up; forgetting one is exactly what silently drops
+ * an option from live updates. Layout-only props (width / height / style /
+ * className) are intentionally excluded.
+ */
+export const SPARKLINE_OPTION_KEYS = [
+  "type",
+  "data",
+  "color",
+  "fill",
+  "baseline",
+  "maxCandles",
+  "totalSlots",
+  "session",
+  "breakGap",
+  "densityFallback",
+  "colors",
+  "hover",
+] as const satisfies readonly (keyof SparklineOptions)[];
+
 export type SparklineHandle = {
   /** Update options and re-render. Pass partial; only changed fields apply. */
   update(opts: Partial<SparklineOptions>): void;

--- a/packages/chart/vue/sparkline.ts
+++ b/packages/chart/vue/sparkline.ts
@@ -33,6 +33,7 @@ import {
   createSparkline,
   createSparklineGroup,
   type HoverPayload,
+  SPARKLINE_OPTION_KEYS,
   type SparklineCandle,
   type SparklineGroup,
   type SparklineHandle,
@@ -119,20 +120,13 @@ export const Sparkline = defineComponent({
     const handleRef = shallowRef<SparklineHandle | null>(null);
     const groupRef = inject(GROUP_KEY, null);
 
-    const buildOpts = (): SparklineOptions => ({
-      type: props.type,
-      data: props.data as SparklineOptions["data"],
-      color: props.color,
-      fill: props.fill,
-      baseline: props.baseline,
-      maxCandles: props.maxCandles,
-      totalSlots: props.totalSlots,
-      session: props.session,
-      breakGap: props.breakGap,
-      colors: props.colors,
-      densityFallback: props.densityFallback,
-      hover: props.hover,
-    });
+    const buildOpts = (): SparklineOptions => {
+      const out: Record<string, unknown> = {};
+      for (const k of SPARKLINE_OPTION_KEYS) {
+        out[k] = (props as Record<string, unknown>)[k];
+      }
+      return out as SparklineOptions;
+    };
 
     /** Track which mode the current handle was attached in, so we can detect
      *  the standalone→group transition (children mount before parent's onMounted
@@ -170,20 +164,7 @@ export const Sparkline = defineComponent({
     }
 
     watch(
-      [
-        () => props.data,
-        () => props.type,
-        () => props.fill,
-        () => props.baseline,
-        () => props.color,
-        () => props.maxCandles,
-        () => props.totalSlots,
-        () => props.session,
-        () => props.breakGap,
-        () => props.colors,
-        () => props.densityFallback,
-        () => props.hover,
-      ],
+      SPARKLINE_OPTION_KEYS.map((k) => () => (props as Record<string, unknown>)[k]),
       () => handleRef.value?.update(buildOpts()),
     );
 


### PR DESCRIPTION
## Summary

Pre-release cleanup: extract five small pieces of duplicated logic into shared helpers. All changes are behavior-preserving and there is no public API change. Split into one commit per item for review.

## Commits

1. **`renderFibLevels`** — `renderFibRetracement` and `renderFibExtension` (`drawing-renderer.ts`) drew the same idiom (a line per level, light shading between levels, a `pct% (price)` label) and differed only in how a level maps to a price and in the color table. Extracted `renderFibLevels(ctx, c, fontSize, levels, colors, priceAt)`; both call it with their own `priceAt` closure and palette. Both remain non-exported, dispatched from `renderDrawings`.

2. **sparkline y-scale + baseline** — `drawMiniLine` and `drawMiniCandles` had byte-identical y-scale math and an identical dashed-baseline block. Extracted `computeYScale()` and `drawSparkBaseline()` into `sparkline/scale.ts`. Each renderer keeps its own raw min/max scan (line: close; candle: low/high). Deliberately kept separate from the main-chart series renderers so the `PriceScale`/`TimeScale` machinery stays out of the sparkline bundle.

3. **`isFiniteOHLC`** — the candlestick and timeframe-overlay renderers carried the same four-field finite-OHLC guard verbatim. Added `isFiniteOHLC()` to `core/validation` and used it in both. The `setCandles` filter (a superset that also null- and time-checks) and the two-field `updateCandle` variant are left untouched.

4. **`roundRectPath`** — the Regime Heatmap pill and the Price Patterns label both hand-traced the same nine-segment rounded-rectangle path, differing only in corner radius. Added `roundRectPath(ctx, x, y, w, h, r)` to `draw-helper` (path only; fill/stroke stay with the caller). Uses manual `quadraticCurveTo` corners rather than native `ctx.roundRect` for canvas-mock compatibility in tests. The Wyckoff square chip is a different idiom and is left as-is.

5. **`SPARKLINE_OPTION_KEYS`** — the set of option keys a live `update()` must react to was maintained by hand in three places (React effect deps, Vue watch sources, Vue prop→options builder); forgetting one silently dropped an option from live updates. Added `SPARKLINE_OPTION_KEYS` as the single source and drive the Vue watch sources and `buildOpts` from it. React's `useEffect` deps must be an array literal (hooks lint), so that list stays explicit with a comment to keep it in sync.

## Test plan

- `npx tsc --noEmit --ignoreDeprecations 6.0` — clean
- `pnpm build` — passes
- `pnpm test` — 912 passed (78 files); no tests removed (behavior-preserving)
- `pnpm size-check` — all entries within budget; Sparkline (vanilla) 3.78 kB / 5 kB, Main 40.32 kB / 41 kB

Net diff: +202 / -170 across 14 files.