### PR TITLE
feat(core): add time-series stock screening (screenStockSeries)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Added — time-series screening
+
+- **`screenStockSeries(ticker, candles, criteria)`** — screens a stock across
+  every bar of its history, returning the entry/exit signal as of each bar,
+  rather than only the latest bar like `screenStock`. Useful for finding *when* a
+  stock first matched a screen, backtesting a screen, or screening as of a past
+  date (`result.points[i]`). Returns `{ ticker, points }` with one
+  `ScreeningSeriesPoint` (`index`, `time`, `close`, `entrySignal`, `exitSignal`)
+  per candle.
+- It evaluates each bar with the same per-bar condition evaluator the backtest
+  engine uses, so its latest-bar result matches `screenStock` and its per-bar
+  results match what a backtest sees. Indicators are computed once over the full
+  series; as with backtesting, that is point-in-time correct for causal
+  indicators but can look ahead near the right edge for non-causal ones
+  (forward-displaced Ichimoku spans, swing points that need future bars).
+
 ### Added — warmup detection helpers
 
 - **`firstValidIndex(series)` / `warmupBars(series)` / `trimWarmup(series)`** —

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -793,6 +793,7 @@ export {
   getAvailableConditions,
   screenStock,
   screenStockSafe,
+  screenStockSeries,
 } from "./screening/screen-stock";
 export type {
   // Candlestick Pattern types
@@ -1340,6 +1341,8 @@ export type {
   ScreeningCriteria,
   ScreeningOptions,
   ScreeningResult,
+  ScreeningSeriesPoint,
+  ScreeningSeriesResult,
   ScreeningSessionResult,
 } from "./screening";
 // Strategy JSON Serialization

--- a/packages/core/src/screening/__tests__/screen-stock.test.ts
+++ b/packages/core/src/screening/__tests__/screen-stock.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
+import { deadCross, goldenCross } from "../../backtest/conditions";
 import type { Condition, NormalizedCandle } from "../../types";
 import {
   CONDITION_PRESETS,
   createCriteriaFromNames,
   getAvailableConditions,
   screenStock,
+  screenStockSeries,
 } from "../screen-stock";
 
 // =============================================================================
@@ -118,6 +120,70 @@ describe("screenStock", () => {
     const candles = createTestCandles(30);
     const result = screenStock("TEST", candles, { entry: alwaysTrue });
     expect(result.timestamp).toBe(candles[candles.length - 1].time);
+  });
+});
+
+// =============================================================================
+// screenStockSeries
+// =============================================================================
+
+describe("screenStockSeries", () => {
+  it("returns one point per candle, echoing the ticker and bar metadata", () => {
+    const candles = createTestCandles(30);
+    const { ticker, points } = screenStockSeries("TEST", candles, { entry: alwaysTrue });
+    expect(ticker).toBe("TEST");
+    expect(points).toHaveLength(candles.length);
+    points.forEach((p, i) => {
+      expect(p.index).toBe(i);
+      expect(p.time).toBe(candles[i].time);
+      expect(p.close).toBe(candles[i].close);
+    });
+  });
+
+  it("evaluates the entry condition at every bar", () => {
+    const candles = createTestCandles(30);
+    expect(
+      screenStockSeries("TEST", candles, { entry: alwaysTrue }).points.every((p) => p.entrySignal),
+    ).toBe(true);
+    expect(
+      screenStockSeries("TEST", candles, { entry: alwaysFalse }).points.some((p) => p.entrySignal),
+    ).toBe(false);
+  });
+
+  it("reflects per-bar data, not just the latest bar", () => {
+    const candles = createTestCandles(30); // close oscillates around 100
+    const aboveHundred: Condition = (_ind, candle) => candle.close > 100;
+    const { points } = screenStockSeries("TEST", candles, { entry: aboveHundred });
+    // Each bar's signal matches that bar's own close, and both states occur.
+    points.forEach((p, i) => {
+      expect(p.entrySignal).toBe(candles[i].close > 100);
+    });
+    expect(points.some((p) => p.entrySignal)).toBe(true);
+    expect(points.some((p) => !p.entrySignal)).toBe(true);
+  });
+
+  it("reports exitSignal=false at every bar when no exit criteria", () => {
+    const candles = createTestCandles(30);
+    const { points } = screenStockSeries("TEST", candles, { entry: alwaysTrue });
+    expect(points.every((p) => p.exitSignal === false)).toBe(true);
+  });
+
+  it("agrees with screenStock on the latest bar (faithful generalization)", () => {
+    const candles = createTestCandles(60);
+    const criteria = { entry: goldenCross(5, 25), exit: deadCross(5, 25) };
+    const series = screenStockSeries("TEST", candles, criteria);
+    const latest = screenStock("TEST", candles, criteria);
+    const last = series.points[series.points.length - 1];
+    expect(last.index).toBe(candles.length - 1);
+    expect(last.entrySignal).toBe(latest.entrySignal);
+    expect(last.exitSignal).toBe(latest.exitSignal);
+  });
+
+  it("returns an empty point list for empty candles", () => {
+    expect(screenStockSeries("TEST", [], { entry: alwaysTrue })).toEqual({
+      ticker: "TEST",
+      points: [],
+    });
   });
 });
 

--- a/packages/core/src/screening/index.ts
+++ b/packages/core/src/screening/index.ts
@@ -41,6 +41,7 @@ export {
   getAvailableConditions,
   screenStock,
   screenStockSafe,
+  screenStockSeries,
 } from "./screen-stock";
 // Node.js-only functions (require fs)
 export { runScreening, runScreeningSafe } from "./screener";
@@ -52,5 +53,7 @@ export type {
   ScreeningCriteria,
   ScreeningOptions,
   ScreeningResult,
+  ScreeningSeriesPoint,
+  ScreeningSeriesResult,
   ScreeningSessionResult,
 } from "./types";

--- a/packages/core/src/screening/screen-stock.ts
+++ b/packages/core/src/screening/screen-stock.ts
@@ -12,7 +12,12 @@ import { calculateAtrPercent } from "../indicators/volatility/atr-filter";
 import { volumeMa } from "../indicators/volume/volume-ma";
 import type { Condition, NormalizedCandle } from "../types";
 import { err, ok, type Result, tcError } from "../types/result";
-import type { ScreeningCriteria, ScreeningResult } from "./types";
+import type {
+  ScreeningCriteria,
+  ScreeningResult,
+  ScreeningSeriesPoint,
+  ScreeningSeriesResult,
+} from "./types";
 
 /**
  * Screen a single stock against criteria
@@ -87,6 +92,67 @@ export function screenStock(
     },
     candles: includeCandles ? candles : undefined,
   };
+}
+
+/**
+ * Screen a single stock across every bar of its history, reporting when the
+ * criteria matched as of each bar — rather than only the latest bar as
+ * {@link screenStock} does. Useful for finding *when* a stock first matched,
+ * backtesting a screen, or screening as of a past date (`result.points[i]`).
+ *
+ * Each bar is evaluated with the same per-bar condition evaluator the backtest
+ * engine uses, so the result is identical to what a backtest would see at that
+ * bar. Like the backtest engine, indicators are computed once over the full
+ * series; this is point-in-time correct for causal indicators (moving averages,
+ * RSI, …) but, for non-causal ones (e.g. Ichimoku's forward-displaced spans,
+ * swing points that need future bars to confirm), a match near the right edge
+ * can reflect data that would not yet have been known live — the same caveat
+ * that applies to backtesting.
+ *
+ * Unlike {@link screenStock}, this does not throw on empty input — it returns an
+ * empty `points` array, since a screen over zero bars is naturally empty.
+ *
+ * @param ticker - Stock ticker symbol
+ * @param candles - Normalized candle data
+ * @param criteria - Entry/exit conditions
+ * @returns Per-bar screen results, one entry per candle
+ *
+ * @example
+ * ```ts
+ * import { screenStockSeries } from "trendcraft/screening";
+ * import { goldenCross, deadCross } from "trendcraft";
+ *
+ * const { points } = screenStockSeries("6758.T", candles, {
+ *   entry: goldenCross(5, 25),
+ *   exit: deadCross(5, 25),
+ * });
+ * const entryBars = points.filter((p) => p.entrySignal);
+ * ```
+ */
+export function screenStockSeries(
+  ticker: string,
+  candles: NormalizedCandle[],
+  criteria: ScreeningCriteria,
+): ScreeningSeriesResult {
+  // One shared indicator cache across all bars, matching the backtest engine:
+  // each indicator is computed once over the full series and read by index.
+  const indicators: Record<string, unknown> = {};
+  const points: ScreeningSeriesPoint[] = [];
+
+  for (let index = 0; index < candles.length; index++) {
+    const candle = candles[index];
+    points.push({
+      index,
+      time: candle.time,
+      close: candle.close,
+      entrySignal: evaluateCondition(criteria.entry, indicators, candle, index, candles),
+      exitSignal: criteria.exit
+        ? evaluateCondition(criteria.exit, indicators, candle, index, candles)
+        : false,
+    });
+  }
+
+  return { ticker, points };
 }
 
 // ============================================

--- a/packages/core/src/screening/types.ts
+++ b/packages/core/src/screening/types.ts
@@ -43,6 +43,32 @@ export type ScreeningResult = {
 };
 
 /**
+ * One bar of a time-series screen — whether the criteria matched as of that bar.
+ */
+export type ScreeningSeriesPoint = {
+  /** Index of this bar in the input candles. */
+  index: number;
+  /** Bar timestamp. */
+  time: number;
+  /** Close price at this bar. */
+  close: number;
+  /** Whether the entry condition matched as of this bar. */
+  entrySignal: boolean;
+  /** Whether the exit condition matched as of this bar (false when no exit criteria). */
+  exitSignal: boolean;
+};
+
+/**
+ * Result of screening a single stock across every bar of its history.
+ */
+export type ScreeningSeriesResult = {
+  /** Stock ticker/identifier. */
+  ticker: string;
+  /** Per-bar screen results, one entry per input candle, in chronological order. */
+  points: ScreeningSeriesPoint[];
+};
+
+/**
  * Screening session options
  */
 export type ScreeningOptions = {


### PR DESCRIPTION
## Summary

Adds **`screenStockSeries(ticker, candles, criteria)`** — screens a stock across **every bar of its history**, returning the entry/exit signal as of each bar, rather than only the latest bar like `screenStock`.

This answers questions the latest-bar screen can't:
- **When** did a stock first match a screen?
- Backtest a screen (which bars would it have flagged?).
- Screen **as of a past date** (`result.points[i]`).

## API

- **`screenStockSeries(ticker, candles, criteria): ScreeningSeriesResult`**
  - Returns `{ ticker, points }`, one `ScreeningSeriesPoint` per candle.
  - **`ScreeningSeriesPoint`** = `{ index, time, close, entrySignal, exitSignal }`.
  - Takes the same `ScreeningCriteria` (`{ entry, exit? }`) as `screenStock`, so existing conditions work unchanged.
  - Unlike `screenStock`, does not throw on empty input — returns an empty `points` array.

## Implementation

- **Reuses the same per-bar `evaluateCondition` the backtest engine uses** — no new evaluation path. The latest-bar result therefore matches `screenStock`, and the per-bar results match what a backtest sees at each bar (single source of truth).
- Indicators are computed once over the full series (shared cache across bars, like the engine), so evaluation is O(n) total.
- **Point-in-time note:** as with backtesting, this is point-in-time correct for causal indicators (moving averages, RSI, …) but can look ahead near the right edge for non-causal ones (forward-displaced Ichimoku spans, swing points that need future bars). Documented on the function.

## Testing

- 6 new tests: one point per candle with correct bar metadata; entry evaluated at every bar; per-bar signals reflect each bar's own data (not just the latest); `exitSignal` false without exit criteria; **agrees with `screenStock` on the latest bar** (faithful generalization); empty candles → empty points.
- Full core suite: **6229 passed**. `tsc --noEmit` clean, lint clean, build clean.