### PR TITLE
feat(core): regime-conditioned attribution + first-class equity curve

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 ## [Unreleased]
 
+### Added — first-class equity curve on `BacktestResult`
+
+- **`BacktestResult.equityCurve`** — `runBacktest` now emits the mark-to-market
+  account equity at each candle's close, aligned index-for-index with the
+  candles (`equityCurve[0]` is the starting capital, `equityCurve.length ===
+  candles.length`). Equity is `cash + position claim − loan`, signed by
+  direction, matching the engine's own margin-equity accounting. This is a
+  faithful curve: it tracks an open position's unrealized P&L and realizes each
+  partial exit / scale-out leg correctly.
+
+### Fixed
+
+- **Daily-returns-based metrics are now faithful for shorts and partial
+  exits.** The returns underlying `report()`, `backtestByRegime()` and the
+  optimization metrics were reconstructed from trade records, which (a) marked
+  open positions long-only — so a profitable short showed interim losses — and
+  (b) treated the first partial exit as closing the whole position, dropping the
+  P&L of every later scale-out leg. These metrics now derive from the engine's
+  `equityCurve` when present, which handles direction, partials and margin
+  correctly. The from-trades reconstruction remains as a fallback for hand-built
+  results and was itself corrected to respect trade direction.
+
+### Added — regime-conditioned attribution: `backtestByRegime()`
+
+- **`backtestByRegime(result, { candles, regimes, ... })`** — attributes a
+  backtest's performance to the market regime active on each bar. Returns a
+  per-regime performance table (bars, share of period, total/annualised
+  return, annualised volatility, Sharpe, regime-local max drawdown, win rate,
+  and an entry-attributed trade count) plus the empirical regime transition
+  matrix. `regimes` is a per-bar label series aligned to `candles` — the
+  output of `hmmRegimes(candles)` satisfies it directly, but any per-bar
+  `{ regime, label }` source works.
+- Attribution is **bar/return-level** (each daily return is assigned to the
+  regime of the bar it is realised on, the convention shared across the quant
+  ecosystem), so a position held across a regime change has its P&L split
+  across regimes. The per-regime `tradeCount` is a separate trade-level view,
+  counted by the regime at trade entry.
+- The transition matrix is **row-stochastic** (`matrix[from][to]`, each row
+  summing to 1, the diagonal being regime persistence) and is returned with a
+  parallel `counts` matrix so small-sample cells are visible.
+- Documented caveats: regime labels from a full-sequence (smoothed/Viterbi)
+  fit embed look-ahead bias, making the table descriptive rather than
+  tradeable; and per-regime ratios from few `bars` are unreliable.
+
 ### Added — tearsheet metrics and `report()`
 
 - **Return-distribution metrics** operating on a periodic-returns array
@@ -17,7 +61,8 @@
 - **Rolling metrics**: `rollingSharpe` and `rollingVolatility` over a trailing
   window (default 126 periods), returning arrays aligned index-for-index with
   the input (leading `window - 1` entries are `NaN`). Sharpe is annualised by
-  `sqrt(periodsPerYear)`; volatility always is.
+  `sqrt(periodsPerYear)`; volatility always is. `sharpeFromReturns` exposes the
+  scalar annualised Sharpe kernel they (and the per-regime attribution) share.
 - **`captureRatios(returns, benchmark, periodsPerYear?)`** — up/down capture
   versus a benchmark, dividing the strategy's geometric annualised return by
   the benchmark's over the periods where the benchmark is strictly up or down.

--- a/packages/core/src/analysis/__tests__/backtest-by-regime.test.ts
+++ b/packages/core/src/analysis/__tests__/backtest-by-regime.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import { at, never, stepCandles } from "../../backtest/__tests__/step-candles";
+import { runBacktest } from "../../backtest/engine";
+import { hmmRegimes } from "../../indicators/regime";
+import type { NormalizedCandle, Series } from "../../types";
+import { backtestByRegime, type RegimeLabel } from "../backtest-by-regime";
+
+/** Build a per-bar regime series aligned to `candles` from a state-index list. */
+function regimesFrom(candles: NormalizedCandle[], states: number[]): Series<RegimeLabel> {
+  return candles.map((c, i) => ({
+    time: c.time,
+    value: { regime: states[i], label: `s${states[i]}` },
+  }));
+}
+
+describe("backtestByRegime — attribution", () => {
+  // Flat at 100 then a single jump to 110: one held position captures +10%,
+  // concentrated on the bar where the close steps up.
+  const CANDLES = stepCandles([
+    { price: 100, bars: 5 },
+    { price: 110, bars: 5 },
+  ]);
+  // Entry signal at bar 1 fills at bar 2 open (100); exit signal at bar 8 fills
+  // at bar 9 open (110) -> a single +10% trade. The MTM step from 100 to 110
+  // lands as returns[4] (moving into bar 5).
+  const result = runBacktest(CANDLES, at(1), at(8), { capital: 100_000 });
+
+  it("attributes each return to the regime of the bar it is realised on", () => {
+    // Bars 0-4 -> regime 0, bars 5-9 -> regime 1. The +10% step is realised
+    // moving into bar 5 (return index 4 -> regimes[5] = regime 1).
+    const regimes = regimesFrom(CANDLES, [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]);
+    const { regimes: table } = backtestByRegime(result, { candles: CANDLES, regimes });
+
+    expect(table).toHaveLength(2);
+    const calm = table[0];
+    const rally = table[1];
+
+    expect(calm.regime).toBe(0);
+    expect(rally.regime).toBe(1);
+    // returns[0..3] -> regimes[1..4] (regime 0); returns[4..8] -> regimes[5..9] (regime 1).
+    expect(calm.bars).toBe(4);
+    expect(rally.bars).toBe(5);
+    expect(calm.bars + rally.bars).toBe(CANDLES.length - 1);
+
+    expect(calm.totalReturnPercent).toBeCloseTo(0, 9);
+    expect(rally.totalReturnPercent).toBeCloseTo(10, 6);
+
+    // fractionOfPeriod partitions the return series.
+    expect(calm.fractionOfPeriod + rally.fractionOfPeriod).toBeCloseTo(1, 12);
+  });
+
+  it("counts trades by their entry regime (trade-level view)", () => {
+    // Entry fills on bar 2 (regime 0), so the trade is attributed to regime 0.
+    const regimes = regimesFrom(CANDLES, [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]);
+    const { regimes: table } = backtestByRegime(result, { candles: CANDLES, regimes });
+    expect(table[0].tradeCount).toBe(1);
+    expect(table[1].tradeCount).toBe(0);
+    expect(table.reduce((a, r) => a + r.tradeCount, 0)).toBe(result.trades.length);
+  });
+
+  it("yields NaN Sharpe for a regime with fewer than two bars", () => {
+    // Only one bar lands in regime 1 (regimes[9]); the rest are regime 0.
+    const regimes = regimesFrom(CANDLES, [0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+    const { regimes: table } = backtestByRegime(result, { candles: CANDLES, regimes });
+    const single = table.find((r) => r.regime === 1);
+    expect(single?.bars).toBe(1);
+    expect(Number.isNaN(single?.sharpeRatio ?? 0)).toBe(true);
+  });
+
+  it("throws when regimes are not aligned with candles", () => {
+    const regimes = regimesFrom(CANDLES, [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]).slice(0, 5);
+    expect(() => backtestByRegime(result, { candles: CANDLES, regimes })).toThrow(/aligned/);
+  });
+
+  it("attributes a profitable short to the regime it falls in", () => {
+    // Flat at 100, then down to 90: a short captures +10%, realised on the
+    // step into bar 5 (return index 4 -> regimes[5] = regime 1).
+    const down = stepCandles([
+      { price: 100, bars: 5 },
+      { price: 90, bars: 5 },
+    ]);
+    const short = runBacktest(down, at(1), at(8), { capital: 100_000, direction: "short" });
+    expect(short.trades).toHaveLength(1);
+
+    const regimes = regimesFrom(down, [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]);
+    const { regimes: table } = backtestByRegime(short, { candles: down, regimes });
+    expect(table[0].totalReturnPercent).toBeCloseTo(0, 9);
+    expect(table[1].totalReturnPercent).toBeCloseTo(10, 6);
+  });
+
+  it("attributes the full P&L of a scaled-out position (all partials counted)", () => {
+    // Entry at 100, climbing through three scale-out levels. A from-trades
+    // reconstruction that stopped at the first partial would under-count the
+    // later legs; the engine's equity curve keeps every leg.
+    const rising = stepCandles([
+      { price: 100, bars: 2 },
+      { price: 106, bars: 2 },
+      { price: 111, bars: 2 },
+      { price: 121, bars: 2 },
+    ]);
+    const scaled = runBacktest(rising, at(1), () => false, {
+      capital: 1_000_000,
+      scaleOut: {
+        levels: [
+          { threshold: 5, sellPercent: 33 },
+          { threshold: 10, sellPercent: 50 },
+          { threshold: 20, sellPercent: 100 },
+        ],
+      },
+      fillMode: "same-bar-close",
+      slTpMode: "intraday",
+    });
+    expect(scaled.trades.length).toBeGreaterThan(1);
+
+    // One regime over the whole window: its total return must match the run.
+    const regimes = rising.map((c) => ({ time: c.time, value: { regime: 0, label: "s0" } }));
+    const { regimes: table } = backtestByRegime(scaled, { candles: rising, regimes });
+    expect(table).toHaveLength(1);
+    expect(table[0].totalReturnPercent).toBeCloseTo(scaled.totalReturnPercent, 4);
+  });
+
+  it("keeps a no-trade report flat across every regime", () => {
+    const flat = runBacktest(CANDLES, never, never, { capital: 100_000 });
+    expect(flat.tradeCount).toBe(0);
+
+    const regimes = regimesFrom(CANDLES, [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]);
+    const { regimes: table } = backtestByRegime(flat, { candles: CANDLES, regimes });
+    expect(table.reduce((a, r) => a + r.bars, 0)).toBe(CANDLES.length - 1);
+    for (const r of table) {
+      expect(r.totalReturnPercent).toBeCloseTo(0, 12);
+      expect(r.maxDrawdownPercent).toBeCloseTo(0, 12);
+      expect(r.tradeCount).toBe(0);
+    }
+  });
+});
+
+describe("backtestByRegime — transition matrix", () => {
+  it("counts bar-to-bar transitions and normalises each row to 1", () => {
+    const candles = stepCandles([{ price: 100, bars: 6 }]);
+    const flat = runBacktest(candles, never, never, { capital: 100_000 });
+    // Sequence 0,0,1,1,0,1 -> transitions 0->0, 0->1, 1->1, 1->0, 0->1.
+    const regimes = regimesFrom(candles, [0, 0, 1, 1, 0, 1]);
+
+    const { transition } = backtestByRegime(flat, { candles, regimes });
+    expect(transition.states).toEqual([0, 1]);
+    expect(transition.labels).toEqual(["s0", "s1"]);
+    // from 0: to0=1, to1=2 ; from 1: to0=1, to1=1
+    expect(transition.counts).toEqual([
+      [1, 2],
+      [1, 1],
+    ]);
+    expect(transition.matrix[0]).toEqual([1 / 3, 2 / 3]);
+    expect(transition.matrix[1]).toEqual([1 / 2, 1 / 2]);
+    // Counts total the number of bar-to-bar steps.
+    const totalCounts = transition.counts.flat().reduce((a, c) => a + c, 0);
+    expect(totalCounts).toBe(candles.length - 1);
+  });
+
+  it("emits an all-zero row for a state with no outgoing transitions", () => {
+    const candles = stepCandles([{ price: 100, bars: 4 }]);
+    const flat = runBacktest(candles, never, never, { capital: 100_000 });
+    // State 1 appears only as the final bar, so it never transitions out.
+    const regimes = regimesFrom(candles, [0, 0, 0, 1]);
+    const { transition } = backtestByRegime(flat, { candles, regimes });
+    expect(transition.states).toEqual([0, 1]);
+    expect(transition.matrix[1]).toEqual([0, 0]);
+  });
+});
+
+describe("backtestByRegime — integration with hmmRegimes", () => {
+  // Three distinct segments: up-trend, down-trend, choppy — so the HMM has
+  // real structure to separate.
+  function trendCandles(): NormalizedCandle[] {
+    const candles: NormalizedCandle[] = [];
+    let t = 1_700_000_000_000;
+    let price = 100;
+    const push = (p: number) => {
+      candles.push({ time: t, open: p, high: p + 1, low: p - 1, close: p, volume: 1_000_000 });
+      t += 86_400_000;
+    };
+    for (let i = 0; i < 60; i++) {
+      price += 0.8; // up-trend
+      push(price);
+    }
+    for (let i = 0; i < 60; i++) {
+      price -= 0.7; // down-trend
+      push(price);
+    }
+    for (let i = 0; i < 60; i++) {
+      price += i % 2 === 0 ? 0.5 : -0.5; // choppy
+      push(price);
+    }
+    return candles;
+  }
+
+  const candles = trendCandles();
+  const result = runBacktest(candles, at(10), at(80), { capital: 100_000 });
+  const regimes = hmmRegimes(candles, { numStates: 3 });
+
+  it("accepts hmmRegimes output and preserves the structural invariants", () => {
+    const { regimes: table, transition } = backtestByRegime(result, { candles, regimes });
+
+    // One row per observed state, ascending, matching the transition labels.
+    const observed = [...new Set(regimes.map((r) => r.value.regime))].sort((a, b) => a - b);
+    expect(table.map((r) => r.regime)).toEqual(observed);
+    expect(transition.states).toEqual(observed);
+
+    // Bars partition the return series; fractions sum to 1.
+    expect(table.reduce((a, r) => a + r.bars, 0)).toBe(candles.length - 1);
+    expect(table.reduce((a, r) => a + r.fractionOfPeriod, 0)).toBeCloseTo(1, 9);
+
+    // Every transition row is a probability distribution (sum 1) or all-zero.
+    for (const row of transition.matrix) {
+      const s = row.reduce((a, c) => a + c, 0);
+      expect(s === 0 || Math.abs(s - 1) < 1e-12).toBe(true);
+    }
+    expect(transition.counts.flat().reduce((a, c) => a + c, 0)).toBe(candles.length - 1);
+
+    // Trade attribution stays within the realised trades.
+    expect(table.reduce((a, r) => a + r.tradeCount, 0)).toBeLessThanOrEqual(result.trades.length);
+  });
+});

--- a/packages/core/src/analysis/__tests__/tearsheet.test.ts
+++ b/packages/core/src/analysis/__tests__/tearsheet.test.ts
@@ -48,11 +48,12 @@ describe("report", () => {
     const sheet = report(result, { candles: CANDLES });
     expect(Number.isFinite(sheet.annualizedVolatilityPercent)).toBe(true);
     expect(sheet.drawdowns.count).toBe(result.drawdownPeriods.length);
-    // The run takes a real loss, so the loss magnitude is non-zero and
-    // gain-to-pain is defined. (Tail ratio can be NaN here because the
-    // step-price returns are mostly zeros, driving the 5th percentile to 0 —
-    // that edge case is covered precisely in return-metrics.test.ts.)
-    expect(Number.isFinite(sheet.gainToPainRatio)).toBe(true);
+    // Both trades win and the strategy is flat (no position, no mark-to-market
+    // loss) through the price drop between them, so the faithful equity curve
+    // only steps up — there are no losing daily periods. Gain-to-pain and the
+    // tail ratio are therefore undefined (NaN); their finite-value paths are
+    // covered precisely in return-metrics.test.ts.
+    expect(Number.isNaN(sheet.gainToPainRatio)).toBe(true);
     expect(typeof sheet.tailRatio).toBe("number");
     expect(typeof sheet.ulcerPerformanceIndex).toBe("number");
   });

--- a/packages/core/src/analysis/backtest-by-regime.ts
+++ b/packages/core/src/analysis/backtest-by-regime.ts
@@ -1,0 +1,247 @@
+/**
+ * Regime-conditioned performance attribution.
+ *
+ * Slices a completed backtest's per-bar returns by the market regime active on
+ * each bar and reports a performance table per regime, plus the empirical
+ * regime transition matrix observed over the candle window.
+ *
+ * Attribution is **bar/return-level**, the convention shared by pyfolio,
+ * quantstats and Alphalens (grouping period returns by a categorical label):
+ * each daily return is assigned to the regime of the bar it is realised on,
+ * then the headline statistics are aggregated within each regime. A position
+ * held across a regime change therefore has its P&L split across regimes, which
+ * is the intended behaviour. The per-regime `tradeCount` is a separate,
+ * explicitly trade-level view (counted by the regime at trade entry).
+ *
+ * **Look-ahead caveat.** When the regime labels come from an HMM (or any model)
+ * fitted with smoothing / Viterbi over the full sequence, each label embeds
+ * future information, and a model fitted once on the whole sample also leaks
+ * its parameters across time. A regime-attribution table built on such labels
+ * is *descriptive* — "where returns landed across regimes" — not a tradeable,
+ * ex-ante claim. Use filtered (causal) labels or a walk-forward re-fit before
+ * drawing tradeable conclusions.
+ *
+ * **Small samples.** Rare regimes yield unreliable per-regime Sharpe,
+ * volatility and especially max drawdown. Always read each row's `bars` (and
+ * `tradeCount`) before trusting its ratios; the transition `counts` matrix is
+ * returned alongside the probabilities for the same reason.
+ */
+
+import { calculateDailyReturns } from "../optimization/metrics";
+import type { BacktestResult, NormalizedCandle, Series } from "../types";
+import {
+  annualizedReturnFraction,
+  sampleStd,
+  sharpeFromReturns,
+  winRateFromReturns,
+} from "./return-metrics";
+
+/** Minimal per-bar regime label (structurally satisfied by `HmmRegimeValue`). */
+export type RegimeLabel = {
+  /** Zero-based regime/state index. */
+  regime: number;
+  /** Human-readable regime label. */
+  label: string;
+};
+
+/** Options for {@link backtestByRegime}. */
+export type RegimeAttributionOptions = {
+  /** Candles the backtest ran on (to reconstruct the daily equity returns). */
+  candles: NormalizedCandle[];
+  /**
+   * Per-bar regime labels aligned index-for-index with `candles`
+   * (e.g. the output of `hmmRegimes(candles)`).
+   */
+  regimes: Series<RegimeLabel>;
+  /** Starting capital (default: `result.initialCapital`). */
+  initialCapital?: number;
+  /** Annual risk-free rate as a fraction (default 0). */
+  riskFree?: number;
+  /** Periods per year for annualisation (default 252). */
+  periodsPerYear?: number;
+};
+
+/** Bar/return-level performance statistics for a single regime. */
+export type RegimeStats = {
+  /** Zero-based regime/state index. */
+  regime: number;
+  /** Human-readable regime label. */
+  label: string;
+  /** Number of daily returns attributed to this regime. */
+  bars: number;
+  /** Share of the return series spent in this regime, in [0, 1]. */
+  fractionOfPeriod: number;
+  /** Compounded return earned while in this regime, in percent. */
+  totalReturnPercent: number;
+  /** Geometric annualised return over the regime's bars, in percent (`NaN` if no bars). */
+  annualizedReturnPercent: number;
+  /** Annualised volatility over the regime's bars, in percent. */
+  annualizedVolatilityPercent: number;
+  /** Annualised Sharpe over the regime's bars (`NaN` for fewer than two bars or zero volatility). */
+  sharpeRatio: number;
+  /** Regime-local max drawdown of the in-regime equity sub-curve, in percent (≤ 0). */
+  maxDrawdownPercent: number;
+  /** Win rate over the regime's non-zero returns, in [0, 1]. */
+  winRate: number;
+  /** Trades whose entry bar fell in this regime (trade-level, entry-attributed). */
+  tradeCount: number;
+};
+
+/** Empirical regime transition matrix over the candle window. */
+export type RegimeTransition = {
+  /** Regime labels; index = matrix row/column. */
+  labels: string[];
+  /** Regime/state indices matching `labels`, ascending. */
+  states: number[];
+  /** Bar-to-bar transition counts, `counts[from][to]`. */
+  counts: number[][];
+  /**
+   * Row-stochastic transition probabilities, `matrix[from][to]`, each row
+   * summing to 1 (a row with no observed transitions is all zeros). The
+   * diagonal is the regime's persistence / self-transition probability.
+   */
+  matrix: number[][];
+};
+
+/** Regime-conditioned attribution of a backtest result. */
+export type RegimeAttributionReport = {
+  /** Per-regime performance table, ascending by state index. */
+  regimes: RegimeStats[];
+  /** Empirical regime transition matrix observed over the candles. */
+  transition: RegimeTransition;
+};
+
+/** Regime-local max drawdown (percent, ≤ 0) of an equity curve built from `returns`. */
+function maxDrawdownPercentFromReturns(returns: number[]): number {
+  let equity = 1;
+  let peak = 1;
+  let maxDd = 0;
+  for (const r of returns) {
+    equity *= 1 + r;
+    if (equity > peak) peak = equity;
+    const dd = peak > 0 ? (equity - peak) / peak : 0;
+    if (dd < maxDd) maxDd = dd;
+  }
+  return maxDd * 100;
+}
+
+/**
+ * Attribute a backtest's performance to the market regime active on each bar.
+ *
+ * @param result - The backtest result to attribute
+ * @param options - Candles, per-bar regime labels and annualisation options
+ * @returns A per-regime performance table plus the empirical transition matrix
+ * @throws If `regimes` is not aligned index-for-index with `candles`
+ *
+ * @example
+ * ```ts
+ * import { runBacktest, hmmRegimes, backtestByRegime } from "trendcraft";
+ *
+ * const result = runBacktest(candles, entry, exit, { capital: 100_000 });
+ * const regimes = hmmRegimes(candles, { numStates: 3 });
+ * const attribution = backtestByRegime(result, { candles, regimes });
+ * for (const r of attribution.regimes) {
+ *   console.log(r.label, r.bars, r.sharpeRatio, r.maxDrawdownPercent);
+ * }
+ * ```
+ */
+export function backtestByRegime(
+  result: BacktestResult,
+  options: RegimeAttributionOptions,
+): RegimeAttributionReport {
+  const {
+    candles,
+    regimes,
+    initialCapital = result.initialCapital,
+    riskFree = 0,
+    periodsPerYear = 252,
+  } = options;
+
+  if (regimes.length !== candles.length) {
+    throw new Error(
+      `backtestByRegime: regimes (${regimes.length}) must be aligned index-for-index with candles (${candles.length})`,
+    );
+  }
+
+  // The empirical transition matrix and the state list are derived from the
+  // full per-bar regime sequence (independent of trades), so the stat table and
+  // the transition matrix share the same ordered set of states.
+  const stateLabels = new Map<number, string>();
+  for (const point of regimes) {
+    if (!stateLabels.has(point.value.regime)) {
+      stateLabels.set(point.value.regime, point.value.label);
+    }
+  }
+  const states = [...stateLabels.keys()].sort((a, b) => a - b);
+  // `states` is built from the map's keys, so every lookup resolves.
+  const labels = states.map((s) => stateLabels.get(s) as string);
+  const stateIndex = new Map<number, number>(states.map((s, i) => [s, i]));
+  const n = states.length;
+
+  const counts: number[][] = Array.from({ length: n }, () => new Array<number>(n).fill(0));
+  for (let i = 1; i < regimes.length; i++) {
+    const from = stateIndex.get(regimes[i - 1].value.regime);
+    const to = stateIndex.get(regimes[i].value.regime);
+    if (from !== undefined && to !== undefined) counts[from][to]++;
+  }
+  const matrix = counts.map((row) => {
+    const rowSum = row.reduce((acc, c) => acc + c, 0);
+    return rowSum === 0 ? row.map(() => 0) : row.map((c) => c / rowSum);
+  });
+
+  // Reconstruct the daily returns. A valid no-trade backtest produces none;
+  // keep it candle-aligned (flat) so attribution still covers every bar.
+  const rawReturns = calculateDailyReturns(result, candles, initialCapital);
+  const returns =
+    rawReturns.length === 0 && candles.length >= 2
+      ? new Array<number>(candles.length - 1).fill(0)
+      : rawReturns;
+
+  // Bar/return-level bucketing: returns[i] is realised on candle i+1, so it is
+  // attributed to that bar's regime.
+  const byState: number[][] = states.map(() => []);
+  for (let i = 0; i < returns.length; i++) {
+    const idx = stateIndex.get(regimes[i + 1].value.regime);
+    if (idx !== undefined) byState[idx].push(returns[i]);
+  }
+
+  // Trade-level (entry-attributed) counts: map each entry bar's time to its regime.
+  const tradeCounts = new Array<number>(n).fill(0);
+  const timeToState = new Map<number, number>();
+  for (const point of regimes) timeToState.set(point.time, point.value.regime);
+  for (const trade of result.trades) {
+    const state = timeToState.get(trade.entryTime);
+    if (state === undefined) continue;
+    const idx = stateIndex.get(state);
+    if (idx !== undefined) tradeCounts[idx]++;
+  }
+
+  const total = returns.length;
+
+  const regimeStats: RegimeStats[] = states.map((state, idx) => {
+    const r = byState[idx];
+    const bars = r.length;
+
+    let compounded = 1;
+    for (const v of r) compounded *= 1 + v;
+
+    return {
+      regime: state,
+      label: labels[idx],
+      bars,
+      fractionOfPeriod: total > 0 ? bars / total : 0,
+      totalReturnPercent: (compounded - 1) * 100,
+      annualizedReturnPercent: annualizedReturnFraction(r, periodsPerYear) * 100,
+      annualizedVolatilityPercent: sampleStd(r) * Math.sqrt(periodsPerYear) * 100,
+      sharpeRatio: sharpeFromReturns(r, { riskFree, periodsPerYear }),
+      maxDrawdownPercent: maxDrawdownPercentFromReturns(r),
+      winRate: winRateFromReturns(r),
+      tradeCount: tradeCounts[idx],
+    };
+  });
+
+  return {
+    regimes: regimeStats,
+    transition: { labels, states, counts, matrix },
+  };
+}

--- a/packages/core/src/analysis/index.ts
+++ b/packages/core/src/analysis/index.ts
@@ -4,6 +4,15 @@
  * Provides comprehensive analysis functions for evaluating trading performance.
  */
 
+export type {
+  RegimeAttributionOptions,
+  RegimeAttributionReport,
+  RegimeLabel,
+  RegimeStats,
+  RegimeTransition,
+} from "./backtest-by-regime";
+// Regime-conditioned attribution
+export { backtestByRegime } from "./backtest-by-regime";
 export type { BehaviorEquityPoint, BehaviorInsight } from "./behavior-insights";
 // Behavior Insights
 export { generateBehaviorInsights } from "./behavior-insights";
@@ -61,6 +70,7 @@ export {
   profitFactorFromReturns,
   rollingSharpe,
   rollingVolatility,
+  sharpeFromReturns,
   tailRatio,
   winRateFromReturns,
 } from "./return-metrics";

--- a/packages/core/src/analysis/return-metrics.ts
+++ b/packages/core/src/analysis/return-metrics.ts
@@ -281,6 +281,44 @@ export type RollingOptions = {
 };
 
 /**
+ * Annualised Sharpe ratio of a returns series — mean excess return over sample
+ * standard deviation (ddof = 1), scaled by `sqrt(periodsPerYear)` when
+ * annualising. The risk-free rate is de-annualised to a per-period rate and
+ * subtracted from each observation (subtracting a constant leaves the standard
+ * deviation unchanged). Returns `NaN` for fewer than two observations or a flat
+ * (zero-volatility) series, per the module's undefined-ratio convention.
+ *
+ * This is the scalar kernel shared by {@link rollingSharpe} (one call per
+ * window) and the per-regime Sharpe in `backtest-by-regime.ts`, so all three
+ * report comparable, identically-defined Sharpe values.
+ *
+ * @param returns - Periodic returns as fractions
+ * @param options - Annualisation options (`window` is ignored)
+ * @returns Annualised Sharpe ratio, or `NaN` when undefined
+ *
+ * @example
+ * ```ts
+ * import { sharpeFromReturns } from "trendcraft";
+ *
+ * const sharpe = sharpeFromReturns(dailyReturns, { periodsPerYear: 252 });
+ * ```
+ */
+export function sharpeFromReturns(returns: number[], options: RollingOptions = {}): number {
+  const { riskFree = 0, periodsPerYear = 252, annualize = true } = options;
+  if (returns.length < 2) return Number.NaN;
+
+  const sd = sampleStd(returns);
+  if (sd === 0) return Number.NaN;
+
+  const perPeriodRf = riskFree === 0 ? 0 : (1 + riskFree) ** (1 / periodsPerYear) - 1;
+  let mean = 0;
+  for (const r of returns) mean += r;
+  mean = mean / returns.length - perPeriodRf;
+
+  return (mean / sd) * (annualize ? Math.sqrt(periodsPerYear) : 1);
+}
+
+/**
  * Rolling annualised Sharpe ratio over a trailing window (quantstats
  * `rolling_sharpe`). The first `window - 1` entries are `NaN` (insufficient
  * data), so the result aligns index-for-index with `returns`. A flat window
@@ -302,18 +340,13 @@ export function rollingSharpe(returns: number[], options: RollingOptions = {}): 
   const { window = 126, riskFree = 0, periodsPerYear = 252, annualize = true } = options;
   if (window < 1) throw new Error("rollingSharpe: window must be at least 1");
 
-  const perPeriodRf = riskFree === 0 ? 0 : (1 + riskFree) ** (1 / periodsPerYear) - 1;
-  const excess = perPeriodRf === 0 ? returns : returns.map((r) => r - perPeriodRf);
-  const scale = annualize ? Math.sqrt(periodsPerYear) : 1;
-
   const out: number[] = new Array(returns.length).fill(Number.NaN);
-  for (let i = window - 1; i < excess.length; i++) {
-    const slice = excess.slice(i - window + 1, i + 1);
-    let mean = 0;
-    for (const v of slice) mean += v;
-    mean /= window;
-    const sd = sampleStd(slice);
-    out[i] = sd === 0 ? Number.NaN : (mean / sd) * scale;
+  for (let i = window - 1; i < returns.length; i++) {
+    out[i] = sharpeFromReturns(returns.slice(i - window + 1, i + 1), {
+      riskFree,
+      periodsPerYear,
+      annualize,
+    });
   }
   return out;
 }
@@ -342,8 +375,11 @@ export function rollingVolatility(returns: number[], options: RollingOptions = {
 /**
  * Geometric annualised return of a returns series (empyrical `annual_return`):
  * `prod(1 + r) ^ (periodsPerYear / n) - 1`. Returns `NaN` for an empty series.
+ *
+ * Shared by the capture ratios here and the per-regime attribution in
+ * `backtest-by-regime.ts`; not part of the public barrel.
  */
-function annualizedReturnFraction(returns: number[], periodsPerYear: number): number {
+export function annualizedReturnFraction(returns: number[], periodsPerYear: number): number {
   if (returns.length === 0) return Number.NaN;
   let ending = 1;
   for (const r of returns) ending *= 1 + r;

--- a/packages/core/src/backtest/__tests__/equity-curve.test.ts
+++ b/packages/core/src/backtest/__tests__/equity-curve.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { calculateDailyReturns } from "../../optimization/metrics";
+import type { NormalizedCandle } from "../../types";
+import { runBacktest } from "../engine";
+import { at, stepCandles } from "./step-candles";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** Compound a daily-returns series into a final equity from `capital`. */
+function compound(capital: number, returns: number[]): number {
+  return returns.reduce((eq, r) => eq * (1 + r), capital);
+}
+
+describe("runBacktest equityCurve", () => {
+  it("is candle-aligned, starts at capital and ends at final capital", () => {
+    const candles = stepCandles([
+      { price: 100, bars: 5 },
+      { price: 110, bars: 5 },
+    ]);
+    const result = runBacktest(candles, at(1), at(8), { capital: 100_000 });
+
+    expect(result.equityCurve).toBeDefined();
+    expect(result.equityCurve).toHaveLength(candles.length);
+    expect(result.equityCurve?.[0]).toBe(100_000);
+    expect(result.equityCurve?.[candles.length - 1]).toBeCloseTo(result.finalCapital, 6);
+  });
+
+  it("marks an open long up as the price rises", () => {
+    const candles = stepCandles([
+      { price: 100, bars: 5 },
+      { price: 110, bars: 5 },
+    ]);
+    const result = runBacktest(candles, at(1), at(8), { capital: 100_000 });
+    // Entry fills at bar 2 (100); bar 5 closes at 110 -> +10% on the open position.
+    const curve = result.equityCurve ?? [];
+    expect(curve[4]).toBeCloseTo(100_000, 6); // last bar before the step
+    expect(curve[5]).toBeCloseTo(110_000, 6); // step to 110 marked to market
+  });
+
+  it("marks an open short up as the price falls", () => {
+    const candles = stepCandles([
+      { price: 100, bars: 5 },
+      { price: 90, bars: 5 },
+    ]);
+    const result = runBacktest(candles, at(1), at(8), {
+      capital: 100_000,
+      direction: "short",
+    });
+    const curve = result.equityCurve ?? [];
+    expect(curve[4]).toBeCloseTo(100_000, 6);
+    expect(curve[5]).toBeCloseTo(110_000, 6); // a short gains 10% when price drops 10%
+  });
+
+  it("reconstructs daily returns that compound back to the final capital", () => {
+    const candles = stepCandles([
+      { price: 100, bars: 5 },
+      { price: 110, bars: 5 },
+      { price: 105, bars: 5 },
+    ]);
+    const result = runBacktest(candles, at(1), at(12), { capital: 100_000 });
+    const returns = calculateDailyReturns(result, candles, 100_000);
+    expect(compound(100_000, returns)).toBeCloseTo(result.finalCapital, 4);
+  });
+});
+
+describe("runBacktest equityCurve — partial exits / scale-out", () => {
+  function risingCandles(entryPrice: number, sequence: number[]): NormalizedCandle[] {
+    const candles: NormalizedCandle[] = [];
+    const base = 1_700_000_000_000;
+    // Bar 0 + entry-signal bar 1, both at entryPrice.
+    candles.push({
+      time: base,
+      open: entryPrice,
+      high: entryPrice * 1.01,
+      low: entryPrice * 0.99,
+      close: entryPrice,
+      volume: 1_000_000,
+    });
+    candles.push({
+      time: base + MS_PER_DAY,
+      open: entryPrice,
+      high: entryPrice * 1.01,
+      low: entryPrice * 0.99,
+      close: entryPrice,
+      volume: 1_000_000,
+    });
+    for (let i = 0; i < sequence.length; i++) {
+      const p = sequence[i];
+      candles.push({
+        time: base + (i + 2) * MS_PER_DAY,
+        open: p,
+        high: p * 1.01,
+        low: p * 0.99,
+        close: p,
+        volume: 1_000_000,
+      });
+    }
+    return candles;
+  }
+
+  // Entry at 100, then a staged climb that trips three scale-out levels.
+  const candles = risingCandles(100, [103, 105, 108, 110, 115, 120, 125]);
+  const result = runBacktest(candles, at(1), () => false, {
+    capital: 1_000_000,
+    scaleOut: {
+      levels: [
+        { threshold: 5, sellPercent: 33 },
+        { threshold: 10, sellPercent: 50 },
+        { threshold: 20, sellPercent: 100 },
+      ],
+    },
+    fillMode: "same-bar-close",
+    slTpMode: "intraday",
+  });
+
+  it("emits three partial trades sharing one entry", () => {
+    expect(result.tradeCount).toBe(3);
+    expect(result.trades.every((t) => t.entryTime === result.trades[0].entryTime)).toBe(true);
+    expect(result.trades[0].isPartial).toBe(true);
+    expect(result.trades[2].isPartial).toBe(false);
+  });
+
+  it("keeps the equity curve faithful through every partial exit", () => {
+    const curve = result.equityCurve ?? [];
+    expect(curve).toHaveLength(candles.length);
+    expect(curve[0]).toBe(1_000_000);
+    expect(curve[candles.length - 1]).toBeCloseTo(result.finalCapital, 4);
+
+    // The reconstructed daily returns must compound to the true final capital.
+    // A from-trades reconstruction that stops at the first partial exit would
+    // drop the later legs' P&L and fall short here.
+    const returns = calculateDailyReturns(result, candles, 1_000_000);
+    expect(compound(1_000_000, returns)).toBeCloseTo(result.finalCapital, 4);
+
+    // Prices only rise, so the faithful curve never steps down.
+    for (let i = 1; i < curve.length; i++) {
+      expect(curve[i]).toBeGreaterThanOrEqual(curve[i - 1] - 1e-6);
+    }
+  });
+});

--- a/packages/core/src/backtest/engine.ts
+++ b/packages/core/src/backtest/engine.ts
@@ -42,6 +42,7 @@ import {
 } from "./engine-utils";
 import type { MarginState } from "./margin";
 import {
+  accountEquity,
   accrueInterest,
   calculateBuyingPower,
   checkMarginCall,
@@ -239,6 +240,11 @@ export function runBacktest(
   const returns: number[] = [];
   const ddTracker = createDrawdownTracker(capital);
 
+  // Mark-to-market equity at each candle's close, aligned to `candles`. Bar 0
+  // is never traded (the loop starts at index 1), so it holds the starting
+  // capital; every later bar is filled at the end of its iteration.
+  const equityCurve: number[] = new Array(candles.length).fill(capital);
+
   // Margin state tracking
   let marginState: MarginState | null = null;
   if (marginConfig) {
@@ -381,6 +387,25 @@ export function runBacktest(
       maxDrawdown = drawdown;
     }
     ddTracker.update(currentCapital, time, barIndex);
+  }
+
+  /**
+   * Mark-to-market account equity at a candle's close, via the shared
+   * {@link accountEquity} definition — pure cash when flat, `cash + position
+   * claim` for the common non-margin case, less loan and accrued interest under
+   * margin. Sharing the formula keeps the equity curve consistent with
+   * margin-call accounting.
+   */
+  function markToMarketEquity(close: number): number {
+    if (position === null) return currentCapital;
+    return accountEquity(
+      close * position.shares,
+      currentCapital,
+      position.direction ?? "long",
+      position.entryPrice * position.shares,
+      marginState?.borrowedAmount ?? 0,
+      marginState?.accumulatedInterest ?? 0,
+    );
   }
 
   /**
@@ -890,6 +915,7 @@ export function runBacktest(
 
       // Skip remaining checks if position was closed by scale-out
       if (position === null) {
+        equityCurve[i] = markToMarketEquity(candle.close);
         continue;
       }
 
@@ -1040,6 +1066,7 @@ export function runBacktest(
         }
       }
     }
+    equityCurve[i] = markToMarketEquity(candle.close);
   }
 
   // Close any open position at the end
@@ -1063,6 +1090,9 @@ export function runBacktest(
     currentCapital += result.netProceeds - repayMarginLoan(1);
     returns.push(result.returnPercent / 100);
     ddTracker.update(currentCapital, lastCandle.time, candles.length - 1);
+    // The end-of-data close realizes the final bar's equity (the in-loop value
+    // was the still-open mark-to-market); align it with the realized capital.
+    equityCurve[candles.length - 1] = currentCapital;
   }
 
   // Cancel any unfilled pending order at end of data
@@ -1070,7 +1100,7 @@ export function runBacktest(
 
   ddTracker.finalize(candles[candles.length - 1].time, candles.length - 1);
 
-  return calculateStats(
+  const result = calculateStats(
     trades,
     returns,
     capital,
@@ -1082,4 +1112,6 @@ export function runBacktest(
       ? { firstTime: candles[0].time, lastTime: candles[candles.length - 1].time }
       : undefined,
   );
+  result.equityCurve = equityCurve;
+  return result;
 }

--- a/packages/core/src/backtest/margin.ts
+++ b/packages/core/src/backtest/margin.ts
@@ -95,6 +95,37 @@ export function calculateBuyingPower(capital: number, leverage: number): number 
  * // state.marginRatio === 8000 / 18000 ≈ 0.44
  * ```
  */
+/**
+ * Mark-to-market account equity: `cash + position claim − loan − interest`.
+ *
+ * The position claim is direction-signed — a long's claim is its market value,
+ * a short's is the entry proceeds plus unrealized P&L
+ * (`entryValue + (entryValue − positionValue)`), with `positionValue` the
+ * current cover cost. This is the single definition shared by
+ * {@link updateMarginState} (margin-call accounting) and the per-bar equity
+ * curve emitted by `runBacktest`, so the two never drift.
+ *
+ * @param positionValue - Current market value of the position (cover cost for shorts)
+ * @param capital - Cash not deployed in the position
+ * @param direction - Position direction (default: "long")
+ * @param entryValue - Entry notional (entry price × shares); required for shorts
+ * @param borrowedAmount - Outstanding margin loan (default 0)
+ * @param accumulatedInterest - Accrued, unsettled margin interest (default 0)
+ * @returns Mark-to-market account equity
+ */
+export function accountEquity(
+  positionValue: number,
+  capital: number,
+  direction: "long" | "short" = "long",
+  entryValue: number = positionValue,
+  borrowedAmount = 0,
+  accumulatedInterest = 0,
+): number {
+  const positionClaim =
+    direction === "short" ? entryValue + (entryValue - positionValue) : positionValue;
+  return capital + positionClaim - borrowedAmount - accumulatedInterest;
+}
+
 export function updateMarginState(
   state: MarginState,
   positionValue: number,
@@ -102,9 +133,14 @@ export function updateMarginState(
   direction: "long" | "short" = "long",
   entryValue: number = positionValue,
 ): MarginState {
-  const positionEquity =
-    direction === "short" ? entryValue + (entryValue - positionValue) : positionValue;
-  const equity = capital + positionEquity - state.borrowedAmount - state.accumulatedInterest;
+  const equity = accountEquity(
+    positionValue,
+    capital,
+    direction,
+    entryValue,
+    state.borrowedAmount,
+    state.accumulatedInterest,
+  );
   const marginRatio = positionValue > 0 ? equity / positionValue : 1.0;
 
   return {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1067,6 +1067,11 @@ export type {
   OmegaOptions,
   PatternProjection,
   PatternProjectionOptions,
+  RegimeAttributionOptions,
+  RegimeAttributionReport,
+  RegimeLabel,
+  RegimeStats,
+  RegimeTransition,
   ReportOptions,
   RollingOptions,
   RuntimeMetrics,
@@ -1089,6 +1094,8 @@ export {
   analyzeMarketContext,
   analyzeMfeMae,
   analyzeStreaks,
+  // Regime-conditioned attribution
+  backtestByRegime,
   calculateRuntimeMetrics,
   calculateTradeStats,
   // Return-distribution & rolling metrics
@@ -1109,6 +1116,7 @@ export {
   report,
   rollingSharpe,
   rollingVolatility,
+  sharpeFromReturns,
   tailRatio,
   winRateFromReturns,
 } from "./analysis";

--- a/packages/core/src/optimization/__tests__/metrics.test.ts
+++ b/packages/core/src/optimization/__tests__/metrics.test.ts
@@ -5,6 +5,7 @@ import {
   annualizeReturn,
   calculateAllMetrics,
   calculateCalmarRatio,
+  calculateDailyReturns,
   calculateMAR,
   calculateRecoveryFactor,
   calculateSharpeRatio,
@@ -302,6 +303,62 @@ describe("Optimization Metrics", () => {
       expect(metrics.calmar).toBeNaN();
       expect(metrics.recoveryFactor).toBeNaN();
       expect(metrics.mar).toBeNaN();
+    });
+  });
+
+  describe("calculateDailyReturns — direction-aware mark-to-market", () => {
+    // Flat at 100, then a step down to 90: a short held across the step is in
+    // profit, a long is in loss. The interim MTM return must be signed by
+    // direction, not always treated as long.
+    const flat = (price: number, t: number): NormalizedCandle => ({
+      time: t,
+      open: price,
+      high: price + 1,
+      low: price - 1,
+      close: price,
+      volume: 1_000_000,
+    });
+    const candles: NormalizedCandle[] = [flat(100, 0), flat(100, 1), flat(90, 2), flat(90, 3)];
+
+    it("marks a short to market as a gain when the price falls", () => {
+      const result = createMockBacktestResult({
+        trades: [
+          {
+            entryTime: 0,
+            entryPrice: 100,
+            exitTime: 3,
+            exitPrice: 90,
+            return: 10_000,
+            returnPercent: 10,
+            holdingDays: 3,
+            direction: "short",
+          },
+        ],
+      });
+
+      const returns = calculateDailyReturns(result, candles, 100_000);
+      // The 100 -> 90 step (into candle index 2) is a +10% interim gain.
+      expect(returns[1]).toBeCloseTo(0.1, 12);
+    });
+
+    it("marks an otherwise-identical long to market as a loss on the same step", () => {
+      const result = createMockBacktestResult({
+        trades: [
+          {
+            entryTime: 0,
+            entryPrice: 100,
+            exitTime: 3,
+            exitPrice: 90,
+            return: -10_000,
+            returnPercent: -10,
+            holdingDays: 3,
+            direction: "long",
+          },
+        ],
+      });
+
+      const returns = calculateDailyReturns(result, candles, 100_000);
+      expect(returns[1]).toBeCloseTo(-0.1, 12);
     });
   });
 });

--- a/packages/core/src/optimization/metrics.ts
+++ b/packages/core/src/optimization/metrics.ts
@@ -4,7 +4,7 @@
  * Functions for calculating advanced performance metrics for backtest optimization.
  */
 
-import type { BacktestResult, NormalizedCandle } from "../types";
+import type { BacktestResult, NormalizedCandle, PositionDirection } from "../types";
 import type { OptimizationMetric } from "../types/optimization";
 
 /**
@@ -160,6 +160,20 @@ export function calculateDailyReturns(
   initialCapital: number,
 ): number[] {
   if (candles.length < 2) return [];
+
+  // Prefer the engine's faithful mark-to-market equity curve when present: it
+  // already accounts for trade direction, partial exits and margin, none of
+  // which the from-trades reconstruction below can recover. Fall back to that
+  // reconstruction only for hand-built results that omit the curve.
+  const curve = result.equityCurve;
+  if (curve && curve.length === candles.length) {
+    const dailyReturns: number[] = [];
+    for (let i = 1; i < curve.length; i++) {
+      dailyReturns.push(curve[i - 1] > 0 ? (curve[i] - curve[i - 1]) / curve[i - 1] : 0);
+    }
+    return dailyReturns;
+  }
+
   if (result.trades.length === 0) return [];
 
   // Build equity curve
@@ -167,6 +181,7 @@ export function calculateDailyReturns(
   let currentEquity = initialCapital;
   let positionValue = 0;
   let entryPrice = 0;
+  let positionDirection: PositionDirection = "long";
   let inPosition = false;
   let tradeIndex = 0;
 
@@ -183,6 +198,7 @@ export function calculateDailyReturns(
       const trade = result.trades[tradeIndex];
       entryPrice = trade.entryPrice;
       positionValue = currentEquity;
+      positionDirection = trade.direction ?? "long";
       inPosition = true;
       break;
     }
@@ -198,9 +214,11 @@ export function calculateDailyReturns(
         break;
       }
 
-      // Mark-to-market if still in position
+      // Mark-to-market if still in position. A short position gains as price
+      // falls, so the unrealized return is the price move signed by direction.
       if (inPosition && entryPrice > 0) {
-        const unrealizedReturn = (candle.close - entryPrice) / entryPrice;
+        const priceReturn = (candle.close - entryPrice) / entryPrice;
+        const unrealizedReturn = positionDirection === "short" ? -priceReturn : priceReturn;
         equity[i] = positionValue * (1 + unrealizedReturn);
       } else {
         equity[i] = currentEquity;

--- a/packages/core/src/types/backtest.ts
+++ b/packages/core/src/types/backtest.ts
@@ -474,6 +474,18 @@ export type BacktestResult = {
   settings: BacktestSettings;
   /** Individual drawdown periods with peak-trough-recovery tracking */
   drawdownPeriods: DrawdownPeriod[];
+  /**
+   * Mark-to-market account equity at each candle's close, aligned
+   * index-for-index with the candles the backtest ran on (so
+   * `equityCurve[0]` is the starting capital and `equityCurve.length ===
+   * candles.length`). Equity is `cash + position claim − loan`, signed by
+   * direction, so it tracks unrealized P&L of an open position and realizes
+   * each partial exit faithfully — unlike a from-trades reconstruction, which
+   * cannot recover the open fraction after a partial exit. Emitted by
+   * `runBacktest`; optional because hand-built results may omit it (consumers
+   * fall back to reconstructing returns from trades).
+   */
+  equityCurve?: number[];
 };
 
 // ============================================


### PR DESCRIPTION
## Summary

Adds `backtestByRegime()` — regime-conditioned performance attribution — and, to make the returns it (and `report()`) consume faithful, gives `BacktestResult` a first-class mark-to-market equity curve.

### `backtestByRegime(result, { candles, regimes, ... })`
Attributes a backtest's performance to the market regime active on each bar.

- **Per-regime table** (ascending by state): `bars`, `fractionOfPeriod`, `totalReturnPercent`, `annualizedReturnPercent`, `annualizedVolatilityPercent`, `sharpeRatio`, regime-local `maxDrawdownPercent`, `winRate`, and an entry-attributed `tradeCount`.
- **Empirical transition matrix**: row-stochastic (`matrix[from][to]`, rows sum to 1, diagonal = persistence) with a parallel `counts` matrix so small-sample cells stay visible.
- **Attribution is bar/return-level** — each daily return is assigned to the regime of the bar it is realised on (the convention shared across the quant ecosystem), so a position held across a regime change has its P&L split. `tradeCount` is a separate, explicitly trade-level (entry-attributed) view.
- `regimes` is a per-bar `{ regime, label }` series aligned to `candles`; the output of `hmmRegimes(candles)` satisfies it directly, and any other per-bar regime source works too.
- Documented caveats: regime labels from a full-sequence (smoothed/Viterbi) fit embed look-ahead bias (descriptive, not tradeable); per-regime ratios from few `bars` are unreliable.

### First-class equity curve (`BacktestResult.equityCurve`)
`runBacktest` now emits mark-to-market account equity at each candle's close (`cash + direction-signed position claim − loan`), aligned index-for-index with the candles (`equityCurve[0]` = starting capital, `length === candles.length`).

`report()`, `backtestByRegime()` and the optimization metrics derive their daily returns from this curve when present. This fixes two reconstruction gaps that affected short and scaled-out backtests:

1. **Direction** — the from-trades reconstruction marked open positions long-only, so a profitable short showed interim losses while prices fell.
2. **Partial exits / scale-outs** — it treated the first partial exit as closing the whole position and dropped the P&L of every later leg.

The from-trades reconstruction remains as a fallback for hand-built results (without an equity curve) and was itself corrected to respect trade direction. The equity formula is shared through a single `accountEquity()` helper so the curve and margin-call accounting cannot drift.

### Also
- `sharpeFromReturns()` — the shared annualised Sharpe kernel, now used by both `rollingSharpe` and the per-regime Sharpe.
- Corrected a `tearsheet` test whose comment/assertion assumed a losing trade that the scenario never produces; the faithful equity curve surfaces that both trades win and the strategy is flat through the drawdown between them.

## Test plan
- New `backtest-by-regime.test.ts` (attribution arithmetic, transition matrix counts/normalisation, no-trade flat case, short attribution, scaled-out full-P&L attribution, alignment guard, `hmmRegimes` integration invariants).
- New `equity-curve.test.ts` (candle alignment, `[0]` = capital and last = final capital, long/short MTM, daily returns compounding back to final capital, partial/scale-out faithfulness + monotonicity).
- New direction-aware `calculateDailyReturns` regression tests in `metrics.test.ts`.
- Full core suite green: **6183 tests**. `tsc --noEmit` clean (from `packages/core`), Biome lint clean, build OK.