### PR TITLE
feat(core): add warmup detection helpers for indicator series

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+### Added — warmup detection helpers
+
+- **`firstValidIndex(series)` / `warmupBars(series)` / `trimWarmup(series)`** —
+  series utilities that report (or strip) an indicator's warmup region by reading
+  the actual output: the index of the first valid value, the count of leading
+  warmup placeholders, and the series with that region removed. The TrendCraft
+  analogue of TA-Lib's `*_Lookback()`, but derived from the output rather than a
+  hand-maintained per-indicator formula, so it stays correct for option-dependent
+  warmups (e.g. `sma({ period })`) without drifting from the implementations.
+- For scalar `number | null` series (moving averages, RSI, ATR, …) a warmup bar
+  is simply `null`/non-finite, which is the default. Object-valued outputs have
+  no reliable generic warmup rule — a null field can mean "warming up" (Bollinger
+  Bands) or a normal state (`swingPoints` between swings), and some use non-null
+  sentinels while warming up — so the typed overloads **require an explicit
+  validity predicate** for non-scalar series (e.g.
+  `firstValidIndex(macd(c), (v) => v.macd !== null)`), making the per-indicator
+  semantics the caller's choice instead of an unsafe guess.
+
 ### Added — S/R zone clustering multi-restart
 
 - **`srZones()` / `srZonesSeries()` accept a `restarts` option** (default `1`):

--- a/packages/core/src/__tests__/utils-series.test.ts
+++ b/packages/core/src/__tests__/utils-series.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it } from "vitest";
-import type { Series } from "../types";
-import { alignSeries, filterSeries, mapSeries, zipSeries } from "../utils/series";
+import { macd } from "../indicators/momentum/macd";
+import { rsi } from "../indicators/momentum/rsi";
+import { ema } from "../indicators/moving-average/ema";
+import { sma } from "../indicators/moving-average/sma";
+import { swingPoints } from "../indicators/price/swing-points";
+import { atr } from "../indicators/volatility/atr";
+import { bollingerBands } from "../indicators/volatility/bollinger-bands";
+import type { NormalizedCandle, Series } from "../types";
+import {
+  alignSeries,
+  filterSeries,
+  firstValidIndex,
+  mapSeries,
+  trimWarmup,
+  warmupBars,
+  zipSeries,
+} from "../utils/series";
 
 describe("zipSeries", () => {
   it("should merge two series by aligned timestamps", () => {
@@ -150,5 +165,124 @@ describe("alignSeries", () => {
       { time: 1, value: null },
       { time: 2, value: null },
     ]);
+  });
+});
+
+describe("warmup detection", () => {
+  // 60 candles with a varied (non-flat) price so momentum indicators warm up.
+  const candles: NormalizedCandle[] = Array.from({ length: 60 }, (_, i) => {
+    const close = 100 + Math.sin(i / 5) * 10;
+    return {
+      time: 1700000000 + i * 86400,
+      open: close,
+      high: close + 1,
+      low: close - 1,
+      close,
+      volume: 1000,
+    };
+  });
+
+  describe("firstValidIndex", () => {
+    it("matches the known warmup of period-based indicators (scalar output)", () => {
+      expect(firstValidIndex(sma(candles, { period: 3 }))).toBe(2); // period - 1
+      expect(firstValidIndex(sma(candles, { period: 20 }))).toBe(19);
+      expect(firstValidIndex(ema(candles, { period: 3 }))).toBe(2);
+      expect(firstValidIndex(rsi(candles, { period: 14 }))).toBe(14);
+      expect(firstValidIndex(atr(candles, { period: 14 }))).toBe(14);
+    });
+
+    it("resolves an object-valued indicator's warmup via a field predicate", () => {
+      const bb = bollingerBands(candles, { period: 20 });
+      // Name the basis (middle) band as the marker of a real value.
+      const idx = firstValidIndex(bb, (v) => v.middle !== null);
+      expect(idx).toBe(19); // period - 1, same as the underlying SMA
+      expect(bb[idx - 1].value.middle).toBeNull();
+      expect(bb[idx].value.middle).not.toBeNull();
+    });
+
+    it("lets the predicate choose which component defines validity (MACD)", () => {
+      const m = macd(candles);
+      // The MACD line warms up before the signal line, so requiring the signal
+      // too pushes the warmup boundary later.
+      const lineIdx = firstValidIndex(m, (v) => v.macd !== null);
+      const fullIdx = firstValidIndex(m, (v) => v.macd !== null && v.signal !== null);
+      expect(m[lineIdx].value.macd).not.toBeNull();
+      expect(fullIdx).toBeGreaterThan(lineIdx);
+    });
+
+    it("handles event-style outputs with semantic nulls via a predicate", () => {
+      // swingPoints emits boolean flags from the first bar; swingHighPrice /
+      // swingLowPrice stay null until a swing prints. There is no generic rule
+      // for this — the caller names what a real value means.
+      const sp = swingPoints(candles, { leftBars: 2, rightBars: 2 });
+      // "Any output at all" — emitted from the first bar.
+      expect(firstValidIndex(sp, () => true)).toBe(0);
+      // "First actual swing" — a later, data-driven bar.
+      const firstSwing = firstValidIndex(sp, (v) => v.isSwingHigh || v.isSwingLow);
+      expect(firstSwing).toBeGreaterThan(0);
+    });
+
+    it("requires an explicit predicate for object-valued series (compile-time)", () => {
+      // Object value cannot use the scalar default; omitting the predicate is a
+      // type error, which prevents silently-wrong warmup for these shapes.
+      const guard = () =>
+        // @ts-expect-error object-valued series requires a validity predicate
+        firstValidIndex(bollingerBands(candles, { period: 20 }));
+      expect(typeof guard).toBe("function");
+    });
+
+    it("returns -1 when nothing is ever valid", () => {
+      const allNull: Series<number | null> = [
+        { time: 1, value: null },
+        { time: 2, value: null },
+      ];
+      expect(firstValidIndex(allNull)).toBe(-1);
+    });
+
+    it("treats NaN and Infinity as warmup placeholders", () => {
+      const s: Series<number> = [
+        { time: 1, value: Number.NaN },
+        { time: 2, value: Number.POSITIVE_INFINITY },
+        { time: 3, value: 42 },
+      ];
+      expect(firstValidIndex(s)).toBe(2);
+    });
+  });
+
+  describe("warmupBars", () => {
+    it("counts the leading warmup region", () => {
+      expect(warmupBars(sma(candles, { period: 20 }))).toBe(19);
+    });
+
+    it("equals the series length when the indicator never warms up", () => {
+      const short = candles.slice(0, 5);
+      const s = sma(short, { period: 20 });
+      expect(warmupBars(s)).toBe(s.length);
+    });
+  });
+
+  describe("trimWarmup", () => {
+    it("drops the warmup region and keeps valid bars", () => {
+      const s = sma(candles, { period: 20 });
+      const trimmed = trimWarmup(s);
+      expect(trimmed).toHaveLength(s.length - 19);
+      expect(trimmed[0].value).not.toBeNull();
+      expect(trimmed[0].time).toBe(s[19].time);
+    });
+
+    it("returns an empty series when nothing is valid", () => {
+      const s = sma(candles.slice(0, 5), { period: 20 });
+      expect(trimWarmup(s)).toEqual([]);
+    });
+
+    it("preserves the element type of a non-null numeric series (compile-time)", () => {
+      const s: Series<number> = [
+        { time: 1, value: 1 },
+        { time: 2, value: 2 },
+      ];
+      // Must stay Series<number>, not widen to Series<number | null>.
+      const trimmed: Series<number> = trimWarmup(s);
+      expect(trimmed).toHaveLength(2);
+    });
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1426,8 +1426,11 @@ export {
   alignAndNormalize,
   alignSeries,
   filterSeries,
+  firstValidIndex,
   mapSeries,
   normalizeToPercent,
+  trimWarmup,
+  warmupBars,
   zipSeries,
 } from "./utils/series";
 export type {

--- a/packages/core/src/utils/series.ts
+++ b/packages/core/src/utils/series.ts
@@ -7,6 +7,103 @@
 
 import type { Series } from "../types";
 
+// ---------------------------------------------------------------------------
+// Warmup detection
+//
+// TrendCraft indicators emit a value for every input candle, using `null`
+// during the warmup region before the indicator has seen enough data. These
+// helpers report (or strip) that region by reading the actual output, rather
+// than a hand-maintained per-indicator lookback formula that would duplicate
+// the logic inside each indicator and drift from it.
+//
+// For scalar `number | null` series — the large majority of indicators (moving
+// averages, RSI, ATR, ROC, …) — a warmup bar is unambiguously `null` (or a
+// non-finite number), and that is the default test. For object-valued outputs
+// there is NO reliable generic rule: a `null` field can mean "still warming up"
+// (Bollinger Bands) OR a normal post-warmup state (`swingPoints` leaves
+// `swingHighPrice` null between swings), and some indicators even use non-null
+// sentinels while warming up (Supertrend emits `direction: 0`). Only the
+// indicator's own semantics can resolve this, so the overloads below REQUIRE an
+// explicit validity predicate for non-scalar series — the caller names the field
+// that marks a real value (e.g. `(v) => v.macd !== null`).
+//
+// These read warmup from a computed series; they do not give an a-priori bar
+// count without first running the indicator.
+// ---------------------------------------------------------------------------
+
+/** Default validity for scalar series: a finite, non-null number. */
+const isFiniteNumber = (value: unknown): boolean =>
+  typeof value === "number" && Number.isFinite(value);
+
+/**
+ * Index of the first valid (non-warmup) value in a series, or `-1` if every
+ * value is a warmup placeholder. The TrendCraft analogue of TA-Lib's
+ * `*_Lookback()`, but read from the actual output so it never drifts from the
+ * indicator implementation.
+ *
+ * Scalar (`number | null`) series use the default test (a finite number).
+ * Object-valued series must supply `isValid` naming what counts as a real value.
+ *
+ * @example
+ * ```ts
+ * import { sma, macd, firstValidIndex } from "trendcraft";
+ *
+ * firstValidIndex(sma(candles, { period: 20 })); // 19 — valid from period - 1
+ * // Object output: name the field(s) that mark a real value.
+ * firstValidIndex(macd(candles), (v) => v.macd !== null);
+ * ```
+ */
+export function firstValidIndex(series: Series<number | null>): number;
+export function firstValidIndex<T>(series: Series<T>, isValid: (value: T) => boolean): number;
+export function firstValidIndex<T>(
+  series: Series<T>,
+  isValid: (value: T) => boolean = isFiniteNumber,
+): number {
+  for (let i = 0; i < series.length; i++) {
+    if (isValid(series[i].value)) return i;
+  }
+  return -1;
+}
+
+/**
+ * Number of leading warmup bars in a series — the count of placeholder values
+ * before the first valid one. Equals {@link firstValidIndex} when a valid value
+ * exists, or the full series length when the indicator never warms up on this
+ * data (too few bars). See {@link firstValidIndex} for the scalar-vs-object rule.
+ *
+ * @example
+ * ```ts
+ * import { rsi, warmupBars } from "trendcraft";
+ *
+ * warmupBars(rsi(candles, { period: 14 })); // 14
+ * ```
+ */
+export function warmupBars(series: Series<number | null>): number;
+export function warmupBars<T>(series: Series<T>, isValid: (value: T) => boolean): number;
+export function warmupBars<T>(
+  series: Series<T>,
+  isValid: (value: T) => boolean = isFiniteNumber,
+): number {
+  const idx = firstValidIndex(series, isValid);
+  return idx === -1 ? series.length : idx;
+}
+
+/**
+ * Drop the leading warmup region, returning the series from its first valid
+ * value onward (empty if the indicator never warms up). Useful when feeding
+ * indicator output into logic that should not see warmup placeholders, such as
+ * per-bar screening. See {@link firstValidIndex} for the scalar-vs-object rule.
+ */
+export function trimWarmup<V extends number | null>(series: Series<V>): Series<V>;
+export function trimWarmup<T>(series: Series<T>, isValid: (value: T) => boolean): Series<T>;
+export function trimWarmup<T>(
+  series: Series<T>,
+  isValid: (value: T) => boolean = isFiniteNumber,
+): Series<T> {
+  const idx = firstValidIndex(series, isValid);
+  return idx === -1 ? [] : series.slice(idx);
+}
+
 /**
  * Combine two series by aligning on timestamp and applying a merge function.
  * Only produces output for timestamps that exist in both series.


### PR DESCRIPTION
## Summary

Adds three series utilities that report or strip an indicator's **warmup region** — the leading bars before it produces a real value — by reading the indicator's actual output:

- **`firstValidIndex(series)`** — index of the first valid (non-warmup) value, or `-1` if none.
- **`warmupBars(series)`** — count of leading warmup placeholders (or the full length if the indicator never warms up on the given data).
- **`trimWarmup(series)`** — the series with the warmup region removed.

This is the TrendCraft analogue of TA-Lib's `*_Lookback()`, but derived from the output rather than a hand-maintained per-indicator formula. A static formula registry would duplicate the lookback logic already inside each indicator and drift from it; reading the output keeps the answer correct for option-dependent warmups (e.g. `sma({ period })`) for free.

## Scalar vs. object-valued series

- **Scalar `number | null` series** (moving averages, RSI, ATR, ROC, …): a warmup bar is unambiguously `null`/non-finite. This is the default — no predicate needed.
- **Object-valued outputs**: there is no reliable generic warmup rule. A null field can mean "still warming up" (Bollinger Bands' all-null placeholder) **or** a normal post-warmup state (`swingPoints` leaves `swingHighPrice` null between swings), and some indicators emit non-null sentinels while warming up (Supertrend's `direction: 0`). Only the indicator's own semantics resolve this, so the **typed overloads require an explicit validity predicate** for non-scalar series — the caller names the field that marks a real value:

```ts
firstValidIndex(macd(candles), (v) => v.macd !== null);
```

Requiring the predicate via the type system (rather than guessing from field contents) makes silently-wrong warmup impossible for these shapes.

`trimWarmup` preserves the element type (`Series<number>` stays `Series<number>`, not widened to `Series<number | null>`).

## Testing

- 13 new tests: scalar warmup matches the known lookback of SMA/EMA/RSI/ATR; object-valued indicators resolved via field predicates (Bollinger, MACD line vs. signal); event-style outputs with semantic nulls (swingPoints); NaN/Infinity treated as warmup; empty/never-valid cases; and two compile-time guards (object series rejected without a predicate; `Series<number>` element type preserved).
- Full core suite: **6223 passed**. `tsc --noEmit` clean, lint clean, build clean.