### PR TITLE
fix(core,chart): doc-snippet correctness + preset alias gaps + unknown-preset suggestions

### DIFF
--- a/packages/chart/docs/API.md
+++ b/packages/chart/docs/API.md
@@ -595,7 +595,7 @@ import {
   DataLayer, TimeScale, PriceScale, LayoutEngine, Viewport,
   SeriesRegistry, RendererRegistry,
   DrawHelper,
-  introspect, IndicatorPreset, INDICATOR_PRESETS,
+  introspect, type IndicatorPreset, INDICATOR_PRESETS,
   lttb, decimateCandles, getDecimationTarget,
   autoFormatPrice, autoFormatTime, formatCrosshairTime, formatVolume,
   detectPrecision, fixedPriceFormatter,

--- a/packages/chart/docs/LIVE.md
+++ b/packages/chart/docs/LIVE.md
@@ -238,7 +238,7 @@ chart.addIndicator(sma20Series, { label: 'SMA 20' });
 
 // Later, drive incremental updates from live
 const sma20Incr = incremental.createSma({ period: 20 }, {
-  fromState: sma(candles, { period: 20 })._state,  // if available
+  warmUp: candles,  // replay history to prime the incremental state
 });
 live.on('tick', ({ candle, snapshot }) => {
   // push the latest value to the chart series

--- a/packages/chart/docs/PLUGINS.md
+++ b/packages/chart/docs/PLUGINS.md
@@ -244,7 +244,7 @@ render: ({ ctx, draw, theme }) => {
 ```typescript
 type SeriesRenderContext = {
   ctx: CanvasRenderingContext2D;
-  series: InternalSeries;       // id, data, config, channels
+  series: InternalSeries;       // id, data, config
   timeScale: TimeScale;         // low-level scale (draw.x wraps this)
   priceScale: PriceScale;       // low-level scale (draw.y wraps this)
   dataLayer: DataLayer;         // global data model (rarely needed in plugins)
@@ -352,19 +352,23 @@ render: ({ draw, series }) => {
   draw.line(values, { color: '#fff' });
 }
 
-// ✓ good — precompute or cache
-const valuesCache = new WeakMap<InternalSeries, number[]>();
+// ✓ good — precompute and cache, invalidating on the series data version.
+// `_dataVersion` bumps on every data mutation — including a same-length
+// live update that replaces the last candle in place — so keying on it
+// (not on `data.length`) avoids drawing stale values.
+const valuesCache = new WeakMap<InternalSeries, { version: number; values: number[] }>();
 render: ({ draw, series }) => {
-  let values = valuesCache.get(series);
-  if (!values || values.length !== series.data.length) {
-    values = series.data.map(d => d.value);
-    valuesCache.set(series, values);
+  const version = series._dataVersion ?? 0;
+  let entry = valuesCache.get(series);
+  if (!entry || entry.version !== version) {
+    entry = { version, values: series.data.map(d => d.value) };
+    valuesCache.set(series, entry);
   }
-  draw.line(values, { color: '#fff' });
+  draw.line(entry.values, { color: '#fff' });
 }
 ```
 
-For series renderers, the chart internally caches decomposed channels — use `series.channels.get(name)` instead of mapping `series.data` yourself.
+For series renderers, precompute or cache derived values (see the `WeakMap` example above) instead of re-mapping `series.data` on every frame.
 
 ### Defensive rendering
 

--- a/packages/chart/src/__tests__/connect-indicators.test.ts
+++ b/packages/chart/src/__tests__/connect-indicators.test.ts
@@ -922,3 +922,39 @@ describe("connectIndicators", () => {
     });
   });
 });
+
+describe("conn.add — unknown preset errors", () => {
+  const candles = [candle(1, 100), candle(2, 101)];
+
+  it("suggests the canonical key for an alias-style name (normalized match)", () => {
+    const { chart } = createMockChart();
+    // Real registries (e.g. trendcraft's indicatorPresets) carry a display
+    // `name`; "bollingerBands" normalizes to "Bollinger Bands" → key "bb".
+    const presets: Record<string, IndicatorPresetEntry> = {
+      bb: { ...makeComputePreset("BB"), name: "Bollinger Bands" } as IndicatorPresetEntry,
+      rsi: makeComputePreset("rsi"),
+    };
+    const conn = connectIndicators(chart, { presets, candles });
+    expect(() => conn.add("bollingerBands")).toThrow(/Did you mean "bb"\?/);
+  });
+
+  it("suggests the closest key for a typo (edit distance)", () => {
+    const { chart } = createMockChart();
+    const presets = { rsi: makeComputePreset("rsi") };
+    const conn = connectIndicators(chart, { presets, candles });
+    expect(() => conn.add("rsii")).toThrow(/Did you mean "rsi"\?/);
+  });
+
+  it("reports no close match for a far-off id", () => {
+    const { chart } = createMockChart();
+    const presets = { rsi: makeComputePreset("rsi") };
+    const conn = connectIndicators(chart, { presets, candles });
+    expect(() => conn.add("zzzznope")).toThrow(/No close match among 1 registered preset/);
+  });
+
+  it("guides the caller to pass presets when the registry is empty", () => {
+    const { chart } = createMockChart();
+    const conn = connectIndicators(chart, { presets: {}, candles });
+    expect(() => conn.add("rsi")).toThrow(/No presets are registered/);
+  });
+});

--- a/packages/chart/src/integration/connect-indicators.ts
+++ b/packages/chart/src/integration/connect-indicators.ts
@@ -220,6 +220,72 @@ export function defineIndicator(presetId: string, options?: AddIndicatorOptions)
   return { presetId, options };
 }
 
+/** Iterative Levenshtein distance (single-row DP). */
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const curr = [i];
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    prev = curr;
+  }
+  return prev[b.length];
+}
+
+/**
+ * Suggest the closest registered preset id for an unknown `id`, using ONLY the
+ * passed registry's own keys + metadata — no external alias table — so it works
+ * for any duck-typed `presets` registry without coupling the chart to core.
+ *
+ * Two passes:
+ * 1. Normalized match (lowercase, alphanumerics only) against each preset's key,
+ *    display `name`, or `meta.label`. Catches alias-style names — e.g. the
+ *    descriptive `"bollingerBands"` resolves to the `"bb"` key (name "Bollinger
+ *    Bands"), which an edit-distance check would miss.
+ * 2. Smallest Levenshtein distance against the keys, within a small threshold.
+ *    Catches typos — e.g. `"rsii"` → `"rsi"`.
+ */
+function suggestPresetId(
+  id: string,
+  presets: Record<string, IndicatorPresetEntry>,
+): string | undefined {
+  const normalize = (s: string): string => s.toLowerCase().replace(/[^a-z0-9]/g, "");
+  const target = normalize(id);
+  if (target === "") return undefined;
+  const keys = Object.keys(presets);
+
+  // Pass 1: normalized match on key / display name / label.
+  for (const key of keys) {
+    const preset = presets[key];
+    const name = (preset as { name?: unknown }).name;
+    if (
+      normalize(key) === target ||
+      (typeof name === "string" && normalize(name) === target) ||
+      (typeof preset?.meta?.label === "string" && normalize(preset.meta.label) === target)
+    ) {
+      return key;
+    }
+  }
+
+  // Pass 2: closest key by edit distance, gated by a small typo threshold.
+  let best: string | undefined;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const key of keys) {
+    const distance = levenshtein(target, normalize(key));
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = key;
+    }
+  }
+  const threshold = Math.max(2, Math.floor(target.length / 4));
+  return bestDistance <= threshold ? best : undefined;
+}
+
 // ============================================
 // Internal Types
 // ============================================
@@ -438,8 +504,22 @@ export function connectIndicators(
 
     const preset = presets[presetId];
     if (!preset) {
+      const keys = Object.keys(presets);
+      if (keys.length === 0) {
+        throw new Error(
+          `Unknown indicator preset: "${presetId}". No presets are registered — pass them via connectIndicators({ presets: indicatorPresets }).`,
+        );
+      }
+      const suggestion = suggestPresetId(presetId, presets);
       throw new Error(
-        `Unknown indicator preset: "${presetId}". Pass it via connectIndicators({ presets: indicatorPresets }).`,
+        suggestion
+          ? `Unknown indicator preset: "${presetId}". Did you mean "${suggestion}"? (${keys.length} presets registered)`
+          : `Unknown indicator preset: "${presetId}". No close match among ${keys.length} registered presets (e.g. ${keys
+              .slice(0, 5)
+              .map((k) => `"${k}"`)
+              .join(
+                ", ",
+              )}). Preset ids are the keys of the registry passed to connectIndicators({ presets }).`,
       );
     }
 

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -236,8 +236,8 @@ const custom = emaRibbon(candles, { periods: [8, 13, 21, 34, 55], source: 'close
 ```typescript
 interface EmaRibbonValue {
   values: (number | null)[];  // 各EMAの値
-  bullish: boolean;           // 短期EMA>長期EMA順で整列
-  expanding: boolean;         // スプレッド拡大中
+  bullish: boolean | null;    // 短期EMA>長期EMA順で整列（warmup中はnull）
+  expanding: boolean | null;  // スプレッド拡大中（warmup中はnull）
 }
 ```
 
@@ -1102,8 +1102,8 @@ const custom = weisWave(candles, { method: 'close', threshold: 0 });
 
 ```typescript
 interface WeisWaveValue {
-  waveVolume: number;   // 波動の累積ボリューム
-  direction: 1 | -1;   // 波動の方向（1=上昇, -1=下降）
+  waveVolume: number;          // 波動の累積ボリューム
+  direction: "up" | "down";    // 波動の方向
 }
 ```
 
@@ -1133,10 +1133,10 @@ const custom = marketProfile(candles, {
 
 ```typescript
 interface MarketProfileValue {
-  poc: number;              // Point of Control（最頻出価格帯）
-  valueAreaHigh: number;    // Value Area上限
-  valueAreaLow: number;     // Value Area下限
-  profile: Map<number, number>;  // 価格帯ごとのTPOカウント
+  poc: number | null;              // Point of Control（最頻出価格帯）
+  valueAreaHigh: number | null;    // Value Area上限
+  valueAreaLow: number | null;     // Value Area下限
+  profile: Map<number, number> | null;  // 価格帯ごとのTPOカウント
 }
 ```
 
@@ -1989,29 +1989,32 @@ type TrendReason =
 #### レンジ相場条件（バックテスト用）
 
 ```typescript
-// レンジブレイクアウトでエントリー
-rangeBreakout()
-
-// レンジ相場ではない時のみエントリー（フィルター）
-notInRange()
-
-// レンジ形成中にイグジット
-rangeForming()
-
-// レンジ確定中にのみエントリー
+// レンジ状態（任意のレンジ）
 inRangeBound()
 
-// 上方ブレイクアウトリスク
-breakoutRiskUp()
+// レンジ形成中
+rangeForming()
 
-// 下方ブレイクアウトリスク
-breakoutRiskDown()
+// レンジ確定
+rangeConfirmed()
+
+// レンジからトレンドへの転換（ブレイクアウト）
+rangeBreakout()
 
 // タイトレンジ検出
 tightRange()
 
-// トレンド中
-isTrending()
+// 上方ブレイクアウトリスク（上限付近）
+breakoutRiskUp()
+
+// 下方ブレイクアウトリスク（下限付近）
+breakoutRiskDown()
+
+// レンジスコアが閾値超
+rangeScoreAbove(70)
+
+// レンジ相場ではない時のみ（フィルター）
+not(inRangeBound())
 ```
 
 ---
@@ -3814,19 +3817,16 @@ Period 3: Train 2015-01-01〜2019-12-31 → Test 2020
 interface AWFResult {
   periods: AWFPeriod[];
   aggregateMetrics: {
-    avgInSampleSharpe: number;
-    avgOutOfSampleSharpe: number;
-    avgInSampleReturn: number;
-    avgOutOfSampleReturn: number;
-    stabilityRatio: number;      // OOS / IS Sharpe 比率
-    consistency: number;         // プラスリターン期間の割合
+    avgInSample: Record<OptimizationMetric, number>;
+    avgOutOfSample: Record<OptimizationMetric, number>;
+    stabilityRatio: number;      // OOS / IS パフォーマンス比率
+    oosReturnStdDev: number;     // OOS リターンのボラティリティ
   };
   stabilityAnalysis: {
-    entryConditionFrequency: Record<string, number>;
-    exitConditionFrequency: Record<string, number>;
-    stableEntryConditions: string[];  // 50%以上で選択
+    conditionFrequency: Record<string, number>;  // 条件の出現率（%）
+    stableEntryConditions: string[];   // 50%超の期間で出現
     stableExitConditions: string[];
-    consistencyScore: number;         // 0-100
+    consistencyScore: number;          // 0-100
   };
   recommendation: {
     useOptimized: boolean;
@@ -3840,8 +3840,10 @@ interface AWFPeriod {
   periodNumber: number;
   trainStart: number;
   trainEnd: number;
+  trainCandleCount: number;
   testStart: number;
   testEnd: number;
+  testCandleCount: number;
   bestEntryConditions: string[];
   bestExitConditions: string[];
   inSampleMetrics: Record<OptimizationMetric, number>;

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -3533,7 +3533,7 @@ Pre-configured scoring strategies for common trading styles.
 import { getPreset, listPresets } from 'trendcraft';
 
 const config = getPreset('trendFollowing');
-const available = listPresets();  // ['momentum', 'meanReversion', 'trendFollowing', 'balanced']
+const available = listPresets();  // ['momentum', 'meanReversion', 'trendFollowing', 'balanced', 'aggressive', 'conservative']
 ```
 
 | Preset | Focus | Thresholds (S/M/W) | Description |
@@ -3647,7 +3647,7 @@ const result = atrBasedSize({
 import { calculateAtrStopDistance, recommendedAtrMultiplier } from 'trendcraft';
 
 const stopDistance = calculateAtrStopDistance(2.5, 2);  // 5
-const multiplier = recommendedAtrMultiplier('conservative');  // 2.5-3.0
+const multiplier = recommendedAtrMultiplier('conservative');  // 3
 ```
 
 ---
@@ -5311,11 +5311,12 @@ Wraps a streaming pipeline to automatically emit `TradeSignal` events.
 
 ```typescript
 import { streaming } from 'trendcraft';
+import { createRsi } from 'trendcraft/incremental';
 
 const emitter = streaming.createSignalEmitter({
   intervalMs: 60000,
   pipeline: {
-    indicators: [{ name: 'rsi14', create: () => streaming.incremental.rsi({ period: 14 }) }],
+    indicators: [{ name: 'rsi14', create: () => createRsi({ period: 14 }) }],
     entry: rsiBelow(30),
     exit: rsiAbove(70),
   },
@@ -5469,7 +5470,7 @@ const tracker = streaming.createPositionTracker({
   trailingStop: 3,    // Trail from trough
 });
 
-tracker.openPosition(100, currentTime, 1000);
+tracker.openPosition(100, 1000, currentTime);
 
 // Unrealized P&L is direction-aware
 const account = tracker.getAccount();
@@ -6421,13 +6422,16 @@ live.addCandle(partialCandle, { partial: true });
 |---|---|
 | `addTick(trade)` | Feed a trade tick (tick mode). |
 | `addCandle(candle, opts?)` | Feed a candle. `opts.partial = true` for forming candles. |
-| `addIndicator({ name, create })` | Register an indicator factory after construction. |
+| `addIndicator(name, create, state?)` | Register an indicator factory after construction. |
 | `removeIndicator(name)` | Remove an indicator. |
-| `snapshot()` | Get the current indicator snapshot (keyed by registered name). |
+| `getIndicator(name)` | Latest value for a single named indicator. |
+| `snapshot` | Readonly getter — snapshot of all indicator latest values (keyed by registered name). |
 | `completedCandles` | Readonly array of closed candles since start. |
-| `formingCandle` | The in-progress candle, or `null`. |
-| `on(event, handler)` / `off(event, handler)` | Event subscription. Events: `tick`, `candleComplete`. |
+| `candle` | Readonly — the in-progress (forming) candle, or `null`. |
+| `on(event, handler)` | Subscribe to events (`tick`, `candleComplete`). Returns an unsubscribe function (there is no separate `off`). |
+| `flush()` | Force-complete the forming candle (tick mode); returns it or `null`. |
 | `getState()` | Serialize state (aggregator + indicators + completed candles). |
+| `dispose()` | Clear all listeners and internal references. |
 
 ### `livePresets`
 

--- a/packages/core/docs/COOKBOOK.md
+++ b/packages/core/docs/COOKBOOK.md
@@ -128,7 +128,7 @@ const exit = deadCrossCondition(5, 25);
 
 const result = runBacktest(dailyCandles, entry, exit, {
   capital: 1_000_000,
-  mtfTimeframes: ["1W"],   // Enable weekly MTF data
+  mtfTimeframes: ["1w"],   // Enable weekly MTF data
   stopLoss: 5,
 });
 
@@ -171,10 +171,10 @@ const lastAtr = atrSeries[atrSeries.length - 1]?.value ?? 0;
 const lastPrice = candles[candles.length - 1].close;
 
 const position = riskBasedSize({
-  capital: 1_000_000,
+  accountSize: 1_000_000,
   riskPercent: 2,
   entryPrice: lastPrice,
-  stopPrice: lastPrice - lastAtr * 2,
+  stopLossPrice: lastPrice - lastAtr * 2,
 });
 
 console.log(`Shares: ${position.shares}, Risk: $${position.riskAmount.toFixed(0)}`);
@@ -253,7 +253,7 @@ console.log(`Stability: ${wfResult.aggregateMetrics.stabilityRatio.toFixed(2)}`)
 **Indicators:** RSI(14), SMA(20)
 
 ```typescript
-import * as streaming from "trendcraft/streaming";
+import { streaming } from "trendcraft";
 import * as incremental from "trendcraft/incremental";
 
 const session = streaming.createTradingSession({

--- a/packages/core/docs/GUIDE.md
+++ b/packages/core/docs/GUIDE.md
@@ -1805,8 +1805,8 @@ const chandelier = chandelierExit(candles, {
 });
 
 chandelier.forEach(({ time, value }) => {
-  console.log(`Long stop: ${value.longStop}`);
-  console.log(`Short stop: ${value.shortStop}`);
+  console.log(`Long exit: ${value.longExit}`);
+  console.log(`Short exit: ${value.shortExit}`);
 });
 ```
 

--- a/packages/core/src/streaming/__tests__/indicator-preset-lookup.test.ts
+++ b/packages/core/src/streaming/__tests__/indicator-preset-lookup.test.ts
@@ -27,7 +27,9 @@ describe("getIndicatorPreset", () => {
     ["fairValueGap", "fvg"],
     ["historicalVolatility", "hv"],
     ["keltnerChannel", "keltner"],
+    ["mcginleyDynamic", "mcginley"],
     ["openingRange", "orb"],
+    ["schaffTrendCycle", "stc"],
     ["ulcerIndex", "ulcer"],
   ])("alias %s → %s resolves to the same preset", (long, short) => {
     expect(getIndicatorPreset(long)).toBe(indicatorPresets[short]);
@@ -145,7 +147,9 @@ describe("getIndicatorPreset", () => {
     ["fairValueGap", "fvg"],
     ["historicalVolatility", "hv"],
     ["keltnerChannel", "keltner"],
+    ["mcginleyDynamic", "mcginley"],
     ["openingRange", "orb"],
+    ["schaffTrendCycle", "stc"],
     ["ulcerIndex", "ulcer"],
   ])("getIndicatorPresetKey: alias %s → %s", (long, short) => {
     expect(getIndicatorPresetKey(long)).toBe(short);

--- a/packages/core/src/streaming/indicator-presets.ts
+++ b/packages/core/src/streaming/indicator-presets.ts
@@ -2169,7 +2169,9 @@ const KIND_ALIASES: Record<string, string> = {
   fairValueGap: "fvg",
   historicalVolatility: "hv",
   keltnerChannel: "keltner",
+  mcginleyDynamic: "mcginley",
   openingRange: "orb",
+  schaffTrendCycle: "stc",
   ulcerIndex: "ulcer",
 };
 


### PR DESCRIPTION
## Why

A documentation-correctness pass found that several documented code snippets did not match the real API — they threw or produced wrong output on copy-paste — plus two genuine source/DX gaps:

- Two indicators (`mcginleyDynamic`, `schaffTrendCycle`) had no entry in the preset alias table, so even the resolver returned `undefined` for their long names.
- `connectIndicators().add()` answered an unknown preset id with a bare "Unknown indicator preset" and no hint toward the right key.

## What

**Doc-snippet fixes (no API change)**
- **core docs**: API.md / COOKBOOK / GUIDE / API.ja — `openPosition(price, shares, time)` argument order; `createSignalEmitter` uses `createRsi` from `trendcraft/incremental` (there is no `streaming.incremental`); `riskBasedSize` uses `accountSize` / `stopLossPrice`; `mtfTimeframes: ["1w"]`; `chandelierExit` value keys `longExit` / `shortExit`; the `createLiveCandle` method table matches the real type; Japanese-mirror type drift.
- **chart docs**: drop the non-existent `series.channels` advice and key the renderer cache on `series._dataVersion` (length-only caching went stale on same-length live updates); `import type` for the type-only headless export; replace a fictional `_state` warm-up with the real `createSma(opts, { warmUp })` option.

**Source / DX fixes**
- **core**: add `mcginleyDynamic → mcginley` and `schaffTrendCycle → stc` to `KIND_ALIASES` so `getIndicatorPreset` / `getIndicatorPresetKey` resolve them; extend the lookup tests.
- **chart**: on an unknown `conn.add()` preset id, suggest the closest registered id — a normalized match on key / display name / label (so `"bollingerBands"` → `"bb"`) plus a Levenshtein fallback for typos — computed only from the passed registry (no cross-package import, no alias-table duplication). Keeps the fail-fast throw.

## Test plan

- chart: `pnpm test` **909 passed**; `pnpm typecheck` clean; `pnpm size-check` Main **40.77 kB / 41 kB**.
- core: preset-lookup tests **41 passed**; `npx tsc --noEmit` clean.
- Each change verified against the real source (signatures, option names, preset/type keys, exports).
