### PR TITLE
feat(core): add benchmark backtest option for Relative Strength

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ## [Unreleased]
 
+### Added — `benchmark` backtest option for Relative Strength
+
+- **`runBacktest` now accepts a `benchmark` option** carrying the benchmark
+  candles (e.g. S&P 500, Nikkei 225). This is the supported, ergonomic way to
+  supply the reference series that Relative Strength conditions (`rsAbove`,
+  `rsRising`, `rsRatingAbove`, `outperformanceAbove`, …) compare against:
+
+  ```ts
+  runBacktest(candles, rsAbove(1.0), rsBelow(0.9), {
+    capital: 1_000_000,
+    benchmark: sp500Candles,
+  });
+  ```
+
+  Previously there was no working public path — the documented `setup:` callback
+  was never a real option and never took effect. The benchmark is a per-run
+  input (not a candle-derived value), so pass it on every run that uses RS
+  conditions; the derived RS series is still cached and reused across runs that
+  share an `IndicatorCache`, the same candles, and the same benchmark.
+- The option flows through every backtest entry point: `runBacktestScaled`
+  (including the multi-tranche path, which previously had no way to receive a
+  benchmark), `batchBacktest`, and `portfolioBacktest` (one benchmark shared by
+  all symbols).
+
+### Fixed — benchmark/shared-cache correctness for Relative Strength
+
+- The benchmark is now treated as a run-local input and is never stored in a
+  shared `IndicatorCache`. Reusing one cache across runs with the same candles no
+  longer lets a benchmark supplied on an earlier run leak into a later run that
+  omits it (which previously made RS conditions trade when they should evaluate
+  `false`, leaving results order-dependent).
+- The cached RS series key now includes the benchmark identity, so reusing one
+  cache across runs that share the same candles but use **different** benchmarks
+  no longer returns RS data computed against the previous benchmark. Runs that
+  share a benchmark still hit the cache as before.
+
+### Breaking — removed `setBenchmark` helper
+
+- **`setBenchmark(indicators, benchmark)` has been removed.** It only mutated an
+  indicators object and never reached a backtest run on its own (the documented
+  `setup:` callback it was paired with does not exist). Use the new `benchmark`
+  backtest option instead. `BENCHMARK_CACHE_KEY` remains exported as the
+  indicators-object slot for advanced callers that evaluate RS conditions
+  directly against a hand-built indicators object.
+
 ### Added — MTF conditions in screening
 
 - **`screenStock` / `screenStockSafe` / `screenStockSeries` accept an

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -2777,26 +2777,27 @@ const result = TrendCraft.from(dailyCandles)
 
 #### 相対強度（RS）条件
 
-RS条件は株式のパフォーマンスをベンチマークと比較します。ベンチマークデータの設定が必要です。
+RS条件は株式のパフォーマンスをベンチマークと比較します。ベンチマークのローソク足を `benchmark` バックテストオプションで渡します。
 
 ```typescript
-import { rsAbove, rsRising, rsRatingAbove, setBenchmark, and } from 'trendcraft';
+import { rsAbove, rsRising, rsRatingAbove, and } from 'trendcraft';
 
-// バックテスト前にベンチマークを設定
 const entry = and(
   rsAbove(1.0),       // ベンチマークをアウトパフォーム
   rsRising(),         // RS上昇トレンド
   rsRatingAbove(80),  // 過去比較で上位20%
 );
 
-// バックテストでの使用
+// `benchmark` オプションでベンチマークを渡す
 runBacktest(candles, entry, exit, {
   capital: 1000000,
-  setup: (indicators) => {
-    setBenchmark(indicators, sp500Candles);
-  }
+  benchmark: sp500Candles,
 });
 ```
+
+ベンチマークは run ごとの入力なので、RS 条件を使う実行では毎回渡します。最適化時
+（同じ candles・同じベンチマークで `IndicatorCache` を共有）は、派生 RS シリーズが
+引き続きキャッシュされ再利用されます。
 
 | 関数 | 説明 |
 |------|------|

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -3204,26 +3204,27 @@ const result = TrendCraft.from(dailyCandles)
 
 #### Relative Strength (RS) Conditions
 
-RS conditions compare stock performance against a benchmark. Requires setting benchmark data.
+RS conditions compare stock performance against a benchmark. Pass the benchmark candles via the `benchmark` backtest option.
 
 ```typescript
-import { rsAbove, rsRising, rsRatingAbove, setBenchmark, and } from 'trendcraft';
+import { rsAbove, rsRising, rsRatingAbove, and } from 'trendcraft';
 
-// Set benchmark before backtest
 const entry = and(
   rsAbove(1.0),       // Outperforming benchmark
   rsRising(),         // RS trending up
   rsRatingAbove(80),  // In top 20% historically
 );
 
-// Usage with backtest setup
+// Supply the benchmark via the `benchmark` option
 runBacktest(candles, entry, exit, {
   capital: 1000000,
-  setup: (indicators) => {
-    setBenchmark(indicators, sp500Candles);
-  }
+  benchmark: sp500Candles,
 });
 ```
+
+The benchmark is a per-run input, so pass it on every run that uses RS
+conditions. When optimizing (sharing an `IndicatorCache` across runs with the
+same candles and benchmark), the derived RS series is still cached and reused.
 
 | Function | Description |
 |----------|-------------|

--- a/packages/core/docs/GUIDE.ja.md
+++ b/packages/core/docs/GUIDE.ja.md
@@ -1002,7 +1002,7 @@ rankings.slice(0, 5).forEach((r, i) => {
 ### バックテストでのRS
 
 ```typescript
-import { rsAbove, rsRising, rsRatingAbove, setBenchmark, and, goldenCrossCondition } from 'trendcraft';
+import { rsAbove, rsRising, rsRatingAbove, and, goldenCrossCondition } from 'trendcraft';
 
 // エントリー: 強いRS + トレンド確認
 const entry = and(
@@ -1012,12 +1012,10 @@ const entry = and(
   goldenCrossCondition()         // テクニカルエントリー
 );
 
-// ベンチマーク付きバックテスト実行
+// ベンチマーク付きバックテスト実行 — `benchmark` オプションでベンチマークのローソク足を渡す
 runBacktest(candles, entry, exit, {
   capital: 1000000,
-  setup: (indicators) => {
-    setBenchmark(indicators, nikkei225Candles);
-  }
+  benchmark: nikkei225Candles,
 });
 ```
 

--- a/packages/core/docs/GUIDE.md
+++ b/packages/core/docs/GUIDE.md
@@ -1001,7 +1001,7 @@ rankings.slice(0, 5).forEach((r, i) => {
 ### RS in Backtesting
 
 ```typescript
-import { rsAbove, rsRising, rsRatingAbove, setBenchmark, and } from 'trendcraft';
+import { rsAbove, rsRising, rsRatingAbove, and, goldenCrossCondition } from 'trendcraft';
 
 // Entry: Strong RS + trend confirmation
 const entry = and(
@@ -1011,12 +1011,10 @@ const entry = and(
   goldenCrossCondition()  // Technical entry
 );
 
-// Run backtest with benchmark
+// Run backtest with benchmark — pass the benchmark candles via the `benchmark` option
 runBacktest(candles, entry, exit, {
   capital: 1000000,
-  setup: (indicators) => {
-    setBenchmark(indicators, sp500Candles);
-  }
+  benchmark: sp500Candles,
 });
 ```
 

--- a/packages/core/src/backtest/__tests__/benchmark-option.test.ts
+++ b/packages/core/src/backtest/__tests__/benchmark-option.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { IndicatorCache } from "../../core/indicator-cache";
+import type { NormalizedCandle } from "../../types";
+import { rsAbove, rsBelow } from "../conditions/relative-strength";
+import { runBacktest } from "../engine";
+import { runBacktestScaled } from "../scaled-entry";
+
+const DAY = 86_400_000;
+const BASE_TIME = new Date("2024-01-01T00:00:00Z").getTime();
+
+/** Linear price series: `base + i * trend` per bar. */
+function makeCandles(count: number, base: number, trend: number): NormalizedCandle[] {
+  return Array.from({ length: count }, (_, i) => {
+    const price = base + i * trend;
+    return {
+      time: BASE_TIME + i * DAY,
+      open: price - 0.5,
+      high: price + 1,
+      low: price - 1,
+      close: price,
+      volume: 1_000_000,
+    };
+  });
+}
+
+describe("runBacktest — benchmark option", () => {
+  // Stock climbs faster than the benchmark, so RS stays above 1.0.
+  const stock = makeCandles(150, 100, 0.8);
+  const weakBenchmark = makeCandles(150, 100, 0.2);
+
+  it("seeds benchmark candles so RS conditions can enter", () => {
+    const result = runBacktest(stock, rsAbove(1.0), rsBelow(1.0), {
+      capital: 1_000_000,
+      takeProfit: 5,
+      benchmark: weakBenchmark,
+    });
+
+    expect(result.tradeCount).toBeGreaterThan(0);
+  });
+
+  it("produces no trades when benchmark is omitted (RS conditions evaluate false)", () => {
+    const result = runBacktest(stock, rsAbove(1.0), rsBelow(1.0), {
+      capital: 1_000_000,
+      takeProfit: 5,
+    });
+
+    expect(result.tradeCount).toBe(0);
+  });
+
+  it("does not leak the benchmark into a later run that omits it (shared cache)", () => {
+    const cache = new IndicatorCache();
+
+    const seededRun = runBacktest(
+      stock,
+      rsAbove(1.0),
+      rsBelow(1.0),
+      { capital: 1_000_000, takeProfit: 5, benchmark: weakBenchmark },
+      cache,
+    );
+    // Same cache + candles, but no benchmark this time: the option contract says
+    // RS conditions evaluate false, so no trades — the prior benchmark must not
+    // have been persisted into the shared cache.
+    const omittedRun = runBacktest(
+      stock,
+      rsAbove(1.0),
+      rsBelow(1.0),
+      { capital: 1_000_000, takeProfit: 5 },
+      cache,
+    );
+
+    expect(seededRun.tradeCount).toBeGreaterThan(0);
+    expect(omittedRun.tradeCount).toBe(0);
+  });
+
+  it("does not reuse stale RS data when the benchmark changes on a shared cache", () => {
+    // Stock outperforms the weak benchmark (RS > 1.0 → rsAbove enters) but
+    // underperforms the strong one (RS < 1.0 → rsAbove never enters).
+    const strongBenchmark = makeCandles(150, 100, 1.5);
+    const cache = new IndicatorCache();
+
+    const weakRun = runBacktest(
+      stock,
+      rsAbove(1.0),
+      rsBelow(1.0),
+      { capital: 1_000_000, takeProfit: 5, benchmark: weakBenchmark },
+      cache,
+    );
+    // Reuse the same cache + same candles, but a stronger benchmark.
+    const strongRun = runBacktest(
+      stock,
+      rsAbove(1.0),
+      rsBelow(1.0),
+      { capital: 1_000_000, takeProfit: 5, benchmark: strongBenchmark },
+      cache,
+    );
+
+    expect(weakRun.tradeCount).toBeGreaterThan(0);
+    // If RS data were reused from the weak-benchmark run, this would also trade.
+    expect(strongRun.tradeCount).toBe(0);
+  });
+});
+
+describe("runBacktestScaled — benchmark option", () => {
+  const stock = makeCandles(150, 100, 0.8);
+  const weakBenchmark = makeCandles(150, 100, 0.2);
+  const scaledEntry = {
+    tranches: 3,
+    strategy: "equal" as const,
+    intervalType: "signal" as const,
+  };
+
+  it("seeds benchmark in the scaled tranche path so RS conditions can enter", () => {
+    const result = runBacktestScaled(stock, rsAbove(1.0), rsBelow(1.0), {
+      capital: 1_000_000,
+      takeProfit: 5,
+      scaledEntry,
+      benchmark: weakBenchmark,
+    });
+
+    expect(result.tradeCount).toBeGreaterThan(0);
+  });
+
+  it("produces no trades when benchmark is omitted", () => {
+    const result = runBacktestScaled(stock, rsAbove(1.0), rsBelow(1.0), {
+      capital: 1_000_000,
+      takeProfit: 5,
+      scaledEntry,
+    });
+
+    expect(result.tradeCount).toBe(0);
+  });
+});

--- a/packages/core/src/backtest/__tests__/conditions/coverage.test.ts
+++ b/packages/core/src/backtest/__tests__/conditions/coverage.test.ts
@@ -41,6 +41,7 @@ import {
   weeklyUptrend,
 } from "../../conditions/mtf";
 import {
+  BENCHMARK_CACHE_KEY,
   mansfieldRSAbove,
   mansfieldRSBelow,
   outperformanceAbove,
@@ -53,7 +54,6 @@ import {
   rsRatingAbove,
   rsRatingBelow,
   rsRising,
-  setBenchmark,
 } from "../../conditions/relative-strength";
 import {
   hasActiveOrderBlocks,
@@ -594,7 +594,7 @@ describe("Relative Strength conditions - behavior verification", () => {
 
   it("rsAbove returns true when stock outperforms weak benchmark", () => {
     const indicators: Record<string, unknown> = {};
-    setBenchmark(indicators, weakBenchmark);
+    indicators[BENCHMARK_CACHE_KEY] = weakBenchmark;
     const cond = rsAbove(1.0);
     // Stock trend=0.5 vs benchmark trend=0.3; stock should outperform (RS > 1.0)
     const result = cond.evaluate(indicators, stock[110], 110, stock);
@@ -603,7 +603,7 @@ describe("Relative Strength conditions - behavior verification", () => {
 
   it("rsAbove returns false when stock underperforms strong benchmark", () => {
     const indicators: Record<string, unknown> = {};
-    setBenchmark(indicators, strongBenchmark);
+    indicators[BENCHMARK_CACHE_KEY] = strongBenchmark;
     const cond = rsAbove(1.0);
     // Stock trend=0.5 vs benchmark trend=1.0; stock should underperform (RS < 1.0)
     const result = cond.evaluate(indicators, stock[110], 110, stock);
@@ -616,7 +616,7 @@ describe("Relative Strength conditions - behavior verification", () => {
 
   it("rsBelow returns true when stock underperforms strong benchmark", () => {
     const indicators: Record<string, unknown> = {};
-    setBenchmark(indicators, strongBenchmark);
+    indicators[BENCHMARK_CACHE_KEY] = strongBenchmark;
     const result = rsBelow(1.0).evaluate(indicators, stock[110], 110, stock);
     expect(result).toBe(true);
   });
@@ -631,7 +631,7 @@ describe("Relative Strength conditions - behavior verification", () => {
 
   it("rsRising/rsFalling are mutually exclusive at same index", () => {
     const indicators: Record<string, unknown> = {};
-    setBenchmark(indicators, weakBenchmark);
+    indicators[BENCHMARK_CACHE_KEY] = weakBenchmark;
     const rising = rsRising().evaluate(indicators, stock[110], 110, stock);
     const falling = rsFalling().evaluate(indicators, stock[110], 110, stock);
     // They should not both be true (one or both can be false)
@@ -648,14 +648,14 @@ describe("Relative Strength conditions - behavior verification", () => {
 
   it("rsNewHigh returns false at early index where lookback is insufficient", () => {
     const indicators: Record<string, unknown> = {};
-    setBenchmark(indicators, weakBenchmark);
+    indicators[BENCHMARK_CACHE_KEY] = weakBenchmark;
     const result = rsNewHigh(10).evaluate(indicators, stock[0], 0, stock);
     expect(result).toBe(false);
   });
 
   it("rsNewLow returns false at early index where lookback is insufficient", () => {
     const indicators: Record<string, unknown> = {};
-    setBenchmark(indicators, weakBenchmark);
+    indicators[BENCHMARK_CACHE_KEY] = weakBenchmark;
     const result = rsNewLow(10).evaluate(indicators, stock[0], 0, stock);
     expect(result).toBe(false);
   });
@@ -670,7 +670,7 @@ describe("Relative Strength conditions - behavior verification", () => {
 
   it("rsRatingAbove/Below produce opposite results for moderate thresholds", () => {
     const indicators: Record<string, unknown> = {};
-    setBenchmark(indicators, weakBenchmark);
+    indicators[BENCHMARK_CACHE_KEY] = weakBenchmark;
     const above50 = rsRatingAbove(50).evaluate(indicators, stock[110], 110, stock);
     const below50 = rsRatingBelow(50).evaluate(indicators, stock[110], 110, stock);
     // They should not both be true
@@ -687,7 +687,7 @@ describe("Relative Strength conditions - behavior verification", () => {
 
   it("mansfieldRSAbove with very negative threshold succeeds when benchmark exists", () => {
     const indicators: Record<string, unknown> = {};
-    setBenchmark(indicators, weakBenchmark);
+    indicators[BENCHMARK_CACHE_KEY] = weakBenchmark;
     // Mansfield RS > -100 should be true for any reasonable stock
     const result = mansfieldRSAbove(-100).evaluate(indicators, stock[110], 110, stock);
     expect(result).toBe(true);
@@ -695,7 +695,7 @@ describe("Relative Strength conditions - behavior verification", () => {
 
   it("mansfieldRSBelow with very high threshold succeeds when benchmark exists", () => {
     const indicators: Record<string, unknown> = {};
-    setBenchmark(indicators, weakBenchmark);
+    indicators[BENCHMARK_CACHE_KEY] = weakBenchmark;
     const result = mansfieldRSBelow(100).evaluate(indicators, stock[110], 110, stock);
     expect(result).toBe(true);
   });
@@ -710,7 +710,7 @@ describe("Relative Strength conditions - behavior verification", () => {
 
   it("outperformanceAbove detects outperformance against weak benchmark", () => {
     const indicators: Record<string, unknown> = {};
-    setBenchmark(indicators, weakBenchmark);
+    indicators[BENCHMARK_CACHE_KEY] = weakBenchmark;
     // Stock growing faster than benchmark; outperformance should be > 0
     const result = outperformanceAbove(0).evaluate(indicators, stock[110], 110, stock);
     expect(result).toBe(true);
@@ -718,7 +718,7 @@ describe("Relative Strength conditions - behavior verification", () => {
 
   it("outperformanceBelow detects underperformance against strong benchmark", () => {
     const indicators: Record<string, unknown> = {};
-    setBenchmark(indicators, strongBenchmark);
+    indicators[BENCHMARK_CACHE_KEY] = strongBenchmark;
     // Stock growing slower than benchmark; outperformance should be < 0
     const result = outperformanceBelow(0).evaluate(indicators, stock[110], 110, stock);
     expect(result).toBe(true);
@@ -726,7 +726,7 @@ describe("Relative Strength conditions - behavior verification", () => {
 
   it("RS cache is reused: second call with same indicators returns consistent result", () => {
     const indicators: Record<string, unknown> = {};
-    setBenchmark(indicators, weakBenchmark);
+    indicators[BENCHMARK_CACHE_KEY] = weakBenchmark;
     const cond = rsAbove(0.5);
     const first = cond.evaluate(indicators, stock[100], 100, stock);
     const second = cond.evaluate(indicators, stock[100], 100, stock);

--- a/packages/core/src/backtest/conditions/__tests__/relative-strength.test.ts
+++ b/packages/core/src/backtest/conditions/__tests__/relative-strength.test.ts
@@ -14,7 +14,6 @@ import {
   rsRatingAbove,
   rsRatingBelow,
   rsRising,
-  setBenchmark,
 } from "../relative-strength";
 
 // Fixed base time for consistent alignment between stock and benchmark
@@ -125,8 +124,7 @@ function evaluateCondition(
   benchmark: NormalizedCandle[],
   index?: number,
 ): boolean {
-  const indicators: Record<string, unknown> = {};
-  setBenchmark(indicators, benchmark);
+  const indicators: Record<string, unknown> = { [BENCHMARK_CACHE_KEY]: benchmark };
   const idx = index ?? candles.length - 1;
   return condition.evaluate(indicators, candles[idx], idx, candles);
 }
@@ -282,12 +280,12 @@ describe("RS Backtest Conditions", () => {
     });
   });
 
-  describe("setBenchmark helper", () => {
-    it("should set benchmark in indicators cache", () => {
+  describe("BENCHMARK_CACHE_KEY", () => {
+    it("is the slot RS conditions read benchmark candles from", () => {
       const indicators: Record<string, unknown> = {};
       const benchmark = generateFlatCandles(100, 100);
 
-      setBenchmark(indicators, benchmark);
+      indicators[BENCHMARK_CACHE_KEY] = benchmark;
 
       expect(indicators[BENCHMARK_CACHE_KEY]).toBe(benchmark);
     });

--- a/packages/core/src/backtest/conditions/index.ts
+++ b/packages/core/src/backtest/conditions/index.ts
@@ -129,6 +129,7 @@ export {
   outperformanceAbove,
   outperformanceBelow,
   type RSConditionOptions,
+  RUN_LOCAL_CACHE_KEYS,
   rsAbove,
   rsBelow,
   rsFalling,
@@ -137,7 +138,7 @@ export {
   rsRatingAbove,
   rsRatingBelow,
   rsRising,
-  setBenchmark,
+  seedBenchmark,
 } from "./relative-strength";
 // RSI conditions
 export { rsiAbove, rsiBelow } from "./rsi";

--- a/packages/core/src/backtest/conditions/relative-strength.ts
+++ b/packages/core/src/backtest/conditions/relative-strength.ts
@@ -2,17 +2,16 @@
  * Relative Strength (RS) Backtest Conditions
  *
  * Conditions for comparing stock performance against a benchmark.
- * Requires benchmark data to be set in the indicators cache as `__benchmarkCandles`.
+ * Pass the benchmark candles via the `benchmark` backtest option — the engine
+ * seeds them so these conditions can compute RS.
  *
  * @example
  * ```ts
- * // Set benchmark before running backtest
- * const conditions = { entry: rsAbove(1.0), exit: rsBelow(0.8) };
- * const result = runBacktest(candles, {
- *   ...conditions,
- *   setup: (indicators) => {
- *     indicators.__benchmarkCandles = sp500Candles;
- *   }
+ * import { runBacktest, rsAbove, rsBelow } from "trendcraft";
+ *
+ * const result = runBacktest(candles, rsAbove(1.0), rsBelow(0.8), {
+ *   capital: 1_000_000,
+ *   benchmark: sp500Candles,
  * });
  * ```
  */
@@ -23,6 +22,24 @@ import type { Candle, NormalizedCandle, PresetCondition, Series } from "../../ty
 
 const BENCHMARK_KEY = "__benchmarkCandles";
 const RS_CACHE_PREFIX = "rs_";
+
+/**
+ * Stable per-array identity for benchmark candles. The RS cache key embeds this
+ * id so that reusing a shared `IndicatorCache` across runs with *different*
+ * benchmarks (same candles) does not return RS data computed against the
+ * previous benchmark. The same benchmark array always maps to the same id, so
+ * the cache still hits across runs that share a benchmark.
+ */
+const benchmarkIds = new WeakMap<object, number>();
+let nextBenchmarkId = 0;
+function benchmarkId(benchmark: object): number {
+  let id = benchmarkIds.get(benchmark);
+  if (id === undefined) {
+    id = nextBenchmarkId++;
+    benchmarkIds.set(benchmark, id);
+  }
+  return id;
+}
 
 /**
  * Options for RS conditions
@@ -43,13 +60,16 @@ function getRSData(
   options: RSConditionOptions = {},
 ): Series<RSValue> | null {
   const { period = 52, smaPeriod = 52 } = options;
-  const cacheKey = `${RS_CACHE_PREFIX}${period}_${smaPeriod}`;
-
-  const cached = indicators[cacheKey] as Series<RSValue> | undefined;
-  if (cached) return cached;
 
   const benchmark = indicators[BENCHMARK_KEY] as (Candle | NormalizedCandle)[] | undefined;
   if (!benchmark?.length) return null;
+
+  // Cache key includes the benchmark identity so changing benchmark (with the
+  // same candles + shared cache) recomputes instead of returning stale RS data.
+  const cacheKey = `${RS_CACHE_PREFIX}${benchmarkId(benchmark)}_${period}_${smaPeriod}`;
+
+  const cached = indicators[cacheKey] as Series<RSValue> | undefined;
+  if (cached) return cached;
 
   const rsData = benchmarkRS(candles, benchmark, { period, smaPeriod });
   indicators[cacheKey] = rsData;
@@ -418,25 +438,50 @@ export function outperformanceBelow(
 }
 
 /**
- * Helper function to set benchmark data in indicators cache
+ * Indicators-object key under which RS conditions read benchmark candles.
  *
- * Call this in your backtest setup to enable RS conditions.
+ * Supply a benchmark to a backtest via the `benchmark` option — that is the
+ * supported path. This key is exported for advanced callers that evaluate RS
+ * conditions directly against a hand-built indicators object:
  *
  * @example
  * ```ts
- * setBenchmark(indicators, sp500Candles);
- * ```
- */
-export function setBenchmark(
-  indicators: Record<string, unknown>,
-  benchmark: (Candle | NormalizedCandle)[],
-): void {
-  indicators[BENCHMARK_KEY] = benchmark;
-}
-
-/**
- * Key for storing benchmark in indicators cache
+ * import { BENCHMARK_CACHE_KEY, rsAbove } from "trendcraft";
  *
- * You can set benchmark manually: `indicators.__benchmarkCandles = benchmarkData`
+ * const indicators = { [BENCHMARK_CACHE_KEY]: sp500Candles };
+ * rsAbove(1.0).evaluate(indicators, candle, index, candles);
+ * ```
+ *
+ * The benchmark is a per-run input, not a candle-derived value, so it is never
+ * stored in a shared {@link IndicatorCache}; pass it on every run that needs it.
  */
 export const BENCHMARK_CACHE_KEY = BENCHMARK_KEY;
+
+/**
+ * Indicator keys that are run-local inputs rather than candle-derived
+ * computations. The benchmark is supplied per run (the same candles can be run
+ * against different benchmarks), so it must not be shared through the
+ * candle-keyed {@link IndicatorCache}. Passed to `createCachedIndicators` so a
+ * benchmark seeded on one run never leaks into a later run that omits it.
+ *
+ * Internal plumbing — not part of the public API.
+ */
+export const RUN_LOCAL_CACHE_KEYS: ReadonlySet<string> = new Set([BENCHMARK_KEY]);
+
+/**
+ * Seed benchmark candles into a backtest's indicators object so RS conditions
+ * can read them. No-op when `benchmark` is undefined.
+ *
+ * Internal plumbing — the single owner of the `BENCHMARK_CACHE_KEY` write,
+ * shared by every backtest engine entry point (`runBacktest`,
+ * `runBacktestScaled`). Not part of the public API; supply a benchmark through
+ * the `benchmark` backtest option instead.
+ */
+export function seedBenchmark(
+  indicators: Record<string, unknown>,
+  benchmark: (Candle | NormalizedCandle)[] | undefined,
+): void {
+  if (benchmark) {
+    indicators[BENCHMARK_KEY] = benchmark;
+  }
+}

--- a/packages/core/src/backtest/engine.ts
+++ b/packages/core/src/backtest/engine.ts
@@ -26,7 +26,7 @@ import type {
 import type { ValidationOptions } from "../validation/types";
 import { validateCandles } from "../validation/validate";
 import type { ExtendedCondition } from "./conditions";
-import { evaluateCondition } from "./conditions";
+import { evaluateCondition, RUN_LOCAL_CACHE_KEYS, seedBenchmark } from "./conditions";
 import { createDrawdownTracker } from "./drawdown-tracker";
 import type { Position } from "./engine-utils";
 import {
@@ -172,7 +172,16 @@ export function runBacktest(
   }
 
   const trades: Trade[] = [];
-  const indicators: Record<string, unknown> = createCachedIndicators(candles, cache);
+  // The benchmark is a run-local input, so it is kept off the shared cache
+  // (see RUN_LOCAL_CACHE_KEYS) and must be re-supplied each run.
+  const indicators: Record<string, unknown> = createCachedIndicators(
+    candles,
+    cache,
+    RUN_LOCAL_CACHE_KEYS,
+  );
+
+  // Seed benchmark candles for Relative Strength conditions.
+  seedBenchmark(indicators, options.benchmark);
 
   // Setup MTF context if timeframes are specified
   const mtfSetup = buildMtfSetup(candles, mtfTimeframes);

--- a/packages/core/src/backtest/index.ts
+++ b/packages/core/src/backtest/index.ts
@@ -161,7 +161,6 @@ export {
   rsRatingAbove,
   rsRatingBelow,
   rsRising,
-  setBenchmark,
   stochAbove,
   // Stochastics conditions
   stochBelow,

--- a/packages/core/src/backtest/scaled-entry.ts
+++ b/packages/core/src/backtest/scaled-entry.ts
@@ -22,7 +22,7 @@ import type {
   Trade,
 } from "../types";
 import type { ExtendedCondition } from "./conditions";
-import { evaluateCondition } from "./conditions";
+import { evaluateCondition, seedBenchmark } from "./conditions";
 import {
   applySlippage,
   calculateStats,
@@ -187,6 +187,9 @@ export function runBacktestScaled(
 
   const trades: Trade[] = [];
   const indicators: Record<string, unknown> = {};
+
+  // Seed benchmark candles so Relative Strength conditions can read them
+  seedBenchmark(indicators, options.benchmark);
 
   // Setup MTF context if timeframes are specified
   const mtfSetup = buildMtfSetup(candles, mtfTimeframes);

--- a/packages/core/src/core/indicator-cache.ts
+++ b/packages/core/src/core/indicator-cache.ts
@@ -75,11 +75,17 @@ export class IndicatorCache {
  *
  * @param candles - Candle array (used as cache identity key)
  * @param cache - Shared IndicatorCache instance (optional)
+ * @param localOnlyKeys - Keys that are run-local inputs rather than candle-derived
+ *   computations (e.g. the RS benchmark). The shared cache only stores values
+ *   that are a pure function of the candle array, so these keys are kept on the
+ *   local object and never read from or written to the shared cache — otherwise
+ *   they would leak into later runs that reuse the same cache and candles.
  * @returns Proxied indicators object
  */
 export function createCachedIndicators(
   candles: object,
   cache?: IndicatorCache,
+  localOnlyKeys?: ReadonlySet<string>,
 ): Record<string, unknown> {
   const local: Record<string, unknown> = {};
 
@@ -89,6 +95,9 @@ export function createCachedIndicators(
     get(target, prop: string) {
       // Check local first
       if (prop in target) return target[prop];
+
+      // Run-local inputs are never shared via the cache
+      if (localOnlyKeys?.has(prop)) return undefined;
 
       // Then check shared cache
       const cached = cache.get(prop, candles);
@@ -101,7 +110,9 @@ export function createCachedIndicators(
     },
     set(target, prop: string, value) {
       target[prop] = value;
-      cache.set(prop, candles, value);
+      if (!localOnlyKeys?.has(prop)) {
+        cache.set(prop, candles, value);
+      }
       return true;
     },
   });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -167,7 +167,6 @@ export {
   // Engine
   runBacktest,
   runBacktestScaled,
-  setBenchmark,
   stochAbove,
   // Stochastics conditions
   stochBelow,

--- a/packages/core/src/types/backtest.ts
+++ b/packages/core/src/types/backtest.ts
@@ -5,7 +5,7 @@
 import type { MarginConfig } from "../backtest/margin";
 import type { OrderType, TimeInForce } from "../backtest/order-types";
 import type { SlippageModel } from "../backtest/slippage-model";
-import type { NormalizedCandle, TimeframeShorthand } from "./candle";
+import type { Candle, NormalizedCandle, TimeframeShorthand } from "./candle";
 
 /**
  * Position direction for long/short trading
@@ -348,6 +348,14 @@ export type BacktestOptions = {
   margin?: MarginConfig;
   /** Position sizing per entry (default: full-capital, the legacy behavior) */
   sizing?: BacktestSizingConfig;
+  /**
+   * Benchmark candles for Relative Strength conditions (e.g. S&P 500, Nikkei 225).
+   *
+   * Required by RS conditions (`rsAbove`, `rsRising`, `rsRatingAbove`, …) — they
+   * compare the traded symbol against this series. Must be time-aligned with
+   * `candles`. When omitted, RS conditions evaluate to `false`.
+   */
+  benchmark?: (Candle | NormalizedCandle)[];
 };
 
 /**


### PR DESCRIPTION
## Summary

Relative Strength conditions (`rsAbove`, `rsRising`, `rsRatingAbove`, `outperformanceAbove`, …) compare a symbol against a benchmark series, but there was **no working public way to supply that benchmark**: the documented `setup:` callback was never a real `BacktestOptions` field and the engine never read it.

This adds a first-class `benchmark` option to the backtest API.

```ts
runBacktest(candles, rsAbove(1.05), rsBelow(0.9), {
  capital: 1_000_000,
  benchmark: sp500Candles,
});
```

The benchmark is now an explicit per-call input rather than a hidden, string-keyed cache slot.

## Changes

- **New `benchmark` option on `BacktestOptions`**, seeded into every backtest entry point — `runBacktest`, `runBacktestScaled` (including the multi-tranche path, which previously had no way to receive a benchmark), `batchBacktest`, and `portfolioBacktest` — through a single shared `seedBenchmark` helper (one owner of the write).
- **Benchmark treated as a per-run input, not a candle-derived value:**
  - It is never stored in a shared `IndicatorCache`. A new generic `localOnlyKeys` parameter on `createCachedIndicators` keeps run-local inputs off the candle-keyed cache, so a benchmark supplied on one run no longer leaks into a later run that omits it (which would otherwise make RS conditions trade when they should evaluate `false`, leaving results order-dependent).
  - The cached RS series key now includes the benchmark identity, so reusing one cache across runs with the same candles but **different** benchmarks no longer returns RS data computed against the previous benchmark.
- **Removed the `setBenchmark` helper.** It only mutated an indicators object and never reached a backtest run on its own (it was paired with the non-existent `setup:` callback). `BENCHMARK_CACHE_KEY` remains exported as the indicators-object slot for advanced callers that evaluate RS conditions directly against a hand-built indicators object.
- Updated core docs (GUIDE/API, English + Japanese) and CHANGELOG (Added / Fixed / Breaking).

## Breaking changes

- `setBenchmark` is removed (minor bump under 0.x). Use the `benchmark` option instead.

## Test plan

- New `benchmark-option.test.ts`: option seeds the benchmark so RS conditions can enter; omitting it produces no trades; no benchmark leak across runs on a shared cache; no stale RS data when the benchmark changes on a shared cache; same coverage for the scaled-tranche path.
- Existing RS condition tests updated to read the benchmark slot directly.
- `tsc --noEmit` passes, lint passes, full suite (6255 tests) passes, build passes.