### PR TITLE
feat(core): detect hidden (continuation) divergence

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Added — hidden (continuation) divergence
+
+- **`detectDivergence()` now detects hidden divergence** in addition to regular
+  divergence, selected via the new `DivergenceOptions.kinds` option. Hidden
+  divergence is a continuation signal: hidden bullish is a price higher low
+  against an indicator lower low; hidden bearish is a price lower high against an
+  indicator higher high (the mirror of the regular/reversal forms).
+- Every `DivergenceSignal` now carries a `kind: "regular" | "hidden"` field
+  alongside its directional `type`. `kinds` defaults to `["regular"]`, so
+  existing callers keep getting reversal signals only; pass
+  `["regular", "hidden"]` (or `["hidden"]`) to opt into continuation signals.
+  The `obvDivergence` / `rsiDivergence` / `macdDivergence` / `cvdDivergence`
+  wrappers forward the option unchanged.
+- New `DivergenceClass` type export.
+
 ### Added — event study: `eventStudy()`
 
 - **`eventStudy(candles, events, options?)`** — measures whether a pattern

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -811,6 +811,7 @@ export type {
   CrossValidationOptions,
   CupHandleOptions,
   DebounceConfig,
+  DivergenceClass,
   DivergenceOptions,
   DivergenceSignal,
   DoublePatternOptions,

--- a/packages/core/src/signals/__tests__/divergence.test.ts
+++ b/packages/core/src/signals/__tests__/divergence.test.ts
@@ -187,6 +187,112 @@ describe("detectDivergence", () => {
   });
 });
 
+describe("hidden divergence", () => {
+  // Build candles whose timestamps line up with a price/indicator series.
+  function candlesFor(length: number): NormalizedCandle[] {
+    return Array.from({ length }, (_, i) => createCandle(i + 1, 100));
+  }
+
+  // Two price troughs (idx 5, idx 15) where the second is a HIGHER low, paired
+  // with indicator troughs where the second is a LOWER low → hidden bullish.
+  const hiddenBullishPrice = [
+    20, 18, 16, 14, 12, 10, 12, 14, 16, 18, 20, 19, 18, 17, 16, 15, 17, 18, 19, 20, 21,
+  ];
+  const hiddenBullishInd = [
+    50, 48, 46, 44, 42, 40, 42, 44, 46, 48, 50, 48, 46, 44, 42, 38, 40, 42, 44, 46, 48,
+  ];
+
+  // Two price peaks (idx 5, idx 15) where the second is a LOWER high, paired
+  // with indicator peaks where the second is a HIGHER high → hidden bearish.
+  const hiddenBearishPrice = [
+    10, 12, 14, 16, 18, 20, 18, 16, 14, 12, 10, 11, 12, 13, 14, 15, 13, 12, 11, 10, 9,
+  ];
+  const hiddenBearishInd = [
+    40, 42, 44, 46, 48, 50, 48, 46, 44, 42, 40, 44, 46, 48, 50, 52, 50, 48, 46, 44, 42,
+  ];
+
+  const opts = { swingLookback: 2 };
+
+  it("detects hidden bullish (price higher low, indicator lower low)", () => {
+    const candles = candlesFor(hiddenBullishPrice.length);
+    const signals = detectDivergence(candles, hiddenBullishPrice, hiddenBullishInd, {
+      ...opts,
+      kinds: ["hidden"],
+    });
+
+    expect(signals).toHaveLength(1);
+    const [s] = signals;
+    expect(s.type).toBe("bullish");
+    expect(s.kind).toBe("hidden");
+    expect(s.firstIdx).toBe(5);
+    expect(s.secondIdx).toBe(15);
+    expect(s.price.second).toBeGreaterThan(s.price.first); // higher low
+    expect(s.indicator.second).toBeLessThan(s.indicator.first); // lower low
+  });
+
+  it("detects hidden bearish (price lower high, indicator higher high)", () => {
+    const candles = candlesFor(hiddenBearishPrice.length);
+    const signals = detectDivergence(candles, hiddenBearishPrice, hiddenBearishInd, {
+      ...opts,
+      kinds: ["hidden"],
+    });
+
+    expect(signals).toHaveLength(1);
+    const [s] = signals;
+    expect(s.type).toBe("bearish");
+    expect(s.kind).toBe("hidden");
+    expect(s.firstIdx).toBe(5);
+    expect(s.secondIdx).toBe(15);
+    expect(s.price.second).toBeLessThan(s.price.first); // lower high
+    expect(s.indicator.second).toBeGreaterThan(s.indicator.first); // higher high
+  });
+
+  it("does not report hidden patterns when only regular kinds are requested", () => {
+    const candles = candlesFor(hiddenBullishPrice.length);
+    expect(detectDivergence(candles, hiddenBullishPrice, hiddenBullishInd, opts)).toHaveLength(0);
+    expect(
+      detectDivergence(candles, hiddenBullishPrice, hiddenBullishInd, {
+        ...opts,
+        kinds: ["regular"],
+      }),
+    ).toHaveLength(0);
+  });
+
+  it("tags default (regular) signals with kind 'regular'", () => {
+    // Regular bullish: price lower low, indicator higher low.
+    const price = [
+      20, 18, 16, 14, 12, 10, 12, 14, 16, 18, 20, 19, 18, 17, 16, 8, 10, 12, 14, 16, 18,
+    ];
+    const ind = [
+      50, 48, 46, 44, 42, 40, 42, 44, 46, 48, 50, 49, 47, 45, 43, 42, 44, 46, 48, 50, 52,
+    ];
+    const candles = candlesFor(price.length);
+
+    const signals = detectDivergence(candles, price, ind, opts);
+    expect(signals.length).toBeGreaterThan(0);
+    for (const s of signals) {
+      expect(s.kind).toBe("regular");
+    }
+    expect(signals.some((s) => s.type === "bullish")).toBe(true);
+  });
+
+  it("returns both classes when requested", () => {
+    const candles = candlesFor(hiddenBullishPrice.length);
+    const hiddenOnly = detectDivergence(candles, hiddenBullishPrice, hiddenBullishInd, {
+      ...opts,
+      kinds: ["hidden"],
+    });
+    const both = detectDivergence(candles, hiddenBullishPrice, hiddenBullishInd, {
+      ...opts,
+      kinds: ["regular", "hidden"],
+    });
+    // This fixture has only a hidden bullish pattern, so the union equals the
+    // hidden-only result here, and every signal carries a kind.
+    expect(both).toHaveLength(hiddenOnly.length);
+    expect(both.every((s) => s.kind === "regular" || s.kind === "hidden")).toBe(true);
+  });
+});
+
 describe("rsiDivergence", () => {
   it("should return empty array for insufficient data", () => {
     const candles = [createCandle(1, 100), createCandle(2, 101)];

--- a/packages/core/src/signals/__tests__/trade-signal.test.ts
+++ b/packages/core/src/signals/__tests__/trade-signal.test.ts
@@ -69,6 +69,7 @@ describe("fromDivergenceSignal", () => {
     const signal: DivergenceSignal = {
       time: 2000,
       type: "bullish",
+      kind: "regular",
       firstIdx: 5,
       secondIdx: 10,
       price: { first: 100, second: 95 },
@@ -85,6 +86,7 @@ describe("fromDivergenceSignal", () => {
     const signal: DivergenceSignal = {
       time: 3000,
       type: "bearish",
+      kind: "regular",
       firstIdx: 5,
       secondIdx: 10,
       price: { first: 100, second: 110 },

--- a/packages/core/src/signals/cvd-divergence.ts
+++ b/packages/core/src/signals/cvd-divergence.ts
@@ -4,10 +4,13 @@
  * Detects divergence between price and CVD, which can signal
  * potential reversals in buying/selling pressure.
  *
- * - Bullish divergence: Price makes lower low, CVD makes higher low
- *   (hidden buying pressure despite falling price)
- * - Bearish divergence: Price makes higher high, CVD makes lower high
- *   (weakening buying pressure despite rising price)
+ * - Regular bullish: Price makes lower low, CVD makes higher low
+ *   (buying pressure building despite falling price — a reversal signal)
+ * - Regular bearish: Price makes higher high, CVD makes lower high
+ *   (buying pressure weakening despite rising price — a reversal signal)
+ *
+ * Pass `{ kinds: ["regular", "hidden"] }` to also detect hidden (continuation)
+ * divergence; see {@link detectDivergence}.
  */
 
 import { isNormalized, normalizeCandles } from "../core/normalize";

--- a/packages/core/src/signals/divergence.ts
+++ b/packages/core/src/signals/divergence.ts
@@ -10,13 +10,29 @@ import { obv } from "../indicators/volume/obv";
 import type { Candle, NormalizedCandle } from "../types";
 
 /**
+ * Divergence class.
+ *
+ * - `"regular"` — a reversal signal: price and indicator pull apart at an
+ *   extreme that the price is still extending (price lower low / indicator
+ *   higher low for bullish; price higher high / indicator lower high for
+ *   bearish).
+ * - `"hidden"` — a continuation signal seen during a pullback: the indicator
+ *   extends past its prior extreme while price holds back (price higher low /
+ *   indicator lower low for bullish; price lower high / indicator higher high
+ *   for bearish).
+ */
+export type DivergenceClass = "regular" | "hidden";
+
+/**
  * Divergence signal type
  */
 export type DivergenceSignal = {
   /** Timestamp of the divergence point (second peak/trough) */
   time: number;
-  /** Type of divergence */
+  /** Directional bias of the divergence (a buy lean vs. a sell lean) */
   type: "bullish" | "bearish";
+  /** Regular (reversal) vs. hidden (continuation) divergence */
+  kind: DivergenceClass;
   /** First peak/trough index */
   firstIdx: number;
   /** Second peak/trough index */
@@ -37,6 +53,12 @@ export type DivergenceOptions = {
   minSwingDistance?: number;
   /** Maximum bars between two peaks/troughs (default: 60) */
   maxSwingDistance?: number;
+  /**
+   * Which divergence classes to detect. Defaults to `["regular"]` so existing
+   * callers keep getting reversal signals only; pass `["regular", "hidden"]`
+   * (or `["hidden"]`) to opt into continuation signals.
+   */
+  kinds?: DivergenceClass[];
 };
 
 /**
@@ -145,13 +167,34 @@ export function macdDivergence(
 }
 
 /**
- * Generic divergence detection between price and any indicator
+ * Generic divergence detection between price and any indicator.
+ *
+ * Detects up to four divergence types, gated by {@link DivergenceOptions.kinds}:
+ * - Regular bullish (reversal): price lower low, indicator higher low
+ * - Regular bearish (reversal): price higher high, indicator lower high
+ * - Hidden bullish (continuation): price higher low, indicator lower low
+ * - Hidden bearish (continuation): price lower high, indicator higher high
+ *
+ * Each signal carries a `type` (`"bullish"`/`"bearish"` directional bias) and a
+ * `kind` (`"regular"`/`"hidden"`). Only regular divergences are detected by
+ * default.
  *
  * @param candles - Normalized candles (for timestamps)
  * @param prices - Price series (typically close prices)
  * @param indicator - Indicator series
  * @param options - Detection options
- * @returns Array of divergence signals
+ * @returns Array of divergence signals, sorted by time
+ *
+ * @example
+ * ```ts
+ * // Reversal signals only (default)
+ * const reversals = detectDivergence(candles, prices, rsiValues);
+ * // Both reversal and continuation signals
+ * const all = detectDivergence(candles, prices, rsiValues, {
+ *   kinds: ["regular", "hidden"],
+ * });
+ * const continuation = all.filter((s) => s.kind === "hidden");
+ * ```
  */
 export function detectDivergence(
   candles: NormalizedCandle[],
@@ -159,77 +202,72 @@ export function detectDivergence(
   indicator: number[],
   options: DivergenceOptions = {},
 ): DivergenceSignal[] {
-  const { swingLookback = 5, minSwingDistance = 5, maxSwingDistance = 60 } = options;
+  const {
+    swingLookback = 5,
+    minSwingDistance = 5,
+    maxSwingDistance = 60,
+    kinds = ["regular"],
+  } = options;
 
-  const results: DivergenceSignal[] = [];
-
-  // Find swing highs and lows for price
+  // Find swing highs and lows for both series once; the detector loops below
+  // reuse these pivot lists.
   const priceHighs = findSwingHighs(prices, swingLookback);
   const priceLows = findSwingLows(prices, swingLookback);
-
-  // Find swing highs and lows for indicator
   const indHighs = findSwingHighs(indicator, swingLookback);
   const indLows = findSwingLows(indicator, swingLookback);
 
-  // Detect bearish divergence (price higher high, indicator lower high)
-  for (let i = 1; i < priceHighs.length; i++) {
-    const prev = priceHighs[i - 1];
-    const curr = priceHighs[i];
+  // Required first->second pivot move directions for each (kind, type). Bearish
+  // works on peaks, bullish on troughs; `priceHigher`/`indHigher` say which way
+  // each series must move. Hidden is the mirror of regular (booleans flipped).
+  const directions: Record<
+    DivergenceClass,
+    Record<"bullish" | "bearish", { priceHigher: boolean; indHigher: boolean }>
+  > = {
+    regular: {
+      bearish: { priceHigher: true, indHigher: false }, // price higher high, ind lower high
+      bullish: { priceHigher: false, indHigher: true }, // price lower low, ind higher low
+    },
+    hidden: {
+      bearish: { priceHigher: false, indHigher: true }, // price lower high, ind higher high
+      bullish: { priceHigher: true, indHigher: false }, // price higher low, ind lower low
+    },
+  };
 
-    // Check distance constraint
-    const distance = curr.idx - prev.idx;
-    if (distance < minSwingDistance || distance > maxSwingDistance) continue;
+  const results: DivergenceSignal[] = [];
 
-    // Price makes higher high
-    if (curr.value <= prev.value) continue;
+  for (const kind of kinds) {
+    for (const type of ["bearish", "bullish"] as const) {
+      const { priceHigher, indHigher } = directions[kind][type];
+      const pricePivots = type === "bearish" ? priceHighs : priceLows;
+      const indPivots = type === "bearish" ? indHighs : indLows;
 
-    // Find corresponding indicator highs
-    const prevIndHigh = findNearestSwing(indHighs, prev.idx, swingLookback);
-    const currIndHigh = findNearestSwing(indHighs, curr.idx, swingLookback);
+      for (let i = 1; i < pricePivots.length; i++) {
+        const prev = pricePivots[i - 1];
+        const curr = pricePivots[i];
 
-    if (!prevIndHigh || !currIndHigh) continue;
+        const distance = curr.idx - prev.idx;
+        if (distance < minSwingDistance || distance > maxSwingDistance) continue;
 
-    // Indicator makes lower high (bearish divergence)
-    if (currIndHigh.value < prevIndHigh.value) {
-      results.push({
-        time: candles[curr.idx].time,
-        type: "bearish",
-        firstIdx: prev.idx,
-        secondIdx: curr.idx,
-        price: { first: prev.value, second: curr.value },
-        indicator: { first: prevIndHigh.value, second: currIndHigh.value },
-      });
-    }
-  }
+        // Price must move strictly in the required direction.
+        if (priceHigher ? curr.value <= prev.value : curr.value >= prev.value) continue;
 
-  // Detect bullish divergence (price lower low, indicator higher low)
-  for (let i = 1; i < priceLows.length; i++) {
-    const prev = priceLows[i - 1];
-    const curr = priceLows[i];
+        const prevInd = findNearestSwing(indPivots, prev.idx, swingLookback);
+        const currInd = findNearestSwing(indPivots, curr.idx, swingLookback);
+        if (!prevInd || !currInd) continue;
 
-    // Check distance constraint
-    const distance = curr.idx - prev.idx;
-    if (distance < minSwingDistance || distance > maxSwingDistance) continue;
+        // Indicator must move strictly in the (opposing) required direction.
+        if (indHigher ? currInd.value <= prevInd.value : currInd.value >= prevInd.value) continue;
 
-    // Price makes lower low
-    if (curr.value >= prev.value) continue;
-
-    // Find corresponding indicator lows
-    const prevIndLow = findNearestSwing(indLows, prev.idx, swingLookback);
-    const currIndLow = findNearestSwing(indLows, curr.idx, swingLookback);
-
-    if (!prevIndLow || !currIndLow) continue;
-
-    // Indicator makes higher low (bullish divergence)
-    if (currIndLow.value > prevIndLow.value) {
-      results.push({
-        time: candles[curr.idx].time,
-        type: "bullish",
-        firstIdx: prev.idx,
-        secondIdx: curr.idx,
-        price: { first: prev.value, second: curr.value },
-        indicator: { first: prevIndLow.value, second: currIndLow.value },
-      });
+        results.push({
+          time: candles[curr.idx].time,
+          type,
+          kind,
+          firstIdx: prev.idx,
+          secondIdx: curr.idx,
+          price: { first: prev.value, second: curr.value },
+          indicator: { first: prevInd.value, second: currInd.value },
+        });
+      }
     }
   }
 

--- a/packages/core/src/signals/index.ts
+++ b/packages/core/src/signals/index.ts
@@ -46,6 +46,7 @@ export {
 } from "./cross";
 export { cvdDivergence } from "./cvd-divergence";
 export {
+  type DivergenceClass,
   type DivergenceOptions,
   type DivergenceSignal,
   detectDivergence,

--- a/packages/core/src/signals/trade-signal/converters.ts
+++ b/packages/core/src/signals/trade-signal/converters.ts
@@ -66,7 +66,7 @@ export function fromCrossSignal(signal: CrossSignalQuality, entryPrice?: number)
 export function fromDivergenceSignal(signal: DivergenceSignal, entryPrice?: number): TradeSignal {
   const isBullish = signal.type === "bullish";
   return {
-    id: `divergence-${signal.type}-${signal.time}`,
+    id: `divergence-${signal.kind}-${signal.type}-${signal.time}`,
     time: signal.time,
     action: isBullish ? "BUY" : "SELL",
     direction: isBullish ? "LONG" : "SHORT",
@@ -75,7 +75,7 @@ export function fromDivergenceSignal(signal: DivergenceSignal, entryPrice?: numb
     reasons: [
       {
         source: "divergence",
-        name: signal.type,
+        name: `${signal.kind} ${signal.type}`,
         detail: `price ${signal.price.first.toFixed(2)}->${signal.price.second.toFixed(2)}, indicator ${signal.indicator.first.toFixed(2)}->${signal.indicator.second.toFixed(2)}`,
       },
     ],


### PR DESCRIPTION
## Summary

Adds **hidden (continuation) divergence** detection to `detectDivergence()`, complementing the existing regular (reversal) divergence. Hidden divergence flags trend-continuation setups during pullbacks, where regular divergence flags reversals.

| Class | Pivot | Price | Indicator | Meaning |
|---|---|---|---|---|
| Regular bullish | trough | lower low | higher low | reversal up |
| **Hidden bullish** | trough | **higher low** | **lower low** | continuation up |
| Regular bearish | peak | higher high | lower high | reversal down |
| **Hidden bearish** | peak | **lower high** | **higher high** | continuation down |

## API

- New `DivergenceOptions.kinds: ("regular" | "hidden")[]`, defaulting to `["regular"]` — **fully backward compatible**. Pass `["regular", "hidden"]` or `["hidden"]` to opt in.
- New `DivergenceSignal.kind: "regular" | "hidden"` field, orthogonal to the existing directional `type` (`"bullish" | "bearish"`).
- New `DivergenceClass` type export.
- The `obvDivergence` / `rsiDivergence` / `macdDivergence` / `cvdDivergence` wrappers forward the option unchanged.
- `fromDivergenceSignal()` now includes `kind` in the trade signal's `id` and reason name, so a regular and hidden signal of the same direction/time no longer collide.

## Design

- The two previously hardcoded reversal loops are generalized into a direction-table-driven scan (`directions[kind][type] → { priceHigher, indHigher }`), so regular and hidden share one code path and differ only in the two move directions.
- Hidden vs. regular is the mirror of those two booleans; the table makes all four (kind × type) combinations explicit and co-located.

## Out of scope

- The streaming/incremental divergence detector (`streaming/signals/divergence.ts`) uses a different buffer-halves algorithm and has no `kind` field; it remains regular-only here and can follow separately.

## Testing

- 5 new deterministic tests with hand-constructed strict-pivot fixtures: hidden bullish, hidden bearish, regular-only does not surface hidden patterns, default signals are tagged `kind: "regular"`, and the union request behaves.
- Full core suite: **6207 passed**. `tsc --noEmit` clean, lint clean, build clean.