### PR TITLE
fix(core): correct margin accounting in the backtest engine

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 ## [Unreleased]
 
+### Fixed — leveraged backtests now repay the margin loan on position close
+
+`runBacktest` with a `margin` config credited the full exit proceeds —
+including the loan-funded notional — back to capital without ever deducting
+the borrowed principal, overstating final capital by roughly the borrowed
+amount (e.g. 1M capital at 2x leverage on a +20% trade reported 2.4M instead
+of 1.4M). The borrowed principal is now repaid proportionally as the position
+unwinds (full exits, partial take profits, scale-outs, margin-call
+liquidations, and end-of-data closes), and margin interest is settled against
+the outstanding loan before repayment.
+
+Margin-call detection was also broken: the equity check passed the entry
+notional instead of remaining cash into the margin-ratio computation, so the
+ratio could effectively never fall below maintenance. The check now uses
+cash + position claim − loan, and is direction-aware
+(`updateMarginState` gained optional `direction` / `entryValue` params): a
+short's equity rises as the price falls — proceeds plus unrealized P&L —
+so profitable shorts are no longer at risk of being liquidated while losing
+shorts breach maintenance correctly, and `marginCallAction: "liquidate"`
+actually triggers.
+
+`marginCallAction: "reduceToMaintenance"` is now implemented (it was
+accepted by the config type but did nothing): on a maintenance breach the
+engine sells just enough of the position — a fair-value partial close with
+`exitReason: "marginCall"` — to restore the margin ratio to the maintenance
+level, repaying the loan proportionally; if equity is exhausted it falls
+back to full liquidation.
+
+Margin interest is now charged per repaid tranche: partial take profits and
+scale-outs settle interest on the repaid portion for exactly the days it
+was outstanding, instead of the final close charging only the residual
+loan. Settled interest also no longer inflates `accumulatedInterest` (which
+the equity check subtracts as *unpaid* interest — recording paid charges
+there double-counted them against equity). Leveraged results (final
+capital, drawdowns, Sharpe) will be lower — and correct — after these
+fixes; unlevered backtests are unaffected. The `repayLoan` helper is
+exported alongside the other margin utilities.
+
 ### Added — position sizing wired into the backtest engine (`sizing` option)
 
 `runBacktest` now accepts a `sizing` option (`BacktestSizingConfig`) that

--- a/packages/core/src/backtest/__tests__/margin-integration.test.ts
+++ b/packages/core/src/backtest/__tests__/margin-integration.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import { runBacktest } from "../engine";
+import { at, stepCandles } from "./step-candles";
+
+// Same layout as sizing-integration.test.ts — entry signal at bar 20 fills
+// at bar 21's open, exit signal at bar 32 fills at bar 33's open.
+const UP_20 = stepCandles([
+  { price: 100, bars: 30 },
+  { price: 120, bars: 10 },
+]);
+const DOWN_10 = stepCandles([
+  { price: 100, bars: 30 },
+  { price: 90, bars: 10 },
+]);
+const ENTRY = at(20);
+const EXIT = at(32);
+const CAPITAL = 1_000_000;
+const MARGIN_2X = { leverage: 2, maintenanceMargin: 0.25, marginCallAction: "liquidate" as const };
+
+/**
+ * Leveraged equity accounting: exit proceeds include the loan-funded
+ * notional, so the borrowed principal must be repaid when the position
+ * closes. 1M capital at 2x buys 20,000 shares @100 (borrowing 1M).
+ */
+describe("backtest margin loan repayment", () => {
+  it("repays the borrowed principal on a winning trade (2x, +20% → equity 1.4M, not 2.4M)", () => {
+    const result = runBacktest(UP_20, ENTRY, EXIT, { capital: CAPITAL, margin: MARGIN_2X });
+    // 20,000 shares @100 → exit 120: proceeds 2.4M − 1M loan = 1.4M.
+    // Before the fix this reported 2.4M (loan never left the account).
+    expect(result.trades.length).toBe(1);
+    expect(result.finalCapital).toBeCloseTo(1_400_000, 6);
+  });
+
+  it("amplifies losses correctly (2x, -10% → equity 0.8M)", () => {
+    const result = runBacktest(DOWN_10, ENTRY, EXIT, { capital: CAPITAL, margin: MARGIN_2X });
+    // 20,000 shares @100 → exit 90: proceeds 1.8M − 1M loan = 0.8M
+    expect(result.finalCapital).toBeCloseTo(800_000, 6);
+  });
+
+  it("2x leverage doubles the P&L of the unlevered run", () => {
+    const levered = runBacktest(UP_20, ENTRY, EXIT, { capital: CAPITAL, margin: MARGIN_2X });
+    const unlevered = runBacktest(UP_20, ENTRY, EXIT, { capital: CAPITAL });
+    expect(levered.finalCapital - CAPITAL).toBeCloseTo(2 * (unlevered.finalCapital - CAPITAL), 6);
+  });
+
+  it("repays the loan proportionally across partial exits (partial TP + final exit)", () => {
+    const result = runBacktest(UP_20, ENTRY, EXIT, {
+      capital: CAPITAL,
+      margin: MARGIN_2X,
+      partialTakeProfit: { threshold: 20, sellPercent: 50 },
+    });
+    // Half closed at the +20% partial TP, half at the exit signal — both at
+    // 120, so the final equity must equal the single-exit case exactly
+    expect(result.trades.length).toBe(2);
+    expect(result.finalCapital).toBeCloseTo(1_400_000, 6);
+  });
+
+  it("still deducts margin interest on top of the loan repayment", () => {
+    const result = runBacktest(UP_20, ENTRY, EXIT, {
+      capital: CAPITAL,
+      margin: { ...MARGIN_2X, interestRate: 0.0365 },
+    });
+    // Entry fills bar 21, exit fills bar 33 → 12 holding days on a 1M loan
+    // at 0.01%/day = 1,200 interest
+    expect(result.finalCapital).toBeCloseTo(1_400_000 - 1_200, 6);
+  });
+
+  it("repays the loan on a margin-call liquidation", () => {
+    const crash = stepCandles([
+      { price: 100, bars: 30 },
+      { price: 60, bars: 10 },
+    ]);
+    const result = runBacktest(crash, ENTRY, at(38), { capital: CAPITAL, margin: MARGIN_2X });
+    // At 60: equity 1.2M − 1M = 0.2M is 16.7% of position value < 25%
+    // maintenance → liquidate. Proceeds 1.2M − 1M loan = 0.2M
+    expect(result.trades.length).toBe(1);
+    expect(result.trades[0].exitReason).toBe("marginCall");
+    expect(result.finalCapital).toBeCloseTo(200_000, 6);
+  });
+
+  it("does NOT margin-call a deeply profitable leveraged short", () => {
+    const crash = stepCandles([
+      { price: 100, bars: 30 },
+      { price: 60, bars: 10 },
+    ]);
+    const result = runBacktest(crash, ENTRY, at(35), {
+      capital: CAPITAL,
+      direction: "short",
+      margin: MARGIN_2X,
+    });
+    // Short 20,000 @100, covered @60: equity RISES as price falls
+    // (2M proceeds + 800k unrealized − 1M loan), so no maintenance breach.
+    // Proceeds 2M + 800k profit − 1M loan = 1.8M
+    expect(result.trades.length).toBe(1);
+    expect(result.trades[0].exitReason).toBe("signal");
+    expect(result.finalCapital).toBeCloseTo(1_800_000, 6);
+  });
+
+  it("margin-calls a leveraged short when the price moves up against it", () => {
+    const squeeze = stepCandles([
+      { price: 100, bars: 30 },
+      { price: 130, bars: 10 },
+    ]);
+    const result = runBacktest(squeeze, ENTRY, at(38), {
+      capital: CAPITAL,
+      direction: "short",
+      margin: MARGIN_2X,
+    });
+    // At 130: equity = 2M + (2M − 2.6M) − 1M = 0.4M, which is 15.4% of the
+    // 2.6M cover liability < 25% maintenance → liquidate.
+    // Proceeds 2M − 600k loss − 1M loan = 0.4M
+    expect(result.trades.length).toBe(1);
+    expect(result.trades[0].exitReason).toBe("marginCall");
+    expect(result.finalCapital).toBeCloseTo(400_000, 6);
+  });
+
+  it("charges interest on each repaid tranche for exactly its outstanding days", () => {
+    const result = runBacktest(UP_20, ENTRY, EXIT, {
+      capital: CAPITAL,
+      margin: { ...MARGIN_2X, interestRate: 0.0365 },
+      partialTakeProfit: { threshold: 20, sellPercent: 50 },
+    });
+    // Partial closes half at bar 30 (9 days): tranche interest 1M × 0.01%/day
+    // × 9 × 0.5 = 450, repay 500k. Full close at bar 33 (12 days): interest
+    // 500k × 0.01%/day × 12 = 600, repay 500k. Final = 1.4M − 450 − 600.
+    // Charging full-period interest only at the final close would give
+    // 1.4M − 1,200 instead.
+    expect(result.trades.length).toBe(2);
+    expect(result.finalCapital).toBeCloseTo(1_400_000 - 450 - 600, 6);
+  });
+
+  it("reduceToMaintenance sells just enough to restore the maintenance ratio", () => {
+    const crash = stepCandles([
+      { price: 100, bars: 30 },
+      { price: 60, bars: 10 },
+    ]);
+    const result = runBacktest(crash, ENTRY, at(38), {
+      capital: CAPITAL,
+      margin: { ...MARGIN_2X, marginCallAction: "reduceToMaintenance" },
+    });
+    // At 60 the ratio is 200k/1.2M ≈ 16.7% → sell f = 1 − 0.167/0.25 = 1/3
+    // of the position (one partial marginCall trade, no second call since
+    // the ratio lands exactly on 25%). A fair-value reduction keeps equity
+    // at 200k, so with no price recovery the final capital matches the
+    // liquidation path — but the account stays in the market.
+    expect(result.trades.length).toBe(2);
+    expect(result.trades[0].exitReason).toBe("marginCall");
+    expect(result.trades[0].isPartial).toBe(true);
+    expect(result.trades[1].exitReason).toBe("signal");
+    expect(result.finalCapital).toBeCloseTo(200_000, 6);
+  });
+
+  it("reduceToMaintenance keeps upside that a liquidation would forfeit", () => {
+    const dipAndRecover = stepCandles([
+      { price: 100, bars: 30 },
+      { price: 60, bars: 5 },
+      { price: 100, bars: 5 },
+    ]);
+    const reduced = runBacktest(dipAndRecover, ENTRY, at(38), {
+      capital: CAPITAL,
+      margin: { ...MARGIN_2X, marginCallAction: "reduceToMaintenance" },
+    });
+    const liquidated = runBacktest(dipAndRecover, ENTRY, at(38), {
+      capital: CAPITAL,
+      margin: MARGIN_2X,
+    });
+    // The reduced account still holds 13,333 shares through the recovery
+    // back to 100; the liquidated one is flat from 60 onward.
+    expect(reduced.finalCapital).toBeGreaterThan(liquidated.finalCapital);
+  });
+
+  it("works for short positions (2x short, -20% move → equity 1.4M)", () => {
+    const down20 = stepCandles([
+      { price: 100, bars: 30 },
+      { price: 80, bars: 10 },
+    ]);
+    const result = runBacktest(down20, ENTRY, EXIT, {
+      capital: CAPITAL,
+      direction: "short",
+      margin: MARGIN_2X,
+    });
+    // 20,000 shares short @100 → cover 80: entry value 2M + 400k profit
+    // − 1M loan = 1.4M
+    expect(result.finalCapital).toBeCloseTo(1_400_000, 6);
+  });
+
+  it("leaves unlevered backtests untouched (no margin config)", () => {
+    const result = runBacktest(UP_20, ENTRY, EXIT, { capital: CAPITAL });
+    expect(result.finalCapital).toBeCloseTo(1_200_000, 6);
+  });
+});

--- a/packages/core/src/backtest/__tests__/sizing-integration.test.ts
+++ b/packages/core/src/backtest/__tests__/sizing-integration.test.ts
@@ -1,39 +1,7 @@
 import { describe, expect, it } from "vitest";
-import type { BacktestSizingContext, ConditionFn, NormalizedCandle } from "../../types";
+import type { BacktestSizingContext } from "../../types";
 import { runBacktest } from "../engine";
-
-/**
- * Step-price candles: a flat segment per step, with open=close=price and a
- * ±1 high/low band. Flat segments keep ATR exactly 2 (TR = high-low = 2),
- * making ATR-based sizing arithmetic exact.
- */
-function stepCandles(
-  steps: { price: number; bars: number }[],
-  volume = 1_000_000,
-): NormalizedCandle[] {
-  const candles: NormalizedCandle[] = [];
-  let t = 1_700_000_000_000;
-  for (const s of steps) {
-    for (let i = 0; i < s.bars; i++) {
-      candles.push({
-        time: t,
-        open: s.price,
-        high: s.price + 1,
-        low: s.price - 1,
-        close: s.price,
-        volume,
-      });
-      t += 86_400_000;
-    }
-  }
-  return candles;
-}
-
-const at =
-  (...indices: number[]): ConditionFn =>
-  (_ind, _candle, i) =>
-    indices.includes(i);
-const never: ConditionFn = () => false;
+import { at, never, stepCandles } from "./step-candles";
 
 /**
  * Layout A: 30 bars at 100, then 10 bars at 120. Entry signal at bar 20

--- a/packages/core/src/backtest/__tests__/step-candles.ts
+++ b/packages/core/src/backtest/__tests__/step-candles.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared step-price candle fixtures for backtest integration tests.
+ */
+
+import type { ConditionFn, NormalizedCandle } from "../../types";
+
+/**
+ * Step-price candles: a flat segment per step, with open=close=price and a
+ * ±1 high/low band. Flat segments keep ATR exactly 2 (TR = high-low = 2),
+ * making sizing/risk arithmetic in assertions exact.
+ */
+export function stepCandles(
+  steps: { price: number; bars: number }[],
+  volume = 1_000_000,
+): NormalizedCandle[] {
+  const candles: NormalizedCandle[] = [];
+  let t = 1_700_000_000_000;
+  for (const s of steps) {
+    for (let i = 0; i < s.bars; i++) {
+      candles.push({
+        time: t,
+        open: s.price,
+        high: s.price + 1,
+        low: s.price - 1,
+        close: s.price,
+        volume,
+      });
+      t += 86_400_000;
+    }
+  }
+  return candles;
+}
+
+/** Condition firing exactly at the given bar indices */
+export const at =
+  (...indices: number[]): ConditionFn =>
+  (_ind, _candle, i) =>
+    indices.includes(i);
+
+/** Condition that never fires */
+export const never: ConditionFn = () => false;

--- a/packages/core/src/backtest/engine.ts
+++ b/packages/core/src/backtest/engine.ts
@@ -46,6 +46,7 @@ import {
   calculateBuyingPower,
   checkMarginCall,
   createMarginState,
+  repayLoan,
   updateMarginState,
 } from "./margin";
 import type { PendingOrder } from "./order-types";
@@ -383,14 +384,32 @@ export function runBacktest(
   }
 
   /**
-   * Deduct margin interest when closing a position
+   * Repay the borrowed principal for the fraction of the position being
+   * closed (no-op without margin). See {@link repayLoan} — in particular,
+   * settle interest before a full-close repayment zeroes the loan.
    */
-  function deductMarginInterest(entryTime: number, exitTime: number): void {
+  function repayMarginLoan(fraction: number): number {
+    return marginState ? repayLoan(marginState, fraction) : 0;
+  }
+
+  /**
+   * Deduct margin interest for the fraction of the loan being settled,
+   * charged on the outstanding `borrowedAmount` over the entry-to-exit
+   * holding period. Call BEFORE `repayMarginLoan` reduces the balance, so
+   * each repaid tranche is charged for exactly the days it was outstanding.
+   *
+   * The charge is settled in cash immediately, so it is deliberately NOT
+   * added to `accumulatedInterest` — the equity check subtracts that field
+   * as *unpaid* interest, and recording a paid charge there would deduct
+   * it from equity a second time.
+   */
+  function deductMarginInterest(entryTime: number, exitTime: number, fraction = 1): void {
     if (marginConfig && marginState && marginConfig.interestRate) {
       const holdDays = Math.max(1, Math.round((exitTime - entryTime) / MS_PER_DAY));
-      const interest = accrueInterest(marginState, marginConfig.interestRate / 365, holdDays);
+      const interest =
+        accrueInterest(marginState, marginConfig.interestRate / 365, holdDays) *
+        Math.min(1, Math.max(0, fraction));
       currentCapital -= interest;
-      marginState.accumulatedInterest += interest;
     }
   }
 
@@ -574,8 +593,8 @@ export function runBacktest(
       });
 
       trades.push(result.trade);
-      currentCapital += result.netProceeds;
       deductMarginInterest(position.entryTime, candle.time);
+      currentCapital += result.netProceeds - repayMarginLoan(1);
       returns.push(result.returnPercent / 100);
       trackDrawdown(candle.time, i);
 
@@ -659,14 +678,55 @@ export function runBacktest(
       // === Margin call check ===
       if (marginConfig && marginState) {
         const positionValue = candle.close * position.shares;
-        const entryValue = position.entryPrice * position.shares;
-        marginState = updateMarginState(marginState, positionValue, entryValue);
+        // Equity = cash + position claim - loan. Passing remaining cash
+        // (not the entry notional) is what lets the margin ratio actually
+        // fall below maintenance as the position loses value; the direction
+        // and entry notional let shorts gain equity as the price falls.
+        marginState = updateMarginState(
+          marginState,
+          positionValue,
+          currentCapital,
+          dir,
+          position.entryPrice * position.shares,
+        );
         if (checkMarginCall(marginState, marginConfig.maintenanceMargin)) {
           marginState.isMarginCall = true;
-          if (marginConfig.marginCallAction === "liquidate") {
+          // A fair-value partial close keeps equity constant while scaling
+          // exposure by (1 - f), so selling f = 1 - ratio/maintenance
+          // restores the ratio to exactly the maintenance level. f >= 1
+          // means equity is gone and no reduction can restore it.
+          const reduceFraction = 1 - marginState.marginRatio / marginConfig.maintenanceMargin;
+          if (marginConfig.marginCallAction === "liquidate" || reduceFraction >= 1) {
             shouldExit = true;
             exitPrice = candle.close;
             exitReason = "marginCall";
+          } else if (reduceFraction > 1e-9) {
+            // The epsilon guard absorbs float error when a previous
+            // reduction landed the ratio exactly on maintenance — without
+            // it, a one-ulp shortfall fires a second, dust-sized close.
+            const reduceShares = position.shares * reduceFraction;
+            const reduceSlip = getSlippage(candle, i);
+            const result = calculateTradeClose({
+              position,
+              exitTime: candle.time,
+              exitPrice: candle.close,
+              exitReason: "marginCall",
+              sharesToClose: reduceShares,
+              isPartial: true,
+              exitPercent: reduceFraction * 100,
+              commission,
+              commissionRate,
+              taxRate,
+              slippage: reduceSlip,
+            });
+
+            trades.push(result.trade);
+            deductMarginInterest(position.entryTime, candle.time, reduceFraction);
+            currentCapital += result.netProceeds - repayMarginLoan(reduceFraction);
+            returns.push(result.returnPercent / 100);
+            trackDrawdown(candle.time, i);
+
+            position.shares -= reduceShares;
           }
         }
       }
@@ -765,7 +825,9 @@ export function runBacktest(
           });
 
           trades.push(result.trade);
-          currentCapital += result.netProceeds;
+          const partialFraction = sharesToSell / position.shares;
+          deductMarginInterest(position.entryTime, candle.time, partialFraction);
+          currentCapital += result.netProceeds - repayMarginLoan(partialFraction);
           returns.push(result.returnPercent / 100);
           trackDrawdown(candle.time, i);
 
@@ -809,7 +871,9 @@ export function runBacktest(
             });
 
             trades.push(result.trade);
-            currentCapital += result.netProceeds;
+            const scaleOutFraction = sharesToSell / position.shares;
+            deductMarginInterest(position.entryTime, candle.time, scaleOutFraction);
+            currentCapital += result.netProceeds - repayMarginLoan(scaleOutFraction);
             returns.push(result.returnPercent / 100);
             trackDrawdown(candle.time, i);
 
@@ -959,8 +1023,8 @@ export function runBacktest(
           });
 
           trades.push(result.trade);
-          currentCapital += result.netProceeds;
           deductMarginInterest(position.entryTime, candle.time);
+          currentCapital += result.netProceeds - repayMarginLoan(1);
           returns.push(result.returnPercent / 100);
           trackDrawdown(candle.time, i);
 
@@ -995,8 +1059,8 @@ export function runBacktest(
     });
 
     trades.push(result.trade);
-    currentCapital += result.netProceeds;
     deductMarginInterest(position.entryTime, lastCandle.time);
+    currentCapital += result.netProceeds - repayMarginLoan(1);
     returns.push(result.returnPercent / 100);
     ddTracker.update(currentCapital, lastCandle.time, candles.length - 1);
   }

--- a/packages/core/src/backtest/index.ts
+++ b/packages/core/src/backtest/index.ts
@@ -208,6 +208,7 @@ export {
   calculateBuyingPower,
   checkMarginCall,
   createMarginState,
+  repayLoan,
   updateMarginState,
 } from "./margin";
 export type {

--- a/packages/core/src/backtest/margin.ts
+++ b/packages/core/src/backtest/margin.ts
@@ -73,26 +73,38 @@ export function calculateBuyingPower(capital: number, leverage: number): number 
  * checking `isMarginCall` via {@link checkMarginCall} and setting it
  * on the returned state.
  *
+ * For longs the position is an asset worth its market value. For shorts
+ * the account's claim is what covering would return — the entry proceeds
+ * plus unrealized P&L (`entryValue + (entryValue - positionValue)`), with
+ * `positionValue` being the current cover cost. The margin ratio divides
+ * by `positionValue` in both cases (market exposure).
+ *
  * @param state - Current margin state
- * @param positionValue - Current market value of the position
- * @param capital - Original capital (cost basis)
+ * @param positionValue - Current market value of the position (cover cost for shorts)
+ * @param capital - Remaining cash not deployed in the position
+ * @param direction - Position direction (default: "long")
+ * @param entryValue - Entry notional (entry price × shares); required for shorts
  * @returns Updated margin state
  *
  * @example
  * ```ts
  * let state = createMarginState(10000, 2.0);
- * // Bought $20000 worth, now position is worth $18000
- * state = updateMarginState(state, 18000, 10000);
- * // state.equity === 10000 + 18000 - 10000 - 0 = 18000
- * // state.marginRatio === 18000 / 18000 = 1.0
+ * // Bought $20000 worth at 2x (cash 0 left), now position is worth $18000
+ * state = updateMarginState(state, 18000, 0);
+ * // state.equity === 0 + 18000 - 10000 - 0 = 8000
+ * // state.marginRatio === 8000 / 18000 ≈ 0.44
  * ```
  */
 export function updateMarginState(
   state: MarginState,
   positionValue: number,
   capital: number,
+  direction: "long" | "short" = "long",
+  entryValue: number = positionValue,
 ): MarginState {
-  const equity = capital + positionValue - state.borrowedAmount - state.accumulatedInterest;
+  const positionEquity =
+    direction === "short" ? entryValue + (entryValue - positionValue) : positionValue;
+  const equity = capital + positionEquity - state.borrowedAmount - state.accumulatedInterest;
   const marginRatio = positionValue > 0 ? equity / positionValue : 1.0;
 
   return {
@@ -120,6 +132,29 @@ export function updateMarginState(
  */
 export function accrueInterest(state: MarginState, dailyRate: number, days: number): number {
   return state.borrowedAmount * dailyRate * days;
+}
+
+/**
+ * Repay the borrowed principal for the fraction of a position being closed.
+ *
+ * Exit proceeds include the loan-funded notional, so the loan must leave
+ * the account as the position that borrowed it unwinds — otherwise
+ * leveraged backtests overstate final capital by roughly the borrowed
+ * amount. Mutates `state.borrowedAmount` and returns the repaid amount for
+ * the caller to subtract from the close proceeds.
+ *
+ * Settle interest (which accrues on the outstanding `borrowedAmount`)
+ * BEFORE calling this on a full close, since repayment zeroes the balance.
+ *
+ * @param state - Current margin state (mutated)
+ * @param fraction - Fraction of the position being closed (clamped to [0, 1])
+ * @returns Repaid principal amount
+ */
+export function repayLoan(state: MarginState, fraction: number): number {
+  if (state.borrowedAmount <= 0) return 0;
+  const repaid = state.borrowedAmount * Math.min(1, Math.max(0, fraction));
+  state.borrowedAmount -= repaid;
+  return repaid;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1123,6 +1123,7 @@ export {
   limitAtrBelow,
   // Preset limit/stop strategies
   limitBelowClose,
+  repayLoan,
   resolveSlippageModel,
   scoreBacktestResult,
   stopAboveHigh,


### PR DESCRIPTION
## Summary

Leveraged backtests (`margin` config on `runBacktest`) had four related accounting defects. The headline one: exit proceeds — which include the loan-funded notional — were credited back to capital in full, while the borrowed principal was never deducted. A 1M account at 2x leverage on a +20% trade reported a final capital of 2.4M instead of 1.4M, overstating results by roughly the borrowed amount on every round trip.

## Fixes

1. **Loan repayment on close.** A new `repayLoan(state, fraction)` helper in `backtest/margin.ts` repays the borrowed principal proportionally as the position unwinds, wired into all five close paths (full exits, partial take profits, scale-outs, margin-call closes, end-of-data).

2. **Margin-call detection was inert.** The per-bar equity check passed the entry notional instead of remaining cash into the margin-ratio computation, so the ratio effectively never fell below maintenance. `updateMarginState` now receives remaining cash and gained optional `direction` / `entryValue` parameters (backward compatible): a short's equity is its entry proceeds plus unrealized P&L, so it rises as the price falls — profitable shorts are no longer at risk of liquidation while losing shorts breach maintenance correctly.

3. **`marginCallAction: "reduceToMaintenance"` is now implemented** (the config type accepted it but the engine ignored it). On a maintenance breach the engine sells `f = 1 − ratio/maintenance` of the position — a fair-value partial close keeps equity constant while scaling exposure by `1 − f`, landing the ratio exactly on the maintenance level — recorded as a partial trade with `exitReason: "marginCall"`. Falls back to full liquidation when equity is exhausted; an epsilon guard prevents dust-sized re-closes when a prior reduction landed exactly on maintenance.

4. **Interest accounting.** Margin interest is settled per repaid tranche (each tranche is charged for exactly the days it was outstanding, instead of the final close charging only the residual loan), interest is deducted before repayment zeroes the outstanding balance, and settled interest no longer feeds `accumulatedInterest` — the equity check subtracts that field as *unpaid* interest, so recording paid charges there double-counted them against equity.

Leveraged results (final capital, drawdowns, Sharpe) will be lower — and correct — after this fix. Unlevered backtests are unaffected (regression-guarded by test).

## Test plan

- New `margin-integration.test.ts` (13 tests) covering: exact loan repayment on wins/losses (1.4M / 0.8M), 2x-leverage P&L doubling vs unlevered, proportional repayment across partial exits, per-tranche interest arithmetic (1.4M − 450 − 600 vs the 1,200 a single-settlement model would charge), margin-call liquidation for longs and shorts, no-liquidation of deeply profitable shorts, reduce-to-maintenance ratio restoration and its upside retention vs liquidation, and the unlevered baseline
- Shared step-price candle fixtures extracted to `step-candles.ts` (reused by the sizing integration tests)
- Full suite: 6,111 core tests pass; `tsc --noEmit`, `pnpm build`, `pnpm lint` clean