### PR TITLE
chore: release core v0.4.0, chart v0.3.0, mcp v0.2.0

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `@trendcraft/chart` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2026-06-09
 
 ### Breaking — `snapshotName` is now a default label, not a uniqueness key
 

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trendcraft/chart",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Finance-specialized charting library with native TrendCraft Series<T> support",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.4.0] - 2026-06-09
 
 ### Breaking — `dmiBullish` / `dmiBearish` ADX param renamed `minAdx` → `threshold`
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trendcraft",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Technical analysis library for TypeScript — 130+ indicators, backtesting, optimization, streaming, and zero dependencies",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.0 (2026-06-09)
 
 ### Fixed — reject non-finite candle OHLCV at the input boundary
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trendcraft/mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Model Context Protocol server for TrendCraft — exposes 96+ indicator manifests (whenToUse / pitfalls / synergy / regime) plus calc and signal dispatchers to LLM clients like Claude Desktop and Cursor",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Coordinated release of all three packages. Each commit promotes that package's `Unreleased` CHANGELOG section to a dated version heading and bumps `package.json`. No source changes — this PR is version metadata only.

| Package | From | To | Bump rationale |
|---|---|---|---|
| `trendcraft` (core) | 0.3.0 | **0.4.0** | minor — breaking: backtest `dmiBullish`/`dmiBearish` ADX param renamed `minAdx` → `threshold` (default 20 → 25), plus registry-parity and volume-constrained-fill fixes |
| `@trendcraft/chart` | 0.2.0 | **0.3.0** | minor — breaking: `snapshotName` is now a default label, not a uniqueness key; plus the Price Patterns plugin, the `replay` subpath, `connectLivePrimitives`, and rendering consolidation |
| `@trendcraft/mcp` | 0.1.0 | **0.2.0** | minor — stricter input validation (rejects non-finite OHLCV and missing volume for volume-reading signals); `zod` bumped to v4 |

## Release order (serial, after merge)

Publishes happen locally after this merges, in order: **core → chart → mcp**.

- `@trendcraft/mcp` depends on `trendcraft` via `workspace:^`, which resolves to `^0.4.0` at publish time, so core 0.4.0 must be live on npm first.
- `@trendcraft/chart`'s `trendcraft` peer stays `>=0.3.0` — it uses no new core 0.4.0 symbol, so no peer bump is needed.

## Test plan

- `pnpm install --frozen-lockfile` — clean (version bumps need no lockfile change)
- CI runs lint + build + test + size-check (core & chart) on this PR
- Each package's `prepublishOnly` re-runs build + test (+ `verify:publish` for core/chart) at publish time