### PR TITLE
docs(chart): correct event payload, headless scale, and util signatures

### DIFF
--- a/packages/chart/docs/API.md
+++ b/packages/chart/docs/API.md
@@ -70,9 +70,9 @@ All fields optional.
 | `theme` | `'dark' \| 'light' \| ThemeColors` | `'dark'` | Color theme |
 | `pixelRatio` | `number` | `window.devicePixelRatio` | Canvas backing-store ratio (one-time; not runtime-mutable) |
 | `priceAxisWidth` | `number` | `60` | Right axis width (px) |
-| `timeAxisHeight` | `number` | `24` | Bottom axis height (px) |
+| `timeAxisHeight` | `number` | `32` | Bottom axis height (px) |
 | `fontFamily` | `string` | system | Font family (one-time) |
-| `fontSize` | `number` | `11` | Font size (px), clamped to [8, 32] |
+| `fontSize` | `number` | `11` | Font size (px) |
 | `priceFormatter` | `(price: number) => string` | auto-precision | Custom price formatter |
 | `timeFormatter` | `(time: number) => string` | smart date/time | Custom time formatter |
 | `watermark` | `string` | — | Background watermark text |
@@ -112,15 +112,14 @@ The price/time label text color is chosen via WCAG relative luminance of the cro
 ### Hotkeys
 
 ```typescript
-type HotkeyMap = Partial<{
-  hline: string;        // default 'Alt+H'
-  vline: string;        // default 'Alt+V'
-  trendline: string;    // default 'Alt+T'
-  fibRetracement: string; // default 'Alt+F'
-  channel: string;      // default 'Alt+C'
-  hideAllSeries: string; // default 'Ctrl+Alt+H'
-  cancel: string;       // default 'Escape'
-}>;
+type HotkeyAction = DrawingType | 'cancel' | 'toggleOverlays';
+// Keyed by KeyboardEvent.code combos; value = action.
+type HotkeyMap = Partial<Record<string, HotkeyAction>>;
+// Defaults: {
+//   'Alt+KeyH': 'hline', 'Alt+KeyV': 'vline', 'Alt+KeyT': 'trendline',
+//   'Alt+KeyF': 'fibRetracement', 'Alt+KeyC': 'channel',
+//   'Ctrl+Alt+KeyH': 'toggleOverlays', 'Escape': 'cancel',
+// }
 ```
 
 Matching uses `KeyboardEvent.code`, so Option+letter on macOS resolves correctly despite the altered character output. `Alt` is treated the same as `Option`; `Ctrl` and `Cmd` are interchangeable. Pass `hotkeys: false` to disable every keyboard shortcut, including the pre-existing viewport nav keys (arrows / `+` / `-` / `Home` / `End` / `F`).
@@ -318,7 +317,7 @@ All time values are epoch milliseconds.
 | Event | Payload shape |
 |---|---|
 | `crosshairMove` | `CrosshairMoveData = { time, price, x, y, paneId }` |
-| `click` | `CrosshairMoveData` |
+| `click` | `ChartClickData = { x, y, index, time, shiftKey, altKey, metaKey, ctrlKey }` |
 | `visibleRangeChange` | `VisibleRangeChangeData = { startTime, endTime, startIndex, endIndex }` |
 | `resize` | `{ width: number, height: number }` |
 | `paneResize` | `{ paneId: string, height: number }` |
@@ -638,21 +637,21 @@ Use `introspect()` to replicate the chart's auto-detection in custom code (e.g. 
 ### Decimation
 
 ```typescript
-lttb(points: Point[], threshold: number): Point[]
-// Largest-Triangle-Three-Buckets downsampling. threshold = target point count.
+lttb(data: readonly DataPoint<number | null>[], targetCount: number, indexOffset?: number): DecimatedPoints<number | null>
+// Largest-Triangle-Three-Buckets downsampling. targetCount = target point count.
 
-decimateCandles(candles: CandleData[], target: number): CandleData[]
+decimateCandles(candles: readonly CandleData[], startIndex: number, endIndex: number, maxBars: number): DecimatedCandles
 // OHLC aggregation for candles.
 
-getDecimationTarget(visibleBars: number, pixelsWide: number): number
+getDecimationTarget(dataCount: number, pixelWidth: number, minPixelsPerPoint?: number): number
 // Heuristic: one point per pixel column, with a floor.
 ```
 
 ### Formatters
 
 ```typescript
-autoFormatPrice(price: number, precision?: number): string
-autoFormatTime(time: number, context?): string
+autoFormatPrice(price: number): string
+autoFormatTime(time: number, prevTime: number | null, intervalMs?: number): string
 formatCrosshairTime(time: number): string
 formatVolume(vol: number): string
 detectPrecision(values: number[]): number

--- a/packages/chart/docs/COOKBOOK.md
+++ b/packages/chart/docs/COOKBOOK.md
@@ -430,10 +430,10 @@ const data = new DataLayer();
 data.setCandles(candles);
 
 const time = new TimeScale();
-time.setRange(candles[0].time, candles[candles.length - 1].time);
+time.setTotalCount(candles.length);
 
 const price = new PriceScale();
-price.setRangeFromCandles(candles);
+price.setDataRange(Math.min(...candles.map((c) => c.low)), Math.max(...candles.map((c) => c.high)));
 
 // Decimate a long series for a 480-pixel-wide thumbnail
 const decimated = lttb(series, 480);

--- a/packages/chart/docs/GUIDE.md
+++ b/packages/chart/docs/GUIDE.md
@@ -308,7 +308,7 @@ Subscribe via `chart.on(event, handler)`. Unsubscribe via `chart.off`. Events ar
 |---|---|
 | `crosshairMove` | `CrosshairMoveData` — time, price, x, y, paneId |
 | `visibleRangeChange` | `VisibleRangeChangeData` — startTime, endTime, startIndex, endIndex |
-| `click` | `CrosshairMoveData` — same as crosshairMove, fires on pointer up |
+| `click` | `ChartClickData` — x, y, index, time, shiftKey, altKey, metaKey, ctrlKey; fires on pointer up |
 | `resize` | `{ width, height }` |
 | `paneResize` | `{ paneId, height }` — fires when the user drags a pane divider |
 | `seriesAdded` | `{ id, label }` |


### PR DESCRIPTION
## Summary

A documentation-correctness pass over the chart package docs surfaced documented
APIs that contradicted the implementation. These are **not** import errors — the
doc import-check test guards those — they are event payload types, headless scale
methods, and utility signatures that had drifted from `packages/chart/src`.

### Fixes
- **`click` event payload**: `CrosshairMoveData` → `ChartClickData`
  (`{ x, y, index, time, shiftKey, altKey, metaKey, ctrlKey }`)
- **`HotkeyMap`**: `Partial<{ hline: string; ... }>` → `Partial<Record<string, HotkeyAction>>`
  where `HotkeyAction = DrawingType | 'cancel' | 'toggleOverlays'`
- **headless `TimeScale`**: documented `setRange(...)` does not exist → `setTotalCount(count)`
- **headless `PriceScale`**: documented `setRangeFromCandles(...)` does not exist → `setDataRange(min, max)`
- **util signatures**: `autoFormatPrice(price)` (no `precision` arg),
  `autoFormatTime(time, prevTime, intervalMs?)`, and `lttb`/`decimateCandles`/
  `getDecimationTarget` arg names aligned to source
- **`timeAxisHeight`** default 24 → 32; removed an inaccurate "clamped to [8, 32]"
  note on `fontSize` (no such clamp on the axis font)

### Deliberately out of scope
The `crosshairMove` payload docs were **left unchanged**. The runtime emit
(`{ time, index, ohlcv, paneId }`) does not match the exported `CrosshairMoveData`
type (`{ time, price, x, y, paneId }`). That is a source-level type/runtime
mismatch that needs a code fix first; the docs can then be updated to match. It
is tracked separately so this docs-only PR stays correct and self-consistent.

## Test plan
- `packages/chart`: `docs-import-check.test.ts` — 4 passed (no imports broke).
- Each corrected symbol/signature spot-checked against its source definition
  (`hotkeys.ts`, `core/types/event.ts`, `core/scale.ts`, `core/format.ts`,
  `core/decimation.ts`, `renderer/canvas-chart.ts`).
- Residual-token grep: `setRangeFromCandles` / `.setRange(` gone; remaining
  `CrosshairMoveData` occurrences are the intentionally-deferred crosshairMove docs.