### PR TITLE
fix(chart): drop timezone-artifact time from daily axis first label

### DIFF
--- a/packages/chart/src/__tests__/format.test.ts
+++ b/packages/chart/src/__tests__/format.test.ts
@@ -71,6 +71,26 @@ describe("autoFormatTime", () => {
     expect(label).toContain("15");
   });
 
+  it("first label of a daily series omits the wall-clock time artifact", () => {
+    // A daily bar stamped at 00:00 UTC renders as 09:00 in a +09:00 TZ. With a
+    // daily interval hint the first label must stay a bare date, not "09:00".
+    const DAY = 24 * 60 * 60 * 1000;
+    const label = autoFormatTime(day1, null, DAY);
+    expect(label).not.toContain(":");
+    expect(label).toContain("Jan");
+    expect(label).toContain("15");
+  });
+
+  it("first label of an intraday series keeps the wall-clock time", () => {
+    // intraday1 is 10:30 UTC; with a 1h interval hint the time must survive
+    // (in TZs where 10:30 UTC is not local midnight).
+    const HOUR = 60 * 60 * 1000;
+    const label = autoFormatTime(intraday1, null, HOUR);
+    const localMidnight =
+      new Date(intraday1).getHours() === 0 && new Date(intraday1).getMinutes() === 0;
+    if (!localMidnight) expect(label).toMatch(/\d{2}:\d{2}/);
+  });
+
   it("day change shows month + day", () => {
     const label = autoFormatTime(day2, day1);
     expect(label).toContain("16");

--- a/packages/chart/src/core/format.ts
+++ b/packages/chart/src/core/format.ts
@@ -77,15 +77,21 @@ export function setMonthNames(names: readonly string[]): void {
   if (names.length === 12) MONTH_NAMES = [...names];
 }
 
+/** One day in milliseconds — the threshold at/above which a series is "daily+". */
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 /**
  * Smart time label formatting.
  * Uses the difference from the previous label to determine the appropriate level of detail.
  *
  * @param time - Epoch milliseconds
  * @param prevTime - Previous label's epoch milliseconds (null for first label)
+ * @param intervalMs - Optional dominant bar interval. When the series is
+ *   daily-grained or coarser, the first label's wall-clock time is suppressed
+ *   (see below). Omit to keep the legacy "show time if non-midnight" behavior.
  * @returns Formatted string
  */
-export function autoFormatTime(time: number, prevTime: number | null): string {
+export function autoFormatTime(time: number, prevTime: number | null, intervalMs?: number): string {
   const d = new Date(time);
   const year = d.getFullYear();
   const month = d.getMonth();
@@ -94,8 +100,13 @@ export function autoFormatTime(time: number, prevTime: number | null): string {
   const minutes = d.getMinutes();
 
   if (prevTime === null) {
-    // First label: show full date
-    if (hours === 0 && minutes === 0) {
+    // First label: show full date. The wall-clock time is suppressed for
+    // daily+ bars, where the hour is a timezone artifact (e.g. a 00:00 UTC
+    // daily bar renders as 09:00 in JST) that would clash with the bare
+    // month/year anchors used for every later tick. With no interval hint we
+    // keep the legacy behavior of showing the time when it is non-midnight.
+    const coarse = (intervalMs ?? 0) >= DAY_MS;
+    if ((hours === 0 && minutes === 0) || coarse) {
       return `${MONTH_NAMES[month]} ${day}`;
     }
     return `${MONTH_NAMES[month]} ${day} ${pad2(hours)}:${pad2(minutes)}`;

--- a/packages/chart/src/renderer/axis-renderer.ts
+++ b/packages/chart/src/renderer/axis-renderer.ts
@@ -7,6 +7,7 @@ import {
   autoFormatTime,
   formatShortDate,
   formatShortTime,
+  measureTextWidth,
   pickNiceStep,
 } from "../core/format";
 import type { PriceScale, TimeScale } from "../core/scale";
@@ -171,6 +172,12 @@ export function renderTimeAxis(
   const firstAnchor = Math.ceil(start / labelInterval) * labelInterval;
   let prevLabelTime: number | null = null;
 
+  // Dominant bar interval, used to decide whether the first label's wall-clock
+  // time is meaningful (intraday) or a timezone artifact (daily+). Derived
+  // straight from the candle timestamps — not timeScale.medianBarIntervalMs,
+  // which is only populated in time-proportional layout mode and is 0 here.
+  const barIntervalMs = estimateBarIntervalMs(candles);
+
   for (let i = firstAnchor; i < end && i < candles.length; i += labelInterval) {
     const candle = candles[i];
     if (!candle) continue;
@@ -178,11 +185,43 @@ export function renderTimeAxis(
     const labelX = timeScale.indexToX(i);
     const label = timeFormatter
       ? timeFormatter(candle.time)
-      : autoFormatTime(candle.time, prevLabelTime);
+      : autoFormatTime(candle.time, prevLabelTime, barIntervalMs);
     prevLabelTime = candle.time;
 
-    ctx.fillText(label, labelX, y + 6);
+    // Keep edge labels fully on-screen: a centered label whose tick sits at the
+    // plot boundary loses ~half its text to clipping. Left-align (and nudge in)
+    // the first label, right-align one overflowing the right edge; center the
+    // rest. Matches the inward-nudge the price axis does via textBaseline.
+    const half = measureTextWidth(ctx, label) / 2;
+    if (labelX - half < x) {
+      ctx.textAlign = "left";
+      ctx.fillText(label, Math.max(labelX, x + 2), y + 6);
+    } else if (labelX + half > x + width) {
+      ctx.textAlign = "right";
+      ctx.fillText(label, Math.min(labelX, x + width - 2), y + 6);
+    } else {
+      ctx.textAlign = "center";
+      ctx.fillText(label, labelX, y + 6);
+    }
   }
+}
+
+/**
+ * Estimate the dominant bar interval (ms) from candle timestamps by taking the
+ * minimum positive gap across a bounded sample. Minimum (rather than
+ * mean/median) returns the regular bar spacing while ignoring the larger gaps
+ * introduced by weekends and holidays. Returns 0 when it cannot be determined
+ * (no time data or <2 candles).
+ */
+function estimateBarIntervalMs(candles: readonly CandleData[]): number {
+  const n = candles.length;
+  if (n < 2) return 0;
+  let min = Number.POSITIVE_INFINITY;
+  for (let i = 1; i < n && i <= 32; i++) {
+    const dt = candles[i].time - candles[i - 1].time;
+    if (dt > 0 && dt < min) min = dt;
+  }
+  return Number.isFinite(min) ? min : 0;
 }
 
 /**


### PR DESCRIPTION
## Problem

On a daily (or coarser) chart, the **first x-axis label showed a wall-clock time** such as `09:00`, while every later tick rendered a bare date:

```
09:00   Jan 10   Jan 17   Jan 24   Feb   ...
```

That time is a timezone artifact, not real data: a daily bar stamped at `00:00 UTC` renders as `09:00` in a `+09:00` zone. Only the first label exposed it — later labels are already collapsed to dates by the prev-label diffing in `autoFormatTime`, but the first label has no previous tick to compare against.

## Fix

```
Jan 3   Jan 10   Jan 17   Jan 24   Feb   ...
```

- **`autoFormatTime`** gains an optional `intervalMs` hint. When the series is daily-grained or coarser, the first label's wall-clock time is suppressed and a bare date is shown. Omitting the hint preserves the legacy "show time if non-midnight" behavior, so all existing callers are unaffected.
- **`renderTimeAxis`** derives the dominant bar interval straight from the candle timestamps and passes it in. `timeScale.medianBarIntervalMs` cannot be used here because it is `0` outside time-proportional layout mode (the legacy single-row axis path).
- **Edge-label clipping** is fixed as part of the same path: a centered label whose tick sits at the plot boundary loses ~half its text (e.g. `Jan 3` was clipped to `n 3`). The first/last labels are now left/right-aligned and nudged inward so they stay fully on-screen, mirroring the inward-nudge the price axis already does.

## Testing

- `pnpm test` — 905 tests pass (2 new tests cover the daily vs. intraday first-label behavior)
- `npx tsc --noEmit` — clean
- `pnpm build` and `pnpm size-check` — within limits (Main 40.44/41 kB, Headless 10.83/11 kB)