### PR TITLE
feat(core): add K-means multi-restart to S/R zone clustering

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Added — S/R zone clustering multi-restart
+
+- **`srZones()` / `srZonesSeries()` accept a `restarts` option** (default `1`):
+  K-means is only locally optimal, so the clustering can settle in a worse
+  arrangement depending on its initialization. With `restarts > 1` the algorithm
+  runs that many initializations and keeps the lowest-inertia (within-cluster sum
+  of squares) result. Restart 0 always uses the existing deterministic
+  k-means++ seeding, so `restarts: 1` reproduces previous results exactly and any
+  higher value can only match or improve on them — never degrade.
+- Extra restarts use randomized D²-weighted k-means++ seeding driven by a seeded
+  PRNG, controlled by the new `seed` option (default `42`); results stay fully
+  deterministic for a given seed.
+
 ### Added — hidden (continuation) divergence
 
 - **`detectDivergence()` now detects hidden divergence** in addition to regular

--- a/packages/core/src/indicators/__tests__/sr-zones.test.ts
+++ b/packages/core/src/indicators/__tests__/sr-zones.test.ts
@@ -180,3 +180,70 @@ describe("srZones", () => {
     }
   });
 });
+
+describe("srZones multi-restart", () => {
+  // Cluster only a known set of custom levels (all other sources disabled), so
+  // the K-means inertia can be recomputed from the returned zone centroids.
+  const levels = [10, 11, 12, 40, 41, 42, 43, 70, 71, 72, 95];
+  const candles = makeSwingCandles();
+  const baseOptions = {
+    includeSwingPoints: false,
+    includePivotPoints: false,
+    includeVwap: false,
+    includeVolumeProfile: false,
+    includeRoundNumbers: false,
+    customLevels: levels,
+    numZones: 3,
+  } as const;
+
+  /** Weighted (here unit-weight) within-cluster sum of squares to nearest centroid. */
+  function inertiaOf(centroids: number[]): number {
+    let sum = 0;
+    for (const p of levels) {
+      let best = Number.POSITIVE_INFINITY;
+      for (const c of centroids) {
+        const d = (p - c) ** 2;
+        if (d < best) best = d;
+      }
+      sum += best;
+    }
+    return sum;
+  }
+
+  it("never produces a worse clustering than a single restart", () => {
+    const single = srZones(candles, { ...baseOptions, restarts: 1 });
+    const many = srZones(candles, { ...baseOptions, restarts: 25 });
+
+    const singleInertia = inertiaOf(single.zones.map((z) => z.price));
+    const manyInertia = inertiaOf(many.zones.map((z) => z.price));
+
+    // Restart 0 is always the deterministic init, so multi-restart keeps the
+    // best of (deterministic, randomized...) and can only match or improve it.
+    expect(manyInertia).toBeLessThanOrEqual(singleInertia + 1e-9);
+  });
+
+  it("is deterministic for a given seed", () => {
+    const a = srZones(candles, { ...baseOptions, restarts: 25, seed: 7 });
+    const b = srZones(candles, { ...baseOptions, restarts: 25, seed: 7 });
+    expect(b.zones).toEqual(a.zones);
+  });
+
+  it("defaults (restarts: 1) reproduce the explicit single-restart result", () => {
+    const implicit = srZones(candles, baseOptions);
+    const explicit = srZones(candles, { ...baseOptions, restarts: 1 });
+    expect(explicit.zones).toEqual(implicit.zones);
+  });
+
+  it("produces finite, well-formed zones with restarts enabled", () => {
+    const { zones } = srZones(candles, { ...baseOptions, restarts: 10 });
+    expect(zones.length).toBeGreaterThan(0);
+    for (const z of zones) {
+      expect(Number.isFinite(z.price)).toBe(true);
+      expect(z.low).toBeLessThanOrEqual(z.high);
+    }
+    // Sorted by strength descending.
+    for (let i = 1; i < zones.length; i++) {
+      expect(zones[i - 1].strength).toBeGreaterThanOrEqual(zones[i].strength);
+    }
+  });
+});

--- a/packages/core/src/indicators/price/sr-zones.ts
+++ b/packages/core/src/indicators/price/sr-zones.ts
@@ -10,6 +10,7 @@
  */
 
 import { isNormalized, normalizeCandles } from "../../core/normalize";
+import { mulberry32 } from "../../core/random";
 import { tagSeries } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, Series } from "../../types";
 import { volumeProfile } from "../volume/volume-profile";
@@ -68,6 +69,20 @@ export type SrZonesOptions = {
   swingLookback?: number;
   /** Max K-means iterations (default: 50) */
   maxIterations?: number;
+  /**
+   * Number of K-means initializations to try, keeping the lowest-inertia run
+   * (default: 1). K-means is only locally optimal, so a single initialization
+   * can land in a worse clustering; extra restarts make the result more robust.
+   * The first restart always uses the deterministic k-means++ seeding, so the
+   * default (`1`) reproduces the previous behavior exactly, and any higher value
+   * can only match or improve on it.
+   */
+  restarts?: number;
+  /**
+   * Seed for the randomized k-means++ seeding used by restarts beyond the first
+   * (default: 42). Results are fully deterministic for a given seed.
+   */
+  seed?: number;
 };
 
 /** Result of S/R zone detection. */
@@ -198,8 +213,26 @@ interface KMeansInput {
 }
 
 /**
- * K-means++ initialization: pick first center at random (deterministic: use
- * median), then pick subsequent centers proportional to squared distance.
+ * The k-means++ D² term: for each point, the squared distance to its nearest
+ * already-chosen center, weighted by the point's weight. Shared by both the
+ * deterministic and randomized seeding variants.
+ */
+function weightedNearestDist2(data: KMeansInput[], centers: number[]): number[] {
+  return data.map((d) => {
+    let minD = Number.POSITIVE_INFINITY;
+    for (const ctr of centers) {
+      const dd = (d.price - ctr) ** 2;
+      if (dd < minD) minD = dd;
+    }
+    return minD * d.weight;
+  });
+}
+
+/**
+ * Deterministic k-means++ initialization: first center is the price-median
+ * point, then each subsequent center is the point with the largest weighted
+ * squared distance from the nearest chosen center (a greedy, reproducible
+ * farthest-point rule).
  */
 function kmeansppInit(data: KMeansInput[], k: number): number[] {
   if (data.length === 0 || k <= 0) return [];
@@ -210,15 +243,7 @@ function kmeansppInit(data: KMeansInput[], k: number): number[] {
   centers.push(sorted[Math.floor(sorted.length / 2)].price);
 
   for (let c = 1; c < k; c++) {
-    // Compute distance² from each point to nearest existing center
-    const dist2: number[] = data.map((d) => {
-      let minD = Number.POSITIVE_INFINITY;
-      for (const ctr of centers) {
-        const dd = (d.price - ctr) ** 2;
-        if (dd < minD) minD = dd;
-      }
-      return minD * d.weight;
-    });
+    const dist2 = weightedNearestDist2(data, centers);
 
     const totalDist = dist2.reduce((s, v) => s + v, 0);
     if (totalDist === 0) {
@@ -242,14 +267,71 @@ function kmeansppInit(data: KMeansInput[], k: number): number[] {
   return centers;
 }
 
-function kmeansCluster(
+/**
+ * Pick an index with probability proportional to `weights`, given a uniform
+ * draw `r` in `[0, sum(weights))`. The caller scales its random number by the
+ * weight total before calling.
+ */
+function weightedPick(weights: number[], r: number): number {
+  let acc = r;
+  for (let i = 0; i < weights.length; i++) {
+    acc -= weights[i];
+    if (acc < 0) return i;
+  }
+  return weights.length - 1;
+}
+
+/**
+ * Randomized k-means++ initialization: the canonical D²-weighted seeding. The
+ * first center is sampled proportional to point weight, and each subsequent
+ * center proportional to its weighted squared distance from the nearest chosen
+ * center. Used for the extra restarts so they explore different starts than the
+ * deterministic {@link kmeansppInit}.
+ */
+function kmeansppInitSeeded(data: KMeansInput[], k: number, rng: () => number): number[] {
+  if (data.length === 0 || k <= 0) return [];
+  const centers: number[] = [];
+
+  // First center: sample proportional to weight.
+  const weights = data.map((d) => d.weight);
+  const totalWeight = weights.reduce((s, v) => s + v, 0);
+  centers.push(
+    totalWeight > 0 ? data[weightedPick(weights, rng() * totalWeight)].price : data[0].price,
+  );
+
+  for (let c = 1; c < k; c++) {
+    const dist2 = weightedNearestDist2(data, centers);
+
+    const totalDist = dist2.reduce((s, v) => s + v, 0);
+    if (totalDist === 0) {
+      // All remaining points coincide with existing centers; duplicate last.
+      centers.push(centers[centers.length - 1]);
+      continue;
+    }
+    centers.push(data[weightedPick(dist2, rng() * totalDist)].price);
+  }
+
+  return centers;
+}
+
+/** Weighted within-cluster sum of squares (the k-means objective). */
+function computeInertia(data: KMeansInput[], centers: number[], assignments: number[]): number {
+  let inertia = 0;
+  for (let i = 0; i < data.length; i++) {
+    const d = data[i].price - centers[assignments[i]];
+    inertia += data[i].weight * d * d;
+  }
+  return inertia;
+}
+
+/** Run Lloyd's algorithm to convergence from a fixed set of initial centers. */
+function runKmeans(
   data: KMeansInput[],
-  k: number,
+  effectiveK: number,
   maxIter: number,
+  initCenters: number[],
 ): { centers: number[]; assignments: number[] } {
-  if (data.length === 0) return { centers: [], assignments: [] };
-  const effectiveK = Math.min(k, data.length);
-  let centers = kmeansppInit(data, effectiveK);
+  let centers = initCenters;
   let assignments = new Array<number>(data.length).fill(0);
 
   for (let iter = 0; iter < maxIter; iter++) {
@@ -300,6 +382,46 @@ function kmeansCluster(
   return { centers, assignments };
 }
 
+/**
+ * Cluster the price levels with K-means, optionally retrying from several
+ * initializations and keeping the lowest-inertia result. Restart 0 always uses
+ * the deterministic {@link kmeansppInit} (so `restarts === 1` matches the prior
+ * behavior); restarts 1..n use seeded randomized k-means++.
+ */
+function kmeansCluster(
+  data: KMeansInput[],
+  k: number,
+  maxIter: number,
+  restarts: number,
+  seed: number,
+): { centers: number[]; assignments: number[] } {
+  if (data.length === 0) return { centers: [], assignments: [] };
+  const effectiveK = Math.min(k, data.length);
+
+  // Restart 0: deterministic init (so restarts === 1 matches prior behavior).
+  let best = runKmeans(data, effectiveK, maxIter, kmeansppInit(data, effectiveK));
+  if (restarts <= 1) return best;
+
+  // Extra restarts: seeded randomized k-means++; keep the lowest-inertia run.
+  let bestInertia = computeInertia(data, best.centers, best.assignments);
+  const rng = mulberry32(seed);
+  for (let r = 1; r < restarts; r++) {
+    const candidate = runKmeans(
+      data,
+      effectiveK,
+      maxIter,
+      kmeansppInitSeeded(data, effectiveK, rng),
+    );
+    const inertia = computeInertia(data, candidate.centers, candidate.assignments);
+    if (inertia < bestInertia) {
+      best = candidate;
+      bestInertia = inertia;
+    }
+  }
+
+  return best;
+}
+
 // ---------------------------------------------------------------------------
 // Main functions
 // ---------------------------------------------------------------------------
@@ -341,6 +463,8 @@ export function srZones(
     customLevels,
     swingLookback = 5,
     maxIterations = 50,
+    restarts = 1,
+    seed = 42,
   } = options;
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
@@ -386,7 +510,7 @@ export function srZones(
 
   const k = numZones ?? Math.min(Math.max(3, Math.floor(rawLevels.length / 3)), 15);
 
-  const { centers, assignments } = kmeansCluster(kInput, k, maxIterations);
+  const { centers, assignments } = kmeansCluster(kInput, k, maxIterations, restarts, seed);
 
   // 3. Build zones from clusters
   const atrValue = simpleAtr(normalized);


### PR DESCRIPTION
## Summary

`srZones()` / `srZonesSeries()` now accept a **`restarts`** option to run K-means from several initializations and keep the lowest-inertia (within-cluster sum of squares) result. K-means is only locally optimal, so a single initialization can settle in a worse clustering; multiple restarts make the result robust against that.

This follows the standard `n_init` convention: run N initializations, keep the best by inertia.

## API

- **`SrZonesOptions.restarts`** (default `1`): number of K-means initializations to try.
  - Restart 0 always uses the existing **deterministic** k-means++ seeding, so `restarts: 1` reproduces previous results **bit-for-bit**, and any higher value can only match or improve the inertia — never degrade it.
  - Restarts 1..n use **seeded randomized D²-weighted k-means++**.
- **`SrZonesOptions.seed`** (default `42`): seed for the randomized restarts. Results are fully deterministic for a given seed.
- `srZonesSeries()` forwards both options unchanged (it calls `srZones` per window).

## Implementation notes

- Adds a seeded PRNG-driven init (`mulberry32` from the shared `core/random`), a weighted index sampler, and an inertia (weighted WCSS) computation.
- The shared D² distance term is extracted into one helper used by both the deterministic and randomized seeding paths.
- Inertia is only computed when `restarts > 1`, so the default path does no extra work.

## Scope / honest note

On cleanly separated data the deterministic farthest-point seeding already finds the optimal clustering, so restarts yield no change there. The value is robustness on ambiguous/overlapping level sets and exposing the standard reproducible `n_init`/seed controls — with a guarantee the result is never worse than before.

## Testing

- 4 new tests: multi-restart never worsens inertia vs. a single restart (recomputed externally from returned centroids), determinism for a fixed seed, `restarts: 1` equals the implicit default, and well-formed finite zones with restarts enabled.
- Full core suite: **6211 passed**. `tsc --noEmit` clean, lint clean, build clean.