### PR TITLE
docs(core): correct docs and JSDoc drift against source (audit round 2)

### DIFF
--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -80,7 +80,7 @@ import { ... } from 'trendcraft/screening';    // 銘柄スクリーニング
 import { ... } from 'trendcraft/manifest';     // インジケーターメタデータ
 ```
 
-`Candle`の`time`はUnixタイムスタンプ・日付文字列・`Date`を受け付け、すべてのインジケーターは`Series<T> = { time: number, value: T }[]`を返します。
+`Candle`の`time`はUnixタイムスタンプ（秒・ミリ秒・マイクロ秒）または日付文字列を受け付け、すべてのインジケーターは`Series<T> = { time: number, value: T }[]`を返します。
 
 3つのCLIツールが同梱されています: `trendcraft-screen`、`trendcraft-backtest`、`trendcraft-analyze`（`npx`で実行。screen/backtest は `--list` で利用可能な条件を確認できます）。
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -80,7 +80,7 @@ import { ... } from 'trendcraft/screening';    // Stock screening
 import { ... } from 'trendcraft/manifest';     // Indicator metadata
 ```
 
-A `Candle` accepts `time` as a Unix timestamp, date string, or `Date`; every indicator emits `Series<T> = { time: number, value: T }[]`.
+A `Candle` accepts `time` as a Unix timestamp (seconds, milliseconds, or microseconds) or a date string; every indicator emits `Series<T> = { time: number, value: T }[]`.
 
 Three CLI tools ship with the package: `trendcraft-screen`, `trendcraft-backtest`, and `trendcraft-analyze` (run with `npx`; pass `--list` to see available conditions for screen/backtest).
 

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -390,8 +390,10 @@ interface MacdValue {
 ストキャスティクス。
 
 ```typescript
-// 生のストキャスティクス
+// ストキャスティクス（デフォルト slowing: 3 = スロー相当）
 const raw = stochastics(candles, { kPeriod: 14, dPeriod: 3 });
+// 生（未平滑）にする場合は slowing: 1 を明示
+// const fastRaw = stochastics(candles, { kPeriod: 14, dPeriod: 3, slowing: 1 });
 
 // ファストストキャスティクス
 const fast = fastStochastics(candles, { kPeriod: 14, dPeriod: 3 });
@@ -469,8 +471,9 @@ const result = stochRsi(candles, {
 
 ```typescript
 interface StochRsiValue {
-  k: number | null;  // %Kライン
-  d: number | null;  // %Dライン
+  stochRsi: number | null; // 生のStochRSI値 (0-100)
+  k: number | null;        // %Kライン（平滑化StochRSI）
+  d: number | null;        // %Dライン（%KのSMA）
 }
 ```
 
@@ -611,7 +614,7 @@ const custom = adxr(candles, { period: 14, dmiPeriod: 14, adxPeriod: 14 });
 
 **戻り値:** `Series<number | null>`
 
-**計算式:** `(ADX[i] + ADX[i - period]) / 2`
+**計算式:** `(ADX[i] + ADX[i - (period - 1)]) / 2`（TA-Lib準拠のルックバック）
 
 **解釈:**
 - 25超: トレンドあり
@@ -819,7 +822,8 @@ const result = volumeMa(candles, { period: 20 });
 **オプション:**
 | オプション | 型 | デフォルト | 説明 |
 |------------|------|---------|------|
-| `period` | `number` | `20` | MA期間 |
+| `period` | `number` | 必須 | MA期間 |
+| `type` | `'sma' \| 'ema'` | `'sma'` | MA種別 |
 
 **戻り値:** `Series<number | null>`
 
@@ -892,7 +896,7 @@ const custom = volumeProfile(candles, { period: 20, levels: 24, valueAreaPercent
 **オプション:**
 | オプション | 型 | デフォルト | 説明 |
 |------------|------|---------|------|
-| `period` | `number` | `20` | 参照期間 |
+| `period` | `number` | 全期間（省略時は全キャンドル対象） | 参照期間（末尾からのキャンドル数） |
 | `levels` | `number` | `24` | 価格レベル数 |
 | `valueAreaPercent` | `number` | `0.7` | Value Area計算の割合（0-1の小数） |
 
@@ -909,10 +913,11 @@ interface VolumeProfileValue {
 }
 
 interface VolumePriceLevel {
-  priceMin: number;
-  priceMax: number;
-  volume: number;
-  percentage: number;  // 総出来高に対する割合
+  priceLow: number;      // 価格レベル下限
+  priceHigh: number;     // 価格レベル上限
+  priceMid: number;      // 価格レベル中央値
+  volume: number;        // このレベルの出来高
+  volumePercent: number; // 総出来高に対する割合
 }
 ```
 
@@ -1248,19 +1253,21 @@ const leaders = filterByRSPercentile(symbolsData, 80);
 
 ### 価格
 
-#### `highest(candles, options)` / `lowest(candles, options)`
+#### `highest(candles, period)` / `lowest(candles, period)`
 
 n期間の最高値/最安値。
 
 ```typescript
-const highestHigh = highest(candles, { period: 20 });
-const lowestLow = lowest(candles, { period: 20 });
+const highestHigh = highest(candles, 20);
+const lowestLow = lowest(candles, 20);
 ```
 
-**オプション:**
-| オプション | 型 | デフォルト | 説明 |
-|------------|------|---------|------|
-| `period` | `number` | 必須 | 参照期間 |
+**引数:**
+| 引数 | 型 | デフォルト | 説明 |
+|------|------|---------|------|
+| `period` | `number` | 必須（位置引数） | 参照期間 |
+
+（オプションオブジェクト版は `highestLowest(candles, { period })` のみで、戻り値は `Series<{highest, lowest}>`）
 
 **戻り値:** `Series<number | null>`
 
@@ -1782,8 +1789,8 @@ const dc = deadCross(candles, { short: 5, long: 25 });
 **オプション:**
 | オプション | 型 | デフォルト | 説明 |
 |------------|------|---------|------|
-| `short` | `number` | 必須 | 短期MA期間 |
-| `long` | `number` | 必須 | 長期MA期間 |
+| `short` | `number` | `5` | 短期MA期間 |
+| `long` | `number` | `25` | 長期MA期間 |
 
 **戻り値:** `Series<boolean>` （バックテスト条件版は `goldenCrossCondition`/`deadCrossCondition`）
 
@@ -1860,6 +1867,7 @@ const signals = macdDivergence(candles);
 | `swingLookback` | `number` | `5` | スイングポイント検出の参照期間 |
 | `minSwingDistance` | `number` | `5` | スイング間の最小バー数 |
 | `maxSwingDistance` | `number` | `60` | スイング間の最大バー数 |
+| `kinds` | `DivergenceClass[]` | `['regular']` | 検出するダイバージェンス種別（`['regular','hidden']` でヒドゥンも検出） |
 
 **戻り値:** `DivergenceSignal[]`
 
@@ -1867,6 +1875,7 @@ const signals = macdDivergence(candles);
 interface DivergenceSignal {
   time: number;
   type: 'bullish' | 'bearish';  // bullish: 強気, bearish: 弱気
+  kind: 'regular' | 'hidden';   // regular: レギュラー（反転）/ hidden: ヒドゥン（継続）
   firstIdx: number;              // 最初のスイングポイントのインデックス
   secondIdx: number;             // 2番目のスイングポイントのインデックス
   price: { first: number; second: number };
@@ -2035,7 +2044,7 @@ const signals = volumeBreakout(candles, { period: 20 });
 ```typescript
 interface VolumeBreakoutSignal {
   time: number;
-  type: 'volume_breakout';
+  type: 'breakout';
   volume: number;
   previousHigh: number;
   ratio: number;
@@ -2071,7 +2080,9 @@ const signals = volumeAccumulation(candles, {
 interface VolumeAccumulationSignal {
   time: number;
   type: 'volume_accumulation';
-  slope: number;           // 正規化傾き
+  volume: number;          // 現在の出来高
+  slope: number;           // 回帰の生の傾き
+  normalizedSlope: number; // 正規化傾き（slope / 平均出来高、minSlope と比較される値）
   rSquared: number;        // R²品質スコア
   consecutiveDays: number; // 蓄積日数
 }
@@ -2131,17 +2142,25 @@ const signals = volumeMaCross(candles, {
 |------------|------|---------|------|
 | `shortPeriod` | `number` | `5` | 短期MA期間 |
 | `longPeriod` | `number` | `20` | 長期MA期間 |
+| `minRatio` | `number` | `1.0` | クロス確定に必要な短期MA/長期MAの最小比率 |
+| `bullishOnly` | `boolean` | `true` | 強気（上抜け）クロスのみ検知 |
 
 **戻り値:** `VolumeMaCrossSignal[]`
 
 ```typescript
 interface VolumeMaCrossSignal {
   time: number;
-  type: 'volume_ma_cross_up' | 'volume_ma_cross_down';
+  type: 'volume_ma_cross';
+  volume: number;                    // 現在の出来高
   shortMa: number;
   longMa: number;
+  direction: 'bullish' | 'bearish';  // bullish: 短期MAが長期MAを上抜け
+  ratio: number;                     // 短期MA / 長期MA
+  daysSinceCross: number;            // クロス以降の連続日数
 }
 ```
+
+**注意:** デフォルトでは `bullishOnly: true` のため強気（上抜け）クロスのみ検知されます。弱気クロスも得るには `bullishOnly: false` を指定してください。
 
 ---
 
@@ -2269,7 +2288,7 @@ const patterns = detectWedge(candles);
 const fallingWedges = patterns.filter(p => p.type === 'falling_wedge');
 ```
 
-**オプション:** `detectTriangle`と同様（`flatTolerance`を除く）。
+**オプション:** `detectTriangle`と同様（`flatTolerance`を除く）。ただし `minPoints` のデフォルトは `3`（トレンドラインあたり3タッチ）。
 
 ---
 
@@ -2356,7 +2375,7 @@ interface PatternSignal {
     neckline?: PatternNeckline;    // H&Sパターン用
     target?: number;         // 目標価格（メジャードムーブ）
     stopLoss?: number;       // 推奨ストップロス
-    height: number;          // パターン高さ
+    height?: number;          // パターン高さ（メジャードムーブ計算用、省略される場合あり）
   };
   confidence: number;        // 0-100 信頼度スコア
   confirmed: boolean;        // ブレイクアウト発生時true
@@ -2750,7 +2769,7 @@ monthlyTrendStrong(adxThreshold = 25)  // 月足ADX > 閾値
 mtfTrendStrong(timeframe, adxThreshold = 25)  // MTF ADX > 閾値
 
 // カスタムMTF条件
-mtfCondition(timeframe, conditionFn)  // MTFデータでのカスタム条件
+mtfCondition(requiredTimeframes, name, evaluateFn)  // MTFデータでのカスタム条件（例: mtfCondition(['weekly', 'monthly'], 'weeklyAboveMonthly', (mtf, indicators, candle, index, candles) => ...)）
 ```
 
 **Fluent APIでの使用:**
@@ -2971,8 +2990,12 @@ const monthly = resample(dailyCandles, 'monthly');
 ```
 
 **サポートされるタイムフレーム:**
-- `'weekly'` または `'1w'`
-- `'monthly'` または `'1M'`
+- ショートハンド: `'1m'` / `'5m'` / `'15m'` / `'30m'` / `'1h'` / `'4h'` / `'1d'`（`'daily'`）/ `'1w'`（`'weekly'`）/ `'1M'`（`'monthly'`）
+- または `{ value, unit }` 形式の `Timeframe` オブジェクト（unit: `'minute' | 'hour' | 'day' | 'week' | 'month'`）
+
+```typescript
+const fourHour = resample(hourlyCandles, '4h');  // 1時間足 → 4時間足
+```
 
 ---
 
@@ -3488,7 +3511,7 @@ Sharpeがベンチマークを超えない場合は `Infinity` を返します�
 import { minTrackRecordLength } from 'trendcraft';
 
 // per-return Sharpe 0.1 — PSR(0) ≥ 95% に必要なバー数は？
-const bars = Math.ceil(minTrackRecordLength(0.1)); // ≈ 274
+const bars = Math.ceil(minTrackRecordLength(0.1)); // ≈ 273 （minTrackRecordLength(0.1) ≈ 272.9）
 ```
 
 ---
@@ -3804,7 +3827,7 @@ Period 3: Train 2015-01-01〜2019-12-31 → Test 2020
 | オプション | 型 | デフォルト | 説明 |
 |--------|------|---------|-------------|
 | `anchorDate` | `number` | 必須 | 固定起点（epoch ms） |
-| `initialTrainSize` | `number` | `252` | 初期訓練期間（バー数） |
+| `initialTrainSize` | `number` | `504` | 初期訓練期間（バー数、約2年） |
 | `expansionStep` | `number` | `252` | 拡張ステップ（バー数） |
 | `testSize` | `number` | `252` | テスト期間（バー数） |
 | `metric` | `OptimizationMetric` | `'sharpe'` | 最適化する指標 |
@@ -3860,13 +3883,11 @@ const formatted = formatAWFResult(awfResult);
 // サマリー取得
 const summary = summarizeAWFResult(awfResult);
 
-// 期間数の事前計算
-const count = calculateAWFPeriodCount(candles, {
-  anchorDate: new Date('2015-01-01').getTime(),
-  initialTrainSize: 500,
-  expansionStep: 252,
-  testSize: 252,
-});
+// 期間数の事前計算（位置引数）
+const anchorDate = new Date('2015-01-01').getTime();
+const anchorIndex = candles.findIndex((c) => c.time >= anchorDate);
+const count = calculateAWFPeriodCount(candles.length, anchorIndex, 500, 252, 252);
+// オプションオブジェクトから求める場合: generateAWFBoundaries(candles, options).length
 
 // 期間境界の生成
 const boundaries = generateAWFBoundaries(candles, options);
@@ -3901,8 +3922,8 @@ const result = runBacktestScaled(candles, goldenCrossCondition(), deadCrossCondi
 | オプション | 型 | デフォルト | 説明 |
 |--------|------|---------|-------------|
 | `tranches` | `number` | 必須 | エントリートランシェ数 (2-10) |
-| `strategy` | `'equal' \| 'pyramid' \| 'reverse-pyramid'` | `'equal'` | 配分戦略 |
-| `intervalType` | `'signal' \| 'price'` | `'signal'` | 追加エントリーのトリガー方法 |
+| `strategy` | `'equal' \| 'pyramid' \| 'reverse-pyramid'` | 必須 | 配分戦略 |
+| `intervalType` | `'signal' \| 'price'` | 必須 | 追加エントリーのトリガー方法 |
 | `priceInterval` | `number` | `-2` | 次のトランシェの価格変動 %（負の値 = 下落） |
 
 **戦略:**
@@ -4737,7 +4758,7 @@ type TradeSignal = {
 import { fromCrossSignal } from 'trendcraft';
 
 const signals = validateCrossSignals(candles);
-const tradeSignals = signals.map(s => fromCrossSignal(s, candles[i].close));
+const tradeSignals = signals.map(s => fromCrossSignal(s, candles.find(c => c.time === s.time)?.close)); // entryPrice は省略可能なので signals.map(s => fromCrossSignal(s)) でも可
 // { action: "BUY", direction: "LONG", confidence: 85, ... }
 ```
 
@@ -4756,7 +4777,7 @@ const tradeSignals = divSignals.map(s => fromDivergenceSignal(s, candles[s.secon
 import { fromSqueezeSignal } from 'trendcraft';
 
 const squeezes = bollingerSqueeze(candles);
-const tradeSignals = squeezes.map(s => fromSqueezeSignal(s, "LONG", candles[i].close));
+const tradeSignals = squeezes.map(s => fromSqueezeSignal(s, "LONG", candles.find(c => c.time === s.time)?.close)); // entryPrice は省略可能なので squeezes.map(s => fromSqueezeSignal(s)) でも可
 ```
 
 #### `fromPatternSignal(signal, entryPrice?)`
@@ -4778,7 +4799,7 @@ const tradeSignals = patterns.map(p => fromPatternSignal(p, 100));
 ```typescript
 import { fromScoreResult } from 'trendcraft';
 
-const breakdown = calculateScoreBreakdown(candles, signals, i);
+const breakdown = calculateScoreBreakdown(candles, i, config); // config: ScoringConfig（例: { signals: [...] }）
 const signal = fromScoreResult(breakdown, candle.time, { minScore: 50, entryPrice: 100 });
 ```
 
@@ -4808,9 +4829,11 @@ const signal = fromPipelineResult(result, candle.time, candle.close);
 #### `createSignalEmitter(options)`
 
 ```typescript
-import { streaming } from 'trendcraft';
+import { streaming, incremental } from 'trendcraft';
 
-const emitter = streaming.createSignalEmitter({
+const { createSignalEmitter, rsiBelow, rsiAbove } = streaming;
+
+const emitter = createSignalEmitter({
   intervalMs: 60000,
   pipeline: {
     indicators: [{ name: 'rsi14', create: () => incremental.createRsi({ period: 14 }) }],
@@ -4967,7 +4990,7 @@ const tracker = streaming.createPositionTracker({
   trailingStop: 3,    // トラフから追跡
 });
 
-tracker.openPosition(100, currentTime, 1000);
+tracker.openPosition(100, 1000, currentTime); // (価格, 株数, 時刻) の順
 
 // 含み損益は方向を考慮
 const account = tracker.getAccount();
@@ -4985,7 +5008,7 @@ if (result.triggered) {
 `batchBacktest()` と `portfolioBacktest()` も同じ `direction` オプションでショートセリングに対応。
 
 ```typescript
-import { batchBacktest, deadCrossCondition, goldenCrossCondition } from 'trendcraft';
+import { batchBacktest, portfolioBacktest, deadCrossCondition, goldenCrossCondition } from 'trendcraft';
 
 // バッチバックテスト: direction をオプションに直接指定
 const batchResult = batchBacktest(datasets, deadCrossCondition(5, 25), goldenCrossCondition(5, 25), {
@@ -5015,7 +5038,7 @@ const portfolioResult = portfolioBacktest(datasets, deadCrossCondition(5, 25), g
 ```typescript
 import {
   and, rsiAbove, rsiBelow, bollingerTouch, deadCrossCondition, goldenCrossCondition,
-  dmiBearish, anyBearishPattern, stochAbove, stochBelow,
+  dmiBearish, anyBearishPattern, stochAbove, stochBelow, runBacktest,
 } from 'trendcraft';
 
 // ミーンリバージョンショート: 買われすぎからの反転
@@ -5482,7 +5505,7 @@ const bbOfHist = pipe(
 
 ### `seriesToCandles(series, options?)`
 
-`Series<number|null>`を擬似`NormalizedCandle[]`に変換してインジケーター関数の入力として使用します。
+`Series<number|null>`を擬似`NormalizedCandle[]`に変換してインジケーター関数の入力として使用します。非nullの値はOHLC全てに同じ値が入り、`null`は全価格が0になります。オプション: `fillMode` — open/high/lowに何を入れるか: シリーズの値（`"value"`、デフォルト）または0（`"zero"`）。`close`は常にシリーズの値を持ちます。
 
 ### `extractField(series, field)`
 
@@ -5833,8 +5856,8 @@ import { createLiveCandle, incremental } from "trendcraft";
 const live = createLiveCandle({
   intervalMs: 60_000,
   indicators: [
-    { name: "sma20", create: (s) => incremental.createSma({ period: 20 }, { fromState: s }) },
-    { name: "rsi14", create: (s) => incremental.createRsi({ period: 14 }, { fromState: s }) },
+    { name: "sma20", create: (s) => incremental.createSma({ period: 20 }, incremental.restoreState(s)) },
+    { name: "rsi14", create: (s) => incremental.createRsi({ period: 14 }, incremental.restoreState(s)) },
   ],
   history: historicalCandles,
   maxHistory: 500,
@@ -5858,7 +5881,7 @@ live.addCandle(partialCandle, { partial: true });
 | オプション | 型 | 説明 |
 |---|---|---|
 | `intervalMs` | `number?` | ローソク足の間隔（ms）。ティックモードでは必須、ローソク足モードでは省略。 |
-| `indicators` | `LiveIndicatorFactory[]?` | 初期登録する指標（`addIndicator` で後から追加可能）。 |
+| `indicators` | `{ name: string; create: LiveIndicatorFactory; state?: unknown }[]?` | 初期登録する指標（`addIndicator` で後から追加可能）。 |
 | `history` | `NormalizedCandle[]?` | コンテキストのみに使う過去ローソク足（emit されない）。 |
 | `maxHistory` | `number?` | メモリに保持する完了ローソク足の上限。 |
 
@@ -5868,12 +5891,12 @@ live.addCandle(partialCandle, { partial: true });
 |---|---|
 | `addTick(trade)` | トレードを流し込む（ティックモード）。 |
 | `addCandle(candle, opts?)` | ローソク足を流し込む。`opts.partial = true` で形成中バー。 |
-| `addIndicator({ name, create })` | 構築後に指標ファクトリを登録。 |
+| `addIndicator(name, create, state?)` | 構築後に指標ファクトリを登録。 |
 | `removeIndicator(name)` | 指標を削除。 |
-| `snapshot()` | 現在の指標スナップショット（登録名キー）。 |
+| `snapshot` | 現在の指標スナップショット（登録名キー）。read-only プロパティ（メソッドではない）。 |
 | `completedCandles` | 開始以降の完了ローソク足配列（read-only）。 |
-| `formingCandle` | 進行中のローソク足、または `null`。 |
-| `on(event, handler)` / `off(event, handler)` | イベント購読。events: `tick`, `candleComplete`。 |
+| `candle` | 進行中のローソク足、または `null`（read-only）。 |
+| `on(event, handler)` | イベント購読。unsubscribe 関数を返す（`off` メソッドは無い）。events: `tick`, `candleComplete`。 |
 | `getState()` | state をシリアライズ（aggregator + 指標 + 完了ローソク足）。 |
 
 ### `livePresets`
@@ -5887,7 +5910,7 @@ const sma = livePresets.sma;
 // {
 //   meta: { kind: 'sma', label: 'SMA', overlay: true, ... },
 //   defaultParams: { period: 20 },
-//   snapshotName: (p) => `sma${p.period}`,
+//   snapshotName: (p) => `sma_${p.source ?? "close"}_${p.period ?? 20}`,
 //   createFactory: (params) => (fromState) => IncrementalIndicator,
 // }
 
@@ -5902,7 +5925,7 @@ const indicator = factory(undefined); // 既存 state なし
 |---|---|---|
 | `meta` | `SeriesMeta` | 描画メタデータ（kind, label, overlay, yRange, referenceLines）。 |
 | `defaultParams` | `Record<string, unknown>` | ユーザーが `{}` を渡したときのデフォルトパラメータ。 |
-| `snapshotName` | `(params) => string` | このインスタンスの snapshot キーを生成（例: `"sma20"`）。 |
+| `snapshotName` | `string \| ((params) => string)` | このインスタンスの snapshot キー（文字列、または params から生成する関数。例: `"sma_close_20"`）。 |
 | `createFactory` | `(params) => LiveIndicatorFactory` | 指定パラメータで closure したインクリメンタルファクトリを生成。 |
 
 ### `indicatorPresets`
@@ -5921,18 +5944,20 @@ const series = rsi.compute(candles, { period: 14 });
 const factory = rsi.createFactory({ period: 14 });
 ```
 
-**エントリー形式 (`IndicatorPreset extends LivePreset`):**
+**エントリー形式 (`IndicatorPreset`):** LivePreset と同形の `meta` / `defaultParams` / `snapshotName` を持つ独立型。`compute?` と `createFactory?` はともにオプショナル（少なくとも一方は定義。インクリメンタル未対応の指標は `compute` のみで、104 エントリー中 25 個は `createFactory` を持たない）。
 
 | フィールド | 型 | 説明 |
 |---|---|---|
-| ...`LivePreset` の全フィールド | — | — |
-| `compute` | `(candles, params) => Series<T>` | 静的モード用のバッチ計算。 |
-| `category` | `IndicatorCategory` | UI 用グルーピング（`"momentum"`、`"trend"` など）。 |
-| `paramSchema` | `ParamSchema?` | UI フォーム自動生成用のパラメータスキーマ。 |
+| `meta` / `defaultParams` / `snapshotName` | — | `LivePreset` と同形。 |
+| `compute` | `((candles, params) => Series<T>)?` | 静的モード用のバッチ計算。 |
+| `createFactory` | `((params) => LiveIndicatorFactory)?` | ストリーミングモード用のインクリメンタルファクトリ。 |
+| `category` | `IndicatorCategory?` | UI 用グルーピング。値は大文字始まり: `"Moving Averages"`, `"Momentum"`, `"Volatility"`, `"Trend"`, `"Volume"`, `"Price"`, `"Wyckoff"`, `"Adaptive"`, `"Session"`, `"SMC"`, `"Filter"`。 |
+| `name` / `description` | `string?` | 指標のフルネーム / 短い説明。 |
+| `paramSchema` | `ParamSchema[]?` | UI フォーム自動生成用のパラメータスキーマ配列（パラメータごとに 1 エントリー）。 |
 
 ### `tagSeries` / `SeriesMeta`
 
-任意の `Series<T>` に非列挙の `__meta` プロパティを付与してドメインメタデータを載せます。組み込み指標はすべて既に tag 済み。自作指標でも下流の利用者（レンダラー、UI ジェネレーター等）に同じ規約で解釈させたい場合に `tagSeries` を使います。
+任意の `Series<T>` に `__meta` プロパティを付与してドメインメタデータを載せます。組み込み指標はすべて既に tag 済み。自作指標でも下流の利用者（レンダラー、UI ジェネレーター等）に同じ規約で解釈させたい場合に `tagSeries` を使います。
 
 ```typescript
 import { tagSeries, rsi, type SeriesMeta } from "trendcraft";
@@ -5976,7 +6001,7 @@ const myCustom = tagSeries(myData, {
 ```typescript
 // 入力用ローソク足（柔軟）
 interface Candle {
-  time: number | string | Date;
+  time: number | string;
   open: number;
   high: number;
   low: number;
@@ -6011,11 +6036,14 @@ type PriceSource = 'open' | 'high' | 'low' | 'close' | 'hl2' | 'hlc3' | 'ohlc4' 
 ### シグナル型
 
 ```typescript
-type SignalType = 'bullish' | 'bearish';
+type SignalType = 'buy' | 'sell' | 'hold';
 
 interface Signal {
   time: number;
   type: SignalType;
+  name: string;
+  confidence?: number;
+  metadata?: Record<string, unknown>;
 }
 ```
 
@@ -6178,7 +6206,7 @@ const patterns = detectHarmonicPatterns(candles, {
 |--------|---------|-------------|
 | `swingLookback` | `5` | スイングポイント検出期間 |
 | `tolerance` | `0.05` | フィボナッチ比率の許容誤差（5%） |
-| `minSwingPoints` | `50` | スイング検出の最小バー数 |
+| `minSwingPoints` | `50` | スキャンするスイングポイント（高値/安値の転換点）の最小個数 |
 | `patterns` | すべて | 検出するパターンタイプ |
 
 **パターンタイプ:** `gartley_bullish`, `gartley_bearish`, `butterfly_bullish`, `butterfly_bearish`, `bat_bullish`, `bat_bearish`, `crab_bullish`, `crab_bearish`, `shark_bullish`, `shark_bearish`
@@ -6212,8 +6240,8 @@ const result = garch(dailyReturns, {
 
 | オプション | デフォルト | 説明 |
 |--------|---------|-------------|
-| `p` | `1` | GARCHラグ次数 |
-| `q` | `1` | ARCHラグ次数 |
+| `p` | `1` | GARCHラグ次数 — 将来の拡張用。現在は `1` のみサポート（それ以外の値は例外をスロー） |
+| `q` | `1` | ARCHラグ次数 — 将来の拡張用。現在は `1` のみサポート（それ以外の値は例外をスロー） |
 | `maxIterations` | `100` | MLE最大反復回数 |
 | `tolerance` | `1e-6` | 収束許容誤差 |
 
@@ -6234,7 +6262,7 @@ const vol = ewmaVolatility(dailyReturns, { lambda: 0.94 });
 |--------|---------|-------------|
 | `lambda` | `0.94` | 減衰係数（RiskMetrics標準） |
 | `calendar` | `US_EQUITY_CALENDAR` | 年率化に用いる取引カレンダープリセット |
-| `periodsPerYear` | `252` | 年率化期間の直接指定（`calendar` より優先） |
+| `periodsPerYear` | `252` | 年率化期間の直接指定（`calendar` が指定されている場合は `calendar` が優先） |
 
 `Series<number>`（年率ボラティリティ、%）を返します。
 
@@ -6282,7 +6310,7 @@ const N = annualizationFactor({ calendar: JPX_CALENDAR }); // 245
 ```
 
 `AnnualizationOptions`（`{ calendar?, periodsPerYear? }`）は次の API が受け付けます：
-`calculateMetricsFromReturns`, `stressTest`, `runAllStressTests`, `ulcerPerformanceIndex`, `garch`, `ewmaVolatility`, `ewmaVolatilityFromCandles`, `volatilityRegime`, `calculateRuntimeMetrics`。デフォルト動作は従来と互換です。
+`calculateMetricsFromReturns`, `stressTest`, `runAllStressTests`, `ulcerPerformanceIndex`, `garch`, `ewmaVolatility`, `ewmaVolatilityFromCandles`, `volatilityRegime`。デフォルト動作は従来と互換です。なお `calculateRuntimeMetrics` は `calendar` を受け付けますが、数値での直接指定は `periodsPerYear` ではなく `annualizationFactor` キーです。
 
 ---
 
@@ -6325,7 +6353,7 @@ console.log(summarizeParetoResult(result));
 | `maxCombinations` | `10000` | 評価するパラメータ組み合わせの最大数 |
 | `progressCallback` | - | 進捗報告コールバック |
 
-**利用可能なメトリクス:** `sharpe`, `returnPercent`, `maxDrawdown`, `profitFactor`, `winRate`, `calmar`, `recoveryFactor`, `avgHoldingDays`
+**利用可能なメトリクス:** `sharpe`, `calmar`, `mar`, `profitFactor`, `recoveryFactor`, `returns`, `winRate`, `tradeCount`, `maxDrawdown`
 
 `ParetoResult` を返します（`paretoFront: ParetoResultEntry[]`、各エントリに `frontIndex`, `crowdingDistance` 付き）。
 
@@ -6393,7 +6421,7 @@ const result = stressTest(dailyReturns, PRESET_SCENARIOS.lehman2008, 1_000_000);
 // result.originalMetrics — { totalReturn, maxDrawdown, sharpe }
 // result.stressedMetrics — { totalReturn, maxDrawdown, sharpe }
 // result.worstCase — { drawdown, duration, recoveryDays }
-// result.survivalRate — 資本生存率
+// result.survivalRate — ストレス適用後のエクイティが一度もゼロ以下にならなければ 1.0、なれば 0.0（生存/破綻の二値フラグ）
 // result.capitalAtRisk — リスク資本額
 // result.stressedVaR, result.stressedCVaR
 ```
@@ -6406,7 +6434,7 @@ const result = stressTest(dailyReturns, PRESET_SCENARIOS.lehman2008, 1_000_000);
 const summary = runAllStressTests(dailyReturns, 1_000_000);
 // summary.results — 各シナリオのStressTestResult[]
 // summary.worstScenario — 最悪パフォーマンスのシナリオ名
-// summary.overallSurvivalRate — 全シナリオ中の最低生存率
+// summary.overallSurvivalRate — 全シナリオの生存率の平均（生存したシナリオの割合）
 // summary.maxStressedDrawdown — 全シナリオ中の最大ドローダウン
 ```
 
@@ -6579,6 +6607,7 @@ type StrategyJSON = {
     commissionRate?: number;
     slippage?: number;
     fillMode?: "same-bar-close" | "next-bar-open";
+    sizing?: BacktestSizingConfigJSON; // JSON-safe なポジションサイジング設定（カスタムコールバック型は非対応）
   };
   metadata?: Record<string, unknown>;
 };

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -394,8 +394,8 @@ interface MacdValue {
 Stochastics Oscillator.
 
 ```typescript
-// Raw Stochastics
-const raw = stochastics(candles, { kPeriod: 14, dPeriod: 3 });
+// Slow Stochastics (default, slowing = 3)
+const result = stochastics(candles, { kPeriod: 14, dPeriod: 3 });
 
 // Fast Stochastics
 const fast = fastStochastics(candles, { kPeriod: 14, dPeriod: 3 });
@@ -473,8 +473,9 @@ const result = stochRsi(candles, {
 
 ```typescript
 interface StochRsiValue {
-  k: number | null;  // %K line
-  d: number | null;  // %D line
+  stochRsi: number | null;  // Raw StochRSI value (0-100)
+  k: number | null;  // %K line (smoothed StochRSI)
+  d: number | null;  // %D line (SMA of %K)
 }
 ```
 
@@ -615,7 +616,7 @@ const custom = adxr(candles, { period: 14, dmiPeriod: 14, adxPeriod: 14 });
 
 **Returns:** `Series<number | null>`
 
-**Formula:** `ADXR = (ADX[i] + ADX[i - period]) / 2`
+**Formula:** `ADXR = (ADX[i] + ADX[i - (period - 1)]) / 2` (TA-Lib-conformant lookback)
 
 **Interpretation:**
 - Above 25: Trending market confirmed
@@ -829,7 +830,8 @@ const result = volumeMa(candles, { period: 20 });
 **Options:**
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `period` | `number` | `20` | MA period |
+| `period` | `number` | required | MA period |
+| `type` | `'sma' \| 'ema'` | `'sma'` | Moving average type |
 
 **Returns:** `Series<number | null>`
 
@@ -902,7 +904,7 @@ const custom = volumeProfile(candles, { period: 20, levels: 24, valueAreaPercent
 **Options:**
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `period` | `number` | `20` | Lookback period |
+| `period` | `number` | all candles | Lookback period (last N candles; omit to use the entire array) |
 | `levels` | `number` | `24` | Number of price levels |
 | `valueAreaPercent` | `number` | `0.7` | Value Area fraction (0-1) |
 
@@ -919,10 +921,11 @@ interface VolumeProfileValue {
 }
 
 interface VolumePriceLevel {
-  priceMin: number;
-  priceMax: number;
-  volume: number;
-  percentage: number;  // Percentage of total volume
+  priceLow: number;   // Price level lower bound
+  priceHigh: number;  // Price level upper bound
+  priceMid: number;   // Price level midpoint
+  volume: number;     // Total volume at this price level
+  volumePercent: number;  // Percentage of total volume
 }
 ```
 
@@ -1412,19 +1415,16 @@ const leaders = filterByRSPercentile(symbolsData, 80);
 
 ### Price
 
-#### `highest(candles, options)` / `lowest(candles, options)`
+#### `highest(candles, period)` / `lowest(candles, period)`
 
 Highest High / Lowest Low over n periods.
 
 ```typescript
-const highestHigh = highest(candles, { period: 20 });
-const lowestLow = lowest(candles, { period: 20 });
+const highestHigh = highest(candles, 20);
+const lowestLow = lowest(candles, 20);
 ```
 
-**Options:**
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `period` | `number` | required | Lookback period |
+**Parameters:** `period` (number, required) — lookback period, passed as a positional parameter (the options-object form is only for `highestLowest(candles, { period })`).
 
 **Returns:** `Series<number | null>`
 
@@ -2288,6 +2288,7 @@ const bearish = signals.filter(s => s.type === 'bearish');
 | `swingLookback` | `number` | `5` | Swing point detection lookback |
 | `minSwingDistance` | `number` | `5` | Minimum bars between swings |
 | `maxSwingDistance` | `number` | `60` | Maximum bars between swings |
+| `kinds` | `DivergenceClass[]` | `['regular']` | Divergence classes to detect (`['regular','hidden']` to include hidden/continuation divergences) |
 
 **Returns:** `DivergenceSignal[]`
 
@@ -2462,7 +2463,7 @@ const signals = volumeBreakout(candles, { period: 20 });
 ```typescript
 interface VolumeBreakoutSignal {
   time: number;
-  type: 'volume_breakout';
+  type: 'breakout';
   volume: number;
   previousHigh: number;
   ratio: number;
@@ -2498,7 +2499,9 @@ const signals = volumeAccumulation(candles, {
 interface VolumeAccumulationSignal {
   time: number;
   type: 'volume_accumulation';
-  slope: number;           // Normalized slope
+  volume: number;          // Current volume
+  slope: number;           // Raw linear-regression slope (volume units per bar)
+  normalizedSlope: number; // slope / average volume — the value compared against minSlope
   rSquared: number;        // R² quality score
   consecutiveDays: number; // Days of accumulation
 }
@@ -2564,11 +2567,17 @@ const signals = volumeMaCross(candles, {
 ```typescript
 interface VolumeMaCrossSignal {
   time: number;
-  type: 'volume_ma_cross_up' | 'volume_ma_cross_down';
+  type: 'volume_ma_cross';
+  volume: number;
   shortMa: number;
   longMa: number;
+  direction: 'bullish' | 'bearish';
+  ratio: number;
+  daysSinceCross: number;
 }
 ```
+
+**Note:** Bearish (`direction: 'bearish'`) signals are only emitted when `bullishOnly: false` (default is `true`).
 
 ---
 
@@ -2696,7 +2705,7 @@ const patterns = detectWedge(candles);
 const fallingWedges = patterns.filter(p => p.type === 'falling_wedge');
 ```
 
-**Options:** Same as `detectTriangle` (minus `flatTolerance`).
+**Options:** Same as `detectTriangle` (minus `flatTolerance`), except `minPoints` defaults to `3` (3 touches per trendline).
 
 ---
 
@@ -2783,7 +2792,7 @@ interface PatternSignal {
     neckline?: PatternNeckline;    // For H&S patterns
     target?: number;         // Price target (measured move)
     stopLoss?: number;       // Suggested stop loss
-    height: number;          // Pattern height
+    height?: number;         // Pattern height (optional, for measured move calculation)
   };
   confidence: number;        // 0-100 confidence score
   confirmed: boolean;        // True if breakout occurred
@@ -3177,13 +3186,13 @@ monthlyTrendStrong(adxThreshold = 25)  // Monthly ADX > threshold
 mtfTrendStrong(timeframe, adxThreshold = 25)  // MTF ADX > threshold
 
 // Custom MTF condition
-mtfCondition(timeframe, conditionFn)  // Custom condition on MTF data
+mtfCondition(requiredTimeframes, name, evaluate)  // Custom condition on MTF data, e.g. mtfCondition(['weekly'], 'myCond', (mtf, indicators, candle, index, candles) => boolean)
 ```
 
 **Usage with Fluent API:**
 
 ```typescript
-import { TrendCraft, weeklyRsiAbove, goldenCrossCondition, and } from 'trendcraft';
+import { TrendCraft, weeklyRsiAbove, goldenCrossCondition, deadCrossCondition, and } from 'trendcraft';
 
 const result = TrendCraft.from(dailyCandles)
   .withMtf(['weekly'])  // Enable weekly timeframe
@@ -3397,9 +3406,7 @@ const weekly = resample(dailyCandles, 'weekly');
 const monthly = resample(dailyCandles, 'monthly');
 ```
 
-**Supported timeframes:**
-- `'weekly'` or `'1w'`
-- `'monthly'` or `'1M'`
+**Supported timeframes:** `'1m'`, `'5m'`, `'15m'`, `'30m'`, `'1h'`, `'4h'`, `'1d'`/`'daily'`, `'1w'`/`'weekly'`, `'1M'`/`'monthly'` — or a `{ value, unit }` Timeframe object.
 
 ---
 
@@ -4009,7 +4016,7 @@ from the benchmark at the given confidence (default 0.95). Returns
 import { minTrackRecordLength } from 'trendcraft';
 
 // Per-return Sharpe 0.1 — how many bars until PSR(0) ≥ 95%?
-const bars = Math.ceil(minTrackRecordLength(0.1)); // ≈ 274
+const bars = Math.ceil(minTrackRecordLength(0.1)); // 273
 ```
 
 ---
@@ -4419,8 +4426,8 @@ const result = runBacktestScaled(candles, goldenCrossCondition(), deadCrossCondi
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `tranches` | `number` | required | Number of entry tranches (2-10) |
-| `strategy` | `'equal' \| 'pyramid' \| 'reverse-pyramid'` | `'equal'` | Weight distribution strategy |
-| `intervalType` | `'signal' \| 'price'` | `'signal'` | How to trigger additional entries |
+| `strategy` | `'equal' \| 'pyramid' \| 'reverse-pyramid'` | required | Weight distribution strategy |
+| `intervalType` | `'signal' \| 'price'` | required | How to trigger additional entries |
 | `priceInterval` | `number` | `-2` | Price change % for next tranche (negative = dip) |
 
 **Strategies:**
@@ -5255,7 +5262,8 @@ Convert existing TrendCraft signal types into the unified `TradeSignal` format.
 import { fromCrossSignal } from 'trendcraft';
 
 const signals = validateCrossSignals(candles);
-const tradeSignals = signals.map(s => fromCrossSignal(s, candles[i].close));
+const tradeSignals = signals.map(s => fromCrossSignal(s, candles.find(c => c.time === s.time)?.close));
+// or simply signals.map(s => fromCrossSignal(s)) since entryPrice is optional
 // { action: "BUY", direction: "LONG", confidence: 85, ... }
 ```
 
@@ -5274,7 +5282,8 @@ const tradeSignals = divSignals.map(s => fromDivergenceSignal(s, candles[s.secon
 import { fromSqueezeSignal } from 'trendcraft';
 
 const squeezes = bollingerSqueeze(candles);
-const tradeSignals = squeezes.map(s => fromSqueezeSignal(s, "LONG", candles[i].close));
+const tradeSignals = squeezes.map(s => fromSqueezeSignal(s, "LONG", candles.find(c => c.time === s.time)?.close));
+// or simply squeezes.map(s => fromSqueezeSignal(s))
 ```
 
 #### `fromPatternSignal(signal, entryPrice?)`
@@ -5296,7 +5305,7 @@ Converts a `ScoreBreakdown` to a `TradeSignal`. Returns `null` if below threshol
 ```typescript
 import { fromScoreResult } from 'trendcraft';
 
-const breakdown = calculateScoreBreakdown(candles, signals, i);
+const breakdown = calculateScoreBreakdown(candles, i, config); // config: ScoringConfig, e.g. { signals: [...] }
 const signal = fromScoreResult(breakdown, candle.time, { minScore: 50, entryPrice: 100 });
 ```
 
@@ -5329,7 +5338,9 @@ Wraps a streaming pipeline to automatically emit `TradeSignal` events.
 import { streaming } from 'trendcraft';
 import { createRsi } from 'trendcraft/incremental';
 
-const emitter = streaming.createSignalEmitter({
+const { createSignalEmitter, rsiBelow, rsiAbove } = streaming;
+
+const emitter = createSignalEmitter({
   intervalMs: 60000,
   pipeline: {
     indicators: [{ name: 'rsi14', create: () => createRsi({ period: 14 }) }],
@@ -5504,7 +5515,7 @@ if (result.triggered) {
 Both `batchBacktest()` and `portfolioBacktest()` support short selling through the same `direction` option.
 
 ```typescript
-import { batchBacktest, deadCrossCondition, goldenCrossCondition } from 'trendcraft';
+import { batchBacktest, portfolioBacktest, deadCrossCondition, goldenCrossCondition } from 'trendcraft';
 
 // Batch backtest: direction is passed directly in options
 const batchResult = batchBacktest(datasets, deadCrossCondition(5, 25), goldenCrossCondition(5, 25), {
@@ -5534,7 +5545,7 @@ Common short strategy patterns using built-in conditions:
 ```typescript
 import {
   and, rsiAbove, rsiBelow, bollingerTouch, deadCrossCondition, goldenCrossCondition,
-  dmiBearish, anyBearishPattern, stochAbove, stochBelow,
+  dmiBearish, anyBearishPattern, stochAbove, stochBelow, runBacktest,
 } from 'trendcraft';
 
 // Mean reversion short: overbought reversal
@@ -6013,7 +6024,7 @@ Apply an indicator function that expects candles to a `Series<number|null>`. Int
 
 ### `seriesToCandles(series, options?)`
 
-Convert a `Series<number|null>` to pseudo `NormalizedCandle[]` for use as input to indicators. Non-null values become OHLC (all the same value).
+Convert a `Series<number|null>` to pseudo `NormalizedCandle[]` for use as input to indicators. Non-null values become OHLC (all the same value); `null` values get 0 for all prices. Options: `fillMode` — what to fill open/high/low with: the series value (`"value"`, default) or 0 (`"zero"`); `close` always carries the series value.
 
 ### `extractField(series, field)`
 
@@ -6403,8 +6414,8 @@ import { createLiveCandle, incremental } from "trendcraft";
 const live = createLiveCandle({
   intervalMs: 60_000,
   indicators: [
-    { name: "sma20", create: (s) => incremental.createSma({ period: 20 }, { fromState: s }) },
-    { name: "rsi14", create: (s) => incremental.createRsi({ period: 14 }, { fromState: s }) },
+    { name: "sma20", create: (s) => incremental.createSma({ period: 20 }, incremental.restoreState(s)) },
+    { name: "rsi14", create: (s) => incremental.createRsi({ period: 14 }, incremental.restoreState(s)) },
   ],
   history: historicalCandles,
   maxHistory: 500,
@@ -6428,7 +6439,7 @@ live.addCandle(partialCandle, { partial: true });
 | Option | Type | Description |
 |---|---|---|
 | `intervalMs` | `number?` | Candle interval in ms. Required for tick mode; omit for candle mode. |
-| `indicators` | `LiveIndicatorFactory[]?` | Initial indicators to register (can also add dynamically via `addIndicator`). |
+| `indicators` | `{ name: string; create: LiveIndicatorFactory; state?: unknown }[]?` | Initial indicators to register (can also add dynamically via `addIndicator`). |
 | `history` | `NormalizedCandle[]?` | Historical candles used only for context (not emitted). |
 | `maxHistory` | `number?` | Cap on the number of completed candles kept in memory. |
 
@@ -6460,7 +6471,7 @@ const sma = livePresets.sma;
 // {
 //   meta: { kind: 'sma', label: 'SMA', overlay: true, ... },
 //   defaultParams: { period: 20 },
-//   snapshotName: (p) => `sma${p.period}`,
+//   snapshotName: (p) => `sma_${p.source ?? "close"}_${p.period ?? 20}`,  // → "sma_close_20"
 //   createFactory: (params) => (fromState) => IncrementalIndicator,
 // }
 
@@ -6475,7 +6486,7 @@ const rsiIndicator = factory(undefined); // no prior state
 |---|---|---|
 | `meta` | `SeriesMeta` | Rendering metadata (kind, label, overlay, yRange, referenceLines). |
 | `defaultParams` | `Record<string, unknown>` | Default parameters when user passes `{}`. |
-| `snapshotName` | `(params) => string` | Derive the snapshot key (e.g. `"sma20"`) for this instance. |
+| `snapshotName` | `string \| (params) => string` | Snapshot key (fixed string or derived from params; e.g. sma → `"sma_close_20"`, ema → `"ema20"`). |
 | `createFactory` | `(params) => LiveIndicatorFactory` | Build the incremental factory closed over the given params. |
 
 ### `indicatorPresets`
@@ -6499,13 +6510,16 @@ const factory = rsi.createFactory({ period: 14 });
 | Field | Type | Description |
 |---|---|---|
 | ...all `LivePreset` fields | — | — |
-| `compute` | `(candles, params) => Series<T>` | Batch compute for static mode. |
-| `category` | `IndicatorCategory` | Grouping hint for UI (`"momentum"`, `"trend"`, etc.). |
-| `paramSchema` | `ParamSchema?` | Parameter schema for automatic UI form generation. |
+| `compute?` | `(candles, params) => Series<T>` | Batch compute for static mode (optional). |
+| `createFactory?` | `(params) => LiveIndicatorFactory` | Incremental factory for streaming mode (optional). |
+| `category` | `IndicatorCategory?` | Grouping hint for UI. Values are capitalized: `"Moving Averages"`, `"Momentum"`, `"Volatility"`, `"Trend"`, `"Volume"`, `"Price"`, `"Wyckoff"`, `"Adaptive"`, `"Session"`, `"SMC"`, `"Filter"`. |
+| `paramSchema` | `ParamSchema[]?` | Array of per-parameter schemas for automatic UI form generation. |
+
+At least one of `compute` or `createFactory` is always defined. All 104 entries have `compute`; 25 batch-only entries (e.g. `zigzag`, `heikinAshi`, `swingPoints`, `orderBlock`, `dpo`, `adaptiveRsi`) have no `createFactory` — check for its presence before using streaming mode.
 
 ### `tagSeries` / `SeriesMeta`
 
-Attach domain metadata to any `Series<T>` via a non-enumerable `__meta` property. Every built-in indicator already tags its output. Use `tagSeries` on your own indicators if you want downstream consumers (renderers, UI generators, etc.) to pick up the same conventions.
+Attach domain metadata to any `Series<T>` via a `__meta` property. Every built-in indicator already tags its output. Use `tagSeries` on your own indicators if you want downstream consumers (renderers, UI generators, etc.) to pick up the same conventions.
 
 ```typescript
 import { tagSeries, rsi, type SeriesMeta } from "trendcraft";
@@ -6549,7 +6563,7 @@ A renderer may translate `overlay` to pane placement and `yRange` to an axis con
 ```typescript
 // Input candle (flexible)
 interface Candle {
-  time: number | string | Date;
+  time: number | string;  // epoch seconds/ms/µs number, or ISO date string
   open: number;
   high: number;
   low: number;
@@ -6584,11 +6598,14 @@ type PriceSource = 'open' | 'high' | 'low' | 'close' | 'hl2' | 'hlc3' | 'ohlc4' 
 ### Signal Types
 
 ```typescript
-type SignalType = 'bullish' | 'bearish';
+type SignalType = 'buy' | 'sell' | 'hold';
 
 interface Signal {
   time: number;
   type: SignalType;
+  name: string;
+  confidence?: number;
+  metadata?: Record<string, unknown>;
 }
 ```
 
@@ -6946,7 +6963,7 @@ const patterns = detectHarmonicPatterns(candles, {
 |--------|---------|-------------|
 | `swingLookback` | `5` | Swing point detection period |
 | `tolerance` | `0.05` | Fibonacci ratio matching tolerance (5%) |
-| `minSwingPoints` | `50` | Minimum bars for swing detection |
+| `minSwingPoints` | `50` | Minimum number of swing points to scan for XABCD windows |
 | `patterns` | all | Pattern types to detect |
 
 **Pattern types:** `gartley_bullish`, `gartley_bearish`, `butterfly_bullish`, `butterfly_bearish`, `bat_bullish`, `bat_bearish`, `crab_bullish`, `crab_bearish`, `shark_bullish`, `shark_bearish`.
@@ -6980,8 +6997,8 @@ const result = garch(dailyReturns, {
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `p` | `1` | GARCH lag order |
-| `q` | `1` | ARCH lag order |
+| `p` | `1` | GARCH lag order — reserved for future use; only `1` is currently supported (any other value throws) |
+| `q` | `1` | ARCH lag order — reserved for future use; only `1` is currently supported (any other value throws) |
 | `maxIterations` | `100` | Max MLE iterations |
 | `tolerance` | `1e-6` | Convergence tolerance |
 
@@ -7002,7 +7019,7 @@ const vol = ewmaVolatility(dailyReturns, { lambda: 0.94 });
 |--------|---------|-------------|
 | `lambda` | `0.94` | Decay factor (RiskMetrics standard) |
 | `calendar` | `US_EQUITY_CALENDAR` | Trading calendar preset for annualization |
-| `periodsPerYear` | `252` | Override annualization (takes precedence over `calendar`) |
+| `periodsPerYear` | `252` | Override annualization (used only when `calendar` is not provided; `calendar` wins if both are set) |
 
 Returns `Series<number>` (annualized volatility, percent).
 
@@ -7058,7 +7075,9 @@ const N = annualizationFactor({ calendar: JPX_CALENDAR }); // 245
 ```
 
 The `AnnualizationOptions` bag (`{ calendar?, periodsPerYear? }`) is accepted by:
-`calculateMetricsFromReturns`, `stressTest`, `runAllStressTests`, `ulcerPerformanceIndex`, `garch`, `ewmaVolatility`, `ewmaVolatilityFromCandles`, `volatilityRegime`, `calculateRuntimeMetrics`. Defaults are unchanged from prior versions.
+`calculateMetricsFromReturns`, `stressTest`, `runAllStressTests`, `ulcerPerformanceIndex`, `garch`, `ewmaVolatility`, `ewmaVolatilityFromCandles`, `volatilityRegime`. Defaults are unchanged from prior versions.
+
+`calculateRuntimeMetrics` accepts `calendar` but not `periodsPerYear`; use its legacy `annualizationFactor: number` field for a raw bars-per-year override (`calendar` wins when both are set).
 
 ---
 
@@ -7101,7 +7120,7 @@ console.log(summarizeParetoResult(result));
 | `maxCombinations` | `10000` | Maximum parameter combinations to evaluate |
 | `progressCallback` | - | Progress reporting callback |
 
-**Available metrics:** `sharpe`, `returnPercent`, `maxDrawdown`, `profitFactor`, `winRate`, `calmar`, `recoveryFactor`, `avgHoldingDays`.
+**Available metrics:** `sharpe`, `calmar`, `mar`, `profitFactor`, `recoveryFactor`, `returns`, `winRate`, `tradeCount`, `maxDrawdown`.
 
 Returns `ParetoResult` with `paretoFront: ParetoResultEntry[]` (each with `frontIndex`, `crowdingDistance`).
 
@@ -7169,7 +7188,7 @@ const result = stressTest(dailyReturns, PRESET_SCENARIOS.lehman2008, 1_000_000);
 // result.originalMetrics — { totalReturn, maxDrawdown, sharpe }
 // result.stressedMetrics — { totalReturn, maxDrawdown, sharpe }
 // result.worstCase — { drawdown, duration, recoveryDays }
-// result.survivalRate — percentage of capital surviving
+// result.survivalRate — 1.0 if stressed equity never falls to/below zero, 0.0 otherwise (binary survive/ruin flag)
 // result.capitalAtRisk — capital at risk amount
 // result.stressedVaR, result.stressedCVaR
 ```
@@ -7182,7 +7201,7 @@ Run all preset stress scenarios at once.
 const summary = runAllStressTests(dailyReturns, 1_000_000);
 // summary.results — StressTestResult[] for each scenario
 // summary.worstScenario — name of the worst-performing scenario
-// summary.overallSurvivalRate — minimum survival across all scenarios
+// summary.overallSurvivalRate — proportion of scenarios that survived (mean of the binary per-scenario survivalRate values)
 // summary.maxStressedDrawdown — maximum drawdown across all scenarios
 ```
 
@@ -7357,6 +7376,7 @@ type StrategyJSON = {
     commissionRate?: number;
     slippage?: number;
     fillMode?: "same-bar-close" | "next-bar-open";
+    sizing?: BacktestSizingConfigJSON;
   };
   metadata?: Record<string, unknown>;
 };

--- a/packages/core/docs/COOKBOOK.md
+++ b/packages/core/docs/COOKBOOK.md
@@ -320,7 +320,7 @@ const candles = normalizeCandles(rawCandles);
 // Option A: Use a preset
 const config = createMomentumPreset();
 const score = calculateScore(candles, candles.length - 1, config);
-console.log(`Score: ${score.totalScore}, Strength: ${score.strength}`);
+console.log(`Score: ${score.normalizedScore}, Strength: ${score.strength}`);
 
 // Option B: Build custom scoring
 const custom = ScoreBuilder.create()
@@ -651,7 +651,7 @@ const alignedWeeklySma = alignSeries(weeklySma, dailySma);
 
 ### Step 1: Provide Context to the LLM
 
-Copy the contents of `llms.txt` (shipped with the package) into your LLM prompt:
+Copy the contents of `llms.txt` (found in the repository at `packages/core/llms.txt`, viewable on GitHub) into your LLM prompt:
 
 ```
 You are a quant strategy developer. Use the TrendCraft library to build strategies.

--- a/packages/core/docs/GUIDE.ja.md
+++ b/packages/core/docs/GUIDE.ja.md
@@ -1243,7 +1243,7 @@ console.log(`勝率: ${result.winRate}%`);
 
 ```
 1. ADXによるトレンド強度チェック（ADX < 25 = 弱いトレンド）
-2. ドンチャンチャネル幅のATR正規化（狭い = レンジ）
+2. ドンチャンチャネル幅（中値で正規化）のパーセンタイル評価（狭い = レンジ）。ボリンジャーバンド幅と ATR/終値 比率も別コンポーネントとしてスコアに合成
 3. 線形回帰の傾き（水平に近い = レンジ）
 4. +DI/-DIの差分（差が小さい = 方向性なし）
 5. 連続するHH（Higher High）/ LL（Lower Low）のカウント
@@ -1296,10 +1296,9 @@ rbData.forEach(({ time, value }) => {
 `rangeScore`は0〜100のスコアで、数値が高いほどレンジ相場の特徴が強いことを示します：
 
 ```
-rangeScore > 80  → 非常にタイトなレンジ（RANGE_TIGHT）
-rangeScore > 60  → レンジ確定（RANGE_CONFIRMED）
-rangeScore > 40  → レンジ形成中（RANGE_FORMING）
-rangeScore <= 40 → トレンドまたは中立
+rangeScore >= 70（デフォルト rangeScoreThreshold。ADXが20〜25の遷移域では+10されて80）かつ ADX <= 20 → レンジ状態（まず RANGE_FORMING、persistBars（デフォルト3本）継続で RANGE_CONFIRMED）
+rangeScore >= 85（tightRangeThreshold）かつ ADX <= 15 → RANGE_TIGHT（非常にタイトなレンジ）
+閾値未満 → TRENDING または NEUTRAL
 ```
 
 ### トレード戦略
@@ -1669,7 +1668,7 @@ TrendCraftは4つのポジションサイジング手法を提供しています
 import { riskBasedSize } from 'trendcraft';
 
 const result = riskBasedSize({
-  accountSize: 100000,     // 口座資金100万円
+  accountSize: 100000,     // 口座資金10万円
   entryPrice: 50,          // エントリー価格50円
   stopLossPrice: 48,       // ストップ48円（4%下）
   riskPercent: 1,          // 口座の1%をリスク（1000円）
@@ -1823,20 +1822,21 @@ const riskRewardRatio =
 ### バックテストでATRを使用
 
 ```typescript
-import { TrendCraft, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
+import { runBacktest, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
-const result = TrendCraft.from(candles)
-  .strategy()
-    .entry(goldenCrossCondition())
-    .exit(deadCrossCondition())
-  .backtest({
+const result = runBacktest(
+  candles,
+  goldenCrossCondition(),  // エントリー: ゴールデンクロス
+  deadCrossCondition(),    // イグジット: デッドクロス
+  {
     capital: 1000000,
     atrRisk: {
       atrPeriod: 14,            // ATR期間
       atrStopMultiplier: 2,     // 2×ATRストップ
       atrTakeProfitMultiplier: 3, // 3×ATR利確
     },
-  });
+  },
+);
 ```
 
 ### ATR倍率ガイドライン
@@ -1998,7 +1998,7 @@ regime = 'extreme'  → 非常に慎重に、様子見も検討
 ### トレードへの応用
 
 ```typescript
-import { regimeIs, regimeNot, atrPercentAbove, and, goldenCrossCondition, bollingerTouch } from 'trendcraft';
+import { regimeIs, regimeNot, atrPercentAbove, and, goldenCrossCondition, bollingerTouch, perfectOrderBullish } from 'trendcraft';
 
 // 低ボラティリティでのレンジ相場戦略
 const rangeEntry = and(
@@ -2201,7 +2201,7 @@ const result2 = runBacktestScaled(candles, goldenCrossCondition(), deadCrossCond
 
 ## リアルタイムストリーミング
 
-バッチ指標（`sma(candles, ...)`、`rsi(candles, ...)` など）は呼ぶたびに全体を再計算します。WebSocket ティック、ペーパートレード Bot、アラートダッシュボードなどのライブデータを扱うときは、v0.2.0 で導入した**インクリメンタル指標**と**ライブローソク足パイプライン**を使います。
+バッチ指標（`sma(candles, ...)`、`rsi(candles, ...)` など）は呼ぶたびに全体を再計算します。WebSocket ティック、ペーパートレード Bot、アラートダッシュボードなどのライブデータを扱うときは、**インクリメンタル指標**と、v0.2.0 で導入した**ライブローソク足パイプライン**を使います。
 
 ### インクリメンタル指標
 
@@ -2231,8 +2231,8 @@ import { createLiveCandle, incremental } from 'trendcraft';
 const live = createLiveCandle({
   intervalMs: 60_000,
   indicators: [
-    { name: 'sma20', create: (s) => incremental.createSma({ period: 20 }, { fromState: s }) },
-    { name: 'rsi14', create: (s) => incremental.createRsi({ period: 14 }, { fromState: s }) },
+    { name: 'sma20', create: (s) => incremental.createSma({ period: 20 }, incremental.restoreState(s)) },
+    { name: 'rsi14', create: (s) => incremental.createRsi({ period: 14 }, incremental.restoreState(s)) },
   ],
   history: historicalCandles,  // 任意の warm-up コンテキスト
 });
@@ -2275,7 +2275,7 @@ const rsiSeries = indicatorPresets.rsi.compute(candles, { period: 14 });
 
 ### シリーズメタデータ（`SeriesMeta` / `tagSeries`）
 
-組み込み指標の出力はすべて、表示規約（ラベル、価格スケールに重ねるか、Y 軸レンジ、参照線）を示す非列挙の `__meta` を持ちます:
+組み込み指標の出力はすべて、表示規約（ラベル、価格スケールに重ねるか、Y 軸レンジ、参照線）を示す `__meta` プロパティを持ちます:
 
 ```typescript
 import { rsi } from 'trendcraft';

--- a/packages/core/docs/GUIDE.md
+++ b/packages/core/docs/GUIDE.md
@@ -1637,7 +1637,7 @@ TrendCraft provides pre-built scoring strategies:
 | `balanced` | Mixed signals | General purpose |
 
 ```typescript
-import { getPreset, scoreAbove } from 'trendcraft';
+import { getPreset, scoreAbove, deadCrossCondition } from 'trendcraft';
 
 // Use preset in backtest
 const result = TrendCraft.from(candles)
@@ -1836,20 +1836,21 @@ const riskRewardRatio =
 ### Using ATR in Backtesting
 
 ```typescript
-import { TrendCraft, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
+import { runBacktest, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
-const result = TrendCraft.from(candles)
-  .strategy()
-    .entry(goldenCrossCondition())
-    .exit(deadCrossCondition())
-  .backtest({
+const result = runBacktest(
+  candles,
+  goldenCrossCondition(),  // Entry: golden cross
+  deadCrossCondition(),    // Exit: dead cross
+  {
     capital: 1000000,
     atrRisk: {
       atrPeriod: 14,             // ATR period
       atrStopMultiplier: 2,      // 2x ATR stop
       atrTakeProfitMultiplier: 3, // 3x ATR take-profit
     },
-  });
+  },
+);
 ```
 
 ### ATR Multiplier Guidelines
@@ -2011,7 +2012,7 @@ regime = 'extreme'  → Very cautious, consider sitting out
 ### Trading Applications
 
 ```typescript
-import { regimeIs, regimeNot, atrPercentAbove, and, goldenCrossCondition, bollingerTouch } from 'trendcraft';
+import { regimeIs, regimeNot, atrPercentAbove, and, goldenCrossCondition, bollingerTouch, perfectOrderBullish } from 'trendcraft';
 
 // Range-bound strategies in low volatility
 const rangeEntry = and(
@@ -2214,7 +2215,7 @@ const result2 = runBacktestScaled(candles, goldenCrossCondition(), deadCrossCond
 
 ## Real-Time Streaming
 
-Batch indicators (`sma(candles, ...)`, `rsi(candles, ...)`, etc.) recompute from scratch every call. For live data — WebSocket ticks, paper-trading bots, alert dashboards — use the **incremental indicators** and the **live candle pipeline** introduced in v0.2.0.
+Batch indicators (`sma(candles, ...)`, `rsi(candles, ...)`, etc.) recompute from scratch every call. For live data — WebSocket ticks, paper-trading bots, alert dashboards — use the **incremental indicators** (available since v0.1.0) and the **live candle pipeline** introduced in v0.2.0.
 
 ### Incremental indicators
 
@@ -2244,8 +2245,8 @@ import { createLiveCandle, incremental } from 'trendcraft';
 const live = createLiveCandle({
   intervalMs: 60_000,
   indicators: [
-    { name: 'sma20', create: (s) => incremental.createSma({ period: 20 }, { fromState: s }) },
-    { name: 'rsi14', create: (s) => incremental.createRsi({ period: 14 }, { fromState: s }) },
+    { name: 'sma20', create: (s) => incremental.createSma({ period: 20 }, incremental.restoreState(s)) },
+    { name: 'rsi14', create: (s) => incremental.createRsi({ period: 14 }, incremental.restoreState(s)) },
   ],
   history: historicalCandles,  // optional warm-up context
 });
@@ -2288,7 +2289,7 @@ const rsiSeries = indicatorPresets.rsi.compute(candles, { period: 14 });
 
 ### Series metadata (`SeriesMeta` / `tagSeries`)
 
-Every built-in indicator output carries a non-enumerable `__meta` with display conventions — label, whether it belongs on the price scale, Y-range, reference lines:
+Every built-in indicator output carries a `__meta` property with display conventions — label, whether it belongs on the price scale, Y-range, reference lines:
 
 ```typescript
 import { rsi } from 'trendcraft';

--- a/packages/core/docs/migration-0.3-to-0.4.md
+++ b/packages/core/docs/migration-0.3-to-0.4.md
@@ -28,7 +28,7 @@ type IndicatorSnapshot<TState> = {
 **Pre-0.4.0 snapshots cannot be resumed.** They have no `meta` field,
 so `fromState` throws `<indicator>: incompatible snapshot, re-warm
 required`. This applies equally to streaming session snapshots
-(`createLiveCandle` / `createPipeline` / `createSession`).
+(`createLiveCandle` / `createPipeline` / `createTradingSession`).
 
 ## How to fix: re-warm
 

--- a/packages/core/examples/echarts-viewer/README.ja.md
+++ b/packages/core/examples/echarts-viewer/README.ja.md
@@ -134,7 +134,7 @@ interface ChartState {
 
 ### 主要アクション
 
-- `loadCandles(candles, fileName)` - ローソク足データ読み込み
+- `loadCandles(candles, fundamentals, fileName)` - ローソク足データ読み込み（PER/PBRデータがない場合は `fundamentals` に `null` を渡す）
 - `setTimeframe(timeframe)` - 時間足切替 (自動変換)
 - `setEnabledIndicators(indicators)` - サブチャート有効化
 - `setEnabledOverlays(overlays)` - オーバーレイ有効化
@@ -273,13 +273,15 @@ buildChartOption(
   trades: Trade[] | null,             // バックテスト取引
   overlays: OverlayData,              // オーバーレイ用データ
   enabledOverlays: OverlayType[],     // 有効なオーバーレイ
-  chartHeight: number                 // チャート高さ
+  _chartHeight = 500,                 // 未使用（グリッド高さは mainHeight=300 等の固定ピクセル定数で決定）
 ): EChartsOption
 ```
 
+この後に `indicatorParams?`, `zoomRange?`, `yAxisType?`, `yAxisPercent?`, `theme?`, `drawings?`, `_subchartHeights?`, `selectedDrawingId?`, `comparisonSymbols?`, `replayEndIndex?`, `projectionFanSeries?` の省略可能引数が続く（詳細は `src/utils/chartConfig.ts` を参照）。
+
 ## カラーパレット
 
-主要な色定義 (`chartConfig.ts`のCOLORS定数):
+主要な色定義 (`chartColors.ts`のCOLORS定数):
 
 | 用途 | 色 |
 |------|------|

--- a/packages/core/examples/echarts-viewer/README.md
+++ b/packages/core/examples/echarts-viewer/README.md
@@ -134,7 +134,7 @@ interface ChartState {
 
 ### Main Actions
 
-- `loadCandles(candles, fileName)` - Load candlestick data
+- `loadCandles(candles, fundamentals, fileName)` - Load candlestick data (pass `null` for fundamentals when PER/PBR data is absent)
 - `setTimeframe(timeframe)` - Switch timeframe (auto-converts)
 - `setEnabledIndicators(indicators)` - Enable subcharts
 - `setEnabledOverlays(overlays)` - Enable overlays
@@ -273,13 +273,14 @@ buildChartOption(
   trades: Trade[] | null,             // Backtest trades
   overlays: OverlayData,              // Overlay data
   enabledOverlays: OverlayType[],     // Enabled overlays
-  chartHeight: number                 // Chart height
+  _chartHeight = 500                  // Unused (layout uses fixed pixel heights)
+  // ...followed by further optional params: indicatorParams?, zoomRange?, yAxisType?, yAxisPercent?, theme?, drawings?, ...
 ): EChartsOption
 ```
 
 ## Color Palette
 
-Main color definitions (`COLORS` constant in `chartConfig.ts`):
+Main color definitions (`COLORS` constant in `chartColors.ts`):
 
 | Usage | Color |
 |-------|-------|

--- a/packages/core/examples/trading-simulator/README.md
+++ b/packages/core/examples/trading-simulator/README.md
@@ -48,5 +48,5 @@ pnpm dev
 
 - This example renders with **ECharts**, not `@trendcraft/chart`. It predates
   the chart package and has not been migrated yet.
-- The Alpaca client expects `VITE_ALPACA_API_KEY` / `VITE_ALPACA_API_SECRET`
-  in `.env.local` if you want live data; otherwise CSV / quick-start works.
+- The Alpaca client expects `ALPACA_API_KEY` / `ALPACA_API_SECRET` in `.env`
+  (see `.env.example`) if you want live data; otherwise CSV / quick-start works.

--- a/packages/core/src/alpha-decay/monitor.ts
+++ b/packages/core/src/alpha-decay/monitor.ts
@@ -108,7 +108,8 @@ export function createObservationsFromTrades(
  *
  * @example
  * ```ts
- * const scores = calculateScoreSeries(config, candles, indicators);
+ * const scoreSeries = calculateScoreSeries(candles, config);
+ * const scores = scoreSeries.map((s) => ({ time: s.time, score: s.score.normalizedScore }));
  * const observations = createObservationsFromScores(scores, candles, 5);
  * const decay = analyzeAlphaDecay(observations);
  * ```

--- a/packages/core/src/analysis/behavior-insights.ts
+++ b/packages/core/src/analysis/behavior-insights.ts
@@ -8,7 +8,18 @@
  * ```ts
  * import { generateBehaviorInsights } from "trendcraft";
  *
- * const insights = generateBehaviorInsights(result.trades, result.equityCurve);
+ * // BacktestResult.equityCurve is a plain number[] aligned with candles —
+ * // build BehaviorEquityPoint[] ({ time, equity, drawdownPercent }) for drawdown analysis
+ * let peak = Number.NEGATIVE_INFINITY;
+ * const equityPoints = (result.equityCurve ?? []).map((equity, i) => {
+ *   peak = Math.max(peak, equity);
+ *   return {
+ *     time: candles[i].time,
+ *     equity,
+ *     drawdownPercent: peak > 0 ? ((peak - equity) / peak) * 100 : 0,
+ *   };
+ * });
+ * const insights = generateBehaviorInsights(result.trades, equityPoints);
  * // [{ type: "strength", title: "Good profit capture", ... }, ...]
  * ```
  */
@@ -68,7 +79,7 @@ export type BehaviorEquityPoint = {
  *
  * @example
  * ```ts
- * const insights = generateBehaviorInsights(result.trades, result.equityCurve);
+ * const insights = generateBehaviorInsights(result.trades);
  * for (const insight of insights) {
  *   console.log(`[${insight.type}] ${insight.title}: ${insight.description}`);
  * }

--- a/packages/core/src/analysis/edge-analysis.ts
+++ b/packages/core/src/analysis/edge-analysis.ts
@@ -363,7 +363,7 @@ export function analyzeStreaks(trades: Trade[]): StreakAnalysis {
  *
  * @example
  * ```ts
- * const result = runBacktest(candles, { entry, exit, stopLoss: 5 });
+ * const result = runBacktest(candles, entry, exit, { capital: 100_000, stopLoss: 5 });
  * const analysis = analyzeAllTrades(result.trades);
  *
  * console.log('Overall:', analysis.overall);

--- a/packages/core/src/backtest/conditions/fundamentals.ts
+++ b/packages/core/src/backtest/conditions/fundamentals.ts
@@ -19,7 +19,7 @@ import type { PresetCondition } from "../../types";
  * @example
  * ```ts
  * // Entry only when stock is undervalued (PER < 15)
- * const entry = and(goldenCross(), perBelow(15));
+ * const entry = and(goldenCrossCondition(), perBelow(15));
  * ```
  */
 export function perBelow(threshold: number): PresetCondition {
@@ -66,7 +66,7 @@ export function perAbove(threshold: number): PresetCondition {
  * @example
  * ```ts
  * // Entry only when PER is in reasonable range (10-20)
- * const entry = and(goldenCross(), perBetween(10, 20));
+ * const entry = and(goldenCrossCondition(), perBetween(10, 20));
  * ```
  */
 export function perBetween(min: number, max: number): PresetCondition {
@@ -93,7 +93,7 @@ export function perBetween(min: number, max: number): PresetCondition {
  * @example
  * ```ts
  * // Entry only when stock trades below book value
- * const entry = and(goldenCross(), pbrBelow(1.0));
+ * const entry = and(goldenCrossCondition(), pbrBelow(1.0));
  * ```
  */
 export function pbrBelow(threshold: number): PresetCondition {
@@ -140,7 +140,7 @@ export function pbrAbove(threshold: number): PresetCondition {
  * @example
  * ```ts
  * // Entry only when PBR is in value range (0.5-1.5)
- * const entry = and(goldenCross(), pbrBetween(0.5, 1.5));
+ * const entry = and(goldenCrossCondition(), pbrBetween(0.5, 1.5));
  * ```
  */
 export function pbrBetween(min: number, max: number): PresetCondition {

--- a/packages/core/src/backtest/conditions/smc.ts
+++ b/packages/core/src/backtest/conditions/smc.ts
@@ -72,10 +72,12 @@ export type OrderBlockConditionOptions = OrderBlockOptions;
  *
  * @example
  * ```ts
- * runBacktest(candles, {
- *   entry: and(priceAtBullishOrderBlock(), rsiBelow(30)),
- *   exit: rsiAbove(70),
- * });
+ * runBacktest(
+ *   candles,
+ *   and(priceAtBullishOrderBlock(), rsiBelow(30)),
+ *   rsiAbove(70),
+ *   { capital: 1_000_000 },
+ * );
  * ```
  */
 export function priceAtBullishOrderBlock(
@@ -98,10 +100,12 @@ export function priceAtBullishOrderBlock(
  *
  * @example
  * ```ts
- * runBacktest(candles, {
- *   entry: and(priceAtBearishOrderBlock(), rsiAbove(70)),
- *   exit: rsiBelow(30),
- * });
+ * runBacktest(
+ *   candles,
+ *   and(priceAtBearishOrderBlock(), rsiAbove(70)),
+ *   rsiBelow(30),
+ *   { capital: 1_000_000 },
+ * );
  * ```
  */
 export function priceAtBearishOrderBlock(
@@ -226,10 +230,12 @@ export type LiquiditySweepConditionOptions = LiquiditySweepOptions;
  * @example
  * ```ts
  * // Enter on bullish sweep (price swept below swing low and recovered)
- * runBacktest(candles, {
- *   entry: liquiditySweepDetected("bullish"),
- *   exit: rsiAbove(70),
- * });
+ * runBacktest(
+ *   candles,
+ *   liquiditySweepDetected("bullish"),
+ *   rsiAbove(70),
+ *   { capital: 1_000_000 },
+ * );
  * ```
  */
 export function liquiditySweepDetected(
@@ -261,10 +267,12 @@ export function liquiditySweepDetected(
  * @example
  * ```ts
  * // Enter when bullish sweep recovers (price swept below and came back)
- * runBacktest(candles, {
- *   entry: liquiditySweepRecovered("bullish"),
- *   exit: priceAboveSma(50),
- * });
+ * runBacktest(
+ *   candles,
+ *   liquiditySweepRecovered("bullish"),
+ *   priceAboveSma(50),
+ *   { capital: 1_000_000 },
+ * );
  * ```
  */
 export function liquiditySweepRecovered(

--- a/packages/core/src/backtest/conditions/volume-trend-obv.ts
+++ b/packages/core/src/backtest/conditions/volume-trend-obv.ts
@@ -177,7 +177,7 @@ export function volumeTrendConfidence(minConfidence = 60): PresetCondition {
  * ```ts
  * // Accumulation phase detection
  * const entry = and(
- *   volumeAccumulationCondition({ minDays: 3 }),
+ *   volumeConfirmsTrend(),
  *   cmfAbove(0),  // Buying pressure dominant
  *   priceAboveSma(50),
  * );
@@ -260,7 +260,7 @@ export function cmfBelow(threshold = 0, period = 20): PresetCondition {
  * ```ts
  * // Accumulation confirmation
  * const entry = and(
- *   volumeAccumulationCondition({ minDays: 3 }),
+ *   volumeConfirmsTrend(),
  *   cmfAbove(0),
  *   obvRising(10),  // OBV trending up
  * );

--- a/packages/core/src/backtest/margin.ts
+++ b/packages/core/src/backtest/margin.ts
@@ -208,7 +208,7 @@ export function repayLoan(state: MarginState, fraction: number): number {
  * checkMarginCall(state, 0.25); // false
  *
  * state = updateMarginState(state, 11000, 10000);
- * // state.marginRatio = (10000 + 11000 - 10000) / 11000 ≈ 0.909
+ * // state.marginRatio = (10000 + 11000 - 10000) / 11000 = 1.0
  * checkMarginCall(state, 0.25); // false
  *
  * // After a large drop:

--- a/packages/core/src/backtest/portfolio.ts
+++ b/packages/core/src/backtest/portfolio.ts
@@ -121,10 +121,15 @@ export function batchBacktest(
 // ============================================
 
 /**
- * Run a portfolio backtest with shared capital, allocation, and optional rebalancing.
+ * Run a portfolio backtest with weight-based capital allocation, exposure constraints, and optional rebalancing.
  *
- * Unlike `batchBacktest()`, this shares a single capital pool across all symbols.
- * Signals compete for capital allocation, and position limits are enforced.
+ * Unlike `batchBacktest()`, this applies portfolio-level allocation and exposure
+ * constraints. Allocation is static: total capital is split across symbols by the
+ * weights from the `allocation` strategy, and `maxSymbolExposure` caps each
+ * symbol's share of total capital. Symbols are currently backtested independently
+ * against their allocated capital (no shared capital pool or signal competition
+ * yet), and `maxPositions` is accepted but not yet enforced; concurrent positions
+ * are reported via `peakConcurrentPositions`.
  *
  * @param datasets - Array of symbol data
  * @param entryCondition - Entry condition
@@ -143,7 +148,7 @@ export function batchBacktest(
  *   {
  *     capital: 3_000_000,
  *     allocation: { type: "equal" },
- *     maxPositions: 5,
+ *     maxPositions: 5, // accepted but not yet enforced
  *     maxSymbolExposure: 25,
  *     tradeOptions: { stopLoss: 5, takeProfit: 15 },
  *   },

--- a/packages/core/src/backtest/scoring.ts
+++ b/packages/core/src/backtest/scoring.ts
@@ -86,7 +86,7 @@ const DEFAULT_WEIGHTS: Required<ScoreWeights> = {
 
 /**
  * Normalize Sharpe ratio to 0-100 scale.
- * 0 -> 0, 1 -> 50, 2 -> 75, 3+ -> ~100
+ * 0 -> 0, 1 -> 50, 2 -> ~67, 3 -> 75 (asymptotically approaches 100)
  */
 function normalizeSharpe(sharpe: number): number {
   if (sharpe <= 0) return 0;
@@ -105,7 +105,7 @@ function normalizeWinRate(winRate: number): number {
 
 /**
  * Normalize max drawdown to 0-100 score (lower DD = higher score).
- * 0% DD -> 100, 10% -> 70, 30% -> 30, 50%+ -> 0
+ * 0% DD -> 100, 10% -> 80, 30% -> 40, 50%+ -> 0
  */
 function normalizeDrawdown(maxDrawdown: number): number {
   if (maxDrawdown <= 0) return 100;
@@ -115,7 +115,7 @@ function normalizeDrawdown(maxDrawdown: number): number {
 
 /**
  * Normalize profit factor to 0-100 score.
- * 0 -> 0, 1 -> 30, 2 -> 60, 3+ -> ~90-100
+ * 0 -> 0, 1 -> 30, 2 -> 65, 3 -> ~77 (asymptotically approaches 100)
  */
 function normalizeProfitFactor(pf: number): number {
   if (pf <= 0) return 0;
@@ -126,7 +126,7 @@ function normalizeProfitFactor(pf: number): number {
 
 /**
  * Normalize total return percentage to 0-100 score.
- * Negative -> 0, 0% -> 0, 20% -> 40, 50% -> 67, 100%+ -> ~90-100
+ * Negative -> 0, 0% -> 0, 20% -> ~29, 50% -> 50, 100% -> ~67 (asymptotically approaches 100)
  */
 function normalizeTotalReturn(returnPercent: number): number {
   if (returnPercent <= 0) return 0;

--- a/packages/core/src/backtest/slippage-model.ts
+++ b/packages/core/src/backtest/slippage-model.ts
@@ -21,14 +21,14 @@ export type FixedSlippageModel = {
 /** Volatility-based slippage scaled by ATR relative to price. */
 export type VolatilitySlippageModel = {
   type: "volatility";
-  /** Multiplier applied to (ATR / close) ratio (default: 1) */
+  /** Multiplier applied to (ATR / close) ratio (e.g., 1) */
   atrMultiplier: number;
 };
 
 /** Volume-based slippage using square-root market impact model. */
 export type VolumeSlippageModel = {
   type: "volume";
-  /** Impact coefficient — higher means more slippage in thin markets (default: 0.1) */
+  /** Impact coefficient — higher means more slippage in thin markets (e.g., 0.1) */
   impactCoeff: number;
 };
 
@@ -79,7 +79,7 @@ export type SlippageModel =
  * );
  * // => 2.0
  *
- * // Volume-based: impactCoeff=0.1, volume=10000 → 0.1/100 * 100 = 1%
+ * // Volume-based: impactCoeff=0.1, volume=10000 → 0.1/100 * 100 = 0.1 (0.1%)
  * const s3 = calculateDynamicSlippage(
  *   { type: "volume", impactCoeff: 0.1 },
  *   candle,

--- a/packages/core/src/calendar/types.ts
+++ b/packages/core/src/calendar/types.ts
@@ -13,10 +13,10 @@
  *
  * @example
  * ```ts
- * import { JPX_CALENDAR, calculateVaR } from "trendcraft";
+ * import { JPX_CALENDAR, calculateRuntimeMetrics } from "trendcraft";
  *
  * // Use ~245 days/year for a Japanese-market strategy instead of US 252
- * const result = calculateVaR(returns, { confidence: 0.95, calendar: JPX_CALENDAR });
+ * const metrics = calculateRuntimeMetrics(trades, { calendar: JPX_CALENDAR });
  * ```
  */
 export interface TradingCalendar {

--- a/packages/core/src/compose/pipe.ts
+++ b/packages/core/src/compose/pipe.ts
@@ -20,7 +20,7 @@ import { seriesToCandles } from "./adapters";
  * ```ts
  * const rsiSeries = rsi(candles, { period: 14 });
  * const smoothed = applyIndicator(rsiSeries, ema, { period: 9 });
- * // Equivalent to: ema(seriesToCandles(rsi(candles, 14)), { period: 9 })
+ * // Equivalent to: ema(seriesToCandles(rsi(candles, { period: 14 })), { period: 9 })
  * ```
  */
 export function applyIndicator<TOpts, TOut>(

--- a/packages/core/src/conditions/unified.ts
+++ b/packages/core/src/conditions/unified.ts
@@ -7,9 +7,9 @@
  *
  * @example
  * ```ts
- * import { defineCondition } from "trendcraft";
+ * import { defineUnifiedCondition } from "trendcraft";
  *
- * const rsiOversold = defineCondition({
+ * const rsiOversold = defineUnifiedCondition({
  *   name: "rsiOversold",
  *   requires: ["rsi"],
  *   evaluate: (ind) => {

--- a/packages/core/src/core/trendcraft.ts
+++ b/packages/core/src/core/trendcraft.ts
@@ -146,8 +146,8 @@ export class TrendCraft<TIndicators extends Record<string, unknown> = {}> {
    * const result = TrendCraft.from(dailyCandles)
    *   .withMtf(["weekly"])
    *   .strategy()
-   *   .entry(and(weeklyRsiAbove(50), goldenCross()))
-   *   .exit(deadCross())
+   *   .entry(and(weeklyRsiAbove(50), goldenCrossCondition()))
+   *   .exit(deadCrossCondition())
    *   .backtest({ capital: 1000000 });
    * ```
    */
@@ -373,15 +373,15 @@ export class TrendCraft<TIndicators extends Record<string, unknown> = {}> {
    * // Simple preset conditions
    * const result = TrendCraft.from(candles)
    *   .strategy()
-   *   .entry(goldenCross())
-   *   .exit(deadCross())
+   *   .entry(goldenCrossCondition())
+   *   .exit(deadCrossCondition())
    *   .backtest({ capital: 1000000 });
    *
    * // Combined conditions
    * const result = TrendCraft.from(candles)
    *   .strategy()
-   *   .entry(and(goldenCross(), rsiBelow(30)))
-   *   .exit(or(deadCross(), rsiAbove(70)))
+   *   .entry(and(goldenCrossCondition(), rsiBelow(30)))
+   *   .exit(or(deadCrossCondition(), rsiAbove(70)))
    *   .backtest({ capital: 1000000 });
    *
    * // Custom function

--- a/packages/core/src/execution/order-types.ts
+++ b/packages/core/src/execution/order-types.ts
@@ -6,9 +6,9 @@
  *
  * @example
  * ```ts
- * import type { OrderIntent, ExecutionResult } from "trendcraft";
+ * import type { execution } from "trendcraft";
  *
- * const order: OrderIntent = {
+ * const order: execution.OrderIntent = {
  *   symbol: "AAPL",
  *   side: "buy",
  *   quantity: 10,

--- a/packages/core/src/execution/reconciler.ts
+++ b/packages/core/src/execution/reconciler.ts
@@ -7,9 +7,9 @@
  *
  * @example
  * ```ts
- * import { reconcilePositions } from "trendcraft/execution";
+ * import { execution } from "trendcraft";
  *
- * const discrepancies = reconcilePositions(internalPositions, brokerPositions, {
+ * const discrepancies = execution.reconcilePositions(internalPositions, brokerPositions, {
  *   priceTolerance: 0.01,
  * });
  *

--- a/packages/core/src/explainability/narrative.ts
+++ b/packages/core/src/explainability/narrative.ts
@@ -25,7 +25,7 @@ import type { ConditionTrace } from "../types/explainability";
  * import { generateNarrative } from "trendcraft";
  *
  * const narrative = generateNarrative(trace, "entry", true, candle);
- * // => "Entry signal fired. rsiBelow(30): passed (rsi14 = 28.5)."
+ * // => "Entry signal fired at close=105.2. rsiBelow(30): passed (rsi14 = 28.5)."
  * ```
  */
 export function generateNarrative(

--- a/packages/core/src/indicators/momentum/adxr.ts
+++ b/packages/core/src/indicators/momentum/adxr.ts
@@ -1,7 +1,7 @@
 /**
  * ADXR (Average Directional Movement Index Rating)
  *
- * Smoothed version of ADX: (ADX[i] + ADX[i-period]) / 2
+ * Smoothed version of ADX: (ADX[i] + ADX[i - (period - 1)]) / 2
  */
 
 import { tagSeries, withLabelParams } from "../../core/tag-series";
@@ -24,7 +24,7 @@ export type AdxrOptions = {
 /**
  * Calculate ADXR (Average Directional Movement Index Rating)
  *
- * ADXR = (ADX[i] + ADX[i - period]) / 2
+ * ADXR = (ADX[i] + ADX[i - (period - 1)]) / 2
  *
  * @param candles - Array of candles (raw or normalized)
  * @param options - Options

--- a/packages/core/src/indicators/momentum/dmi.ts
+++ b/packages/core/src/indicators/momentum/dmi.ts
@@ -49,8 +49,8 @@ export type DmiOptions = {
  *
  * @example
  * ```ts
- * const dmi = dmi(candles, { period: 14 });
- * const { plusDi, minusDi, adx } = dmi[i].value;
+ * const dmiData = dmi(candles, { period: 14 });
+ * const { plusDi, minusDi, adx } = dmiData[i].value;
  *
  * if (adx > 25 && plusDi > minusDi) {
  *   // Strong bullish trend

--- a/packages/core/src/indicators/momentum/stoch-rsi.ts
+++ b/packages/core/src/indicators/momentum/stoch-rsi.ts
@@ -64,7 +64,7 @@ export type StochRsiOptions = {
  * @example
  * ```ts
  * const stochRsiData = stochRsi(candles, { rsiPeriod: 14, stochPeriod: 14 });
- * const { stochRsi, k, d } = stochRsiData[i].value;
+ * const { stochRsi: stochRsiVal, k, d } = stochRsiData[i].value;
  *
  * if (k < 20 && k > d) {
  *   // Oversold with bullish crossover

--- a/packages/core/src/indicators/moving-average/frama.ts
+++ b/packages/core/src/indicators/moving-average/frama.ts
@@ -14,7 +14,7 @@ import { FRAMA_META } from "../indicator-meta";
  * FRAMA options
  */
 export type FramaOptions = {
-  /** Period for FRAMA calculation (must be even, default: 16) */
+  /** Period for FRAMA calculation (rounded up to the next even number if odd; default: 16) */
   period?: number;
   /** Price source to use (default: 'close') */
   source?: PriceSource;
@@ -36,6 +36,9 @@ export type FramaOptions = {
  * 5. FRAMA = alpha * source + (1 - alpha) * prevFRAMA.
  *
  * The `source` option only controls the price term in step 5.
+ *
+ * Odd periods are silently rounded up to the next even number (the series
+ * label still reports the original period).
  *
  * @param candles - Array of candles (raw or normalized)
  * @param options - FRAMA options

--- a/packages/core/src/indicators/price/gap-analysis.ts
+++ b/packages/core/src/indicators/price/gap-analysis.ts
@@ -25,7 +25,7 @@ export type GapValue = {
   type: "up" | "down" | null;
   /** Gap size as a percentage of previous close */
   gapPercent: number;
-  /** Gap classification based on fill status */
+  /** Gap classification: 'full' (open beyond previous high/low), 'partial' (open beyond previous close only), or 'unfilled' (gap reclaimed within its own creation bar) */
   classification: "full" | "partial" | "unfilled" | null;
   /** Whether the gap has been completely filled */
   filled: boolean;
@@ -34,8 +34,8 @@ export type GapValue = {
 /**
  * Calculate Gap Analysis
  *
- * Gap Up: Current Open > Previous High
- * Gap Down: Current Open < Previous Low
+ * Gap Up: Current Open above Previous Close by >= minGapPercent
+ * Gap Down: Current Open below Previous Close by >= minGapPercent
  *
  * Classification:
  * - Full gap: Open beyond previous High/Low (true gap)

--- a/packages/core/src/indicators/price/highest-lowest.ts
+++ b/packages/core/src/indicators/price/highest-lowest.ts
@@ -18,7 +18,7 @@ export type HighestLowestValue = {
  * Calculate Highest and Lowest values over n periods
  *
  * @param candles - Array of candles (raw or normalized)
- * @param options - Options (period, source='high'/'low')
+ * @param options - Options (period)
  * @returns Series of highest/lowest values
  *
  * @example

--- a/packages/core/src/indicators/price/sr-zones.ts
+++ b/packages/core/src/indicators/price/sr-zones.ts
@@ -49,7 +49,7 @@ export type SrZone = {
 
 /** Options for the S/R zone clustering algorithm. */
 export type SrZonesOptions = {
-  /** Number of zones to find (default: auto based on price range) */
+  /** Number of zones to find (default: auto — one third of the collected raw levels, clamped to 3..15) */
   numZones?: number;
   /** ATR multiplier for zone width (default: 0.5) */
   zoneWidth?: number;
@@ -579,7 +579,7 @@ export function srZones(
  * from the preceding `lookback` bars (or all available bars if fewer).
  *
  * @param candles - Array of candles (raw or normalized)
- * @param options - S/R zone options (plus optional `lookback`)
+ * @param options - S/R zone options
  * @param lookback - Number of bars to look back (default: 200)
  * @returns Series of zone arrays, one per bar
  *

--- a/packages/core/src/indicators/regime/hmm-core.ts
+++ b/packages/core/src/indicators/regime/hmm-core.ts
@@ -305,8 +305,9 @@ function initializeModel(
  *
  * @example
  * ```ts
- * import { baumWelch } from "trendcraft";
- *
+ * // baumWelch is internal to the regime module; the public entry point is
+ * // `import { fitHmm } from "trendcraft"` which extracts features from Candle[]
+ * // and calls baumWelch under the hood.
  * const obs = [[0.01, 0.1], [-0.02, 0.3], [0.005, 0.12]];
  * const model = baumWelch(obs, { numStates: 2, seed: 42 });
  * console.log(model.transitionMatrix);

--- a/packages/core/src/indicators/relative-strength/benchmark-rs.ts
+++ b/packages/core/src/indicators/relative-strength/benchmark-rs.ts
@@ -30,7 +30,7 @@ export interface RSValue {
  * Options for benchmark RS calculation
  */
 export interface BenchmarkRSOptions {
-  /** Period for performance calculation (default: 52 for weekly, 252 for daily) */
+  /** Period for performance calculation (default: 52; recommended 52 for weekly bars, 252 for daily bars) */
   period?: number;
   /** Period for RS SMA (for Mansfield RS calculation, default: 52) */
   smaPeriod?: number;
@@ -59,7 +59,7 @@ export interface BenchmarkRSOptions {
  *
  * // Find outperforming stocks
  * const latest = rs[rs.length - 1];
- * if (latest.value.rsRating > 80 && latest.value.trend === 'up') {
+ * if (latest.value.rsRating !== null && latest.value.rsRating > 80 && latest.value.trend === 'up') {
  *   console.log('Strong relative strength!');
  * }
  * ```

--- a/packages/core/src/indicators/session/tz-utils.ts
+++ b/packages/core/src/indicators/session/tz-utils.ts
@@ -20,8 +20,8 @@
  *
  * @example
  * ```ts
- * // 2026-03-08 14:00 UTC = 09:00 New York EST (winter)
- * getTzHourMinute(Date.UTC(2026, 2, 8, 14, 0), "America/New_York");
+ * // 2026-03-01 14:00 UTC = 09:00 New York EST (winter)
+ * getTzHourMinute(Date.UTC(2026, 2, 1, 14, 0), "America/New_York");
  * // => { hour: 9, minute: 0 }
  *
  * // 2026-03-15 14:00 UTC = 10:00 New York EDT (after DST)

--- a/packages/core/src/indicators/smc/order-block.ts
+++ b/packages/core/src/indicators/smc/order-block.ts
@@ -67,7 +67,7 @@ export type OrderBlockOptions = {
   swingPeriod?: number;
   /** Volume MA period for strength calculation (default: 20) */
   volumePeriod?: number;
-  /** Minimum volume ratio above average for valid OB (default: 1.0, no filter) */
+  /** Minimum volume ratio above average for valid OB (default: 1.0 = require at least average volume; set 0 to disable the filter) */
   minVolumeRatio?: number;
   /** Maximum number of active order blocks to track (default: 10) */
   maxActiveOBs?: number;

--- a/packages/core/src/indicators/trend/ichimoku.ts
+++ b/packages/core/src/indicators/trend/ichimoku.ts
@@ -70,7 +70,10 @@ export type IchimokuValue = {
  *
  * // Check if price is above the cloud (bullish)
  * const current = ichi[i].value;
- * const isAboveCloud = candles[i].close > Math.max(current.senkouA, current.senkouB);
+ * const isAboveCloud =
+ *   current.senkouA !== null &&
+ *   current.senkouB !== null &&
+ *   candles[i].close > Math.max(current.senkouA, current.senkouB);
  * ```
  */
 export function ichimoku(

--- a/packages/core/src/indicators/trend/linear-regression.ts
+++ b/packages/core/src/indicators/trend/linear-regression.ts
@@ -1,7 +1,7 @@
 /**
  * Linear Regression indicators
  *
- * Provides linear regression line value, slope, angle, intercept,
+ * Provides linear regression line value, slope, intercept,
  * and R-squared for a rolling window of price data.
  */
 

--- a/packages/core/src/indicators/trend/schaff-trend-cycle.ts
+++ b/packages/core/src/indicators/trend/schaff-trend-cycle.ts
@@ -21,7 +21,7 @@ export type SchaffTrendCycleOptions = {
   cyclePeriod?: number;
   /**
    * Smoothing factor for both stochastic passes (default: 0.5).
-   * Doug Schaff's published value; range [0, 1]. Lower values produce
+   * Doug Schaff's published value; range (0, 1]. Lower values produce
    * smoother but more lagged output.
    */
   factor?: number;

--- a/packages/core/src/indicators/trend/vortex.ts
+++ b/packages/core/src/indicators/trend/vortex.ts
@@ -53,7 +53,7 @@ export type VortexValue = {
  * const vortexData = vortex(candles, { period: 14 });
  * const { viPlus, viMinus } = vortexData[i].value;
  *
- * if (viPlus > viMinus) {
+ * if (viPlus !== null && viMinus !== null && viPlus > viMinus) {
  *   // Bullish signal
  * }
  * ```

--- a/packages/core/src/indicators/volatility/regime.ts
+++ b/packages/core/src/indicators/volatility/regime.ts
@@ -2,7 +2,8 @@
  * Volatility Regime Detection
  *
  * Classifies market volatility into regimes (low, normal, high, extreme)
- * using ATR percentile, Bollinger Bandwidth percentile, and historical volatility.
+ * using percentiles of ATR and Bollinger Bandwidth; historical volatility
+ * is also computed and reported for reference.
  */
 
 import { annualizationFactor } from "../../calendar";
@@ -49,10 +50,13 @@ const DEFAULT_OPTIONS: ResolvedOptions = {
 /**
  * Calculate volatility regime for each candle
  *
- * Combines multiple volatility measures to classify the current market regime:
+ * Classifies the market regime from the average of two volatility percentiles:
  * - ATR percentile: Position of current ATR within historical range
  * - Bollinger Bandwidth percentile: Position of current bandwidth within historical range
- * - Historical volatility: Annualized standard deviation of returns
+ *
+ * Historical volatility (annualized standard deviation of log returns) is also
+ * computed and included in the output (`historicalVol`) for reference, but does
+ * not affect the regime label or confidence.
  *
  * Regime classification based on average percentile:
  * - "low": <= low threshold (default 25)

--- a/packages/core/src/indicators/volume/pvt.ts
+++ b/packages/core/src/indicators/volume/pvt.ts
@@ -20,7 +20,7 @@ import type { Candle, NormalizedCandle, Series } from "../../types";
  * - Divergence between PVT and price can signal reversals
  *
  * @param candles - Array of candles (raw or normalized)
- * @returns Series of PVT values (null for first bar)
+ * @returns Series of PVT values (first bar is 0)
  *
  * @example
  * ```ts

--- a/packages/core/src/manifest/entries/momentum.ts
+++ b/packages/core/src/manifest/entries/momentum.ts
@@ -293,7 +293,7 @@ export const MOMENTUM_MANIFESTS: IndicatorManifest[] = [
     ],
     pitfalls: [
       "Triple-smoothing means significant lag at trend turns",
-      "trendcraft impl is more permissive about warmup than canonical TRIX: null EMA values are treated as 0 inside the nested EMA passes, so TRIX becomes non-null around index `period` rather than after a strict 3-stage EMA warmup. Early values may differ from references like StockCharts until all three EMAs are fully populated",
+      "Strict 3-stage warmup: the null-propagating EMA cascade means the first valid TRIX appears only at index 3*(period-1)+1 — matches StockCharts canonical, but long periods need a correspondingly long candle history",
       "Crossovers in flat/zero-line areas produce whipsaws",
     ],
     marketRegime: ["trending"],

--- a/packages/core/src/manifest/entries/volatility.ts
+++ b/packages/core/src/manifest/entries/volatility.ts
@@ -393,11 +393,11 @@ export const VOLATILITY_MANIFESTS: IndicatorManifest[] = [
     displayName: "Adaptive Bollinger Bands",
     category: "volatility",
     oneLiner:
-      "Bollinger Bands whose stddev multiplier adapts to rolling excess kurtosis of CLOSE PRICES (not returns) — wider in fat-tail price-distribution regimes.",
+      "Bollinger Bands whose stddev multiplier adapts to rolling excess kurtosis of log returns (ln(p_t / p_{t-1})) — wider in fat-tail return regimes.",
     whenToUse: [
-      "Markets with regime-shifting price-distribution shape where fixed 2σ either over- or under-reacts",
+      "Markets with regime-shifting return-distribution shape where fixed 2σ either over- or under-reacts",
       "Mean-reversion strategies that get burned by fat-tail false breakouts",
-      "Adapting risk envelopes to the current price-distribution shape",
+      "Adapting risk envelopes to the current return-distribution shape",
     ],
     signals: [
       "Standard Bollinger interpretations apply (band touches, squeeze, band-walk)",
@@ -406,7 +406,7 @@ export const VOLATILITY_MANIFESTS: IndicatorManifest[] = [
     ],
     pitfalls: [
       "trendcraft custom variant — values are not directly comparable to fixed-multiplier BB",
-      "Kurtosis here is computed on CLOSE PRICES, not log-returns. Differs from textbook 'fat tails of returns' framing — interpretation is about price-level distribution shape over the window",
+      "Kurtosis is computed on log returns ln(p_t/p_{t-1}) — the canonical fat-tail measure (pre-v0.3.0 versions used close prices directly; values recorded under that behavior are not comparable)",
       "Kurtosis is sensitive to outliers in the lookback window — large `kurtosisLookback` (default 100) reduces sensitivity but lags regime shifts",
       "Multiplier capped at min 1.5 / max 3.0 by default — extreme tail-shape regimes still see bounded widening",
     ],

--- a/packages/core/src/ml/conditions.ts
+++ b/packages/core/src/ml/conditions.ts
@@ -37,7 +37,7 @@ function getCachedPredictions(
  * @example
  * ```ts
  * const entry = candleFormerBullish(weights, 60);
- * const result = runBacktest(candles, { entry, exit: rsiAbove(70) });
+ * const result = runBacktest(candles, entry, rsiAbove(70), { capital: 100_000 });
  * ```
  */
 export function candleFormerBullish(
@@ -67,7 +67,7 @@ export function candleFormerBullish(
  * @example
  * ```ts
  * const exit = candleFormerBearish(weights, 60);
- * const result = runBacktest(candles, { entry: rsiBelow(30), exit });
+ * const result = runBacktest(candles, rsiBelow(30), exit, { capital: 100_000 });
  * ```
  */
 export function candleFormerBearish(

--- a/packages/core/src/ml/index.ts
+++ b/packages/core/src/ml/index.ts
@@ -1,7 +1,7 @@
 /**
  * CandleFormer - Mini Transformer for candlestick prediction
  *
- * A pure TypeScript implementation of a 1-layer Transformer decoder
+ * A pure TypeScript implementation of an N-layer Transformer decoder (default: 1 layer)
  * that learns candlestick patterns and predicts next-bar direction.
  *
  * @example

--- a/packages/core/src/ml/types.ts
+++ b/packages/core/src/ml/types.ts
@@ -55,7 +55,7 @@ export type PredictionDirection = "bullish" | "bearish" | "neutral";
  * Model hyperparameters
  */
 export type CandleFormerConfig = {
-  /** Vocabulary size (default: 46) */
+  /** Vocabulary size (default: 69 = VOCAB_SIZE, 17 shapes × 4 volume bins + 1 PAD) */
   vocabSize: number;
   /** Sequence length / context window (default: 16) */
   seqLen: number;
@@ -71,7 +71,7 @@ export type CandleFormerConfig = {
   dropoutRate: number;
   /** Number of transformer layers (default: 1) */
   numLayers: number;
-  /** Pattern vocabulary size for dual embedding (default: 15, 0 = disabled) */
+  /** Pattern vocabulary size for dual embedding (default: 0 = disabled; set to PATTERN_VOCAB_SIZE = 15 to enable) */
   patternVocabSize: number;
 };
 

--- a/packages/core/src/optimization/strategy-json-factory.ts
+++ b/packages/core/src/optimization/strategy-json-factory.ts
@@ -302,8 +302,8 @@ export function composeParamFilter(
 /**
  * Convert path-addressed ranges to the engine's `name`-keyed
  * `ParameterRange[]`. The engine doesn't interpret `name`, so the path
- * string is a valid identifier and round-trips through `bestParams` /
- * `bestEntryConditions` keys.
+ * string is a valid identifier and round-trips through `bestParams` keys
+ * (grid search results and walk-forward period results).
  */
 export function pathRangesToParameterRanges(ranges: PathParameterRange[]): ParameterRange[] {
   return ranges.map((r) => ({

--- a/packages/core/src/pairs/regression.ts
+++ b/packages/core/src/pairs/regression.ts
@@ -15,7 +15,7 @@
  * @example
  * ```ts
  * const { beta, intercept, rSquared } = olsRegression([1, 2, 3], [2.1, 3.9, 6.1]);
- * // beta ≈ 2, intercept ≈ 0.1
+ * // beta ≈ 2, intercept ≈ 0.033
  * ```
  */
 export function olsRegression(

--- a/packages/core/src/risk/risk-parity.ts
+++ b/packages/core/src/risk/risk-parity.ts
@@ -13,11 +13,11 @@
 
 /** Options for risk parity allocation */
 export type RiskParityOptions = {
-  /** Maximum iterations for optimization (default: 100) */
+  /** Maximum iterations for optimization (default: 1000) */
   maxIterations?: number;
   /** Convergence tolerance (default: 1e-8) */
   tolerance?: number;
-  /** Risk-free rate for Sharpe calculations (default: 0) */
+  /** Unused — reserved for future use; riskParityAllocation does not read this option */
   riskFreeRate?: number;
 };
 

--- a/packages/core/src/robustness/quick.ts
+++ b/packages/core/src/robustness/quick.ts
@@ -2,8 +2,8 @@
  * Quick Robustness Score
  *
  * Computes a robustness score from a single BacktestResult without
- * re-running backtests. Uses Monte Carlo trade shuffling, trade
- * consistency analysis, and drawdown resilience.
+ * re-running backtests. Uses Monte Carlo bootstrap resampling of trades
+ * (with replacement), trade consistency analysis, and drawdown resilience.
  */
 
 import { runMonteCarloSimulation } from "../optimization/monte-carlo";
@@ -17,8 +17,8 @@ import { scoreToGrade } from "./grade";
 
 /**
  * Quick robustness assessment from a single backtest result.
- * No re-running of backtests needed — uses Monte Carlo trade shuffling,
- * trade consistency analysis, and drawdown resilience.
+ * No re-running of backtests needed — uses Monte Carlo bootstrap resampling
+ * of trades (with replacement), trade consistency analysis, and drawdown resilience.
  *
  * @param result Backtest result to evaluate
  * @param options Configuration options

--- a/packages/core/src/scoring/deflated-sharpe.ts
+++ b/packages/core/src/scoring/deflated-sharpe.ts
@@ -244,10 +244,10 @@ export function deflatedSharpe(params: DeflatedSharpeParams): number {
  * @returns Deflated Sharpe probability in [0, 1], or `NaN` when undefined
  * @example
  * ```ts
- * import { deflatedSharpeFromReturns, extractTradeReturns } from "trendcraft";
+ * import { deflatedSharpeFromReturns, extractTradeReturns, perReturnSharpe } from "trendcraft";
  *
  * const returns = extractTradeReturns(bestResult);
- * const trialSharpes = gridResult.results.map((r) => perReturnSharpe(r));
+ * const trialSharpes = gridResult.results.map((r) => perReturnSharpe(extractTradeReturns(r.backtest)));
  * const dsr = deflatedSharpeFromReturns(returns, trialSharpes);
  * ```
  */
@@ -318,7 +318,7 @@ export function perReturnSharpe(returns: number[]): number {
  *
  * // Per-return Sharpe 0.1: how many bars until PSR(0) ≥ 95%?
  * const bars = Math.ceil(minTrackRecordLength(0.1));
- * // ≈ 274 observations
+ * // ≈ 273 observations (minTrackRecordLength(0.1) ≈ 272.9)
  * ```
  */
 export function minTrackRecordLength(

--- a/packages/core/src/scoring/presets.ts
+++ b/packages/core/src/scoring/presets.ts
@@ -19,7 +19,7 @@ import { ScoreBuilder } from "./builder";
  * const config = createMomentumPreset();
  * const candles = normalizeCandles(rawCandles);
  * const score = calculateScore(candles, candles.length - 1, config);
- * console.log(score.totalScore, score.strength); // e.g. 72, "strong"
+ * console.log(score.normalizedScore, score.strength); // e.g. 72, "strong"
  * ```
  */
 export function createMomentumPreset(): ScoringConfig {
@@ -71,7 +71,7 @@ export function createMeanReversionPreset(): ScoringConfig {
  * const config = createTrendFollowingPreset();
  * const series = calculateScoreSeries(candles, config);
  * const latest = series[series.length - 1];
- * console.log(latest.value.totalScore, latest.value.strength);
+ * console.log(latest.score.normalizedScore, latest.score.strength);
  * ```
  */
 export function createTrendFollowingPreset(): ScoringConfig {
@@ -98,7 +98,7 @@ export function createTrendFollowingPreset(): ScoringConfig {
  *
  * const config = createBalancedPreset();
  * const score = calculateScore(candles, candles.length - 1, config);
- * console.log(score.totalScore); // 0-100
+ * console.log(score.normalizedScore); // 0-100
  * ```
  */
 export function createBalancedPreset(): ScoringConfig {

--- a/packages/core/src/scoring/signals/momentum.ts
+++ b/packages/core/src/scoring/signals/momentum.ts
@@ -20,7 +20,7 @@ import type { NormalizedCandle, PrecomputedIndicators, SignalDefinition } from "
  * import { ScoreBuilder, createRsiOversoldEvaluator } from "trendcraft";
  *
  * const config = ScoreBuilder.create()
- *   .addSignal({ name: "rsiOS", weight: 2.0, evaluate: createRsiOversoldEvaluator(25) })
+ *   .addSignal({ name: "rsiOS", displayName: "RSI < 25", weight: 2.0, evaluate: createRsiOversoldEvaluator(25) })
  *   .build();
  * ```
  */
@@ -143,7 +143,7 @@ export function createRsiNeutralEvaluator(
  * import { ScoreBuilder, createMacdBullishEvaluator } from "trendcraft";
  *
  * const config = ScoreBuilder.create()
- *   .addSignal({ name: "macdBull", weight: 1.5, evaluate: createMacdBullishEvaluator() })
+ *   .addSignal({ name: "macdBull", displayName: "MACD Bullish", weight: 1.5, evaluate: createMacdBullishEvaluator() })
  *   .build();
  * ```
  */
@@ -263,7 +263,7 @@ export function createMacdBearishEvaluator(
  * import { ScoreBuilder, createStochOversoldEvaluator } from "trendcraft";
  *
  * const config = ScoreBuilder.create()
- *   .addSignal({ name: "stochOS", weight: 2.0, evaluate: createStochOversoldEvaluator(20) })
+ *   .addSignal({ name: "stochOS", displayName: "Stoch < 20", weight: 2.0, evaluate: createStochOversoldEvaluator(20) })
  *   .build();
  * ```
  */
@@ -367,7 +367,7 @@ export function createStochOverboughtEvaluator(
  * import { ScoreBuilder, createStochBullishCrossEvaluator } from "trendcraft";
  *
  * const config = ScoreBuilder.create()
- *   .addSignal({ name: "stochCross", weight: 2.5, evaluate: createStochBullishCrossEvaluator(20) })
+ *   .addSignal({ name: "stochCross", displayName: "Stoch Bull Cross", weight: 2.5, evaluate: createStochBullishCrossEvaluator(20) })
  *   .build();
  * ```
  */

--- a/packages/core/src/scoring/signals/trend.ts
+++ b/packages/core/src/scoring/signals/trend.ts
@@ -17,7 +17,7 @@ import type { NormalizedCandle, PrecomputedIndicators, SignalDefinition } from "
  * import { ScoreBuilder, createPerfectOrderBullishEvaluator } from "trendcraft";
  *
  * const config = ScoreBuilder.create()
- *   .addSignal({ name: "poBull", weight: 3.0, evaluate: createPerfectOrderBullishEvaluator() })
+ *   .addSignal({ name: "poBull", displayName: "Perfect Order (Bull)", weight: 3.0, evaluate: createPerfectOrderBullishEvaluator() })
  *   .build();
  * ```
  */
@@ -180,7 +180,7 @@ export function createPOConfirmationEvaluator(
  * import { ScoreBuilder, createPullbackEntryEvaluator } from "trendcraft";
  *
  * const config = ScoreBuilder.create()
- *   .addSignal({ name: "pullback", weight: 2.5, evaluate: createPullbackEntryEvaluator(20, 1) })
+ *   .addSignal({ name: "pullback", displayName: "Pullback to 20MA", weight: 2.5, evaluate: createPullbackEntryEvaluator(20, 1) })
  *   .build();
  * ```
  */
@@ -250,7 +250,7 @@ export function createPullbackEntryEvaluator(
  * import { ScoreBuilder, createGoldenCrossEvaluator } from "trendcraft";
  *
  * const config = ScoreBuilder.create()
- *   .addSignal({ name: "gc", weight: 2.0, evaluate: createGoldenCrossEvaluator(50, 200) })
+ *   .addSignal({ name: "gc", displayName: "Golden Cross (50/200)", weight: 2.0, evaluate: createGoldenCrossEvaluator(50, 200) })
  *   .build();
  * ```
  */

--- a/packages/core/src/scoring/signals/volume.ts
+++ b/packages/core/src/scoring/signals/volume.ts
@@ -19,7 +19,7 @@ import type { NormalizedCandle, PrecomputedIndicators, SignalDefinition } from "
  * import { ScoreBuilder, createVolumeSpikeEvaluator } from "trendcraft";
  *
  * const config = ScoreBuilder.create()
- *   .addSignal({ name: "volSpike", weight: 1.5, evaluate: createVolumeSpikeEvaluator(1.5) })
+ *   .addSignal({ name: "volSpike", displayName: "Volume Spike", weight: 1.5, evaluate: createVolumeSpikeEvaluator(1.5) })
  *   .build();
  * ```
  */
@@ -224,10 +224,10 @@ export function createBearishVolumeTrendEvaluator(maPeriod = 20): SignalDefiniti
  * @param period - CMF period (default: 20)
  * @example
  * ```ts
- * import { ScoreBuilder, createCmfPositiveEvaluator } from "trendcraft";
+ * import { ScoreBuilder } from "trendcraft";
  *
  * const config = ScoreBuilder.create()
- *   .addSignal({ name: "cmf", weight: 1.5, evaluate: createCmfPositiveEvaluator(0.1) })
+ *   .addSignal({ name: "cmf", displayName: "CMF Positive", weight: 1.5, evaluate: createCmfPositiveEvaluator(0.1) })
  *   .build();
  * ```
  */

--- a/packages/core/src/screening/index.ts
+++ b/packages/core/src/screening/index.ts
@@ -7,22 +7,22 @@
  * @example
  * ```ts
  * import { runScreening, screenStock } from "trendcraft/screening";
- * import { and, goldenCross, volumeAnomalyCondition } from "trendcraft";
+ * import { and, goldenCrossCondition, deadCrossCondition, volumeAnomalyCondition } from "trendcraft";
  *
  * // Screen multiple stocks (Node.js only)
  * const results = runScreening({
  *   dataPath: "./data",
  *   criteria: {
  *     name: "GC + Volume",
- *     entry: and(goldenCross(5, 25), volumeAnomalyCondition(2.0, 20)),
- *     exit: deadCross(5, 25),
+ *     entry: and(goldenCrossCondition(5, 25), volumeAnomalyCondition(2.0, 20)),
+ *     exit: deadCrossCondition(5, 25),
  *   },
  *   minAtrPercent: 2.3,
  * });
  *
  * // Screen single stock (browser-compatible)
  * const result = screenStock("6758.T", candles, {
- *   entry: goldenCross(5, 25),
+ *   entry: goldenCrossCondition(5, 25),
  * });
  * ```
  */

--- a/packages/core/src/screening/screen-stock.ts
+++ b/packages/core/src/screening/screen-stock.ts
@@ -34,11 +34,11 @@ import type {
  * @example
  * ```ts
  * import { screenStock } from "trendcraft/screening";
- * import { and, goldenCross, volumeAnomalyCondition } from "trendcraft";
+ * import { and, goldenCrossCondition, deadCrossCondition, volumeAnomalyCondition } from "trendcraft";
  *
  * const result = screenStock("6758.T", candles, {
- *   entry: and(goldenCross(5, 25), volumeAnomalyCondition(2.0, 20)),
- *   exit: deadCross(5, 25),
+ *   entry: and(goldenCrossCondition(5, 25), volumeAnomalyCondition(2.0, 20)),
+ *   exit: deadCrossCondition(5, 25),
  * });
  *
  * if (result.entrySignal) {
@@ -136,11 +136,11 @@ export function screenStock(
  * @example
  * ```ts
  * import { screenStockSeries } from "trendcraft/screening";
- * import { goldenCross, deadCross } from "trendcraft";
+ * import { goldenCrossCondition, deadCrossCondition } from "trendcraft";
  *
  * const { points } = screenStockSeries("6758.T", candles, {
- *   entry: goldenCross(5, 25),
- *   exit: deadCross(5, 25),
+ *   entry: goldenCrossCondition(5, 25),
+ *   exit: deadCrossCondition(5, 25),
  * });
  * const entryBars = points.filter((p) => p.entrySignal);
  * ```

--- a/packages/core/src/screening/screener.ts
+++ b/packages/core/src/screening/screener.ts
@@ -20,14 +20,14 @@ import type { ScreeningOptions, ScreeningResult, ScreeningSessionResult } from "
  * @example
  * ```ts
  * import { runScreening } from "trendcraft/screening";
- * import { and, goldenCross, volumeAnomalyCondition } from "trendcraft";
+ * import { and, goldenCrossCondition, deadCrossCondition, volumeAnomalyCondition } from "trendcraft";
  *
- * const results = await runScreening({
+ * const results = runScreening({
  *   dataPath: "./data",
  *   criteria: {
  *     name: "GC + Volume",
- *     entry: and(goldenCross(5, 25), volumeAnomalyCondition(2.0, 20)),
- *     exit: deadCross(5, 25),
+ *     entry: and(goldenCrossCondition(5, 25), volumeAnomalyCondition(2.0, 20)),
+ *     exit: deadCrossCondition(5, 25),
  *   },
  *   minAtrPercent: 2.3,
  * });

--- a/packages/core/src/signals/candlestick/index.ts
+++ b/packages/core/src/signals/candlestick/index.ts
@@ -1,9 +1,9 @@
 /**
  * Candlestick Pattern Recognition
  *
- * Detects 20 common candlestick patterns in a single O(n) pass:
+ * Detects 22 common candlestick patterns in a single O(n) pass:
  * - 8 single-candle patterns
- * - 6 double-candle patterns
+ * - 8 double-candle patterns
  * - 6 triple-candle patterns
  */
 

--- a/packages/core/src/signals/lifecycle/batch-adapter.ts
+++ b/packages/core/src/signals/lifecycle/batch-adapter.ts
@@ -31,7 +31,7 @@ import type { SignalManagerOptions } from "./types";
  * @example
  * ```ts
  * const crossSignals = validateCrossSignals(candles)
- *   .map(s => fromCrossSignal(s, candles[s.secondIdx].close));
+ *   .map(s => fromCrossSignal(s, candles.find(c => c.time === s.time)?.close));
  *
  * const filtered = processSignalsBatch(crossSignals, {
  *   cooldown: { bars: 10 },

--- a/packages/core/src/signals/patterns/double-pattern-utils.ts
+++ b/packages/core/src/signals/patterns/double-pattern-utils.ts
@@ -262,7 +262,7 @@ export function countNecklineCrosses(
  * @param endIndex - End of range to check
  * @param necklinePrice - Neckline price level
  * @param direction - "above" for double bottom (check highs), "below" for double top (check lows)
- * @param tolerancePercent - Tolerance for small violations (default: 0.005 = 0.5%)
+ * @param tolerancePercent - Tolerance for small violations (default: 0 = no tolerance)
  * @returns true if a violation exists, false otherwise
  */
 export function hasNecklineViolation(

--- a/packages/core/src/signals/patterns/trendline-utils.ts
+++ b/packages/core/src/signals/patterns/trendline-utils.ts
@@ -122,7 +122,7 @@ export function fitTrendlinePair(
  * @param upper - Upper trendline fit
  * @param lower - Lower trendline fit
  * @param slopeTolerance - Threshold for "flat" slope (default: 0.001)
- * @param parallelTolerance - Max slope difference ratio for "parallel" (default: 0.3)
+ * @param parallelTolerance - Multiplier on slopeTolerance for the "parallel" slope-difference threshold (default: 0.3, i.e. effective threshold 0.3 × slopeTolerance = 0.0003, 0.03% per bar)
  * @returns Classification string
  *
  * @example

--- a/packages/core/src/signals/patterns/types.ts
+++ b/packages/core/src/signals/patterns/types.ts
@@ -201,7 +201,7 @@ export interface CupHandleOptions {
 interface TrendlinePatternBaseOptions {
   /** Swing point detection lookback (default: 3) */
   swingLookback?: number;
-  /** Minimum swing points per trendline (default: 2) */
+  /** Minimum swing points per trendline (default: 2 for detectTriangle/detectFlag, 3 for detectWedge/detectChannel) */
   minPoints?: number;
   /** Minimum R² for trendline fit (default: 0.6) */
   minRSquared?: number;
@@ -247,6 +247,10 @@ export interface ChannelOptions extends TrendlinePatternBaseOptions {
 
 /**
  * Flag and Pennant pattern options
+ *
+ * Note: detectFlag overrides several inherited defaults:
+ * swingLookback defaults to 2 (not 3), minRSquared defaults to 0.5 (not 0.6),
+ * and maxBreakoutBars defaults to 10 (not 20).
  */
 export interface FlagOptions extends TrendlinePatternBaseOptions {
   /** Threshold for flat slope detection (default: 0.0003) */

--- a/packages/core/src/strategy/registry-streaming.ts
+++ b/packages/core/src/strategy/registry-streaming.ts
@@ -6,8 +6,8 @@
  *
  * @example
  * ```ts
- * import { streamingRegistry } from "trendcraft";
- * import { and, or, not } from "trendcraft/streaming";
+ * import { streamingRegistry, streaming } from "trendcraft";
+ * const { and, or, not } = streaming;
  *
  * const condition = streamingRegistry.hydrate(
  *   { name: "rsiBelow", params: { threshold: 30 } },

--- a/packages/core/src/strategy/registry.ts
+++ b/packages/core/src/strategy/registry.ts
@@ -8,7 +8,7 @@
  *
  * @example
  * ```ts
- * import { ConditionRegistry } from "trendcraft";
+ * import { ConditionRegistry, and, or, not } from "trendcraft";
  *
  * const registry = new ConditionRegistry();
  * registry.register({
@@ -25,7 +25,10 @@
  *   ),
  * });
  *
- * const condition = registry.hydrate({ name: "goldenCross", params: { shortPeriod: 10 } });
+ * const condition = registry.hydrate(
+ *   { name: "goldenCross", params: { shortPeriod: 10 } },
+ *   { and, or, not },
+ * );
  * ```
  */
 

--- a/packages/core/src/strategy/types.ts
+++ b/packages/core/src/strategy/types.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * ```ts
- * import { type StrategyDefinition, createSessionFromStrategy } from "trendcraft";
+ * import { type StrategyDefinition, createSessionFromStrategy, streaming } from "trendcraft";
  * import * as inc from "trendcraft/incremental";
  *
  * const strategy: StrategyDefinition = {

--- a/packages/core/src/streaming/conditions/core.ts
+++ b/packages/core/src/streaming/conditions/core.ts
@@ -41,7 +41,7 @@ export function and(...conditions: StreamingCondition[]): StreamingCombinedCondi
  *
  * @example
  * ```ts
- * const exit = or(rsiAbove(70), smaCrossUnder());
+ * const exit = or(rsiAbove(70), smaDeadCross());
  * ```
  */
 export function or(...conditions: StreamingCondition[]): StreamingCombinedCondition {

--- a/packages/core/src/streaming/guards/portfolio-guard.ts
+++ b/packages/core/src/streaming/guards/portfolio-guard.ts
@@ -7,7 +7,9 @@
  *
  * @example
  * ```ts
- * import { createPortfolioGuard } from "trendcraft";
+ * import { streaming } from "trendcraft";
+ *
+ * const { createPortfolioGuard } = streaming;
  *
  * const guard = createPortfolioGuard({
  *   maxTotalExposure: 200,    // max 2x leverage

--- a/packages/core/src/streaming/live-candle.ts
+++ b/packages/core/src/streaming/live-candle.ts
@@ -14,7 +14,7 @@
  * const live = createLiveCandle({
  *   intervalMs: 60_000,
  *   indicators: [
- *     { name: "sma20", create: (s) => createSma({ period: 20 }, { fromState: s }) },
+ *     { name: "sma20", create: (s) => createSma({ period: 20 }, restoreState(s)) },
  *   ],
  * });
  * live.on("candleComplete", ({ snapshot }) => console.log(snapshot.sma20));
@@ -57,8 +57,8 @@ type IndicatorEntry = {
  * const live = createLiveCandle({
  *   intervalMs: 60_000,
  *   indicators: [
- *     { name: "sma20", create: (s) => createSma({ period: 20 }, { fromState: s }) },
- *     { name: "rsi14", create: (s) => createRsi({ period: 14 }, { fromState: s }) },
+ *     { name: "sma20", create: (s) => createSma({ period: 20 }, restoreState(s)) },
+ *     { name: "rsi14", create: (s) => createRsi({ period: 14 }, restoreState(s)) },
  *   ],
  *   history: historicalCandles,
  *   maxHistory: 500,

--- a/packages/core/src/streaming/mtf.ts
+++ b/packages/core/src/streaming/mtf.ts
@@ -6,8 +6,10 @@
  *
  * @example
  * ```ts
- * import { createStreamingMtf } from 'trendcraft/streaming';
+ * import { streaming } from 'trendcraft';
  * import { createSma, createRsi } from 'trendcraft/incremental';
+ *
+ * const { createStreamingMtf } = streaming;
  *
  * const mtf = createStreamingMtf({
  *   timeframes: [

--- a/packages/core/src/streaming/pipeline.ts
+++ b/packages/core/src/streaming/pipeline.ts
@@ -7,8 +7,9 @@
  *
  * @example
  * ```ts
- * import { createPipeline } from 'trendcraft/streaming';
+ * import { streaming } from 'trendcraft';
  * import { createRsi, createSma } from 'trendcraft/incremental';
+ * const { createPipeline } = streaming;
  *
  * const pipeline = createPipeline({
  *   indicators: [

--- a/packages/core/src/streaming/position-manager/types.ts
+++ b/packages/core/src/streaming/position-manager/types.ts
@@ -29,11 +29,15 @@ import type { SessionEvent } from "../types";
  *   entryPrice: 100,
  *   shares: 50,
  *   originalShares: 50,
+ *   direction: 'long',
  *   stopLossPrice: 98,
  *   takeProfitPrice: 106,
  *   peakPrice: 100,
+ *   troughPrice: 100,
  *   maxProfitPercent: 0,
  *   maxLossPercent: 0,
+ *   partialTaken: false,
+ *   breakevenActivated: false,
  * };
  * ```
  */

--- a/packages/core/src/streaming/session.ts
+++ b/packages/core/src/streaming/session.ts
@@ -7,8 +7,10 @@
  *
  * @example
  * ```ts
- * import { createTradingSession } from 'trendcraft/streaming';
+ * import { streaming } from 'trendcraft';
  * import { createRsi, createSma } from 'trendcraft/incremental';
+ *
+ * const { createTradingSession } = streaming;
  *
  * const session = createTradingSession({
  *   intervalMs: 60_000,  // 1-minute candles

--- a/packages/core/src/streaming/signal-emitter.ts
+++ b/packages/core/src/streaming/signal-emitter.ts
@@ -62,7 +62,7 @@ export type SignalEmitter = {
  * const emitter = createSignalEmitter({
  *   intervalMs: 60000,
  *   pipeline: {
- *     indicators: [{ name: 'rsi14', create: () => incremental.rsi({ period: 14 }) }],
+ *     indicators: [{ name: 'rsi14', create: () => incremental.createRsi({ period: 14 }) }],
  *     entry: rsiBelow(30),
  *     exit: rsiAbove(70),
  *   },

--- a/packages/core/src/streaming/types.ts
+++ b/packages/core/src/streaming/types.ts
@@ -507,7 +507,7 @@ export type LiveCandleState = {
  * const live = createLiveCandle({
  *   intervalMs: 60_000,
  *   indicators: [
- *     { name: "sma20", create: (s) => createSma({ period: 20 }, { fromState: s }) },
+ *     { name: "sma20", create: (s) => createSma({ period: 20 }, restoreState(s)) },
  *   ],
  * });
  * live.on("candleComplete", ({ candle, snapshot }) => {


### PR DESCRIPTION
## Summary

Second exhaustive docs-vs-source consistency sweep over the core package, following up on #301. Round 1 focused on `docs/`; this round extends coverage to READMEs, example READMEs, **JSDoc comments** (`@example` / `@param` / `@returns` / `@default`) across `src/`, and manifest entry strings served to MCP clients. Every corrected fact was verified against the implementation with file:line evidence, then adversarially re-verified by an independent pass before editing — no blind find/replace.

### What was wrong (representative classes)

- **Return shapes**: `VolumePriceLevel` documented as `{priceMin, priceMax, volume, percentage}` vs actual `{priceLow, priceHigh, priceMid, volume, volumePercent}`; `StochRsiValue` missing its `stochRsi` field; signal `type` literals (`'volume_breakout'` vs actual `'breakout'`, `'volume_ma_cross_up/down'` vs actual `'volume_ma_cross'` + `direction`)
- **Defaults**: `volumeProfile` `period` documented as 20 (actually all candles; only `volumeProfileSeries` defaults to 20); `volumeMa` `period` documented as optional-with-default (actually required)
- **Signatures**: `highest`/`lowest` take a bare number, not an options object; `mtfCondition` takes `(timeframes[], name, evaluate)`; `calculateScoreBreakdown(candles, index, config, …)`
- **Examples that could not run**: missing imports (`deadCrossCondition`), out-of-scope variables (`candles[i]` with no `i`), namespace members used as bare bindings, `rsi(candles, 14)` where an options object is required
- **Stale claims**: resample timeframe list showed 2 of 12 supported shorthands; `minTrackRecordLength` example said ≈ 274 (actual 273); TRIX manifest pitfall described a null-as-0 warmup that the implementation no longer has
- **EN/JA divergence**: the Japanese twins carried their own independent drift and were audited on their own merits

## Scope

- 11 markdown files (docs, READMEs, example READMEs) + 68 source files with **JSDoc/doc-string-only** edits — no runtime code changes
- Code-side contract bugs found by the same audit are fixed separately in #304 (this PR's doc rows describing garch `p`/`q` validation and `seriesToCandles` `fillMode` match the behavior introduced there — merge #304 first)

## Test plan

- On this branch in isolation: `pnpm test` (core, includes the doc-snippet execution harness and the docs-import-check) → **335 files / 6141 tests, all pass**; `npx tsc --noEmit --ignoreDeprecations 6.0` → pass
- On the full working tree (with #304): core **6281 / 6281** pass, `pnpm build` passes