### PR TITLE
feat(core): add eventStudy() for pattern concept validation

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+### Added — event study: `eventStudy()`
+
+- **`eventStudy(candles, events, options?)`** — measures whether a pattern
+  detector's firings carry predictive power, via the conditional-vs-
+  unconditional forward-return comparison of Lo, Mamaysky & Wang (2000) within
+  the abnormal-return / AAR framework of MacKinlay (1997) and Brown & Warner
+  (1985). `events` is a list of event bar timestamps (epoch ms, matching
+  `candle.time`) or a `Series<boolean>` whose `true` entries mark events, so the
+  output of any detector maps in with a `.filter(...).map(p => p.time)`.
+- Per horizon it reports `n`, mean / median / abnormal-mean (AAR) forward
+  return, sample std, a cross-sectional t-test, a deterministic **pseudo-event
+  bootstrap** p-value (the non-parametric workhorse), a hit rate with a binomial
+  test, and distribution shape (skewness, excess kurtosis, percentiles).
+  Bootstrap p-values are Benjamini-Hochberg adjusted across the horizons.
+- Default baseline is **mean-adjusted** (subtract the unconditional mean forward
+  return); `"raw"` tests against zero. The bootstrap is seeded (default 42) so
+  results are reproducible. `minSeparation` thins overlapping events and
+  `overlappingEvents` flags the non-independence they cause.
+- New shared statistics primitives on `core/statistics`: `normalCdf`,
+  `skewness`, `kurtosis` (the `normalCdf` consolidates two previously-duplicated
+  internal copies in the deflated-Sharpe and alpha-decay modules).
+
 ### Added — first-class equity curve on `BacktestResult`
 
 - **`BacktestResult.equityCurve`** — `runBacktest` now emits the mark-to-market

--- a/packages/core/src/alpha-decay/statistics.ts
+++ b/packages/core/src/alpha-decay/statistics.ts
@@ -6,29 +6,8 @@
  * No external dependencies.
  */
 
+import { normalCdf } from "../core/statistics";
 import { computeRanks } from "../utils/statistics";
-
-/**
- * Approximate CDF of the standard normal distribution
- *
- * Uses Horner form with Abramowitz & Stegun coefficients.
- *
- * @param x - z-score
- * @returns Cumulative probability P(Z <= x)
- */
-function normalCdf(x: number): number {
-  const a1 = 0.254829592;
-  const a2 = -0.284496736;
-  const a3 = 1.421413741;
-  const a4 = -1.453152027;
-  const a5 = 1.061405429;
-  const p = 0.3275911;
-  const sign = x < 0 ? -1 : 1;
-  const absX = Math.abs(x) / Math.SQRT2;
-  const t = 1.0 / (1.0 + p * absX);
-  const y = 1.0 - ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-absX * absX);
-  return 0.5 * (1.0 + sign * y);
-}
 
 /**
  * Log-gamma function using Lanczos approximation

--- a/packages/core/src/analysis/__tests__/event-study.test.ts
+++ b/packages/core/src/analysis/__tests__/event-study.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle, Series } from "../../types";
+import { eventStudy } from "../event-study";
+
+const DAY = 86_400_000;
+const flat = (price: number, t: number): NormalizedCandle => ({
+  time: t,
+  open: price,
+  high: price + 1,
+  low: price - 1,
+  close: price,
+  volume: 1_000_000,
+});
+
+// 30 cycles of 10 bars: bars 0-4 at 100, bars 5-9 at the cycle's "up" price
+// (110 or 112, alternating so event forward returns vary). Bar 4 of each cycle
+// is always followed by a +10%/+12% step.
+const CYCLES = 30;
+function cycleCandles(): NormalizedCandle[] {
+  const candles: NormalizedCandle[] = [];
+  let t = 1_700_000_000_000;
+  for (let c = 0; c < CYCLES; c++) {
+    const up = c % 2 === 0 ? 110 : 112;
+    for (let b = 0; b < 10; b++) {
+      candles.push(flat(b < 5 ? 100 : up, t));
+      t += DAY;
+    }
+  }
+  return candles;
+}
+
+const candles = cycleCandles();
+const edgeIndices = Array.from({ length: CYCLES }, (_, c) => c * 10 + 4);
+const edgeTimes = edgeIndices.map((i) => candles[i].time);
+
+describe("eventStudy — detects a real forward edge", () => {
+  it("reports a large, significant abnormal return after the events", () => {
+    const study = eventStudy(candles, edgeTimes, { horizons: [1, 5] });
+    expect(study.eventCount).toBe(CYCLES);
+
+    const h1 = study.horizons[0];
+    expect(h1.n).toBe(CYCLES);
+    // Every event steps up 10% or 12%, so the mean is ~11% and the hit rate 1.
+    expect(h1.meanReturn).toBeCloseTo(0.11, 2);
+    expect(h1.hitRate).toBe(1);
+    expect(h1.meanAbnormalReturn).toBeGreaterThan(0.09);
+    // The bootstrap null almost never matches a +11% conditional mean.
+    expect(h1.bootstrapPValue).toBeLessThan(0.01);
+    expect(h1.hitRatePValue).toBeLessThan(0.01);
+    expect(h1.tStat).toBeGreaterThan(3);
+  });
+});
+
+describe("eventStudy — null events show no edge", () => {
+  it("is not significant when events sample all phases evenly", () => {
+    // Step 7 is coprime with the 10-bar cycle, so these events cycle through
+    // every phase -> conditional ≈ unconditional.
+    const nullTimes: number[] = [];
+    for (let i = 0; i < candles.length; i += 7) nullTimes.push(candles[i].time);
+
+    const study = eventStudy(candles, nullTimes, { horizons: [1] });
+    expect(Math.abs(study.horizons[0].meanAbnormalReturn)).toBeLessThan(0.02);
+    expect(study.horizons[0].bootstrapPValue).toBeGreaterThan(0.05);
+  });
+});
+
+describe("eventStudy — determinism & input forms", () => {
+  it("is deterministic for a fixed seed", () => {
+    const a = eventStudy(candles, edgeTimes, { horizons: [1], seed: 7 });
+    const b = eventStudy(candles, edgeTimes, { horizons: [1], seed: 7 });
+    expect(a.horizons[0].bootstrapPValue).toBe(b.horizons[0].bootstrapPValue);
+  });
+
+  it("accepts a Series<boolean> equivalently to a timestamp list", () => {
+    const eventSet = new Set(edgeIndices);
+    const series: Series<boolean> = candles.map((c, i) => ({
+      time: c.time,
+      value: eventSet.has(i),
+    }));
+    const fromSeries = eventStudy(candles, series, { horizons: [1], seed: 1 });
+    const fromTimes = eventStudy(candles, edgeTimes, { horizons: [1], seed: 1 });
+    expect(fromSeries.eventCount).toBe(fromTimes.eventCount);
+    expect(fromSeries.horizons[0].meanReturn).toBe(fromTimes.horizons[0].meanReturn);
+  });
+});
+
+describe("eventStudy — windows, separation and edge cases", () => {
+  it("counts overlapping events and thins them with minSeparation", () => {
+    // Events are 10 bars apart; with maxHorizon 20 every gap overlaps.
+    const overlapping = eventStudy(candles, edgeTimes, { horizons: [20], bootstrap: 0 });
+    expect(overlapping.overlappingEvents).toBe(CYCLES - 1);
+
+    const thinned = eventStudy(candles, edgeTimes, {
+      horizons: [1],
+      minSeparation: 11,
+      bootstrap: 0,
+    });
+    // Keeping only events ≥ 11 bars apart drops every other one.
+    expect(thinned.eventCount).toBe(Math.ceil(CYCLES / 2));
+  });
+
+  it("shrinks n at horizons whose window runs off the end of the data", () => {
+    const study = eventStudy(candles, edgeTimes, { horizons: [1, 20], bootstrap: 0 });
+    expect(study.horizons[0].n).toBe(CYCLES);
+    // The last events have no full 20-bar forward window.
+    expect(study.horizons[1].n).toBeLessThan(CYCLES);
+  });
+
+  it("yields NaN stats for a horizon with no events", () => {
+    const study = eventStudy(candles, [], { horizons: [5] });
+    expect(study.eventCount).toBe(0);
+    expect(study.horizons[0].n).toBe(0);
+    expect(Number.isNaN(study.horizons[0].meanReturn)).toBe(true);
+    expect(Number.isNaN(study.horizons[0].bootstrapPValue)).toBe(true);
+  });
+
+  it("populates a Benjamini-Hochberg-adjusted bootstrap p-value per horizon", () => {
+    const study = eventStudy(candles, edgeTimes, { horizons: [1, 5, 10] });
+    for (const h of study.horizons) {
+      expect(h.bootstrapPValueAdjusted).toBeGreaterThanOrEqual(h.bootstrapPValue - 1e-12);
+      expect(h.bootstrapPValueAdjusted).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("supports a raw (vs zero) baseline", () => {
+    const raw = eventStudy(candles, edgeTimes, { horizons: [1], baseline: "raw" });
+    // With a raw baseline the abnormal return equals the mean return itself.
+    expect(raw.horizons[0].meanAbnormalReturn).toBe(raw.horizons[0].meanReturn);
+  });
+
+  it("tests the documented zero null under a raw baseline, even with drift", () => {
+    // A clear ~+1%/bar drift with modest variance. Taking *every* bar as an
+    // event makes the event set identical to the population, so the event mean
+    // equals the unconditional mean exactly — not abnormal. But that same mean
+    // sits far from zero relative to the sampling noise. With the null correctly
+    // imposed (pseudo-event means centred on the unconditional mean), the two
+    // baselines must diverge sharply.
+    const drift: NormalizedCandle[] = [];
+    let t = 1_700_000_000_000;
+    let price = 100;
+    for (let i = 0; i < 200; i++) {
+      drift.push(flat(price, t));
+      price *= 1 + (i % 2 === 0 ? 0.015 : 0.005); // mean ~1%/bar, nonzero variance
+      t += DAY;
+    }
+    const evTimes = drift.map((c) => c.time); // every bar is an event
+
+    const meanAdj = eventStudy(drift, evTimes, { horizons: [1], baseline: "mean-adjusted" });
+    const raw = eventStudy(drift, evTimes, { horizons: [1], baseline: "raw" });
+    // mean-adjusted: the event mean equals the unconditional mean → not abnormal.
+    expect(meanAdj.horizons[0].bootstrapPValue).toBeGreaterThan(0.9);
+    // raw: the same return is significantly different from zero.
+    expect(raw.horizons[0].bootstrapPValue).toBeLessThan(0.01);
+  });
+});

--- a/packages/core/src/analysis/event-study.ts
+++ b/packages/core/src/analysis/event-study.ts
@@ -1,0 +1,333 @@
+/**
+ * Event study — does a pattern detector's firing carry predictive power?
+ *
+ * Given the bars at which a detector fired (order blocks, fair-value gaps,
+ * liquidity sweeps, BOS/CHoCH, VSA signals, divergences, …) plus the candles,
+ * this measures the distribution of forward returns after each event and tests
+ * it for significance against the unconditional baseline — the conditional vs
+ * unconditional comparison of Lo, Mamaysky & Wang (2000), "Foundations of
+ * Technical Analysis" (J. Finance), within the abnormal-return / AAR framework
+ * of MacKinlay (1997) and Brown & Warner (1985).
+ *
+ * For each horizon the report gives the mean and abnormal mean (AAR) forward
+ * return, an asymptotic t-test, a non-parametric **pseudo-event bootstrap**
+ * p-value (the workhorse, since financial returns are non-normal), a hit rate
+ * with a binomial test, and distribution shape (median, skew, excess kurtosis,
+ * percentiles). Bootstrap p-values are also Benjamini-Hochberg adjusted across
+ * the horizons.
+ *
+ * **Caveats** (read before trusting a result):
+ * - *Look-ahead*: the events must be detectable in real time. A detector that
+ *   confirms a pattern only with later bars (two-sided smoothing, lagged
+ *   confirmation) embeds future information and inflates the result. Lag the
+ *   events past their confirmation bar.
+ * - *Overlapping windows*: events spaced closer than a horizon share future
+ *   bars, so their returns are not independent — this understates the standard
+ *   error and inflates significance. `overlappingEvents` reports how many do;
+ *   use `minSeparation` to thin them, and prefer the bootstrap p-value.
+ * - *Small samples*: read `n` before trusting any ratio; few events give
+ *   unreliable t-stats and especially unreliable skew/kurtosis.
+ * - *Multiple testing*: the per-horizon p-values are not independent; use the
+ *   Benjamini-Hochberg-adjusted bootstrap p-value when scanning horizons.
+ */
+
+import { mulberry32 } from "../core/random";
+import { kurtosis, normalCdf, skewness } from "../core/statistics";
+import type { NormalizedCandle, Series } from "../types";
+import { sampleStd } from "./return-metrics";
+
+/** Abnormal-return baseline. */
+export type EventStudyBaseline = "mean-adjusted" | "raw";
+
+/** Options for {@link eventStudy}. */
+export type EventStudyOptions = {
+  /** Forward horizons in bars (default `[1, 5, 10, 20]`). */
+  horizons?: number[];
+  /**
+   * Abnormal-return baseline (default `"mean-adjusted"`): subtract the
+   * unconditional mean forward return at each horizon (the single-instrument
+   * canonical baseline). `"raw"` tests the forward return against zero.
+   */
+  baseline?: EventStudyBaseline;
+  /** Pseudo-event bootstrap resamples (default 1000; 0 disables the bootstrap). */
+  bootstrap?: number;
+  /** Seed for the bootstrap RNG (default 42); results are deterministic. */
+  seed?: number;
+  /**
+   * Drop an event whose bar is within this many bars of the previous kept
+   * event, to thin overlapping windows (default 0 — keep every event).
+   */
+  minSeparation?: number;
+};
+
+/** Per-horizon forward-return statistics for an event study. */
+export type EventHorizonStats = {
+  /** Forward horizon in bars. */
+  horizon: number;
+  /** Events with a full forward window at this horizon. */
+  n: number;
+  /** Mean event forward return (fraction). */
+  meanReturn: number;
+  /** Median event forward return (fraction). */
+  medianReturn: number;
+  /** Unconditional mean forward return over the whole series (the baseline). */
+  unconditionalMeanReturn: number;
+  /** Mean abnormal return = `meanReturn − unconditionalMeanReturn` (the AAR). */
+  meanAbnormalReturn: number;
+  /** Sample standard deviation (ddof = 1) of the event forward returns. */
+  stdReturn: number;
+  /** Cross-sectional t-statistic of the abnormal return: `√n · AAR / std`. */
+  tStat: number;
+  /** Two-sided asymptotic (normal-approximation) p-value of `tStat`. */
+  pValue: number;
+  /**
+   * Two-sided pseudo-event bootstrap p-value of the abnormal return — how often
+   * random event timing deviates from the baseline reference by at least as
+   * much as the events do (`NaN` when disabled or `n = 0`).
+   */
+  bootstrapPValue: number;
+  /** Benjamini-Hochberg-adjusted `bootstrapPValue` across the studied horizons. */
+  bootstrapPValueAdjusted: number;
+  /** Fraction of events with a strictly positive forward return. */
+  hitRate: number;
+  /** Two-sided binomial p-value of the hit rate against 0.5 (normal approx). */
+  hitRatePValue: number;
+  /** Skewness of the event forward returns. */
+  skewness: number;
+  /** Excess kurtosis of the event forward returns. */
+  kurtosis: number;
+  /** Percentiles of the event forward returns. */
+  percentiles: { p5: number; p25: number; p50: number; p75: number; p95: number };
+};
+
+/** Result of an {@link eventStudy}. */
+export type EventStudyResult = {
+  /** Distinct in-range event bars studied (after de-duplication / `minSeparation`). */
+  eventCount: number;
+  /** The abnormal-return baseline used. */
+  baseline: EventStudyBaseline;
+  /** Per-horizon statistics, in the order of the requested horizons. */
+  horizons: EventHorizonStats[];
+  /**
+   * Events that share a forward window with the previous event at the longest
+   * horizon — a non-independence flag (their overlapping returns inflate
+   * significance). `0` when every event is spaced beyond the max horizon.
+   */
+  overlappingEvents: number;
+};
+
+/** Forward return from bar `i` to bar `i + h` (simple fraction). */
+function forwardReturn(candles: NormalizedCandle[], i: number, h: number): number {
+  const base = candles[i].close;
+  return base !== 0 ? (candles[i + h].close - base) / base : 0;
+}
+
+/** Linear-interpolated percentile (`0..100`) from an ascending-sorted array. */
+function percentileSorted(sortedAsc: number[], p: number): number {
+  const n = sortedAsc.length;
+  if (n === 0) return Number.NaN;
+  if (n === 1) return sortedAsc[0];
+  const idx = (p / 100) * (n - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  return lo === hi ? sortedAsc[lo] : sortedAsc[lo] + (sortedAsc[hi] - sortedAsc[lo]) * (idx - lo);
+}
+
+/** Two-sided p-value of a t/z statistic under the normal approximation. */
+function twoSidedP(stat: number): number {
+  if (!Number.isFinite(stat)) return Number.NaN;
+  return Math.min(1, 2 * (1 - normalCdf(Math.abs(stat))));
+}
+
+/** Two-sided binomial p-value of `wins`/`n` against 0.5 (normal approx, continuity-corrected). */
+function binomialTwoSidedP(wins: number, n: number): number {
+  if (n === 0) return Number.NaN;
+  const z = (Math.abs(wins - n / 2) - 0.5) / (0.5 * Math.sqrt(n));
+  return z <= 0 ? 1 : Math.min(1, 2 * (1 - normalCdf(z)));
+}
+
+/** Benjamini-Hochberg-adjusted p-values; `NaN` inputs pass through as `NaN`. */
+function benjaminiHochberg(pValues: number[]): number[] {
+  const finite = pValues
+    .map((p, i) => ({ p, i }))
+    .filter((x) => Number.isFinite(x.p))
+    .sort((a, b) => a.p - b.p);
+  const adjusted = pValues.map(() => Number.NaN);
+  const m = finite.length;
+  let running = 1;
+  for (let rank = m; rank >= 1; rank--) {
+    const { p, i } = finite[rank - 1];
+    running = Math.min(running, Math.min(1, (p * m) / rank));
+    adjusted[i] = running;
+  }
+  return adjusted;
+}
+
+/** Normalize the event input to a sorted, unique array of in-range bar indices. */
+function toEventIndices(
+  events: number[] | Series<boolean>,
+  timeToIndex: Map<number, number>,
+): number[] {
+  if (events.length === 0) return [];
+  const first: unknown = events[0];
+  const times =
+    typeof first === "object" && first !== null && "time" in first
+      ? (events as Series<boolean>).filter((p) => p.value).map((p) => p.time)
+      : (events as number[]);
+  const indices: number[] = [];
+  for (const time of times) {
+    const idx = timeToIndex.get(time);
+    if (idx !== undefined) indices.push(idx);
+  }
+  return [...new Set(indices)].sort((a, b) => a - b);
+}
+
+/**
+ * Run an event study on a detector's firings.
+ *
+ * @param candles - The candles the events were detected on
+ * @param events - Event bar timestamps (epoch ms, matching `candle.time`) or a
+ *   `Series<boolean>` whose `true` entries mark events (e.g. `crossOver(...)`)
+ * @param options - Horizons, baseline, bootstrap and de-duplication options
+ * @returns Per-horizon forward-return distributions with significance tests
+ *
+ * @example
+ * ```ts
+ * import { fairValueGap, eventStudy } from "trendcraft";
+ *
+ * const events = fairValueGap(candles)
+ *   .filter((p) => p.value.newBullishFvg)
+ *   .map((p) => p.time);
+ * const study = eventStudy(candles, events, { horizons: [1, 5, 10] });
+ * for (const h of study.horizons) {
+ *   console.log(h.horizon, h.meanAbnormalReturn, h.bootstrapPValue, h.hitRate);
+ * }
+ * ```
+ */
+export function eventStudy(
+  candles: NormalizedCandle[],
+  events: number[] | Series<boolean>,
+  options: EventStudyOptions = {},
+): EventStudyResult {
+  const {
+    horizons = [1, 5, 10, 20],
+    baseline = "mean-adjusted",
+    bootstrap = 1000,
+    seed = 42,
+    minSeparation = 0,
+  } = options;
+
+  const timeToIndex = new Map<number, number>();
+  for (let i = 0; i < candles.length; i++) timeToIndex.set(candles[i].time, i);
+
+  // Resolve to sorted unique indices, then thin overlapping events.
+  const allIndices = toEventIndices(events, timeToIndex);
+  const eventIndices: number[] = [];
+  for (const idx of allIndices) {
+    if (eventIndices.length === 0 || idx - eventIndices[eventIndices.length - 1] >= minSeparation) {
+      eventIndices.push(idx);
+    }
+  }
+
+  const maxHorizon = horizons.length > 0 ? Math.max(...horizons) : 0;
+  let overlappingEvents = 0;
+  for (let i = 1; i < eventIndices.length; i++) {
+    if (eventIndices[i] - eventIndices[i - 1] < maxHorizon) overlappingEvents++;
+  }
+
+  // One deterministic RNG shared across horizons.
+  const rng = mulberry32(seed);
+
+  const horizonStats: EventHorizonStats[] = horizons.map((h) => {
+    // Precompute every valid forward return for this horizon once; the baseline
+    // mean, the event returns and the bootstrap all sample from this array
+    // (an event at bar `idx` is itself a valid start, since `idx + h ≤ len-1`).
+    const validStarts = candles.length - h;
+    const fwd: number[] = [];
+    for (let i = 0; i < validStarts; i++) fwd.push(forwardReturn(candles, i, h));
+    let baselineSum = 0;
+    for (const r of fwd) baselineSum += r;
+    const baselineMean = validStarts > 0 ? baselineSum / validStarts : Number.NaN;
+
+    const eventReturns: number[] = [];
+    let wins = 0;
+    for (const idx of eventIndices) {
+      if (idx >= validStarts) continue;
+      const r = fwd[idx];
+      eventReturns.push(r);
+      if (r > 0) wins++;
+    }
+
+    const n = eventReturns.length;
+    const reference = baseline === "raw" ? 0 : baselineMean;
+
+    let mean = 0;
+    for (const r of eventReturns) mean += r;
+    mean = n > 0 ? mean / n : Number.NaN;
+
+    const std = sampleStd(eventReturns);
+    const meanAbnormal = mean - reference;
+    const tStat = n >= 2 && std > 0 ? (Math.sqrt(n) * meanAbnormal) / std : Number.NaN;
+
+    // Pseudo-event bootstrap of the abnormal return: draw `n` random start bars
+    // `B` times to get the sampling distribution of the mean forward return.
+    // Random pseudo-events inherit the series' drift, so their means sit at
+    // `baselineMean`; centring each draw on `baselineMean` imposes the null (no
+    // abnormal return) and yields the zero-mean sampling noise. The observed
+    // statistic is the abnormal return `mean − reference` (deviation from the
+    // unconditional mean for "mean-adjusted", from zero for "raw"), so the test
+    // stays consistent with the t-test under either baseline.
+    let bootstrapPValue = Number.NaN;
+    if (bootstrap > 0 && n > 0 && validStarts > 0) {
+      const observedDev = Math.abs(meanAbnormal);
+      let atLeastAsExtreme = 0;
+      for (let b = 0; b < bootstrap; b++) {
+        let sampleSum = 0;
+        for (let k = 0; k < n; k++) sampleSum += fwd[Math.floor(rng() * validStarts)];
+        if (Math.abs(sampleSum / n - baselineMean) >= observedDev) atLeastAsExtreme++;
+      }
+      bootstrapPValue = (1 + atLeastAsExtreme) / (1 + bootstrap);
+    }
+
+    // Sort once for the median and percentiles.
+    const sorted = n > 0 ? [...eventReturns].sort((a, b) => a - b) : [];
+    const median = percentileSorted(sorted, 50);
+
+    return {
+      horizon: h,
+      n,
+      meanReturn: mean,
+      medianReturn: median,
+      unconditionalMeanReturn: baselineMean,
+      meanAbnormalReturn: meanAbnormal,
+      stdReturn: std,
+      tStat,
+      pValue: twoSidedP(tStat),
+      bootstrapPValue,
+      bootstrapPValueAdjusted: Number.NaN, // filled in after all horizons
+      hitRate: n > 0 ? wins / n : Number.NaN,
+      hitRatePValue: binomialTwoSidedP(wins, n),
+      skewness: skewness(eventReturns),
+      kurtosis: kurtosis(eventReturns),
+      percentiles: {
+        p5: percentileSorted(sorted, 5),
+        p25: percentileSorted(sorted, 25),
+        p50: median,
+        p75: percentileSorted(sorted, 75),
+        p95: percentileSorted(sorted, 95),
+      },
+    };
+  });
+
+  const adjusted = benjaminiHochberg(horizonStats.map((s) => s.bootstrapPValue));
+  for (let i = 0; i < horizonStats.length; i++) {
+    horizonStats[i].bootstrapPValueAdjusted = adjusted[i];
+  }
+
+  return {
+    eventCount: eventIndices.length,
+    baseline,
+    horizons: horizonStats,
+    overlappingEvents,
+  };
+}

--- a/packages/core/src/analysis/index.ts
+++ b/packages/core/src/analysis/index.ts
@@ -37,6 +37,14 @@ export {
   // Types
   type TradeStats,
 } from "./edge-analysis";
+export type {
+  EventHorizonStats,
+  EventStudyBaseline,
+  EventStudyOptions,
+  EventStudyResult,
+} from "./event-study";
+// Event study
+export { eventStudy } from "./event-study";
 export type { MarketContext, MarketContextOptions } from "./market-context";
 // Market Context
 export { analyzeMarketContext } from "./market-context";

--- a/packages/core/src/core/__tests__/statistics.test.ts
+++ b/packages/core/src/core/__tests__/statistics.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { median, percentile, quartiles } from "../statistics";
+import { kurtosis, median, normalCdf, percentile, quartiles, skewness } from "../statistics";
 
 describe("percentile", () => {
   it("returns 0 for an empty array", () => {
@@ -79,5 +79,54 @@ describe("quartiles", () => {
 
   it("returns [0, 0, 0] for empty array", () => {
     expect(quartiles([])).toEqual([0, 0, 0]);
+  });
+});
+
+describe("normalCdf", () => {
+  it("is 0.5 at the mean and symmetric", () => {
+    expect(normalCdf(0)).toBeCloseTo(0.5, 6);
+    expect(normalCdf(1.96) + normalCdf(-1.96)).toBeCloseTo(1, 6);
+  });
+
+  it("matches known quantiles within the approximation error", () => {
+    expect(normalCdf(1.96)).toBeCloseTo(0.975, 4); // two-sided 95%
+    expect(normalCdf(2.575)).toBeCloseTo(0.995, 4); // two-sided 99%
+    expect(normalCdf(1)).toBeCloseTo(0.8413, 4);
+  });
+
+  it("saturates in the tails", () => {
+    expect(normalCdf(10)).toBeCloseTo(1, 6);
+    expect(normalCdf(-10)).toBeCloseTo(0, 6);
+  });
+});
+
+describe("skewness", () => {
+  it("is ~0 for a symmetric sample", () => {
+    expect(skewness([-2, -1, 0, 1, 2])).toBeCloseTo(0, 12);
+  });
+
+  it("is positive for a right-skewed sample and negative for left-skewed", () => {
+    expect(skewness([1, 1, 1, 1, 10])).toBeGreaterThan(0);
+    expect(skewness([1, 10, 10, 10, 10])).toBeLessThan(0);
+  });
+
+  it("is NaN for fewer than three values or zero variance", () => {
+    expect(Number.isNaN(skewness([1, 2]))).toBe(true);
+    expect(Number.isNaN(skewness([5, 5, 5, 5]))).toBe(true);
+  });
+});
+
+describe("kurtosis", () => {
+  it("is negative (platykurtic) for a flat/uniform-like sample", () => {
+    expect(kurtosis([1, 2, 3, 4, 5, 6, 7, 8])).toBeLessThan(0);
+  });
+
+  it("is positive (leptokurtic) for a heavy-tailed sample", () => {
+    expect(kurtosis([0, 0, 0, 0, 0, 0, 0, 10])).toBeGreaterThan(0);
+  });
+
+  it("is NaN for fewer than four values or zero variance", () => {
+    expect(Number.isNaN(kurtosis([1, 2, 3]))).toBe(true);
+    expect(Number.isNaN(kurtosis([5, 5, 5, 5, 5]))).toBe(true);
   });
 });

--- a/packages/core/src/core/random.ts
+++ b/packages/core/src/core/random.ts
@@ -1,0 +1,39 @@
+/**
+ * Deterministic pseudo-random number generation.
+ *
+ * A seeded uniform RNG is a foundational numeric primitive (reproducible Monte
+ * Carlo, bootstrap resampling, model initialization), so it lives in `core`
+ * with a single owner rather than being re-implemented per consumer. The HMM /
+ * CandleFormer ML code, the optimization Monte Carlo and the analysis event
+ * study all draw from here.
+ */
+
+/**
+ * Mulberry32 PRNG — a fast, deterministic generator. Returns a function that
+ * produces values in `[0, 1)`; the same seed always yields the same sequence.
+ *
+ * @param seed - Integer seed
+ * @returns A function returning the next value in `[0, 1)`
+ */
+export function mulberry32(seed: number): () => number {
+  let state = seed | 0;
+  return () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Draw a standard-normal sample from a uniform RNG via the Box-Muller
+ * transform.
+ *
+ * @param rng - A uniform `[0, 1)` generator (e.g. from {@link mulberry32})
+ * @returns A sample from `N(0, 1)`
+ */
+export function randNormal(rng: () => number): number {
+  const u1 = rng();
+  const u2 = rng();
+  return Math.sqrt(-2 * Math.log(u1 + 1e-10)) * Math.cos(2 * Math.PI * u2);
+}

--- a/packages/core/src/core/statistics.ts
+++ b/packages/core/src/core/statistics.ts
@@ -52,6 +52,77 @@ export function median(values: number[]): number {
 }
 
 /**
+ * CDF of the standard normal distribution, `P(Z ≤ x)`.
+ *
+ * Horner form with Abramowitz & Stegun 7.1.26 coefficients
+ * (`|error| < 1.5e-7`). The canonical implementation shared by the
+ * probabilistic/deflated Sharpe ratios, alpha-decay significance and the
+ * event-study tests, so every consumer uses the same approximation.
+ */
+export function normalCdf(x: number): number {
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const p = 0.3275911;
+  const sign = x < 0 ? -1 : 1;
+  const absX = Math.abs(x) / Math.SQRT2;
+  const t = 1.0 / (1.0 + p * absX);
+  const y = 1.0 - ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-absX * absX);
+  return 0.5 * (1.0 + sign * y);
+}
+
+/**
+ * Sample skewness (the moment coefficient `g1`): the third standardized
+ * central moment using population moments (`÷ n`). Positive means a longer
+ * right tail. Returns `NaN` for fewer than three values or zero variance.
+ */
+export function skewness(values: number[]): number {
+  const n = values.length;
+  if (n < 3) return Number.NaN;
+  let mean = 0;
+  for (const v of values) mean += v;
+  mean /= n;
+  let m2 = 0;
+  let m3 = 0;
+  for (const v of values) {
+    const d = v - mean;
+    m2 += d * d;
+    m3 += d * d * d;
+  }
+  m2 /= n;
+  m3 /= n;
+  if (m2 === 0) return Number.NaN;
+  return m3 / m2 ** 1.5;
+}
+
+/**
+ * Excess kurtosis (the moment coefficient `g2`): the fourth standardized
+ * central moment minus 3 (so a normal distribution is 0), using population
+ * moments (`÷ n`). Returns `NaN` for fewer than four values or zero variance.
+ */
+export function kurtosis(values: number[]): number {
+  const n = values.length;
+  if (n < 4) return Number.NaN;
+  let mean = 0;
+  for (const v of values) mean += v;
+  mean /= n;
+  let m2 = 0;
+  let m4 = 0;
+  for (const v of values) {
+    const d = v - mean;
+    const d2 = d * d;
+    m2 += d2;
+    m4 += d2 * d2;
+  }
+  m2 /= n;
+  m4 /= n;
+  if (m2 === 0) return Number.NaN;
+  return m4 / (m2 * m2) - 3;
+}
+
+/**
  * Return `[Q1, Q2, Q3]` = `[p25, p50, p75]` from the input values.
  * Sorts internally once (cheaper than three separate `percentile`
  * calls on the same array).

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -232,7 +232,7 @@ export {
 } from "./core/normalize";
 export { getPeriodStart, parseTimeframe, resample } from "./core/resample";
 // Statistics utilities
-export { median, percentile, quartiles } from "./core/statistics";
+export { kurtosis, median, normalCdf, percentile, quartiles, skewness } from "./core/statistics";
 export type { AnalysisResult } from "./core/trendcraft";
 // Fluent API
 export { MtfStrategyBuilder, StrategyBuilder, TrendCraft, TrendCraftMtf } from "./core/trendcraft";
@@ -1055,6 +1055,10 @@ export type {
   BehaviorInsight,
   DrawdownSummary,
   EventExtractor,
+  EventHorizonStats,
+  EventStudyBaseline,
+  EventStudyOptions,
+  EventStudyResult,
   ExitReasonAnalysis,
   HitRate,
   HoldingPeriodAnalysis,
@@ -1103,6 +1107,8 @@ export {
   commonSenseRatio,
   cpcIndex,
   detectMarketRegime,
+  // Event study
+  eventStudy,
   gainToPainRatio,
   // Behavior Insights
   generateBehaviorInsights,

--- a/packages/core/src/ml/tensor.ts
+++ b/packages/core/src/ml/tensor.ts
@@ -6,32 +6,11 @@
  * Uses Mulberry32 PRNG for reproducible initialization.
  */
 
-// ============================================
-// PRNG (Mulberry32)
-// ============================================
+// The canonical PRNG owner is `core/random`; imported for this module's own use
+// and re-exported for the ML callers that import it from here.
+import { mulberry32, randNormal } from "../core/random";
 
-/**
- * Mulberry32 PRNG - deterministic random number generator
- * Returns a function that produces values in [0, 1)
- */
-export function mulberry32(seed: number): () => number {
-  let state = seed | 0;
-  return () => {
-    state = (state + 0x6d2b79f5) | 0;
-    let t = Math.imul(state ^ (state >>> 15), 1 | state);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-/**
- * Box-Muller transform for normal distribution
- */
-export function randNormal(rng: () => number): number {
-  const u1 = rng();
-  const u2 = rng();
-  return Math.sqrt(-2 * Math.log(u1 + 1e-10)) * Math.cos(2 * Math.PI * u2);
-}
+export { mulberry32, randNormal };
 
 // ============================================
 // Tensor class

--- a/packages/core/src/optimization/monte-carlo.ts
+++ b/packages/core/src/optimization/monte-carlo.ts
@@ -10,6 +10,7 @@
  *   drawdown varies — used for sequence-risk analysis.
  */
 
+import { mulberry32 } from "../core/random";
 import type { BacktestResult, Trade } from "../types";
 import type { MetricStatistics, MonteCarloOptions, MonteCarloResult } from "../types/optimization";
 import { err, ok, type Result, tcError } from "../types/result";
@@ -51,20 +52,6 @@ function bootstrapSample<T>(array: T[], random: () => number): T[] {
     result[i] = array[Math.floor(random() * n)];
   }
   return result;
-}
-
-/**
- * Simple seeded random number generator (Mulberry32)
- */
-function createSeededRandom(initialSeed: number): () => number {
-  let seed = initialSeed;
-  return () => {
-    seed += 0x6d2b79f5;
-    let t = seed;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
 }
 
 // Local already-sorted variant of the shared `percentile` utility.
@@ -206,7 +193,7 @@ export function runMonteCarloSimulation(
   }
 
   // Create random generator
-  const random = options.seed !== undefined ? createSeededRandom(options.seed) : Math.random;
+  const random = options.seed !== undefined ? mulberry32(options.seed) : Math.random;
   const resample = method === "shuffle" ? shuffleArray : bootstrapSample;
 
   // Collect simulation results

--- a/packages/core/src/scoring/deflated-sharpe.ts
+++ b/packages/core/src/scoring/deflated-sharpe.ts
@@ -27,26 +27,10 @@
  * No external dependencies.
  */
 
+import { normalCdf } from "../core/statistics";
+
 const EULER_MASCHERONI = 0.5772156649015329;
 const E = Math.E;
-
-/**
- * CDF of the standard normal distribution. Horner form with
- * Abramowitz & Stegun 7.1.26 coefficients (|error| < 1.5e-7).
- */
-function normalCdf(x: number): number {
-  const a1 = 0.254829592;
-  const a2 = -0.284496736;
-  const a3 = 1.421413741;
-  const a4 = -1.453152027;
-  const a5 = 1.061405429;
-  const p = 0.3275911;
-  const sign = x < 0 ? -1 : 1;
-  const absX = Math.abs(x) / Math.SQRT2;
-  const t = 1.0 / (1.0 + p * absX);
-  const y = 1.0 - ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-absX * absX);
-  return 0.5 * (1.0 + sign * y);
-}
 
 /**
  * Inverse CDF (quantile / ppf) of the standard normal distribution.


### PR DESCRIPTION
## Summary

Adds `eventStudy()` — a conditional-forward-return / abnormal-return study that measures whether a pattern detector's firings actually carry predictive power, rather than assuming they do.

### `eventStudy(candles, events, options?)`
Given the bars where a detector fired (order blocks, fair-value gaps, liquidity sweeps, BOS/CHoCH, VSA signals, divergences, …) and the candles, it measures the distribution of forward returns after each event and tests it for significance against the unconditional baseline — the conditional-vs-unconditional comparison of Lo, Mamaysky & Wang (2000) within the abnormal-return / AAR framework of MacKinlay (1997) and Brown & Warner (1985).

- `events` is a list of event bar timestamps (epoch ms, matching `candle.time`) or a `Series<boolean>` whose `true` entries mark events, so any detector maps in with `.filter(...).map(p => p.time)`.
- **Per horizon** it reports: `n`, mean / median / abnormal-mean (AAR) forward return, sample std, a cross-sectional **t-test**, a deterministic **pseudo-event bootstrap** p-value (the non-parametric workhorse, since financial returns are non-normal), a **hit rate** with a binomial test, and distribution shape (skewness, excess kurtosis, percentiles). Bootstrap p-values are **Benjamini-Hochberg adjusted** across the horizons.
- The bootstrap is a proper imposed-null test: pseudo-event means are centred on the unconditional mean to form the zero-mean sampling noise, and the observed abnormal return is measured from the chosen baseline (unconditional mean for `"mean-adjusted"`, zero for `"raw"`), so the bootstrap stays consistent with the t-test under either baseline.
- Default baseline is **mean-adjusted** (subtract the unconditional drift); the bootstrap is **seeded** (default 42) so results are reproducible. `minSeparation` thins overlapping events and `overlappingEvents` flags the non-independence they cause. Look-ahead, small-sample and multiple-testing caveats are documented on the function.

### Shared statistics consolidation (removes duplication)
- `core/statistics` gains **`normalCdf`** (replacing two byte-identical local copies in the deflated-Sharpe and alpha-decay modules), **`skewness`** and **`kurtosis`**.
- `core/random` becomes the single owner of the **`mulberry32` / `randNormal`** PRNG; `ml/tensor` re-exports it and the optimization Monte Carlo drops its own duplicate seeded-RNG copy.

## Test plan
- New `event-study.test.ts`: detects a real planted edge (significant abnormal return, low bootstrap p, high hit rate); correctly finds no edge for null events sampling all phases; determinism for a fixed seed; `number[]` vs `Series<boolean>` equivalence; overlap counting + `minSeparation` thinning; `n` shrinking at horizons that run off the data; NaN stats for empty horizons; BH adjustment; and a definitive raw-vs-mean-adjusted baseline test (constant-drift series, every bar an event → mean-adjusted not abnormal, raw significantly non-zero).
- New statistics tests for `normalCdf` / `skewness` / `kurtosis`.
- Existing Monte Carlo, HMM, deflated-Sharpe and alpha-decay suites stay green after the PRNG / `normalCdf` consolidation (the RNG swap preserves the sequence).
- Full core suite green: **6202 tests**. `tsc --noEmit` clean (from `packages/core`), Biome lint clean, build OK.