### PR TITLE
docs(mcp): correct macd params and rsiDivergence output shape in EXAMPLES

### DIFF
--- a/packages/mcp/EXAMPLES.md
+++ b/packages/mcp/EXAMPLES.md
@@ -167,8 +167,10 @@ The two shapes carry different output structure.
 { "time": 1768259200000, "bandwidth": 0.034, "percentile": 3.2, /* ... */ }
 
 // rsiDivergence output element
-{ "time": 1768259200000, "type": "bullish", "rsiValue": 32.1,
-  "priceLow": 245.5, "rsiLow": 32.1, /* ... */ }
+{ "time": 1768259200000, "type": "bullish", "kind": "regular",
+  "firstIdx": 12, "secondIdx": 34,
+  "price": { "first": 250.0, "second": 245.5 },
+  "indicator": { "first": 28.0, "second": 32.1 } }
 ```
 
 `firedAt` for `events` shape is just the `time` of every event — equivalent to `output.map(e => e.time)`.
@@ -222,7 +224,7 @@ const { handle } = load_candles({ candles, symbol: "BTC" })
 // 2. Fan out — bars are transmitted exactly once total.
 calc_indicator  ({ kind: "rsi",          candlesRef: handle, params: { period: 14 } })
 calc_indicator  ({ kind: "atr",          candlesRef: handle, params: { period: 14 } })
-calc_indicator  ({ kind: "macd",         candlesRef: handle, params: { fast: 12, slow: 26, signal: 9 } })
+calc_indicator  ({ kind: "macd",         candlesRef: handle, params: { fastPeriod: 12, slowPeriod: 26, signalPeriod: 9 } })
 detect_signal   ({ kind: "goldenCross",  candlesRef: handle, params: { short: 5, long: 25 } })
 detect_signal   ({ kind: "bollingerSqueeze", candlesRef: handle })
 ```


### PR DESCRIPTION
## Summary

Two example payloads in `EXAMPLES.md` contradicted the real package surface:

- **`calc_indicator` macd params**: `{ fast, slow, signal }` → `{ fastPeriod, slowPeriod, signalPeriod }`.
  The parameter validator (`validation/params.ts`) accepts `fastPeriod`/`slowPeriod`/`signalPeriod`
  (and a unit test asserts exactly those); `fast`/`slow`/`signal` are not valid keys.
- **`rsiDivergence` output element**: rewritten to the real `DivergenceSignal` shape
  `{ time, type, kind, firstIdx, secondIdx, price: { first, second }, indicator: { first, second } }`.
  The documented `rsiValue` / `priceLow` / `rsiLow` fields do not exist on the type
  (`packages/core/src/signals/divergence.ts`).

## Test plan
- `packages/mcp`: full test suite — 80 passed.
- Residual grep for the old `fast:`/`rsiValue`/`priceLow`/`rsiLow` tokens: none remain.
- Both corrected payloads matched against source (`validation/params.ts`,
  `dispatcher/signal-map.ts`, `core/signals/divergence.ts`).