### PR TITLE
fix(core): prevent MTF look-ahead from the forming higher-timeframe bar

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+### Fixed — MTF look-ahead bias (behavior change)
+
+- **Multi-timeframe conditions no longer see the forming higher-timeframe
+  candle.** The base→higher-timeframe index map pointed each base bar at the
+  higher-timeframe candle *containing* it, but a resampled candle carries the
+  whole period's OHLC (built from bars still in the future relative to a base bar
+  mid-period), so e.g. on Monday a `weekly` condition could already read that
+  week's Friday close. The map now points at the last **closed** higher-timeframe
+  candle (`-1` until one has closed), matching the established convention that a
+  higher-timeframe bar becomes visible only after it closes.
+- This is a correctness fix that **changes existing MTF backtest results**: MTF
+  conditions (`weeklyRsiAbove`, `mtfPriceAboveSma`, `mtfUptrend`, …) now evaluate
+  against the prior completed higher-timeframe bar and return `false` early in
+  the series until the first higher-timeframe bar has closed. `getMtfCandle` /
+  `getCurrentMtfIndicatorValue` return `null` during that initial window.
+- Streaming MTF (`createStreamingMtf`) was already correct — it only feeds closed
+  candles to indicators and builds the in-progress bar incrementally from bars
+  already seen — and is unchanged.
+
 ### Added — time-series screening
 
 - **`screenStockSeries(ticker, candles, criteria)`** — screens a stock across

--- a/packages/core/src/core/__tests__/mtf-context.test.ts
+++ b/packages/core/src/core/__tests__/mtf-context.test.ts
@@ -188,6 +188,55 @@ describe("updateMtfIndices", () => {
   });
 });
 
+describe("MTF look-ahead prevention", () => {
+  // Two trading weeks, Mon-Fri (2024-01-01 is a Monday). Distinct weekly
+  // closes so a leak is unmistakable: week 1 closes at 15, week 2 at 25.
+  function week(mondayIso: string, closes: number[]): NormalizedCandle[] {
+    const start = Date.parse(`${mondayIso}T00:00:00Z`);
+    const MS_PER_DAY = 86400000;
+    return closes.map((close, i) => ({
+      time: start + i * MS_PER_DAY,
+      open: close,
+      high: close + 0.5,
+      low: close - 0.5,
+      close,
+      volume: 1000,
+    }));
+  }
+
+  const candles = [
+    ...week("2024-01-01", [11, 12, 13, 14, 15]),
+    ...week("2024-01-08", [21, 22, 23, 24, 25]),
+  ];
+
+  it("exposes only the last closed higher-timeframe candle, never the forming one", () => {
+    const context = createMtfContext(candles, ["1w"]);
+    const indexMap = buildMtfIndexMap(candles, context);
+
+    const visibleCloses = candles.map((c, i) => {
+      updateMtfIndices(context, indexMap, i, c.time);
+      return getMtfCandle(context, "1w")?.close ?? null;
+    });
+
+    // Week 1 (indices 0-4): no week has closed yet -> null. Critically NOT 15
+    // (week 1's own Friday close), which the forming weekly bar already knows.
+    expect(visibleCloses.slice(0, 5)).toEqual([null, null, null, null, null]);
+    // Week 2 (indices 5-9): the only closed week is week 1 -> 15. Never 25
+    // (week 2's own close), which lies in the future during week 2.
+    expect(visibleCloses.slice(5, 10)).toEqual([15, 15, 15, 15, 15]);
+  });
+
+  it("returns null from value getters while no higher-timeframe candle has closed", () => {
+    const context = createMtfContext(candles, ["1w"]);
+    const indexMap = buildMtfIndexMap(candles, context);
+
+    // First bar of the dataset: no closed weekly candle exists yet.
+    updateMtfIndices(context, indexMap, 0, candles[0].time);
+    expect(getMtfCandle(context, "1w")).toBeNull();
+    expect(context.indices.get("1w")).toBe(-1);
+  });
+});
+
 describe("getMtfCandle", () => {
   it("should retrieve candle for specified timeframe", () => {
     const startDate = new Date("2024-01-01");

--- a/packages/core/src/core/mtf-context.ts
+++ b/packages/core/src/core/mtf-context.ts
@@ -41,7 +41,9 @@ export function createMtfContext(
       candles: resampled,
       indicators: {},
     });
-    indices.set(tf, 0);
+    // -1 = no higher-timeframe candle has closed yet (set per bar by
+    // updateMtfIndices during iteration).
+    indices.set(tf, -1);
   }
 
   return {
@@ -71,21 +73,26 @@ export function buildMtfIndexMap(
     const higherCandles = dataset.candles;
     const indices: number[] = [];
 
-    let higherIdx = 0;
+    let containingIdx = 0;
 
     for (let baseIdx = 0; baseIdx < baseCandles.length; baseIdx++) {
       const baseTime = baseCandles[baseIdx].time;
 
-      // Find the higher timeframe candle that contains this base candle
-      // Move forward until we find a candle that starts after the base candle
+      // Advance to the higher-timeframe candle that CONTAINS this base candle:
+      // the last one whose period has started at or before the base bar.
       while (
-        higherIdx < higherCandles.length - 1 &&
-        higherCandles[higherIdx + 1].time <= baseTime
+        containingIdx < higherCandles.length - 1 &&
+        higherCandles[containingIdx + 1].time <= baseTime
       ) {
-        higherIdx++;
+        containingIdx++;
       }
 
-      indices.push(higherIdx);
+      // Expose only the last CLOSED higher-timeframe candle. The containing
+      // candle's period has not ended yet at this base bar, so its OHLC (built
+      // from the whole period, including bars still in the future) would leak
+      // look-ahead information. Point one bar back instead; -1 means no
+      // higher-timeframe candle has closed yet.
+      indices.push(containingIdx - 1);
     }
 
     indexMap.set(tf, indices);
@@ -133,7 +140,8 @@ export function getMtfCandle(
   const dataset = mtfContext.datasets.get(timeframe);
   const index = mtfContext.indices.get(timeframe);
 
-  if (!dataset || index === undefined) {
+  // index < 0 means no higher-timeframe candle has closed yet at this bar.
+  if (!dataset || index === undefined || index < 0) {
     return null;
   }
 
@@ -195,7 +203,8 @@ export function getCurrentMtfIndicatorValue<T>(
   const dataset = mtfContext.datasets.get(timeframe);
   const index = mtfContext.indices.get(timeframe);
 
-  if (!dataset || index === undefined) {
+  // index < 0 means no higher-timeframe candle has closed yet at this bar.
+  if (!dataset || index === undefined || index < 0) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Fixes a **look-ahead bias** in multi-timeframe (MTF) condition evaluation. The base→higher-timeframe index map pointed each base bar at the higher-timeframe candle **containing** it — but a resampled candle carries the whole period's OHLC, assembled from bars that are still in the future relative to a base bar mid-period. So a `weekly` condition evaluated on Monday could already read that week's Friday close.

The map now points at the **last closed** higher-timeframe candle (`-1` until one has closed), matching the standard convention that a higher-timeframe bar becomes visible only after it closes.

## Demonstration

Two trading weeks (week 1 closes at 15, week 2 at 25). Before the fix, the visible weekly close on the first day of each week was already that week's final close:

| Base day | Before (visible weekly close) | After |
|---|---|---|
| Mon–Fri week 1 | **15** (week 1's own Friday close) | `null` (no week closed yet) |
| Mon–Fri week 2 | **25** (week 2's own Friday close) | **15** (week 1, the last closed week) |

## Changes

- `buildMtfIndexMap` exposes `containingIdx - 1` (last closed higher-TF candle).
- `getMtfCandle` / `getCurrentMtfIndicatorValue` return `null` for `index < 0` (the initial window before any higher-TF candle has closed).
- `createMtfContext` initializes indices to `-1`.

The fix lives in the single place that maps base→higher-timeframe indices, so all MTF preset conditions (`weeklyRsiAbove`, `mtfPriceAboveSma`, `mtfUptrend`, …), the backtest engine, and the fluent `withMtf()` API inherit it automatically.

## Behavior change

This **changes existing MTF backtest results**: MTF conditions now evaluate against the prior completed higher-timeframe bar, and return `false` early in the series until the first higher-timeframe bar has closed. Under 0.x this ships as a fix in a minor release.

Streaming MTF (`createStreamingMtf`) was already correct — it only feeds closed candles to indicators and builds the in-progress bar incrementally from bars already seen — and is unchanged.

## Testing

- New regression test asserting no look-ahead: weekly close is `null` during week 1 and the prior week's close (never the current week's) during week 2; getters return `null` while no higher-TF candle has closed.
- The existing MTF suite continues to pass (its assertions did not pin the alignment boundary, which is why the bias went uncaught).
- Full core suite: **6231 passed**. `tsc --noEmit` clean, lint clean, build clean.