### PR TITLE
test(core,chart): doc-snippet execution harness (Tier 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ docs-site/
 
 # Python
 packages/core/cross-validation/python/.venv/
+# doc-snippet harness temp output (auto-cleaned; ignore if a run is interrupted)
+.docsnippets-tmp/

--- a/packages/chart/docs/COOKBOOK.md
+++ b/packages/chart/docs/COOKBOOK.md
@@ -8,6 +8,7 @@ Practical recipes for common charting tasks. Each recipe is self-contained and c
 
 **Goal:** A chart on plain OHLC data with one indicator, importing only from `@trendcraft/chart` — no `trendcraft` package required.
 
+<!-- doctest-run -->
 ```typescript
 import { createChart } from "@trendcraft/chart";
 
@@ -45,6 +46,7 @@ The series here is detected purely by its `{ time, value }[]` key shape, so any 
 
 **Goal:** The same chart, but letting a TrendCraft indicator auto-place itself.
 
+<!-- doctest-run -->
 ```typescript
 import { createChart } from "@trendcraft/chart";
 import { sma } from "trendcraft";
@@ -64,6 +66,7 @@ chart.addIndicator(sma(candles, { period: 20 }));
 
 **Goal:** Hook up many indicators at once via the bundled presets.
 
+<!-- doctest-run -->
 ```typescript
 import { connectIndicators, createChart } from "@trendcraft/chart";
 import { registerTrendCraftPresets } from "@trendcraft/chart/presets";

--- a/packages/chart/src/__tests__/docs-snippets.test.ts
+++ b/packages/chart/src/__tests__/docs-snippets.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment happy-dom
+/**
+ * Doc-snippet harness (Tier 2 — execute) for @trendcraft/chart.
+ *
+ * Extracts fenced `ts`/`typescript` code blocks from the package docs and
+ * EXECUTES the ones tagged `<!-- doctest-run -->`, asserting they construct a
+ * chart and run without throwing. Catches the doc-bug class type-checking
+ * cannot — wrong preset keys, wrong option shapes, fictional methods.
+ *
+ * Opt-in: only `<!-- doctest-run -->` blocks run. Imports of the published
+ * package name are rewritten to in-repo source entries so snippets exercise the
+ * real, current API. `trendcraft` resolves natively (dev dependency).
+ *
+ * happy-dom has no canvas 2D context, so we stub one (same pattern as
+ * apply-options.test.ts). Common context variables a self-contained recipe
+ * relies on (`container`, `candles`, `chart`) are injected only when the
+ * snippet does not declare them.
+ */
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const docsDir = path.resolve(here, "../../docs");
+const tmpDir = path.resolve(here, ".docsnippets-tmp");
+
+const DOC_FILES = ["COOKBOOK.md"];
+
+// `@trendcraft/chart*` → in-repo source, relative to a temp file at
+// `${tmpDir}/<name>.ts` (one level below src/__tests__). `trendcraft` is left
+// alone — it resolves through the chart package's dev dependency.
+const IMPORT_REWRITES: Array<[RegExp, string]> = [
+  [/(["'])@trendcraft\/chart\/headless\1/g, '"../../headless"'],
+  [/(["'])@trendcraft\/chart\/presets\1/g, '"../../presets"'],
+  [/(["'])@trendcraft\/chart\/replay\1/g, '"../../replay"'],
+  [/(["'])@trendcraft\/chart\/sparkline\1/g, '"../../sparkline"'],
+  [/(["'])@trendcraft\/chart\1/g, '"../../index"'],
+];
+
+const CANDLE_FIXTURE = `[
+  { time: 1717200000000, open: 100, high: 104, low: 99, close: 103, volume: 1200 },
+  { time: 1717286400000, open: 103, high: 106, low: 102, close: 105, volume: 1500 },
+  { time: 1717372800000, open: 105, high: 105, low: 101, close: 102, volume: 1100 },
+  { time: 1717459200000, open: 102, high: 108, low: 102, close: 107, volume: 1800 },
+  { time: 1717545600000, open: 107, high: 110, low: 106, close: 109, volume: 2000 },
+]`;
+
+type Snippet = { file: string; index: number; run: boolean; code: string };
+
+function extractSnippets(file: string): Snippet[] {
+  const lines = readFileSync(path.join(docsDir, file), "utf8").split("\n");
+  const out: Snippet[] = [];
+  let i = 0;
+  let blockIndex = 0;
+  while (i < lines.length) {
+    if (!/^```(ts|typescript)\s*$/.test(lines[i])) {
+      i++;
+      continue;
+    }
+    const lookback = lines.slice(Math.max(0, i - 3), i).join("\n");
+    const run = /<!--\s*doctest-run\s*-->/.test(lookback);
+    const body: string[] = [];
+    i++;
+    while (i < lines.length && !/^```\s*$/.test(lines[i])) body.push(lines[i++]);
+    i++;
+    out.push({ file, index: blockIndex++, run, code: body.join("\n") });
+  }
+  return out;
+}
+
+function rewriteImports(code: string): string {
+  let out = code;
+  for (const [re, repl] of IMPORT_REWRITES) out = out.replace(re, repl);
+  return out;
+}
+
+function declares(code: string, name: string): boolean {
+  return new RegExp(`\\b(?:const|let|var)\\s+${name}\\b`).test(code);
+}
+
+function assembleModule(code: string): string {
+  const rewritten = rewriteImports(code);
+  const lines: string[] = [];
+  // A sized container the recipes' `getElementById("chart")` can find.
+  lines.push(
+    `document.body.innerHTML = '<div id="chart" style="width:800px;height:400px"></div>';`,
+  );
+  if (!declares(rewritten, "container")) {
+    lines.push(`const container = document.getElementById("chart") as HTMLElement;`);
+  }
+  if (!declares(rewritten, "candles")) lines.push(`const candles = ${CANDLE_FIXTURE};`);
+  let preamble = lines.join("\n");
+  if (!declares(rewritten, "chart")) {
+    preamble = `import { createChart as __mkChart } from "../../index";\n${preamble}\nconst chart = __mkChart(container);`;
+  }
+  return `${preamble}\n${rewritten}\n`;
+}
+
+const allSnippets = DOC_FILES.filter((f) => existsSync(path.join(docsDir, f))).flatMap(
+  extractSnippets,
+);
+const runnable = allSnippets.filter((s) => s.run);
+
+beforeAll(() => {
+  const noop = () => {};
+  const ctx = new Proxy(
+    {},
+    {
+      get: (_t, prop) => {
+        if (prop === "canvas") return null;
+        if (prop === "measureText") return () => ({ width: 0 }) as TextMetrics;
+        return noop;
+      },
+      set: () => true,
+    },
+  ) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as { getContext: () => unknown }).getContext = () => ctx;
+});
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("doc snippets — execute (Tier 2)", () => {
+  it("found at least one runnable (doctest-run) snippet", () => {
+    expect(runnable.length).toBeGreaterThan(0);
+  });
+
+  for (const s of runnable) {
+    it(`${s.file} #${s.index} runs without throwing`, async () => {
+      mkdirSync(tmpDir, { recursive: true });
+      const file = path.join(tmpDir, `${s.file.replace(/\W/g, "_")}_${s.index}.ts`);
+      writeFileSync(file, assembleModule(s.code), "utf8");
+      await expect(import(/* @vite-ignore */ file)).resolves.toBeDefined();
+    });
+  }
+});

--- a/packages/core/docs/COOKBOOK.md
+++ b/packages/core/docs/COOKBOOK.md
@@ -9,6 +9,7 @@ Practical recipes for common trading analysis tasks. Each recipe is self-contain
 **Goal:** Backtest a simple trend-following strategy with momentum confirmation.
 **Indicators:** SMA(5), SMA(25), RSI(14)
 
+<!-- doctest-run -->
 ```typescript
 import {
   normalizeCandles,
@@ -43,6 +44,7 @@ console.log(`Max Drawdown: ${result.maxDrawdown.toFixed(2)}%`);
 **Goal:** Follow established trends with multi-indicator confirmation.
 **Indicators:** Supertrend, DMI/ADX, Volume MA
 
+<!-- doctest-run -->
 ```typescript
 import {
   normalizeCandles,
@@ -78,6 +80,7 @@ console.log(`Profit Factor: ${result.profitFactor.toFixed(2)}`);
 **Goal:** Buy at oversold levels, sell at overbought levels.
 **Indicators:** Bollinger Bands(20, 2), RSI(14)
 
+<!-- doctest-run -->
 ```typescript
 import {
   normalizeCandles,
@@ -110,6 +113,7 @@ console.log(`Return: ${result.totalReturnPercent.toFixed(2)}%`);
 **Goal:** Enter daily trades only when the weekly trend is bullish.
 **Indicators:** Weekly SMA(20), Daily Golden Cross
 
+<!-- doctest-run -->
 ```typescript
 import {
   normalizeCandles,
@@ -142,6 +146,7 @@ console.log(`Return: ${result.totalReturnPercent.toFixed(2)}%`);
 **Goal:** Use ATR-based stops and risk-based position sizing.
 **Indicators:** ATR(14), RSI(14)
 
+<!-- doctest-run -->
 ```typescript
 import {
   normalizeCandles,
@@ -187,6 +192,7 @@ console.log(`Shares: ${position.shares}, Risk: $${position.riskAmount.toFixed(0)
 **Goal:** Find optimal parameters and validate with out-of-sample testing.
 **Indicators:** SMA(variable), RSI(variable)
 
+<!-- doctest-run -->
 ```typescript
 import {
   normalizeCandles,

--- a/packages/core/src/__tests__/docs-snippets.test.ts
+++ b/packages/core/src/__tests__/docs-snippets.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+/**
+ * Doc-snippet harness (Tier 2 — execute).
+ *
+ * Extracts fenced `ts`/`typescript` code blocks from the package docs and
+ * EXECUTES the ones tagged `<!-- doctest-run -->`, asserting they run without
+ * throwing. This catches the class of doc bug that type-checking cannot — wrong
+ * argument order, silent-null option typos, wrong runtime string keys — which
+ * is exactly what the doc audit surfaced (e.g. `openPosition(price, time, …)`,
+ * `riskBasedSize({ capital })`, `mtfTimeframes: ["1W"]`).
+ *
+ * Opt-in by design: only blocks explicitly marked `<!-- doctest-run -->` run,
+ * so illustrative / partial snippets (the majority) are never force-executed.
+ * Imports of the published package name are rewritten to the in-repo source
+ * entry points so the snippets run against the real, current API.
+ *
+ * Tier 1 (compile-check every block via `tsc`) is tracked separately.
+ */
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const docsDir = path.resolve(here, "../../docs");
+const tmpDir = path.resolve(here, ".docsnippets-tmp");
+
+// Docs scanned for runnable snippets. Reference-style files (API.md) carry
+// mostly partial fragments and are covered by the compile tier instead.
+const DOC_FILES = ["COOKBOOK.md", "GUIDE.md"];
+
+// `import ... from "<pkg>"` → in-repo source entry, relative to a temp file at
+// `${tmpDir}/<name>.ts` (one level below src/__tests__).
+const IMPORT_REWRITES: Array<[RegExp, string]> = [
+  [/(["'])trendcraft\/incremental\1/g, '"../../indicators/incremental"'],
+  [/(["'])trendcraft\/screening\1/g, '"../../screening"'],
+  [/(["'])trendcraft\/safe\1/g, '"../../indicators/safe"'],
+  [/(["'])trendcraft\/manifest\1/g, '"../../manifest"'],
+  [/(["'])trendcraft\1/g, '"../../index"'],
+];
+
+// Real fixtures for the free variables doc snippets assume from context.
+const FIXTURE_PREAMBLE = `
+const rawCandles = Array.from({ length: 500 }, (_, i) => {
+  const base = 100 + Math.sin(i / 9) * 18 + i * 0.05;
+  return {
+    time: 1_700_000_000_000 + i * 86_400_000,
+    open: base,
+    high: base + 2.5,
+    low: base - 2.5,
+    close: base + Math.cos(i / 6),
+    volume: 1_000_000 + (i % 13) * 25_000,
+  };
+});
+const rawDailyCandles = rawCandles;
+`;
+
+type Snippet = { file: string; index: number; run: boolean; skip: boolean; code: string };
+
+function extractSnippets(file: string): Snippet[] {
+  const text = readFileSync(path.join(docsDir, file), "utf8");
+  const lines = text.split("\n");
+  const out: Snippet[] = [];
+  let i = 0;
+  let blockIndex = 0;
+  while (i < lines.length) {
+    const fence = lines[i].match(/^```(ts|typescript)\s*$/);
+    if (!fence) {
+      i++;
+      continue;
+    }
+    // Look back a few lines for a marker comment.
+    const lookback = lines.slice(Math.max(0, i - 3), i).join("\n");
+    const run = /<!--\s*doctest-run\s*-->/.test(lookback);
+    const skip = /<!--\s*doctest-skip\s*-->/.test(lookback);
+    const body: string[] = [];
+    i++;
+    while (i < lines.length && !/^```\s*$/.test(lines[i])) {
+      body.push(lines[i]);
+      i++;
+    }
+    i++; // consume closing fence
+    out.push({ file, index: blockIndex++, run, skip, code: body.join("\n") });
+  }
+  return out;
+}
+
+function rewriteImports(code: string): string {
+  let out = code;
+  for (const [re, repl] of IMPORT_REWRITES) out = out.replace(re, repl);
+  return out;
+}
+
+const allSnippets = DOC_FILES.filter((f) => existsSync(path.join(docsDir, f))).flatMap(
+  extractSnippets,
+);
+const runnable = allSnippets.filter((s) => s.run);
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("doc snippets — execute (Tier 2)", () => {
+  it("found at least one runnable (doctest-run) snippet", () => {
+    expect(runnable.length).toBeGreaterThan(0);
+  });
+
+  for (const s of runnable) {
+    it(`${s.file} #${s.index} runs without throwing`, async () => {
+      mkdirSync(tmpDir, { recursive: true });
+      const moduleSrc = `${FIXTURE_PREAMBLE}\n${rewriteImports(s.code)}\n`;
+      const file = path.join(tmpDir, `${s.file.replace(/\W/g, "_")}_${s.index}.ts`);
+      writeFileSync(file, moduleSrc, "utf8");
+      // Dynamic import executes the module top-to-bottom; vitest transpiles TS.
+      await expect(import(/* @vite-ignore */ file)).resolves.toBeDefined();
+    });
+  }
+});


### PR DESCRIPTION
## Why

Documentation code snippets drift from the real API and ship broken — a recent doc-correctness pass found several. Type-checking alone misses the worst class (wrong argument order, silent-null option typos, wrong runtime string keys); those only surface when the snippet actually runs.

## What

A vitest harness in each package that extracts ` ```ts ` fences from the docs, rewrites the published-package imports to the in-repo source entry points, and **executes** the snippets tagged `<!-- doctest-run -->`, asserting they run without throwing.

- **Opt-in**: only tagged snippets execute, so partial/illustrative fragments are never force-run.
- **core**: tags COOKBOOK recipes 1–6 (backtests / optimization).
- **chart**: stubs a canvas 2D context (happy-dom) and injects `container` / `candles` / `chart` fixtures only when a snippet does not declare them; tags COOKBOOK recipes 1 / 1b / 2 (standalone, TrendCraft indicator, `connectIndicators`).
- Runs inside the existing `pnpm test` (CI) — no separate job.

This catches exactly the runtime-bug class the audit surfaced (e.g. `openPosition` argument order, `riskBasedSize` option names, `mtfTimeframes` shorthand, preset keys).

## Test plan

- core: harness **7 passed** (6 recipes + a "found runnable snippets" guard).
- chart: `pnpm test` **913 passed** (incl. 4 harness tests); `pnpm typecheck` clean; `pnpm size-check` unchanged (test-only).
- Validated during bring-up: the harness flagged a real input-size condition (walk-forward needs ≥ 315 candles) before the fixture was widened — i.e. it exercises the snippets for real.

## Follow-up (not in this PR)

A Tier-1 import/compile check for the non-executed snippet majority (catches wrong-import/symbol in illustrative fragments).
