### PR TITLE
feat(core): support MTF conditions in stock screening

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+### Added — MTF conditions in screening
+
+- **`screenStock` / `screenStockSafe` / `screenStockSeries` accept an
+  `mtfTimeframes` option** (and `runScreening` via `ScreeningOptions`), so
+  multi-timeframe conditions (`weeklyRsiAbove`, `mtfPriceAboveSma`, `mtfUptrend`,
+  …) can now be used in a screen. Without it, MTF conditions cannot evaluate and
+  resolve to `false` (with a warning), as before.
+- Screening builds the MTF context exactly like the backtest engine — same
+  resampling and same closed-bar alignment — so a screen and a backtest see
+  identical higher-timeframe data. New `ScreenStockOptions` /
+  `ScreenStockSeriesOptions` types are exported.
+- The MTF context now registers each timeframe under all of its interchangeable
+  spellings, so a condition built with an alias (e.g. `weeklyRsiAbove`, which
+  looks up `"weekly"`) resolves against a context requested with the canonical
+  form (`mtfTimeframes: ["1w"]`) and vice versa, instead of silently evaluating
+  `false`. This applies everywhere the shared MTF setup is used (backtest engine,
+  scaled-entry, screening).
+
 ### Fixed — MTF look-ahead bias (behavior change)
 
 - **Multi-timeframe conditions no longer see the forming higher-timeframe

--- a/packages/core/src/backtest/engine.ts
+++ b/packages/core/src/backtest/engine.ts
@@ -6,7 +6,7 @@
 
 import { createFundamentalsMap } from "../core/fundamentals";
 import { createCachedIndicators, type IndicatorCache } from "../core/indicator-cache";
-import { buildMtfIndexMap, createMtfContext, updateMtfIndices } from "../core/mtf-context";
+import { buildMtfSetup, updateMtfIndices } from "../core/mtf-context";
 import { atr } from "../indicators/volatility/atr";
 import type {
   AtrRiskOptions,
@@ -17,7 +17,6 @@ import type {
   ExitReason,
   FillMode,
   FundamentalMetrics,
-  MtfContext,
   NormalizedCandle,
   PositionDirection,
   SlTpMode,
@@ -176,13 +175,9 @@ export function runBacktest(
   const indicators: Record<string, unknown> = createCachedIndicators(candles, cache);
 
   // Setup MTF context if timeframes are specified
-  let mtfContext: MtfContext | undefined;
-  let mtfIndexMap: Map<TimeframeShorthand, number[]> | undefined;
-
-  if (mtfTimeframes && mtfTimeframes.length > 0) {
-    mtfContext = createMtfContext(candles, mtfTimeframes);
-    mtfIndexMap = buildMtfIndexMap(candles, mtfContext);
-  }
+  const mtfSetup = buildMtfSetup(candles, mtfTimeframes);
+  const mtfContext = mtfSetup?.context;
+  const mtfIndexMap = mtfSetup?.indexMap;
 
   // Pre-calculate ATR if ATR risk management, ATR trailing stop, or dynamic slippage is enabled
   const needsAtr = !!(

--- a/packages/core/src/backtest/scaled-entry.ts
+++ b/packages/core/src/backtest/scaled-entry.ts
@@ -6,7 +6,7 @@
  * multiple tranches that are entered based on the configured strategy.
  */
 
-import { buildMtfIndexMap, createMtfContext, updateMtfIndices } from "../core/mtf-context";
+import { buildMtfSetup, updateMtfIndices } from "../core/mtf-context";
 import { atr } from "../indicators/volatility/atr";
 import type {
   AtrRiskOptions,
@@ -15,7 +15,6 @@ import type {
   BacktestSettings,
   Condition,
   FillMode,
-  MtfContext,
   NormalizedCandle,
   ScaledEntryConfig,
   SlTpMode,
@@ -190,13 +189,9 @@ export function runBacktestScaled(
   const indicators: Record<string, unknown> = {};
 
   // Setup MTF context if timeframes are specified
-  let mtfContext: MtfContext | undefined;
-  let mtfIndexMap: Map<TimeframeShorthand, number[]> | undefined;
-
-  if (mtfTimeframes && mtfTimeframes.length > 0) {
-    mtfContext = createMtfContext(candles, mtfTimeframes);
-    mtfIndexMap = buildMtfIndexMap(candles, mtfContext);
-  }
+  const mtfSetup = buildMtfSetup(candles, mtfTimeframes);
+  const mtfContext = mtfSetup?.context;
+  const mtfIndexMap = mtfSetup?.indexMap;
 
   // Pre-calculate ATR if ATR risk management is enabled
   let atrSeries: { time: number; value: number | null }[] | null = null;

--- a/packages/core/src/core/__tests__/mtf-context.test.ts
+++ b/packages/core/src/core/__tests__/mtf-context.test.ts
@@ -237,6 +237,33 @@ describe("MTF look-ahead prevention", () => {
   });
 });
 
+describe("MTF timeframe aliases", () => {
+  // 2 weeks from a Monday so the last bar has a closed weekly candle.
+  const candles = createDailyCandlesFromDate(new Date("2024-01-01"), 14);
+
+  it("resolves alias and canonical spellings to the same dataset", () => {
+    const context = createMtfContext(candles, ["1w"]);
+    // Built under "1w", but a condition asking for "weekly" must still find it.
+    expect(hasMtfTimeframe(context, "weekly")).toBe(true);
+    expect(hasMtfTimeframe(context, "1w")).toBe(true);
+
+    const indexMap = buildMtfIndexMap(candles, context);
+    const last = candles.length - 1;
+    updateMtfIndices(context, indexMap, last, candles[last].time);
+
+    const viaCanonical = getMtfCandle(context, "1w");
+    const viaAlias = getMtfCandle(context, "weekly");
+    expect(viaAlias).not.toBeNull();
+    expect(viaAlias).toEqual(viaCanonical);
+  });
+
+  it("works when built with the alias and queried with the canonical form", () => {
+    const context = createMtfContext(candles, ["weekly"]);
+    expect(hasMtfTimeframe(context, "1w")).toBe(true);
+    expect(hasMtfTimeframe(context, "weekly")).toBe(true);
+  });
+});
+
 describe("getMtfCandle", () => {
   it("should retrieve candle for specified timeframe", () => {
     const startDate = new Date("2024-01-01");

--- a/packages/core/src/core/mtf-context.ts
+++ b/packages/core/src/core/mtf-context.ts
@@ -9,6 +9,23 @@ import type { MtfContext, MtfDataset, NormalizedCandle, TimeframeShorthand } fro
 import { resample } from "./resample";
 
 /**
+ * Interchangeable timeframe spellings. The canonical form is the first member.
+ * Single source of truth for timeframe aliasing, used by both
+ * {@link normalizeTimeframe} and the context builder so a condition that asks
+ * for `"weekly"` finds data registered under `"1w"` and vice versa.
+ */
+const TF_ALIAS_GROUPS: TimeframeShorthand[][] = [
+  ["1d", "daily"],
+  ["1w", "weekly"],
+  ["1M", "monthly"],
+];
+
+/** All interchangeable spellings of a timeframe (e.g. `"1w"` -> `["1w", "weekly"]`). */
+function equivalentTimeframes(tf: TimeframeShorthand): TimeframeShorthand[] {
+  return TF_ALIAS_GROUPS.find((group) => group.includes(tf)) ?? [tf];
+}
+
+/**
  * Create an MTF context from base timeframe candles
  *
  * Generates resampled data for each requested timeframe and builds
@@ -36,14 +53,19 @@ export function createMtfContext(
   // Generate resampled data for each timeframe
   for (const tf of timeframes) {
     const resampled = resample(baseCandles, tf);
-    datasets.set(tf, {
+    const dataset: MtfDataset = {
       timeframe: tf,
       candles: resampled,
       indicators: {},
-    });
-    // -1 = no higher-timeframe candle has closed yet (set per bar by
-    // updateMtfIndices during iteration).
-    indices.set(tf, -1);
+    };
+    // Register the same dataset under every interchangeable spelling (e.g. both
+    // "1w" and "weekly") so conditions resolve regardless of which alias the
+    // caller passed in `timeframes`. -1 = no higher-timeframe candle has closed
+    // yet (set per bar by updateMtfIndices during iteration).
+    for (const key of equivalentTimeframes(tf)) {
+      datasets.set(key, dataset);
+      indices.set(key, -1);
+    }
   }
 
   return {
@@ -99,6 +121,26 @@ export function buildMtfIndexMap(
   }
 
   return indexMap;
+}
+
+/**
+ * Build an MTF context and its base→higher-timeframe index map in one step, or
+ * `undefined` when no timeframes are requested. This is the standard setup used
+ * by every per-bar consumer (backtest engine, scaled-entry simulation, stock
+ * screening), kept in one place so they stay aligned.
+ *
+ * @param candles - Base timeframe candles
+ * @param timeframes - Higher timeframes to generate (omit/empty for none)
+ * @returns `{ context, indexMap }`, or `undefined` when `timeframes` is empty
+ */
+export function buildMtfSetup(
+  candles: NormalizedCandle[],
+  timeframes: TimeframeShorthand[] | undefined,
+): { context: MtfContext; indexMap: Map<TimeframeShorthand, number[]> } | undefined {
+  if (!timeframes || timeframes.length === 0) return undefined;
+  const context = createMtfContext(candles, timeframes);
+  const indexMap = buildMtfIndexMap(candles, context);
+  return { context, indexMap };
 }
 
 /**
@@ -235,12 +277,8 @@ export function getMtfTimeframes(mtfContext: MtfContext): TimeframeShorthand[] {
  * e.g., "weekly" -> "1w", "monthly" -> "1M"
  */
 export function normalizeTimeframe(tf: TimeframeShorthand): TimeframeShorthand {
-  const aliasMap: Partial<Record<TimeframeShorthand, TimeframeShorthand>> = {
-    daily: "1d",
-    weekly: "1w",
-    monthly: "1M",
-  };
-  return aliasMap[tf] ?? tf;
+  // Canonical form is the first member of the alias group (e.g. "weekly" -> "1w").
+  return equivalentTimeframes(tf)[0];
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1344,6 +1344,8 @@ export type {
   ScreeningSeriesPoint,
   ScreeningSeriesResult,
   ScreeningSessionResult,
+  ScreenStockOptions,
+  ScreenStockSeriesOptions,
 } from "./screening";
 // Strategy JSON Serialization
 export type {

--- a/packages/core/src/screening/__tests__/screen-stock.test.ts
+++ b/packages/core/src/screening/__tests__/screen-stock.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { deadCross, goldenCross } from "../../backtest/conditions";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { deadCross, goldenCross, mtfPriceAboveSma } from "../../backtest/conditions";
 import type { Condition, NormalizedCandle } from "../../types";
 import {
   CONDITION_PRESETS,
@@ -184,6 +184,87 @@ describe("screenStockSeries", () => {
       ticker: "TEST",
       points: [],
     });
+  });
+});
+
+// =============================================================================
+// MTF screening
+// =============================================================================
+
+describe("MTF screening", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Six Mon-Fri trading weeks (2024-01-01 is a Monday), steady uptrend so the
+  // weekly close climbs above its 2-week SMA once enough weeks have closed.
+  function weeklyUptrendCandles(): NormalizedCandle[] {
+    const MS_PER_DAY = 86400000;
+    const candles: NormalizedCandle[] = [];
+    let mondayStart = Date.parse("2024-01-01T00:00:00Z");
+    let price = 100;
+    for (let week = 0; week < 6; week++) {
+      for (let day = 0; day < 5; day++) {
+        price += 2;
+        candles.push({
+          time: mondayStart + day * MS_PER_DAY,
+          open: price,
+          high: price + 1,
+          low: price - 1,
+          close: price,
+          volume: 1000,
+        });
+      }
+      mondayStart += 7 * MS_PER_DAY;
+    }
+    return candles;
+  }
+
+  const weeklyCriteria = { entry: mtfPriceAboveSma("1w", 2) };
+
+  it("evaluates MTF conditions when mtfTimeframes is provided (screenStockSeries)", () => {
+    const candles = weeklyUptrendCandles();
+    const { points } = screenStockSeries("TEST", candles, weeklyCriteria, {
+      mtfTimeframes: ["1w"],
+    });
+    // In a sustained weekly uptrend, the condition fires on at least some bars.
+    expect(points.some((p) => p.entrySignal)).toBe(true);
+  });
+
+  it("cannot evaluate MTF conditions without mtfTimeframes (resolves to false)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const candles = weeklyUptrendCandles();
+    const { points } = screenStockSeries("TEST", candles, weeklyCriteria);
+    expect(points.every((p) => p.entrySignal === false)).toBe(true);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("evaluates MTF conditions on the latest bar (screenStock)", () => {
+    const candles = weeklyUptrendCandles();
+    const withMtf = screenStock("TEST", candles, weeklyCriteria, { mtfTimeframes: ["1w"] });
+    expect(withMtf.entrySignal).toBe(true);
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const withoutMtf = screenStock("TEST", candles, weeklyCriteria);
+    expect(withoutMtf.entrySignal).toBe(false);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("latest-bar screenStock agrees with the last series point under MTF", () => {
+    const candles = weeklyUptrendCandles();
+    const latest = screenStock("TEST", candles, weeklyCriteria, { mtfTimeframes: ["1w"] });
+    const series = screenStockSeries("TEST", candles, weeklyCriteria, { mtfTimeframes: ["1w"] });
+    expect(series.points[series.points.length - 1].entrySignal).toBe(latest.entrySignal);
+  });
+
+  it("resolves a condition's alias timeframe against a canonical mtfTimeframes value", () => {
+    const candles = weeklyUptrendCandles();
+    // Condition asks for "weekly"; context is requested as the canonical "1w".
+    const aliasCriteria = { entry: mtfPriceAboveSma("weekly", 2) };
+    const { points } = screenStockSeries("TEST", candles, aliasCriteria, {
+      mtfTimeframes: ["1w"],
+    });
+    expect(points.some((p) => p.entrySignal)).toBe(true);
   });
 });
 

--- a/packages/core/src/screening/index.ts
+++ b/packages/core/src/screening/index.ts
@@ -56,4 +56,6 @@ export type {
   ScreeningSeriesPoint,
   ScreeningSeriesResult,
   ScreeningSessionResult,
+  ScreenStockOptions,
+  ScreenStockSeriesOptions,
 } from "./types";

--- a/packages/core/src/screening/screen-stock.ts
+++ b/packages/core/src/screening/screen-stock.ts
@@ -7,6 +7,7 @@
 // Import all conditions for CLI name resolution
 import * as conditions from "../backtest/conditions";
 import { evaluateCondition } from "../backtest/conditions/core";
+import { buildMtfSetup, updateMtfIndices } from "../core/mtf-context";
 import { rsi } from "../indicators/momentum/rsi";
 import { calculateAtrPercent } from "../indicators/volatility/atr-filter";
 import { volumeMa } from "../indicators/volume/volume-ma";
@@ -17,6 +18,8 @@ import type {
   ScreeningResult,
   ScreeningSeriesPoint,
   ScreeningSeriesResult,
+  ScreenStockOptions,
+  ScreenStockSeriesOptions,
 } from "./types";
 
 /**
@@ -47,9 +50,9 @@ export function screenStock(
   ticker: string,
   candles: NormalizedCandle[],
   criteria: ScreeningCriteria,
-  options: { includeCandles?: boolean } = {},
+  options: ScreenStockOptions = {},
 ): ScreeningResult {
-  const { includeCandles = false } = options;
+  const { includeCandles = false, mtfTimeframes } = options;
 
   if (candles.length === 0) {
     throw new Error("No candle data");
@@ -59,12 +62,25 @@ export function screenStock(
   const lastCandle = candles[lastIndex];
   const indicators: Record<string, unknown> = {};
 
+  // Build MTF context (if requested) and align it to the latest bar.
+  const mtf = buildMtfSetup(candles, mtfTimeframes);
+  if (mtf) {
+    updateMtfIndices(mtf.context, mtf.indexMap, lastIndex, lastCandle.time);
+  }
+
   // Evaluate entry condition on latest bar
-  const entrySignal = evaluateCondition(criteria.entry, indicators, lastCandle, lastIndex, candles);
+  const entrySignal = evaluateCondition(
+    criteria.entry,
+    indicators,
+    lastCandle,
+    lastIndex,
+    candles,
+    mtf?.context,
+  );
 
   // Evaluate exit condition if provided
   const exitSignal = criteria.exit
-    ? evaluateCondition(criteria.exit, indicators, lastCandle, lastIndex, candles)
+    ? evaluateCondition(criteria.exit, indicators, lastCandle, lastIndex, candles, mtf?.context)
     : false;
 
   // Calculate ATR%
@@ -133,21 +149,36 @@ export function screenStockSeries(
   ticker: string,
   candles: NormalizedCandle[],
   criteria: ScreeningCriteria,
+  options: ScreenStockSeriesOptions = {},
 ): ScreeningSeriesResult {
+  const { mtfTimeframes } = options;
+
   // One shared indicator cache across all bars, matching the backtest engine:
   // each indicator is computed once over the full series and read by index.
   const indicators: Record<string, unknown> = {};
+  const mtf = buildMtfSetup(candles, mtfTimeframes);
   const points: ScreeningSeriesPoint[] = [];
 
   for (let index = 0; index < candles.length; index++) {
     const candle = candles[index];
+    // Advance MTF indices to this bar so conditions see only closed HTF data.
+    if (mtf) {
+      updateMtfIndices(mtf.context, mtf.indexMap, index, candle.time);
+    }
     points.push({
       index,
       time: candle.time,
       close: candle.close,
-      entrySignal: evaluateCondition(criteria.entry, indicators, candle, index, candles),
+      entrySignal: evaluateCondition(
+        criteria.entry,
+        indicators,
+        candle,
+        index,
+        candles,
+        mtf?.context,
+      ),
       exitSignal: criteria.exit
-        ? evaluateCondition(criteria.exit, indicators, candle, index, candles)
+        ? evaluateCondition(criteria.exit, indicators, candle, index, candles, mtf?.context)
         : false,
     });
   }
@@ -367,7 +398,7 @@ export function screenStockSafe(
   ticker: string,
   candles: NormalizedCandle[],
   criteria: ScreeningCriteria,
-  options: { includeCandles?: boolean } = {},
+  options: ScreenStockOptions = {},
 ): Result<ScreeningResult> {
   try {
     return ok(screenStock(ticker, candles, criteria, options));

--- a/packages/core/src/screening/screener.ts
+++ b/packages/core/src/screening/screener.ts
@@ -42,6 +42,7 @@ export function runScreening(options: ScreeningOptions): ScreeningSessionResult 
     minDataPoints = 100,
     minAtrPercent,
     includeCandles = false,
+    mtfTimeframes,
     onProgress,
   } = options;
 
@@ -72,7 +73,10 @@ export function runScreening(options: ScreeningOptions): ScreeningSessionResult 
     }
 
     try {
-      const result = screenStock(stock.ticker, stock.candles, criteria, { includeCandles });
+      const result = screenStock(stock.ticker, stock.candles, criteria, {
+        includeCandles,
+        mtfTimeframes,
+      });
 
       // Check ATR% filter
       if (minAtrPercent !== undefined && result.atrPercent < minAtrPercent) {

--- a/packages/core/src/screening/types.ts
+++ b/packages/core/src/screening/types.ts
@@ -2,7 +2,7 @@
  * Screening module types
  */
 
-import type { Condition, NormalizedCandle } from "../types";
+import type { Condition, NormalizedCandle, TimeframeShorthand } from "../types";
 
 /**
  * Screening criteria defining entry and exit conditions
@@ -14,6 +14,30 @@ export type ScreeningCriteria = {
   entry: Condition;
   /** Exit condition - optional, for identifying stocks to exit */
   exit?: Condition;
+};
+
+/**
+ * Options for {@link screenStock} / {@link screenStockSafe}.
+ */
+export type ScreenStockOptions = {
+  /** Include full candle data in the result (default: false). */
+  includeCandles?: boolean;
+  /**
+   * Higher timeframes to make available to MTF conditions (e.g. `["1w"]`).
+   * Without this, MTF conditions cannot evaluate and resolve to `false`.
+   */
+  mtfTimeframes?: TimeframeShorthand[];
+};
+
+/**
+ * Options for {@link screenStockSeries}.
+ */
+export type ScreenStockSeriesOptions = {
+  /**
+   * Higher timeframes to make available to MTF conditions (e.g. `["1w"]`).
+   * Without this, MTF conditions cannot evaluate and resolve to `false`.
+   */
+  mtfTimeframes?: TimeframeShorthand[];
 };
 
 /**
@@ -84,6 +108,8 @@ export type ScreeningOptions = {
   concurrency?: number;
   /** Include full candle data in results (default: false) */
   includeCandles?: boolean;
+  /** Higher timeframes to make available to MTF conditions (e.g. `["1w"]`) */
+  mtfTimeframes?: TimeframeShorthand[];
   /** Progress callback */
   onProgress?: (processed: number, total: number, ticker: string) => void;
 };


### PR DESCRIPTION
## Summary

Lets the screening module use **multi-timeframe (MTF) conditions**, which previously could not evaluate there (they warned and resolved to `false` because screening never supplied an MTF context). Completes MTF support end-to-end.

## API

- **`screenStock` / `screenStockSafe` / `screenStockSeries`** accept an `mtfTimeframes` option; **`runScreening`** forwards it via `ScreeningOptions.mtfTimeframes`.
- Screening builds the MTF context the same way the backtest engine does — same resampling and same closed-bar alignment — so a screen and a backtest see identical higher-timeframe data.
- New `ScreenStockOptions` / `ScreenStockSeriesOptions` types are exported.

```ts
screenStockSeries("6758.T", candles, { entry: weeklyRsiAbove(50) }, { mtfTimeframes: ["1w"] });
```

## Refactor — single MTF setup owner

The `createMtfContext` + `buildMtfIndexMap` setup was duplicated in three places (backtest engine, scaled-entry, screening). Extracted into a single **`buildMtfSetup()`** in `core/mtf-context`, now used by all three.

## Fix — MTF alias mismatch

Conditions built with an alias (`weeklyRsiAbove` looks up `"weekly"`) silently evaluated `false` when the context was requested with the canonical spelling (`mtfTimeframes: ["1w"]`), and vice versa. The context now registers each timeframe under **all interchangeable spellings**, so either form resolves. `TF_ALIAS_GROUPS` is the single source of alias truth, and `normalizeTimeframe` derives from it (removing a duplicated alias map). This applies everywhere the shared setup is used (engine, scaled-entry, screening).

## Testing

- Screening MTF tests: conditions evaluate with `mtfTimeframes` and resolve to `false` without it (both `screenStock` and `screenStockSeries`); latest-bar `screenStock` agrees with the last series point; **alias resolution** (condition `"weekly"` × `mtfTimeframes: ["1w"]`) fires.
- MTF context tests: alias and canonical spellings resolve to the same dataset, both directions.
- Engine / scaled-entry behavior is unchanged (covered by their existing suites after adopting `buildMtfSetup`).
- Full core suite: **6238 passed**. `tsc --noEmit` clean, lint clean (`--error-on-warnings`), build clean.