### PR TITLE
test(core): add doc import-check (Tier 1) and fix stale doc imports

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Fixed — documentation: streaming imports and a stale helper reference
+
+- The API docs imported streaming exports from a `trendcraft/streaming` subpath
+  that was never published — those imports failed to resolve. Streaming exports
+  are reached through the `streaming` namespace of the main entry; the docs now
+  use `import { streaming } from "trendcraft"` accordingly.
+- Removed a leftover `setBenchmark(...)` reference from the docs (the helper was
+  removed; use the `benchmark` backtest option).
+- Added a doc-snippet **import check (Tier 1)** to the test suite: it validates
+  every `trendcraft` import in the docs against the published `exports` subpaths
+  and the real export surface, so a stale subpath or a removed/renamed symbol in
+  a doc snippet now fails CI even for snippets that aren't executed.
+
 ### Added — `benchmark` backtest option for Relative Strength
 
 - **`runBacktest` now accepts a `benchmark` option** carrying the benchmark

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -3961,7 +3961,8 @@ Layer 6 — ポジション管理
 トレードティックのストリームを、固定時間間隔でグループ化してOHLCVキャンドルに変換します。
 
 ```typescript
-import { createCandleAggregator } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createCandleAggregator } = streaming;
 
 const agg = createCandleAggregator({ intervalMs: 60_000 }); // 1分足
 
@@ -4005,7 +4006,8 @@ const last = agg.flush();
 下位時間足のキャンドルを上位時間足にインクリメンタルにリサンプリングします（例: 1分足 → 5分足）。
 
 ```typescript
-import { createCandleResampler } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createCandleResampler } = streaming;
 
 const resampler = createCandleResampler({ targetIntervalMs: 300_000 }); // 5分足
 
@@ -4041,7 +4043,8 @@ for (const candle1m of stream) {
 valueA が valueB を下から上に交差したことを検出します。
 
 ```typescript
-import { createCrossOverDetector } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createCrossOverDetector } = streaming;
 
 const crossOver = createCrossOverDetector();
 crossOver.next(10, 20); // false（初回呼び出し、前の値なし）
@@ -4064,7 +4067,8 @@ crossOver.next(22, 20); // false（既に上にいる、新しいクロスなし
 valueA が valueB を上から下に交差したことを検出します。
 
 ```typescript
-import { createCrossUnderDetector } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createCrossUnderDetector } = streaming;
 
 const crossUnder = createCrossUnderDetector();
 crossUnder.next(20, 10); // false（初回呼び出し）
@@ -4080,7 +4084,8 @@ crossUnder.next(9, 10);  // true （クロスアンダー発生）
 値が固定の閾値を上回ったり下回ったりしたことを検出します。
 
 ```typescript
-import { createThresholdDetector } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createThresholdDetector } = streaming;
 
 const detector = createThresholdDetector(70);
 detector.next(65); // { crossAbove: false, crossBelow: false }
@@ -4107,7 +4112,8 @@ detector.next(68); // { crossAbove: false, crossBelow: true }
 ボリンジャーバンドのスクイーズ状態（低ボラティリティ）とその解放を検出します。
 
 ```typescript
-import { createSqueezeDetector } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createSqueezeDetector } = streaming;
 
 const squeeze = createSqueezeDetector({ bandwidthThreshold: 0.05 });
 squeeze.next(0.08); // { squeezeStart: false, squeezeEnd: false, inSqueeze: false }
@@ -4134,7 +4140,8 @@ squeeze.next(0.06); // { squeezeStart: false, squeezeEnd: true, inSqueeze: false
 価格とインジケーター間のブリッシュ/ベアリッシュ・ダイバージェンスを検出します。
 
 ```typescript
-import { createDivergenceDetector } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createDivergenceDetector } = streaming;
 
 const divergence = createDivergenceDetector({ lookback: 14 });
 for (const candle of stream) {
@@ -4167,7 +4174,8 @@ for (const candle of stream) {
 AND論理で条件を組み合わせます（すべてtrueである必要があります）。
 
 ```typescript
-import { and, rsiBelow, smaGoldenCross } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { and, rsiBelow, smaGoldenCross } = streaming;
 
 const entry = and(rsiBelow(30), smaGoldenCross());
 ```
@@ -4179,7 +4187,8 @@ const entry = and(rsiBelow(30), smaGoldenCross());
 OR論理で条件を組み合わせます（いずれかがtrueであればよい）。
 
 ```typescript
-import { or, rsiAbove, smaDeadCross } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { or, rsiAbove, smaDeadCross } = streaming;
 
 const exit = or(rsiAbove(70), smaDeadCross());
 ```
@@ -4191,7 +4200,8 @@ const exit = or(rsiAbove(70), smaDeadCross());
 条件を否定します。
 
 ```typescript
-import { not, rsiAbove } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { not, rsiAbove } = streaming;
 
 const notOverbought = not(rsiAbove(70));
 ```
@@ -4203,7 +4213,8 @@ const notOverbought = not(rsiAbove(70));
 ストリーミング条件をスナップショットとキャンドルに対して評価します。
 
 ```typescript
-import { evaluateStreamingCondition } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { evaluateStreamingCondition } = streaming;
 
 const isEntry = evaluateStreamingCondition(entryCondition, snapshot, candle);
 ```
@@ -4242,7 +4253,8 @@ const customCondition = (snapshot, candle) => {
 インクリメンタルなインジケーターとストリーミング条件を組み合わせてシグナル評価パイプラインを構築します。キャンドル1本あたりO(1)のコストで処理します。
 
 ```typescript
-import { createPipeline, rsiBelow, rsiAbove } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createPipeline, rsiBelow, rsiAbove } = streaming;
 import { createRsi, createSma } from "trendcraft/incremental";
 
 const pipeline = createPipeline({
@@ -4286,7 +4298,8 @@ for (const candle of stream) {
 ベース時間足のキャンドルストリームを複数の上位時間足にリサンプリングし、各時間足でインジケーターを実行するマルチタイムフレームコンテキストです。
 
 ```typescript
-import { createStreamingMtf } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createStreamingMtf } = streaming;
 import { createSma, createRsi } from "trendcraft/incremental";
 
 const mtf = createStreamingMtf({
@@ -4335,7 +4348,8 @@ for (const candle of stream) {
 エンドツーエンドのパイプライン: ティック → キャンドル → インジケーター → シグナル → イベント。`CandleAggregator` と `StreamingPipeline` を単一のエントリーポイントに統合します。
 
 ```typescript
-import { createTradingSession, rsiBelow, rsiAbove } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createTradingSession, rsiBelow, rsiAbove } = streaming;
 import { createRsi } from "trendcraft/incremental";
 
 const session = createTradingSession({
@@ -4391,7 +4405,8 @@ const closeEvents = session.close();
 日次損失制限、取引回数制限、連続負け後のクールダウンを適用するサーキットブレーカーです。
 
 ```typescript
-import { createRiskGuard } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createRiskGuard } = streaming;
 
 const guard = createRiskGuard({
   maxDailyLoss: -50000,
@@ -4431,7 +4446,8 @@ guard.reportTrade(-200, Date.now());
 取引時間枠、強制決済タイミング、ブラックアウト期間を管理します。
 
 ```typescript
-import { createTimeGuard } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createTimeGuard } = streaming;
 
 const guard = createTimeGuard({
   tradingWindows: [
@@ -4476,7 +4492,8 @@ guard.addBlackout({
 `TradingSession` をリスクガードとタイムガードでラップします。エントリーシグナルはガードによるチェック後に発行され、取引時間枠の終了が近づくと強制決済イベントが挿入されます。
 
 ```typescript
-import { createGuardedSession, rsiBelow, rsiAbove } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createGuardedSession, rsiBelow, rsiAbove } = streaming;
 import { createRsi } from "trendcraft/incremental";
 
 const session = createGuardedSession(
@@ -4533,7 +4550,8 @@ session.riskGuard?.reportTrade(-200, Date.now());
 SL/TP/トレーリングストップ検出とP&L計算を備えたステートフルなポジション・アカウント管理です。
 
 ```typescript
-import { createPositionTracker } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createPositionTracker } = streaming;
 
 const tracker = createPositionTracker({
   capital: 1_000_000,
@@ -4591,7 +4609,8 @@ console.log("P&L:", trade.return);
 フルE2Eのマネージドトレーディングセッション: ティック → キャンドル → インジケーター → シグナル → ポジション → P&L。`GuardedSession` に自動ポジション管理（サイジング、SL/TP/トレーリング、RiskGuardへの自動レポート）を統合します。
 
 ```typescript
-import { createManagedSession, rsiBelow, rsiAbove } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createManagedSession, rsiBelow, rsiAbove } = streaming;
 import { createRsi, createAtr } from "trendcraft/incremental";
 
 const session = createManagedSession(

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -4481,7 +4481,8 @@ Layer 6 — Position Management
 Converts a stream of trade ticks into OHLCV candles by grouping trades within fixed time intervals.
 
 ```typescript
-import { createCandleAggregator } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createCandleAggregator } = streaming;
 
 const agg = createCandleAggregator({ intervalMs: 60_000 }); // 1-min candles
 
@@ -4525,7 +4526,8 @@ const last = agg.flush();
 Incrementally resamples lower-timeframe candles into higher-timeframe candles (e.g., 1-min → 5-min).
 
 ```typescript
-import { createCandleResampler } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createCandleResampler } = streaming;
 
 const resampler = createCandleResampler({ targetIntervalMs: 300_000 }); // 5-min
 
@@ -4561,7 +4563,8 @@ Incremental signal detectors that process one data point at a time. Each detecto
 Detects when valueA crosses from below/equal to above valueB.
 
 ```typescript
-import { createCrossOverDetector } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createCrossOverDetector } = streaming;
 
 const crossOver = createCrossOverDetector();
 crossOver.next(10, 20); // false (first call, no previous)
@@ -4584,7 +4587,8 @@ crossOver.next(22, 20); // false (already above, no new cross)
 Detects when valueA crosses from above/equal to below valueB.
 
 ```typescript
-import { createCrossUnderDetector } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createCrossUnderDetector } = streaming;
 
 const crossUnder = createCrossUnderDetector();
 crossUnder.next(20, 10); // false (first call)
@@ -4600,7 +4604,8 @@ Same methods as `createCrossOverDetector`.
 Detects when a value crosses above or below a fixed threshold level.
 
 ```typescript
-import { createThresholdDetector } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createThresholdDetector } = streaming;
 
 const detector = createThresholdDetector(70);
 detector.next(65); // { crossAbove: false, crossBelow: false }
@@ -4627,7 +4632,8 @@ detector.next(68); // { crossAbove: false, crossBelow: true }
 Detects Bollinger Band squeeze conditions (low volatility) and their release.
 
 ```typescript
-import { createSqueezeDetector } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createSqueezeDetector } = streaming;
 
 const squeeze = createSqueezeDetector({ bandwidthThreshold: 0.05 });
 squeeze.next(0.08); // { squeezeStart: false, squeezeEnd: false, inSqueeze: false }
@@ -4654,7 +4660,8 @@ squeeze.next(0.06); // { squeezeStart: false, squeezeEnd: true, inSqueeze: false
 Detects bullish/bearish divergences between price and an indicator by comparing recent highs/lows.
 
 ```typescript
-import { createDivergenceDetector } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createDivergenceDetector } = streaming;
 
 const divergence = createDivergenceDetector({ lookback: 14 });
 for (const candle of stream) {
@@ -4687,7 +4694,8 @@ Streaming condition system with combinators (`and`, `or`, `not`) and preset cond
 Combine conditions with AND logic (all must be true).
 
 ```typescript
-import { and, rsiBelow, smaGoldenCross } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { and, rsiBelow, smaGoldenCross } = streaming;
 
 const entry = and(rsiBelow(30), smaGoldenCross());
 ```
@@ -4699,7 +4707,8 @@ const entry = and(rsiBelow(30), smaGoldenCross());
 Combine conditions with OR logic (any must be true).
 
 ```typescript
-import { or, rsiAbove, smaDeadCross } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { or, rsiAbove, smaDeadCross } = streaming;
 
 const exit = or(rsiAbove(70), smaDeadCross());
 ```
@@ -4711,7 +4720,8 @@ const exit = or(rsiAbove(70), smaDeadCross());
 Negate a condition.
 
 ```typescript
-import { not, rsiAbove } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { not, rsiAbove } = streaming;
 
 const notOverbought = not(rsiAbove(70));
 ```
@@ -4723,7 +4733,8 @@ const notOverbought = not(rsiAbove(70));
 Evaluate a streaming condition against a snapshot and candle.
 
 ```typescript
-import { evaluateStreamingCondition } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { evaluateStreamingCondition } = streaming;
 
 const isEntry = evaluateStreamingCondition(entryCondition, snapshot, candle);
 ```
@@ -4762,7 +4773,8 @@ const customCondition = (snapshot, candle) => {
 Combines incremental indicators with streaming conditions into a signal evaluation pipeline. Processes one candle at a time with O(1) per-candle cost.
 
 ```typescript
-import { createPipeline, rsiBelow, rsiAbove } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createPipeline, rsiBelow, rsiAbove } = streaming;
 import { createRsi, createSma } from "trendcraft/incremental";
 
 const pipeline = createPipeline({
@@ -4806,7 +4818,8 @@ for (const candle of stream) {
 Multi-timeframe context that resamples a base-timeframe candle stream into multiple higher timeframes and runs indicators on each.
 
 ```typescript
-import { createStreamingMtf } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createStreamingMtf } = streaming;
 import { createSma, createRsi } from "trendcraft/incremental";
 
 const mtf = createStreamingMtf({
@@ -4855,7 +4868,8 @@ Each `StreamingMtfTimeframeConfig`:
 End-to-end pipeline: tick → candle → indicator → signal → event. Combines `CandleAggregator` and `StreamingPipeline` into a single entry point.
 
 ```typescript
-import { createTradingSession, rsiBelow, rsiAbove } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createTradingSession, rsiBelow, rsiAbove } = streaming;
 import { createRsi } from "trendcraft/incremental";
 
 const session = createTradingSession({
@@ -4911,7 +4925,8 @@ const closeEvents = session.close();
 Circuit breaker that enforces daily loss limits, trade count limits, and consecutive loss cooldowns.
 
 ```typescript
-import { createRiskGuard } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createRiskGuard } = streaming;
 
 const guard = createRiskGuard({
   maxDailyLoss: -50000,
@@ -4951,7 +4966,8 @@ guard.reportTrade(-200, Date.now());
 Enforces trading windows, force-close timing, and blackout periods.
 
 ```typescript
-import { createTimeGuard } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createTimeGuard } = streaming;
 
 const guard = createTimeGuard({
   tradingWindows: [
@@ -4996,7 +5012,8 @@ guard.addBlackout({
 Wraps a `TradingSession` with risk and time guards. Entry signals are checked against guards before being emitted; force-close events are injected when trading windows are about to end.
 
 ```typescript
-import { createGuardedSession, rsiBelow, rsiAbove } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createGuardedSession, rsiBelow, rsiAbove } = streaming;
 import { createRsi } from "trendcraft/incremental";
 
 const session = createGuardedSession(
@@ -5053,7 +5070,8 @@ session.riskGuard?.reportTrade(-200, Date.now());
 Stateful position and account management with SL/TP/trailing stop detection and P&L calculation.
 
 ```typescript
-import { createPositionTracker } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createPositionTracker } = streaming;
 
 const tracker = createPositionTracker({
   capital: 1_000_000,
@@ -5111,7 +5129,8 @@ console.log("P&L:", trade.return);
 Full end-to-end managed trading session: tick → candle → indicator → signal → position → P&L. Wraps `GuardedSession` with automatic position management, including sizing, SL/TP/trailing, and auto-reporting to RiskGuard.
 
 ```typescript
-import { createManagedSession, rsiBelow, rsiAbove } from "trendcraft/streaming";
+import { streaming } from "trendcraft";
+const { createManagedSession, rsiBelow, rsiAbove } = streaming;
 import { createRsi, createAtr } from "trendcraft/incremental";
 
 const session = createManagedSession(

--- a/packages/core/llms-full.txt
+++ b/packages/core/llms-full.txt
@@ -722,7 +722,7 @@ const custom = (indicators, candle, index, candles) => {
 - `rsRatingAbove(rating)` / `rsRatingBelow(rating)`
 - `mansfieldRSAbove(threshold)` / `mansfieldRSBelow(threshold)`
 - `outperformanceAbove(percent)` / `outperformanceBelow(percent)`
-- `setBenchmark(indicators, benchmarkCandles)` — Required before RS conditions
+- RS conditions require a benchmark — pass it via the `benchmark` backtest option: `runBacktest(candles, entry, exit, { capital, benchmark: sp500Candles })`
 
 **Price Patterns:**
 - `patternDetected(type, opts?)` / `patternConfirmed(type, opts?)`

--- a/packages/core/src/__tests__/docs-import-check.test.ts
+++ b/packages/core/src/__tests__/docs-import-check.test.ts
@@ -1,0 +1,219 @@
+// @vitest-environment node
+/**
+ * Doc-snippet harness (Tier 1 — import check).
+ *
+ * Scans EVERY fenced `ts`/`typescript` block in the package docs (not just the
+ * `<!-- doctest-run -->` subset that Tier 2 executes) and validates the
+ * `trendcraft` imports against the real package surface:
+ *
+ *   1. Subpath validity — every `from "trendcraft/<sub>"` must be a published
+ *      `exports` subpath in package.json (catches docs referencing a subpath
+ *      that was never wired up, e.g. a stale `trendcraft/streaming`).
+ *   2. Named-export validity — every named *value* import must be a real export
+ *      of the resolved in-repo entry (catches docs importing a removed/renamed
+ *      symbol, e.g. a deleted `setBenchmark`).
+ *   3. Namespace-member validity — when a snippet destructures a namespace it
+ *      imported (`import { streaming } from "trendcraft"; const { foo } =
+ *      streaming;`, or `import * as ns from "trendcraft/<sub>"`), every
+ *      destructured name must be a real member of that namespace (catches a
+ *      removed/renamed helper reached through the namespace).
+ *
+ * This is the cheap, robust complement to Tier 2: it covers the non-executed
+ * majority of snippets without compiling them. Type-only imports (`import type`
+ * and `type`-prefixed specifiers) are skipped — their existence can't be proven
+ * from the runtime module surface, and that is the fragile part Tier 1 avoids.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pkgRoot = path.resolve(here, "../..");
+const docsDir = path.resolve(here, "../../docs");
+
+// All doc files that carry runnable `ts` fences, including the Japanese
+// translations (which contain the same imports and are just as prone to drift).
+const DOC_FILES = ["COOKBOOK.md", "GUIDE.md", "API.md", "GUIDE.ja.md", "API.ja.md"];
+
+// Map each published subpath to its in-repo source entry (relative to this
+// test file). Mirrors the rewrites in the Tier 2 harness; the main entry is "".
+const SUBPATH_TO_SOURCE: Record<string, string> = {
+  "": "../index",
+  screening: "../screening",
+  incremental: "../indicators/incremental",
+  safe: "../indicators/safe",
+  manifest: "../manifest",
+};
+
+// Valid published subpaths come straight from package.json `exports` so this
+// check tracks the real packaging surface, not a hand-maintained list.
+const pkgJson = JSON.parse(readFileSync(path.join(pkgRoot, "package.json"), "utf8"));
+const VALID_SUBPATHS = new Set(
+  Object.keys(pkgJson.exports ?? { ".": {} }).map((k) => (k === "." ? "" : k.replace(/^\.\//, ""))),
+);
+
+type ImportRef = { file: string; source: string; subpath: string; names: string[]; raw: string };
+// A local binding that holds a namespace object (whole module, or a named
+// export that is itself a namespace like `streaming`).
+type NsBinding = { subpath: string; member: string | null };
+type Destructure = {
+  file: string;
+  rhs: string;
+  names: string[];
+  nsBindings: Map<string, NsBinding>;
+};
+
+/** Extract `ts`/`typescript` fenced code from a doc file. */
+function extractFences(file: string): string[] {
+  const text = readFileSync(path.join(docsDir, file), "utf8");
+  const out: string[] = [];
+  const lines = text.split("\n");
+  let i = 0;
+  while (i < lines.length) {
+    if (/^```(ts|typescript)\s*$/.test(lines[i])) {
+      const body: string[] = [];
+      i++;
+      while (i < lines.length && !/^```\s*$/.test(lines[i])) body.push(lines[i++]);
+      out.push(body.join("\n"));
+    }
+    i++;
+  }
+  return out;
+}
+
+/**
+ * Strip `//` line and block comments. Doc imports routinely carry inline
+ * comments inside the braces (`foo, // note`), which would otherwise fold into
+ * the following specifier and hide it from validation. Module specifiers and
+ * destructure right-hand sides are plain identifiers/`"trendcraft…"` strings
+ * with no `//`, so stripping comments before parsing is safe here.
+ */
+function stripComments(code: string): string {
+  return code.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+/** Split a `{ a, b as c, type T }` specifier list into checkable value names. */
+function parseSpecifiers(brace: string): string[] {
+  const names: string[] = [];
+  for (const spec of brace.split(",")) {
+    const s = spec.trim();
+    if (!s || s === "..." || s.startsWith("type ")) continue; // skip ellipsis + type specifiers
+    const name = s.split(/\s+as\s+/)[0].trim(); // `a as b` → check `a`
+    if (/^[A-Za-z_$][\w$]*$/.test(name)) names.push(name);
+  }
+  return names;
+}
+
+const IMPORT_RE = /import\s+([^;]*?)\s+from\s*['"](trendcraft(?:\/[\w-]+)?)['"]/g;
+const DESTRUCTURE_RE = /(?:const|let|var)\s*\{([^}]*)\}\s*=\s*([A-Za-z_$][\w$]*)\s*;?/g;
+
+function parseSnippet(
+  file: string,
+  code: string,
+): { imports: ImportRef[]; destructures: Destructure[] } {
+  const src = stripComments(code);
+  const imports: ImportRef[] = [];
+  const nsBindings = new Map<string, NsBinding>();
+  let m: RegExpExecArray | null;
+
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
+  while ((m = IMPORT_RE.exec(src)) !== null) {
+    const clause = m[1].trim();
+    const source = m[2];
+    const subpath = source === "trendcraft" ? "" : source.replace(/^trendcraft\//, "");
+
+    // Extract any checkable value names per import shape. The *source* is
+    // recorded unconditionally below (every shape — named, namespace, type,
+    // default — feeds the subpath-validity check), so no shape can slip past it.
+    let names: string[] = [];
+    const star = clause.match(/^\*\s+as\s+([A-Za-z_$][\w$]*)$/);
+    if (star) {
+      // `import * as ns from "..."` → ns binds the whole module namespace.
+      nsBindings.set(star[1], { subpath, member: null });
+    } else if (!/^type\s/.test(clause)) {
+      const brace = clause.match(/\{([^}]*)\}/);
+      names = brace ? parseSpecifiers(brace[1]) : [];
+      // A named import may itself be a namespace object (e.g. `streaming`);
+      // record each as a candidate binding so a destructure can be validated.
+      for (const n of names) nsBindings.set(n, { subpath, member: n });
+    }
+    imports.push({ file, source, subpath, names, raw: m[0] });
+  }
+
+  const destructures: Destructure[] = [];
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
+  while ((m = DESTRUCTURE_RE.exec(src)) !== null) {
+    const rhs = m[2];
+    if (!nsBindings.has(rhs)) continue; // only destructures of a trendcraft namespace
+    destructures.push({ file, rhs, names: parseSpecifiers(m[1]), nsBindings });
+  }
+  return { imports, destructures };
+}
+
+const parsed = DOC_FILES.flatMap((file) =>
+  extractFences(file).map((code) => parseSnippet(file, code)),
+);
+const allRefs = parsed.flatMap((p) => p.imports);
+const allDestructures = parsed.flatMap((p) => p.destructures);
+
+describe("doc snippets — import check (Tier 1)", () => {
+  it("found trendcraft imports to validate", () => {
+    expect(allRefs.length).toBeGreaterThan(0);
+  });
+
+  it("every documented import uses a published subpath", () => {
+    const bad = allRefs.filter((r) => !VALID_SUBPATHS.has(r.subpath));
+    const report = bad.map((r) => `  ${r.file}: ${r.raw}`).join("\n");
+    expect(bad.length, `Unpublished subpath(s) in docs:\n${report}`).toBe(0);
+  });
+
+  it("every named value import resolves to a real export", async () => {
+    const exportsBySubpath = new Map<string, Set<string>>();
+    for (const subpath of new Set(allRefs.map((r) => r.subpath))) {
+      const source = SUBPATH_TO_SOURCE[subpath];
+      if (!source) continue; // unpublished subpath — reported by the test above
+      const mod = await import(source);
+      exportsBySubpath.set(subpath, new Set(Object.keys(mod)));
+    }
+
+    const missing: string[] = [];
+    for (const ref of allRefs) {
+      const exported = exportsBySubpath.get(ref.subpath);
+      if (!exported) continue;
+      for (const name of ref.names) {
+        if (!exported.has(name)) missing.push(`  ${ref.file}: "${name}" from "${ref.source}"`);
+      }
+    }
+    expect(missing.length, `Unknown named import(s) in docs:\n${missing.join("\n")}`).toBe(0);
+  });
+
+  it("every destructured namespace member resolves to a real member", async () => {
+    // Cache loaded source modules so each entry is imported once.
+    const modBySubpath = new Map<string, Record<string, unknown>>();
+    async function loadModule(subpath: string): Promise<Record<string, unknown> | null> {
+      if (modBySubpath.has(subpath)) return modBySubpath.get(subpath) ?? null;
+      const source = SUBPATH_TO_SOURCE[subpath];
+      if (!source) return null;
+      const mod = (await import(source)) as Record<string, unknown>;
+      modBySubpath.set(subpath, mod);
+      return mod;
+    }
+
+    const missing: string[] = [];
+    for (const d of allDestructures) {
+      const binding = d.nsBindings.get(d.rhs);
+      if (!binding) continue;
+      const mod = await loadModule(binding.subpath);
+      if (!mod) continue; // unpublished subpath — reported by the subpath test
+      const ns = binding.member === null ? mod : mod[binding.member];
+      // Only validate when the binding is actually a namespace-like object.
+      if (!ns || typeof ns !== "object") continue;
+      const members = new Set(Object.keys(ns));
+      for (const name of d.names) {
+        if (!members.has(name)) missing.push(`  ${d.file}: "${name}" from "${d.rhs}"`);
+      }
+    }
+    expect(missing.length, `Unknown namespace member(s) in docs:\n${missing.join("\n")}`).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the doc-vs-reality gap for `trendcraft` imports, and adds a CI guard so it can't silently reopen.

- **Fixes stale streaming imports.** The API docs imported streaming exports from a `trendcraft/streaming` subpath that was never published (it is not in `package.json` `exports`, nor a build entry), so those imports fail to resolve for consumers. Streaming exports are reached through the `streaming` namespace of the main entry — the canonical example uses `import { streaming } from "trendcraft"` and `streaming.createPipeline(...)`. The docs now follow that: each `import { … } from "trendcraft/streaming"` becomes `import { streaming } from "trendcraft"` plus a `const { … } = streaming` destructure (38 blocks across API.md and API.ja.md). All documented streaming symbols resolve through the namespace.
- **Removes a leftover `setBenchmark` reference** from `llms-full.txt` (the helper was removed; the `benchmark` backtest option replaces it).

## New: doc-snippet import check (Tier 1)

Adds `src/__tests__/docs-import-check.test.ts`, which scans **every** `ts`/`typescript` fence in the docs — not just the executed `<!-- doctest-run -->` subset (Tier 2) — and validates the `trendcraft` imports against the real package surface:

1. **Subpath validity** — every `from "trendcraft/<sub>"` must be a published `exports` subpath (catches an unpublished subpath like the old `trendcraft/streaming`).
2. **Named-export validity** — every named value import must be a real export of the resolved in-repo entry (catches a removed/renamed symbol like a deleted `setBenchmark`).
3. **Namespace-member validity** — destructured members of an imported namespace (`const { foo } = streaming`, or `import * as ns from "…"`) must be real members.

Every import records its source for the subpath check regardless of shape (named, namespace, type, default), comments are stripped before parsing, and type-only imports are skipped (their existence can't be proven from the runtime surface — the fragile part Tier 1 deliberately avoids). This is the cheap, robust complement to Tier 2: it covers the non-executed majority of snippets without compiling them.

## Test plan

- New harness passes against the current docs (4 assertions).
- Verified each check has teeth by injecting and then reverting: an unpublished subpath (both `import { … } from` and `import * as`), an unknown named import, an unknown namespace member, and a specifier hidden after an inline comment — each fails the harness as intended.
- `tsc --noEmit` passes, lint passes, full suite (6259 tests) passes, build passes.