### PR TITLE
feat(core): add overfitting-defense metrics (PBO, purged walk-forward, MinTRL)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## [Unreleased]
 
+### Added — overfitting defense: PBO (CSCV), purged walk-forward, MinTRL
+
+- **`pbo(returnsMatrix, { blocks, metric })`** — Probability of Backtest
+  Overfitting via Combinatorially Symmetric Cross-Validation (Bailey,
+  Borwein, López de Prado & Zhu). Takes a T×N matrix of per-period returns
+  (N parameter combinations over T periods), evaluates all C(S, S/2)
+  in-sample/out-of-sample block splits, and reports how often the IS-best
+  configuration ranks below the OOS median (λ < 0, the canonical CSCV
+  criterion; ties take the average rank so an exactly-median winner is
+  neutral, not overfit). PBO ≥ 0.5 means parameter selection is no better
+  than chance out of sample. `pboSafe` variant included. Building the matrix is the caller's
+  responsibility for now (a grid-search adapter is planned); the default
+  ranking metric is the newly exported `perReturnSharpe`.
+- **`purgeBars` option on `walkForwardAnalysis` / `anchoredWalkForwardAnalysis`**
+  — excludes the last N bars between each training window and its test
+  window, so indicator lookbacks and multi-bar exit labels cannot leak
+  in-sample information across the boundary. Size it to the longest
+  indicator period or holding horizon the strategy uses. Default 0
+  (legacy adjacent windows). An embargo after the test window is a
+  combinatorial-split concept and intentionally not part of causal
+  walk-forward.
+- **`minTrackRecordLength(sharpe, benchmark?, confidence?, skew?, kurt?)`**
+  — the exact inverse of `probabilisticSharpe`: the shortest number of
+  return observations before the observed Sharpe is statistically
+  distinguishable from the benchmark at the given confidence. Returns
+  `Infinity` when there is no edge to establish.
+
 ### Fixed — leveraged backtests now repay the margin loan on position close
 
 `runBacktest` with a `margin` config credited the full exit proceeds —

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -3435,7 +3435,59 @@ console.log('安定性:', result.aggregateMetrics.stabilityRatio);
 | `windowSize` | `number` | `252` | 学習ウィンドウのサイズ（ローソク足本数） |
 | `stepSize` | `number` | `63` | ウィンドウ間のステップサイズ（ローソク足本数） |
 | `testSize` | `number` | `63` | アウト・オブ・サンプル検証期間のサイズ（ローソク足本数） |
+| `purgeBars` | `number` | `0` | 学習とテストの間のパージギャップ（両ウィンドウから除外）。指標のlookbackや複数バーにまたがる出口ラベルが境界越しにリークするのを防ぐ。最長の指標期間/保有期間に合わせる。`anchoredWalkForwardAnalysis` でも利用可 |
 | `metric` | `OptimizationMetric` | `'sharpe'` | 最適化する指標 |
+
+---
+
+### `pbo(returnsMatrix, options)`
+
+CSCV（組合せ対称交差検証）によるバックテスト過学習確率（PBO）。
+「イン・サンプルで最良のパラメーターを選んだとき、それがアウト・オブ・
+サンプルで中央値を下回る頻度はどれだけか？」に答えます（正準の λ < 0
+基準。タイは平均ランクを取るため、ちょうど中央値の勝者は過学習でなく
+中立として扱います）。
+
+```typescript
+import { pbo } from 'trendcraft';
+
+// returns[t][n] = n番目のパラメーター組み合わせの期間tのリターン
+const result = pbo(returns, { blocks: 10 });
+
+console.log(`PBO: ${(result.pbo * 100).toFixed(1)}%`);   // 50%以上 → 選択は偶然と同等
+console.log(`評価したsplit数: ${result.combinations}`);   // C(10, 5) = 252
+```
+
+**オプション:**
+| オプション | 型 | デフォルト | 説明 |
+|--------|------|---------|-------------|
+| `blocks` | `number` | `10` | 連続行ブロック数S（偶数）。C(S, S/2)通りのsplitを評価（S ≤ 20） |
+| `metric` | `(returns: number[]) => number` | per-return Sharpe | 組み合わせごとのランキング指標 |
+
+結果にはsplitごとのOOSランクlogitが含まれ、分布として可視化できます。
+`pboSafe` はthrowせず `Result` を返します。`deflatedSharpe`（選択バイアス
+込みの有意性）、`wfeRatio`（OOS効率）と併用してください — 3つは過学習の
+異なる側面に答えます。
+
+> **注:** 行列の構築は現状呼び出し側の責任です — 全組み合わせを同一の
+> 期間グリッドで評価する必要があります（例: 組み合わせごとに `runBacktest`
+> を実行し、揃ったper-barのequityリターンを導出）。grid-search結果から
+> 行列を構築するadapterは今後提供予定です。
+
+---
+
+### `minTrackRecordLength(observedSharpe, benchmarkSharpe?, confidence?, skewness?, kurtosis?)`
+
+`probabilisticSharpe` の厳密な逆関数: 観測Sharpeがベンチマークと統計的に
+区別できるようになるまでに必要な最小観測数（デフォルト信頼度 0.95）。
+Sharpeがベンチマークを超えない場合は `Infinity` を返します。
+
+```typescript
+import { minTrackRecordLength } from 'trendcraft';
+
+// per-return Sharpe 0.1 — PSR(0) ≥ 95% に必要なバー数は？
+const bars = Math.ceil(minTrackRecordLength(0.1)); // ≈ 274
+```
 
 ---
 

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -3958,7 +3958,62 @@ console.log('Stability:', result.aggregateMetrics.stabilityRatio);
 | `windowSize` | `number` | `252` | Training window size in candles |
 | `stepSize` | `number` | `63` | Step size in candles between windows |
 | `testSize` | `number` | `63` | Out-of-sample test size in candles |
+| `purgeBars` | `number` | `0` | Purge gap between training and test windows — bars excluded from both, so indicator lookbacks and multi-bar exit labels can't leak across the boundary. Size to the longest indicator period or holding horizon. Also available on `anchoredWalkForwardAnalysis` |
 | `metric` | `OptimizationMetric` | `'sharpe'` | Metric to optimize |
+
+---
+
+### `pbo(returnsMatrix, options)`
+
+Probability of Backtest Overfitting via Combinatorially Symmetric
+Cross-Validation (CSCV). Answers: *when I pick the best parameter set
+in-sample, how often does it rank below the median set out-of-sample?*
+(the canonical λ < 0 criterion; tied OOS scores take the average rank, so
+an exactly-median winner counts as neutral rather than overfit.)
+
+```typescript
+import { pbo } from 'trendcraft';
+
+// returns[t][n] = period-t return of the n-th parameter combination,
+// e.g. per-bar or per-week returns collected for every grid-search combo
+const result = pbo(returns, { blocks: 10 });
+
+console.log(`PBO: ${(result.pbo * 100).toFixed(1)}%`);   // ≥50% → selection is chance
+console.log(`Splits evaluated: ${result.combinations}`);  // C(10, 5) = 252
+```
+
+**Options:**
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `blocks` | `number` | `10` | Even number of contiguous row blocks S; evaluates C(S, S/2) splits (S ≤ 20) |
+| `metric` | `(returns: number[]) => number` | per-return Sharpe | Ranking metric per configuration |
+
+The result includes the per-split OOS rank logits, so the full logit
+distribution can be plotted. `pboSafe` returns a `Result` instead of
+throwing. Use alongside `deflatedSharpe` (selection-bias-aware
+significance) and `wfeRatio` (out-of-sample efficiency) — the three answer
+different overfitting questions.
+
+> **Note:** building the matrix is currently the caller's responsibility —
+> every combination must be evaluated over the same period grid (e.g. run
+> `runBacktest` per combination and derive aligned per-bar equity returns).
+> An adapter that builds the matrix from grid-search results is planned.
+
+---
+
+### `minTrackRecordLength(observedSharpe, benchmarkSharpe?, confidence?, skewness?, kurtosis?)`
+
+The exact inverse of `probabilisticSharpe`: the shortest number of return
+observations before the observed Sharpe is statistically distinguishable
+from the benchmark at the given confidence (default 0.95). Returns
+`Infinity` when the Sharpe does not exceed the benchmark.
+
+```typescript
+import { minTrackRecordLength } from 'trendcraft';
+
+// Per-return Sharpe 0.1 — how many bars until PSR(0) ≥ 95%?
+const bars = Math.ceil(minTrackRecordLength(0.1)); // ≈ 274
+```
 
 ---
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -627,6 +627,9 @@ export type {
   ParetoResult,
   ParetoResultEntry,
   PathParameterRange,
+  // PBO (CSCV) types
+  PboOptions,
+  PboResult,
   RecommendedParams,
   SafeZone,
   SensitivityData,
@@ -688,6 +691,9 @@ export {
   // Pareto (Multi-Objective) Optimization
   paretoOptimization,
   paretoOptimizationSafe,
+  // Probability of Backtest Overfitting (CSCV)
+  pbo,
+  pboSafe,
   // Monte Carlo Simulation
   runMonteCarloSimulation,
   runMonteCarloSimulationSafe,
@@ -758,8 +764,10 @@ export {
   macdBearish,
   macdBullish,
   minActiveSignals,
+  minTrackRecordLength,
   perfectOrderBearish as poBearishSignal,
   perfectOrderBullish as poBullishSignal,
+  perReturnSharpe,
   poConfirmation,
   probabilisticSharpe,
   rsiOverbought70,

--- a/packages/core/src/optimization/__tests__/anchored-walkforward.test.ts
+++ b/packages/core/src/optimization/__tests__/anchored-walkforward.test.ts
@@ -164,6 +164,13 @@ describe("Anchored Walk-Forward Analysis", () => {
       expect(count).toBe(1);
     });
 
+    it("accounts for the purge gap so preflight matches the boundary generator", () => {
+      // 756 candles fit exactly one unpurged period; a 10-bar purge gap
+      // pushes the requirement to 766
+      expect(calculateAWFPeriodCount(756, 0, 504, 252, 252, 10)).toBe(0);
+      expect(calculateAWFPeriodCount(766, 0, 504, 252, 252, 10)).toBe(1);
+    });
+
     it("should calculate correct period count", () => {
       // Total: 1500, Initial: 504, Step: 252, Test: 252
       // Period 1: train 0-503, test 504-755 (756 candles used)

--- a/packages/core/src/optimization/__tests__/pbo.test.ts
+++ b/packages/core/src/optimization/__tests__/pbo.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { pbo, pboSafe } from "../pbo";
+
+/** Deterministic seeded PRNG (mulberry32 — same pattern as the pairs tests). */
+function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** T×N matrix from a generator function. */
+function matrix(rows: number, cols: number, fill: (t: number, n: number) => number): number[][] {
+  return Array.from({ length: rows }, (_, t) => Array.from({ length: cols }, (_, n) => fill(t, n)));
+}
+
+describe("pbo (CSCV)", () => {
+  it("reports ~0 for a configuration that dominates in every period", () => {
+    const rand = seededRandom(42);
+    // Column 0 always returns +1%, others are zero-mean noise
+    const m = matrix(120, 10, (_t, n) => (n === 0 ? 0.01 : (rand() - 0.5) * 0.01));
+    const result = pbo(m, { blocks: 10 });
+    // The IS winner is always column 0, which also ranks best OOS
+    expect(result.pbo).toBe(0);
+    expect(result.combinations).toBe(252);
+    expect(result.logits.length).toBe(252);
+    expect(result.logits.every((l) => l > 0)).toBe(true);
+  });
+
+  it("reports 1 for a perfectly anti-persistent winner", () => {
+    // Two configurations, two blocks: col 0 earns in block 0 and loses in
+    // block 1, col 1 mirrored. Both CSCV splits (IS={0} and IS={1}) pick
+    // a winner that is the OOS loser → PBO must be exactly 1. The wiggle
+    // keeps each block's std positive so Sharpe is well-defined.
+    const m = matrix(20, 2, (t, n) => {
+      const inFirstBlock = t < 10;
+      const wins = (n === 0) === inFirstBlock;
+      const wiggle = t % 2 === 0 ? 0.002 : -0.002;
+      return (wins ? 0.01 : -0.01) + wiggle;
+    });
+    const result = pbo(m, { blocks: 2 });
+    expect(result.pbo).toBe(1);
+    expect(result.combinations).toBe(2);
+    expect(result.logits.every((l) => l <= 0)).toBe(true);
+  });
+
+  it("reports ~0.5 for pure noise (selection has no OOS information)", () => {
+    const rand = seededRandom(7);
+    const m = matrix(200, 8, () => (rand() - 0.5) * 0.02);
+    const result = pbo(m, { blocks: 10 });
+    // For i.i.d. noise the IS winner's OOS rank is uniform → PBO ≈ 0.5.
+    // Allow a wide band — 252 splits over correlated subsets is not i.i.d.
+    expect(result.pbo).toBeGreaterThan(0.2);
+    expect(result.pbo).toBeLessThan(0.8);
+  });
+
+  it("treats an all-tied split as neutral, not overfit (PBO 0, not 1)", () => {
+    // Every configuration earns the same constant return every period, so
+    // every IS/OOS split is fully tied. The IS winner is never strictly
+    // below the OOS median → PBO must be 0. A strict-comparison ranking
+    // would rank the winner last in the tie group and report PBO 1.
+    const m = matrix(40, 5, () => 0.01);
+    const result = pbo(m, { blocks: 4 });
+    expect(result.pbo).toBe(0);
+    // Fully-tied → winner sits at the median → logit 0
+    expect(result.logits.every((l) => l === 0)).toBe(true);
+  });
+
+  it("does not penalize a winner tied with the field on flat/no-trade configs", () => {
+    // One genuinely positive config plus four flat (zero-return) ones. The
+    // positive config wins both IS and OOS, so PBO stays 0; the flat ties
+    // among the losers must not distort the winner's rank.
+    const m = matrix(40, 5, (t, n) => (n === 0 ? (t % 2 === 0 ? 0.02 : 0.01) : 0));
+    const result = pbo(m, { blocks: 4 });
+    expect(result.pbo).toBe(0);
+  });
+
+  it("drops the tail remainder so blocks stay equal-sized", () => {
+    const m = matrix(47, 3, (t, n) => ((t + n) % 3 === 0 ? 0.01 : -0.005));
+    const result = pbo(m, { blocks: 4 });
+    // 47 rows / 4 blocks → blockSize 11 → 44 rows used
+    expect(result.observationsUsed).toBe(44);
+    expect(result.blocks).toBe(4);
+    expect(result.trials).toBe(3);
+  });
+
+  it("supports a custom ranking metric", () => {
+    // Rank by total return instead of Sharpe: column 1 has huge variance
+    // but the highest sum, so it must win under the custom metric
+    const m = matrix(40, 2, (t, n) => {
+      if (n === 0) return 0.001; // steady tiny gain (best Sharpe)
+      return t % 2 === 0 ? 0.1 : -0.05; // volatile but higher total
+    });
+    const total = (returns: number[]) => returns.reduce((a, b) => a + b, 0);
+    const result = pbo(m, { blocks: 4, metric: total });
+    // Column 1 dominates on total return in every block → never overfit
+    expect(result.pbo).toBe(0);
+  });
+
+  it("validates inputs", () => {
+    const good = matrix(20, 2, () => 0.01);
+    expect(() => pbo(good, { blocks: 3 })).toThrow(/even integer/);
+    expect(() => pbo(good, { blocks: 22 })).toThrow(/<= 20/);
+    expect(() =>
+      pbo(
+        matrix(4, 2, () => 0),
+        { blocks: 10 },
+      ),
+    ).toThrow(/at least 10 observations/);
+    expect(() =>
+      pbo(
+        matrix(20, 1, () => 0),
+        { blocks: 4 },
+      ),
+    ).toThrow(/at least 2 strategy/);
+    const ragged = [
+      [1, 2],
+      [1, 2, 3],
+    ];
+    expect(() => pbo(ragged, { blocks: 2 })).toThrow(/ragged/);
+  });
+
+  it("tolerates a ragged trailing row that the tail-drop discards", () => {
+    // 9 rows / 4 blocks → blockSize 2 → 8 used, row 8 dropped. A malformed
+    // trailing row must not be rejected, since it never enters the analysis.
+    const m: number[][] = matrix(8, 2, (t, n) => (n === 0 ? 0.01 : t % 2 === 0 ? 0.02 : -0.01));
+    m.push([0.5]); // ragged, length 1 — but it's the dropped remainder
+    const result = pbo(m, { blocks: 4 });
+    expect(result.observationsUsed).toBe(8);
+    expect(result.trials).toBe(2);
+  });
+
+  it("still rejects a ragged row within the used range", () => {
+    const m: number[][] = matrix(8, 2, () => 0.01);
+    m[3] = [0.01]; // row 3 is inside the used range → genuine error
+    expect(() => pbo(m, { blocks: 4 })).toThrow(/ragged/);
+  });
+
+  it("pboSafe returns Result instead of throwing", () => {
+    const bad = pboSafe(
+      matrix(4, 2, () => 0),
+      { blocks: 10 },
+    );
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.error.code).toBe("INSUFFICIENT_DATA");
+
+    const rand = seededRandom(1);
+    const good = pboSafe(
+      matrix(50, 4, () => rand() - 0.5),
+      { blocks: 10 },
+    );
+    expect(good.ok).toBe(true);
+    if (good.ok) expect(good.value.combinations).toBe(252);
+  });
+});

--- a/packages/core/src/optimization/__tests__/walkforward.test.ts
+++ b/packages/core/src/optimization/__tests__/walkforward.test.ts
@@ -135,6 +135,42 @@ describe("Walk-Forward Analysis", () => {
       // Should have at least 1 period
       expect(boundaries.length).toBeGreaterThanOrEqual(1);
     });
+
+    it("leaves a purge gap between every training and test window", () => {
+      const candles = generateUpTrendCandles(320);
+      const boundaries = generatePeriodBoundaries(candles, {
+        windowSize: 100,
+        stepSize: 50,
+        testSize: 50,
+        purgeBars: 10,
+      });
+
+      expect(boundaries.length).toBeGreaterThan(0);
+      for (const b of boundaries) {
+        // The 10 purged bars belong to neither window
+        expect(b.testStart - b.trainEnd - 1).toBe(10);
+        expect(b.testEnd).toBeLessThan(candles.length);
+      }
+      expect(boundaries[0].trainEnd).toBe(99);
+      expect(boundaries[0].testStart).toBe(110);
+      expect(boundaries[0].testEnd).toBe(159);
+
+      // purgeBars: 0 (default) keeps the legacy adjacent layout
+      const adjacent = generatePeriodBoundaries(candles, {
+        windowSize: 100,
+        stepSize: 50,
+        testSize: 50,
+      });
+      expect(adjacent[0].testStart).toBe(100);
+    });
+
+    it("purge gap reduces the period count when data is tight", () => {
+      // 160 bars fit exactly one purged period (100 + 10 + 50)
+      expect(calculatePeriodCount(160, 100, 50, 50, 10)).toBe(1);
+      expect(calculatePeriodCount(159, 100, 50, 50, 10)).toBe(0);
+      // Without purge the same data fits one period with 10 bars to spare
+      expect(calculatePeriodCount(160, 100, 50, 50)).toBe(1);
+    });
   });
 
   describe("walkForwardAnalysis", () => {

--- a/packages/core/src/optimization/anchored-walkforward.ts
+++ b/packages/core/src/optimization/anchored-walkforward.ts
@@ -30,6 +30,7 @@ import {
   combinationSearch,
 } from "./combination-search";
 import { calculateAllMetrics } from "./metrics";
+import { validatePurgeBars } from "./walkforward";
 
 // Re-export public utility functions
 export {
@@ -68,6 +69,8 @@ export function generateAWFBoundaries(
   const initialTrainSize = options.initialTrainSize ?? DEFAULT_OPTIONS.initialTrainSize;
   const expansionStep = options.expansionStep ?? DEFAULT_OPTIONS.expansionStep;
   const testSize = options.testSize ?? DEFAULT_OPTIONS.testSize;
+  const purgeBars = options.purgeBars ?? 0;
+  validatePurgeBars(purgeBars);
   const { anchorDate } = options;
 
   // Find anchor index
@@ -78,8 +81,9 @@ export function generateAWFBoundaries(
 
   let trainEnd = anchorIndex + initialTrainSize - 1;
 
-  while (trainEnd + testSize < candles.length) {
-    const testStart = trainEnd + 1;
+  while (trainEnd + purgeBars + testSize < candles.length) {
+    // The purge gap stays out of both windows — see WalkForwardOptions.purgeBars
+    const testStart = trainEnd + 1 + purgeBars;
     const testEnd = Math.min(testStart + testSize - 1, candles.length - 1);
 
     boundaries.push({
@@ -104,9 +108,10 @@ export function calculateAWFPeriodCount(
   initialTrainSize: number,
   expansionStep: number,
   testSize: number,
+  purgeBars = 0,
 ): number {
   const availableCandles = totalCandles - anchorIndex;
-  const minRequired = initialTrainSize + testSize;
+  const minRequired = initialTrainSize + purgeBars + testSize;
 
   if (availableCandles < minRequired) return 0;
 

--- a/packages/core/src/optimization/index.ts
+++ b/packages/core/src/optimization/index.ts
@@ -106,6 +106,9 @@ export {
   paretoOptimizationSafe,
   summarizeParetoResult,
 } from "./pareto";
+// Probability of Backtest Overfitting (CSCV)
+export type { PboOptions, PboResult } from "./pbo";
+export { pbo, pboSafe } from "./pbo";
 export type {
   DnaGrade,
   DnaGradeItem,

--- a/packages/core/src/optimization/pbo.ts
+++ b/packages/core/src/optimization/pbo.ts
@@ -1,0 +1,241 @@
+/**
+ * Probability of Backtest Overfitting (PBO) via Combinatorially Symmetric
+ * Cross-Validation (CSCV).
+ *
+ * Reference: Bailey, Borwein, López de Prado & Zhu, "The Probability of
+ * Backtest Overfitting" (Journal of Computational Finance, 2017).
+ *
+ * The procedure: split the T×N matrix of per-period returns (T periods,
+ * N strategy configurations) into S contiguous blocks of rows. For each
+ * of the C(S, S/2) ways to pick S/2 blocks as in-sample (IS), select the
+ * configuration with the best IS metric and look up its rank among all N
+ * configurations out-of-sample (OOS, the complementary blocks). The
+ * relative rank ω̄ ∈ (0, 1) maps to a logit λ = ln(ω̄ / (1 − ω̄)); PBO is
+ * the fraction of combinations with λ < 0 — i.e. how often the IS winner
+ * ranks *below* the OOS median (Bailey et al.'s "underperforms the median
+ * OOS"). A winner exactly at the median (λ = 0) is neutral, not overfit.
+ */
+
+import { perReturnSharpe } from "../scoring/deflated-sharpe";
+import type { Result } from "../types/result";
+import { err, ok, tcError } from "../types/result";
+
+/** Options for {@link pbo}. */
+export type PboOptions = {
+  /**
+   * Number of contiguous row blocks S to partition the observations into
+   * (default: 10). Must be an even integer ≥ 2. The analysis evaluates
+   * C(S, S/2) IS/OOS splits — 252 for S=10, 12,870 for S=16 — so cost
+   * grows combinatorially; S ≤ 20 is enforced.
+   */
+  blocks?: number;
+  /**
+   * Ranking metric applied to each configuration's concatenated IS or OOS
+   * returns (default: per-return Sharpe, mean/std; 0 when std is 0).
+   */
+  metric?: (returns: number[]) => number;
+};
+
+/** Result of {@link pbo}. */
+export type PboResult = {
+  /**
+   * Probability of backtest overfitting in [0, 1]: the fraction of CSCV
+   * splits whose IS-best configuration ranked *below* the OOS median.
+   * ~0 = the selection generalizes; ≥ 0.5 = selection is no better than
+   * chance; values near 1 = the IS winner systematically degrades OOS.
+   */
+  pbo: number;
+  /** OOS rank logit λ per CSCV split (ln(ω̄ / (1 − ω̄))). */
+  logits: number[];
+  /** Number of IS/OOS splits evaluated, C(blocks, blocks/2). */
+  combinations: number;
+  /** Number of row blocks used (S). */
+  blocks: number;
+  /** Number of strategy configurations (N, matrix columns). */
+  trials: number;
+  /**
+   * Observations actually used per configuration. Rows beyond the largest
+   * multiple of `blocks` are dropped so blocks stay equal-sized.
+   */
+  observationsUsed: number;
+};
+
+/**
+ * Enumerate all C(S, S/2) subsets of {0..S-1} of size S/2, invoking
+ * `visit` with the IS block indices for each.
+ */
+function forEachHalfSubset(blocks: number, visit: (isBlocks: number[]) => void): void {
+  const half = blocks / 2;
+  const pick: number[] = [];
+
+  function recurse(next: number): void {
+    if (pick.length === half) {
+      visit(pick);
+      return;
+    }
+    // Not enough remaining elements to fill the subset — prune
+    if (blocks - next < half - pick.length) return;
+    pick.push(next);
+    recurse(next + 1);
+    pick.pop();
+    recurse(next + 1);
+  }
+
+  recurse(0);
+}
+
+/** Binomial coefficient C(n, k) for the small n used here. */
+function binomial(n: number, k: number): number {
+  let result = 1;
+  for (let i = 1; i <= k; i++) {
+    result = (result * (n - k + i)) / i;
+  }
+  return Math.round(result);
+}
+
+/**
+ * Probability of Backtest Overfitting via CSCV.
+ *
+ * @param returnsMatrix T×N matrix of per-period returns: `returnsMatrix[t][n]`
+ *   is configuration `n`'s return in period `t`. All rows must have the
+ *   same length N ≥ 2, and T must be ≥ `blocks`.
+ *
+ *   Building the matrix is the caller's responsibility: every parameter
+ *   combination must be evaluated over the SAME period grid — e.g. run
+ *   `runBacktest` per combination and derive aligned per-bar (or
+ *   per-week) equity returns. `gridSearch` results retain per-combination
+ *   trades but not aligned per-period returns, so there is no automatic
+ *   bridge yet; a grid-search adapter is planned.
+ * @param options Block count and ranking metric
+ * @returns PBO with per-split logits
+ *
+ * @example
+ * ```ts
+ * import { pbo } from "trendcraft";
+ *
+ * // returns[t][n]: period-t return of the n-th parameter combination
+ * const { pbo: probability, combinations } = pbo(returns, { blocks: 10 });
+ * console.log(`PBO ${(probability * 100).toFixed(1)}% over ${combinations} splits`);
+ * // PBO ≥ ~50% → the in-sample winner is indistinguishable from chance OOS
+ * ```
+ */
+export function pbo(returnsMatrix: number[][], options: PboOptions = {}): PboResult {
+  const blocks = options.blocks ?? 10;
+  const metric = options.metric ?? perReturnSharpe;
+
+  if (!Number.isInteger(blocks) || blocks < 2 || blocks % 2 !== 0) {
+    throw new Error(`pbo: blocks must be an even integer >= 2, got ${blocks}`);
+  }
+  if (blocks > 20) {
+    throw new Error(
+      `pbo: blocks must be <= 20 (C(${blocks}, ${blocks / 2}) splits would be intractable)`,
+    );
+  }
+
+  const totalRows = returnsMatrix.length;
+  if (totalRows < blocks) {
+    throw new Error(`pbo: need at least ${blocks} observations (one per block), got ${totalRows}`);
+  }
+  const trials = returnsMatrix[0]?.length ?? 0;
+  if (trials < 2) {
+    throw new Error(`pbo: need at least 2 strategy configurations (columns), got ${trials}`);
+  }
+
+  // Equal-sized contiguous blocks; the tail remainder is dropped
+  const blockSize = Math.floor(totalRows / blocks);
+  const observationsUsed = blockSize * blocks;
+
+  // Validate only the rows actually used — the dropped tail remainder may be
+  // ragged or incomplete (it never enters the analysis), so rejecting it
+  // would contradict the documented tail-dropping behavior.
+  for (let t = 0; t < observationsUsed; t++) {
+    if (returnsMatrix[t].length !== trials) {
+      throw new Error(
+        `pbo: ragged matrix — row ${t} has ${returnsMatrix[t].length} columns, expected ${trials}`,
+      );
+    }
+  }
+
+  // Pre-slice each block's rows once: blockRows[b] = row indices of block b
+  const blockRanges: Array<[number, number]> = [];
+  for (let b = 0; b < blocks; b++) {
+    blockRanges.push([b * blockSize, (b + 1) * blockSize]);
+  }
+
+  /** Concatenate one configuration's returns over the given blocks. */
+  function collectColumn(column: number, blockIndices: readonly number[]): number[] {
+    const out: number[] = [];
+    for (const b of blockIndices) {
+      const [start, end] = blockRanges[b];
+      for (let t = start; t < end; t++) {
+        out.push(returnsMatrix[t][column]);
+      }
+    }
+    return out;
+  }
+
+  const allBlocks = Array.from({ length: blocks }, (_, b) => b);
+  const logits: number[] = [];
+  let overfitCount = 0;
+
+  forEachHalfSubset(blocks, (isBlocks) => {
+    const isSet = new Set(isBlocks);
+    const oosBlocks = allBlocks.filter((b) => !isSet.has(b));
+
+    // IS winner: configuration with the best in-sample metric (first wins ties)
+    let best = 0;
+    let bestScore = Number.NEGATIVE_INFINITY;
+    const oosScores = new Array<number>(trials);
+    for (let n = 0; n < trials; n++) {
+      const isScore = metric(collectColumn(n, isBlocks));
+      if (isScore > bestScore) {
+        bestScore = isScore;
+        best = n;
+      }
+      oosScores[n] = metric(collectColumn(n, oosBlocks));
+    }
+
+    // OOS relative rank of the IS winner, in (0, 1). Ties take the average
+    // (mid) rank so a tie group is placed at its centre, not its bottom —
+    // without this, a fully-tied split (common with flat / no-trade
+    // configs all scoring 0) would rank the winner last and bias PBO up.
+    const bestOos = oosScores[best];
+    let nLess = 0;
+    let nEqual = 0; // includes the winner itself
+    for (let n = 0; n < trials; n++) {
+      if (oosScores[n] < bestOos) nLess++;
+      else if (oosScores[n] === bestOos) nEqual++;
+    }
+    const midRank = nLess + (nEqual + 1) / 2;
+    const omega = midRank / (trials + 1);
+    const logit = Math.log(omega / (1 - omega));
+    logits.push(logit);
+    // Overfit = the IS winner ranks strictly BELOW the OOS median (λ < 0);
+    // exactly-median (logit 0, e.g. an all-tied split) is neutral, not overfit.
+    if (logit < 0) overfitCount++;
+  });
+
+  return {
+    pbo: overfitCount / logits.length,
+    logits,
+    combinations: binomial(blocks, blocks / 2),
+    blocks,
+    trials,
+    observationsUsed,
+  };
+}
+
+/**
+ * Safe variant of {@link pbo} returning a Result instead of throwing.
+ */
+export function pboSafe(returnsMatrix: number[][], options: PboOptions = {}): Result<PboResult> {
+  try {
+    return ok(pbo(returnsMatrix, options));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const code = message.includes("need at least")
+      ? ("INSUFFICIENT_DATA" as const)
+      : ("INVALID_PARAMETER" as const);
+    return err(tcError(code, message, {}, error instanceof Error ? error : undefined));
+  }
+}

--- a/packages/core/src/optimization/walkforward.ts
+++ b/packages/core/src/optimization/walkforward.ts
@@ -28,6 +28,7 @@ const DEFAULT_OPTIONS: Required<
   windowSize: 252, // ~1 year of daily data
   stepSize: 63, // ~1 quarter
   testSize: 63, // ~1 quarter
+  purgeBars: 0, // adjacent train/test windows (no purge gap)
   metric: "sharpe",
 };
 
@@ -44,11 +45,19 @@ export function calculatePeriodCount(
   windowSize: number,
   stepSize: number,
   testSize: number,
+  purgeBars = 0,
 ): number {
-  const minDataNeeded = windowSize + testSize;
+  const minDataNeeded = windowSize + purgeBars + testSize;
   if (totalCandles < minDataNeeded) return 0;
 
-  return Math.floor((totalCandles - windowSize - testSize) / stepSize) + 1;
+  return Math.floor((totalCandles - minDataNeeded) / stepSize) + 1;
+}
+
+/** Shared input guard for the boundary generators that accept purgeBars. */
+export function validatePurgeBars(purgeBars: number): void {
+  if (purgeBars < 0 || !Number.isInteger(purgeBars)) {
+    throw new Error(`purgeBars must be a non-negative integer, got ${purgeBars}`);
+  }
 }
 
 /**
@@ -66,7 +75,8 @@ export function generatePeriodBoundaries(
   testStart: number;
   testEnd: number;
 }> {
-  const { windowSize, stepSize, testSize } = { ...DEFAULT_OPTIONS, ...options };
+  const { windowSize, stepSize, testSize, purgeBars } = { ...DEFAULT_OPTIONS, ...options };
+  validatePurgeBars(purgeBars);
 
   const boundaries: Array<{
     trainStart: number;
@@ -77,9 +87,11 @@ export function generatePeriodBoundaries(
 
   let trainStart = 0;
 
-  while (trainStart + windowSize + testSize <= candles.length) {
+  while (trainStart + windowSize + purgeBars + testSize <= candles.length) {
     const trainEnd = trainStart + windowSize - 1;
-    const testStart = trainEnd + 1;
+    // The purge gap stays out of BOTH windows: bars whose indicator
+    // lookbacks or exit labels straddle the boundary can't inform training
+    const testStart = trainEnd + 1 + purgeBars;
     const testEnd = testStart + testSize - 1;
 
     boundaries.push({
@@ -109,22 +121,32 @@ export function walkForwardAnalysis(
   parameterRanges: ParameterRange[],
   options: WalkForwardOptions = {},
 ): WalkForwardResult {
-  const { windowSize, stepSize, testSize, metric, constraints, progressCallback, paramFilter } = {
+  const {
+    windowSize,
+    stepSize,
+    testSize,
+    purgeBars,
+    metric,
+    constraints,
+    progressCallback,
+    paramFilter,
+  } = {
     ...DEFAULT_OPTIONS,
     constraints: [] as OptimizationConstraint[],
     ...options,
   };
 
-  // Generate period boundaries
+  // Generate period boundaries (validates purgeBars)
   const boundaries = generatePeriodBoundaries(candles, {
     windowSize,
     stepSize,
     testSize,
+    purgeBars,
   });
 
   if (boundaries.length === 0) {
     throw new Error(
-      `Insufficient data for walk-forward analysis. Need at least ${windowSize + testSize} candles, got ${candles.length}.`,
+      `Insufficient data for walk-forward analysis. Need at least ${windowSize + purgeBars + testSize} candles, got ${candles.length}.`,
     );
   }
 

--- a/packages/core/src/scoring/__tests__/deflated-sharpe.test.ts
+++ b/packages/core/src/scoring/__tests__/deflated-sharpe.test.ts
@@ -3,8 +3,63 @@ import {
   deflatedSharpe,
   deflatedSharpeFromReturns,
   expectedMaxSharpe,
+  minTrackRecordLength,
+  perReturnSharpe,
   probabilisticSharpe,
 } from "../deflated-sharpe";
+
+describe("minTrackRecordLength", () => {
+  it("is the exact inverse of probabilisticSharpe at the confidence level", () => {
+    const minTrl = minTrackRecordLength(0.1, 0, 0.95);
+    // PSR crosses 0.95 precisely at T = MinTRL (to the precision of the
+    // rational normal-quantile approximation used internally)
+    expect(probabilisticSharpe(0.1, 0, minTrl)).toBeCloseTo(0.95, 6);
+    // One observation fewer falls short, one more clears it
+    expect(probabilisticSharpe(0.1, 0, minTrl - 1)).toBeLessThan(0.95);
+    expect(probabilisticSharpe(0.1, 0, minTrl + 1)).toBeGreaterThan(0.95);
+  });
+
+  it("shrinks as the edge grows and grows with the confidence level", () => {
+    expect(minTrackRecordLength(0.2)).toBeLessThan(minTrackRecordLength(0.1));
+    expect(minTrackRecordLength(0.1, 0, 0.99)).toBeGreaterThan(minTrackRecordLength(0.1, 0, 0.9));
+  });
+
+  it("accounts for non-normality (heavy tails need longer records)", () => {
+    const normal = minTrackRecordLength(0.1, 0, 0.95, 0, 3);
+    const heavyTailed = minTrackRecordLength(0.1, 0, 0.95, -0.5, 6);
+    expect(heavyTailed).toBeGreaterThan(normal);
+  });
+
+  it("is Infinity when the Sharpe does not exceed the benchmark", () => {
+    expect(minTrackRecordLength(0.1, 0.1)).toBe(Number.POSITIVE_INFINITY);
+    expect(minTrackRecordLength(-0.05, 0)).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("rejects confidence outside (0.5, 1)", () => {
+    expect(() => minTrackRecordLength(0.1, 0, 0)).toThrow(/confidence/);
+    expect(() => minTrackRecordLength(0.1, 0, 1)).toThrow(/confidence/);
+    // At or below 0.5 the one-sided test is already satisfied by any
+    // valid sample — the formula would silently answer for 1 - confidence
+    expect(() => minTrackRecordLength(0.1, 0, 0.5)).toThrow(/confidence/);
+    expect(() => minTrackRecordLength(0.1, 0, 0.4)).toThrow(/confidence/);
+  });
+});
+
+describe("perReturnSharpe", () => {
+  it("computes mean over population std", () => {
+    // mean 0.01, population std of [0.012, 0.008] around 0.01 = 0.002
+    expect(perReturnSharpe([0.012, 0.008])).toBeCloseTo(5, 9);
+  });
+
+  it("preserves ordering for zero-variance series", () => {
+    // A risk-free positive series outranks any finite Sharpe; a constant
+    // loss ranks below any finite Sharpe
+    expect(perReturnSharpe([0.01, 0.01, 0.01])).toBe(Number.POSITIVE_INFINITY);
+    expect(perReturnSharpe([-0.01, -0.01])).toBe(Number.NEGATIVE_INFINITY);
+    expect(perReturnSharpe([0, 0, 0])).toBe(0);
+    expect(perReturnSharpe([])).toBe(0);
+  });
+});
 
 describe("probabilisticSharpe", () => {
   it("is 0.5 when the observed Sharpe equals the benchmark", () => {

--- a/packages/core/src/scoring/deflated-sharpe.ts
+++ b/packages/core/src/scoring/deflated-sharpe.ts
@@ -283,3 +283,75 @@ export function deflatedSharpeFromReturns(returns: number[], trialSharpes: numbe
     kurtosis,
   });
 }
+
+/**
+ * Per-return (non-annualized) Sharpe ratio: mean divided by the
+ * *population* standard deviation of the raw return series — the unit
+ * every PSR / DSR / PBO input in this library expects.
+ *
+ * Zero-variance series preserve ranking order instead of collapsing to 0:
+ * a constant positive series returns `+Infinity` (it beats any finite
+ * Sharpe — risk-free gain), a constant negative one `-Infinity`, and an
+ * empty or constant-zero series `0`.
+ */
+export function perReturnSharpe(returns: number[]): number {
+  if (returns.length === 0) return 0;
+  const mu = mean(returns);
+  const sd = Math.sqrt(variance(returns, mu));
+  if (sd > 0) return mu / sd;
+  if (mu > 0) return Number.POSITIVE_INFINITY;
+  if (mu < 0) return Number.NEGATIVE_INFINITY;
+  return 0;
+}
+
+/**
+ * Minimum Track Record Length (MinTRL) — the shortest number of return
+ * observations needed before the {@link probabilisticSharpe} of the
+ * observed Sharpe clears `confidence` against `benchmarkSharpe`; i.e. how
+ * long a track record must be before the edge is statistically
+ * distinguishable from the benchmark.
+ *
+ * `MinTRL = 1 + (1 − γ₃·SR̂ + ((γ₄ − 1)/4)·SR̂²) · (Φ⁻¹(α) / (SR̂ − SR*))²`
+ *
+ * Exact inverse of the PSR formula: `probabilisticSharpe(SR̂, SR*, T)`
+ * crosses `confidence` precisely at `T = MinTRL`. The result is a real
+ * (fractional) observation count — `Math.ceil` it for a usable bar count.
+ *
+ * Returns `Infinity` when the observed Sharpe does not exceed the
+ * benchmark (no track record length can establish the edge) and `NaN`
+ * when the non-normality correction term is non-positive.
+ *
+ * @param observedSharpe Observed per-return (non-annualized) Sharpe (SR̂)
+ * @param benchmarkSharpe Sharpe threshold to beat (SR*, default 0)
+ * @param confidence Required PSR confidence level in (0.5, 1) (default 0.95)
+ * @param skewness Skewness of the return series (default 0 = normal)
+ * @param kurtosis Non-excess kurtosis of the return series (default 3 = normal)
+ * @returns Minimum number of return observations (fractional)
+ *
+ * @example
+ * ```ts
+ * import { minTrackRecordLength } from "trendcraft";
+ *
+ * // Per-return Sharpe 0.1: how many bars until PSR(0) ≥ 95%?
+ * const bars = Math.ceil(minTrackRecordLength(0.1));
+ * // ≈ 274 observations
+ * ```
+ */
+export function minTrackRecordLength(
+  observedSharpe: number,
+  benchmarkSharpe = 0,
+  confidence = 0.95,
+  skewness = 0,
+  kurtosis = 3,
+): number {
+  // Confidence at or below 0.5 is meaningless for this one-sided test:
+  // whenever SR̂ > SR*, PSR already exceeds 0.5 at any valid sample size,
+  // and the squared quantile would silently answer for 1 - confidence.
+  if (!(confidence > 0.5 && confidence < 1)) {
+    throw new Error(`minTrackRecordLength: confidence must be in (0.5, 1), got ${confidence}`);
+  }
+  if (observedSharpe <= benchmarkSharpe) return Number.POSITIVE_INFINITY;
+  const radicand = 1 - skewness * observedSharpe + ((kurtosis - 1) / 4) * observedSharpe ** 2;
+  if (!(radicand > 0)) return Number.NaN;
+  return 1 + radicand * (normalPpf(confidence) / (observedSharpe - benchmarkSharpe)) ** 2;
+}

--- a/packages/core/src/scoring/index.ts
+++ b/packages/core/src/scoring/index.ts
@@ -74,6 +74,8 @@ export {
   deflatedSharpe,
   deflatedSharpeFromReturns,
   expectedMaxSharpe,
+  minTrackRecordLength,
+  perReturnSharpe,
   probabilisticSharpe,
 } from "./deflated-sharpe";
 // Presets

--- a/packages/core/src/types/optimization.ts
+++ b/packages/core/src/types/optimization.ts
@@ -177,6 +177,17 @@ export type WalkForwardOptions = {
   stepSize?: number;
   /** Test period size in candles (default: 63 for ~1 quarter daily) */
   testSize?: number;
+  /**
+   * Purge gap in candles between each training window and its test window
+   * (default: 0). The last `purgeBars` bars before the test window are
+   * excluded from training, so information that leaks across the boundary
+   * — indicator lookback windows, multi-bar exit labels — cannot let the
+   * optimizer peek into the test period. Size it to the longest indicator
+   * period or holding horizon the strategy uses. (An embargo after the
+   * test window is a combinatorial-split concept; in causal walk-forward
+   * the test window precedes no training data of its own period.)
+   */
+  purgeBars?: number;
   /** Metric to optimize (default: "sharpe") */
   metric?: OptimizationMetric;
   /** Constraints to filter results */
@@ -391,6 +402,11 @@ export type AnchoredWalkForwardOptions = {
   expansionStep?: number;
   /** Test period size in candles (default: 252 for ~1 year) */
   testSize?: number;
+  /**
+   * Purge gap in candles between the training window and its test window
+   * (default: 0). See {@link WalkForwardOptions.purgeBars}.
+   */
+  purgeBars?: number;
   /** Metric to optimize (default: "sharpe") */
   metric?: OptimizationMetric;
   /** Constraints for optimization */


### PR DESCRIPTION
## Summary

Adds three out-of-sample / overfitting-defense tools, closing the gap between TrendCraft's broad backtest surface and the statistical rigor needed to trust a backtest. These are established in academic quant finance but absent from the JS/TS ecosystem.

### 1. `pbo(returnsMatrix, options)` / `pboSafe` — Probability of Backtest Overfitting

CSCV (Combinatorially Symmetric Cross-Validation) per Bailey, Borwein, López de Prado & Zhu. Takes a T×N matrix of per-period returns (N parameter combinations over T periods), evaluates all C(S, S/2) in-sample/out-of-sample block splits, and reports the fraction where the IS-best configuration ranks **below** the OOS median (λ < 0 — the canonical criterion).

```typescript
const { pbo: probability, combinations } = pbo(returns, { blocks: 10 });
// probability ≥ 0.5 → in-sample selection is no better than chance OOS
```

- Tied OOS scores take the **average (mid) rank**, so a fully-tied or exactly-median winner is treated as neutral rather than ranked last (which would bias PBO upward).
- Returns per-split logits for plotting the λ distribution.
- Building the matrix is the caller's responsibility for now (run `runBacktest` per combination over a shared period grid); a grid-search adapter is planned and the gap is documented.

### 2. `purgeBars` on `walkForwardAnalysis` / `anchoredWalkForwardAnalysis`

Excludes N bars between each training window and its test window, so indicator lookbacks and multi-bar exit labels cannot leak in-sample information across the boundary. Size it to the longest indicator period or holding horizon. Default 0 (legacy adjacent windows). `calculatePeriodCount` / `calculateAWFPeriodCount` are purge-aware so preflight counts match the boundary generators. (An embargo after the test window is a combinatorial-split concept and intentionally not part of causal walk-forward.)

### 3. `minTrackRecordLength(observedSharpe, benchmark?, confidence?, skew?, kurt?)`

The exact inverse of `probabilisticSharpe`: the shortest number of return observations before the observed Sharpe is statistically distinguishable from the benchmark at the given confidence. Returns `Infinity` when there is no edge. Confidence is restricted to (0.5, 1) — at or below 0.5 the one-sided test is already satisfied.

### Supporting change

`perReturnSharpe` is now exported (the PBO default ranking metric) and preserves ranking order for zero-variance series: a constant positive series returns `+Infinity` (risk-free gain beats any finite Sharpe), a constant negative one `-Infinity`, empty/zero `0`.

## Test plan

- `pbo.test.ts` (11 tests): dominant config → PBO 0, perfectly anti-persistent → PBO 1, i.i.d. noise → ~0.5, all-tied → neutral PBO 0 (not 1), flat/no-trade ties don't distort the winner, custom metric, tail-remainder drop, ragged-trailing-row tolerance vs in-range ragged rejection, input validation, `pboSafe`
- `deflated-sharpe.test.ts`: `minTrackRecordLength` exact-inverse-of-PSR, monotonicity in edge/confidence, non-normality, Infinity with no edge, confidence-domain rejection; `perReturnSharpe` zero-variance ordering
- `walkforward.test.ts` / `anchored-walkforward.test.ts`: purge-gap geometry and purge-aware period counts
- Full suite: 6,132 core tests pass; `tsc --noEmit`, `pnpm build`, `pnpm lint` clean