### PR TITLE
fix(chart): align the event contract with runtime behavior

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to `@trendcraft/chart` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed — `resize`, `paneResize`, and `seriesRemoved` events now fire
+
+These three events were declared in the `ChartEvent` union and documented,
+but the chart never emitted them. They now fire with the documented payloads:
+
+- `resize` `{ width, height }` — once per actual CSS-px size change, whether
+  triggered by `chart.resize()`, an `applyOptions()` size change, or the
+  container's `ResizeObserver`. Same-size calls and DPR-only changes
+  (e.g. dragging the window to a Retina display) stay silent, and the
+  initial sizing during `createChart()` does not emit.
+- `paneResize` `{ paneId, height }` — fires while the user drags a pane
+  divider (per pointer-move), with the pane above the divider and its new
+  height in CSS px. Drags clamped away by the minimum pane height are silent.
+- `seriesRemoved` `{ id }` — fires when a series is removed via its handle
+  (covers `handle.remove()` and `connectIndicators` teardown). Repeat
+  `remove()` calls on the same handle are silent, and `chart.destroy()`
+  emits nothing (matching `seriesAdded`, which is also silent on teardown).
+
+### Fixed — `CrosshairMoveData` type now matches the emitted payload
+
+The exported `CrosshairMoveData` type declared `{ time, price, x, y, paneId }`,
+but the chart has always emitted `{ time, index, ohlcv, paneId }` from
+`crosshairMove`. The type (and docs) now describe the real payload:
+
+- `time: number | null` — epoch ms of the snapped candle
+- `index: number | null` — candle index
+- `ohlcv: { open, high, low, close, volume } | null` — the snapped candle's values
+- `paneId: string | null` — pane under the pointer
+
+All fields are `null` in the single emission fired when the crosshair leaves
+the data area (the `ohlcv: null` key is now included there too). Runtime
+behavior is otherwise unchanged — this is a type/docs correction. TypeScript
+consumers who typed handlers against the old (never-delivered) `price`/`x`/`y`
+fields will get compile errors pointing at the fields that never existed at
+runtime.
+
 ## [0.3.0] - 2026-06-09
 
 ### Breaking — `snapshotName` is now a default label, not a uniqueness key

--- a/packages/chart/docs/API.md
+++ b/packages/chart/docs/API.md
@@ -78,19 +78,19 @@ All fields optional.
 | `watermark` | `string` | — | Background watermark text |
 | `legend` | `boolean` | `true` | Show series legend |
 | `volume` | `boolean` | `true` | Show volume pane |
-| `scrollSensitivity` | `number` | `0.3` | Scroll/pan sensitivity multiplier (one-time; 0.1–2.0) |
+| `scrollSensitivity` | `number` | `0.3` | Scroll/pan sensitivity multiplier (one-time; clamped to a minimum of 0.1) |
 | `chartType` | `'candlestick' \| 'line' \| 'mountain' \| 'ohlc'` | `'candlestick'` | Base chart type |
 | `formatInfoOverlay` | `(data: InfoOverlayData) => string \| null` | — | Custom info overlay HTML (one-time). Return `null` to use default. |
 | `animationDuration` | `number` | `300` | Range transition duration (ms). `0` disables |
 | `locale` | `Partial<ChartLocale>` | — | i18n string overrides (one-time) |
 | `maxCandles` | `number` | — | Cap on retained candles in live mode |
 | `crosshair` | `CrosshairOptions` | `{ mode: 'normal' }` | Crosshair snap behavior — see [Crosshair](#crosshair) |
-| `hotkeys` | `HotkeyMap \| false` | built-in defaults | Keyboard shortcut bindings — see [Hotkeys](#hotkeys). Pass `false` to disable **all** keyboard handling (including viewport nav keys). |
-| `interaction` | `{ wheelInertia?: boolean }` | `{ wheelInertia: true }` | Trackpad/wheel inertia for pan + zoom. Disable to stop the synthetic deceleration tail (macOS OS-level momentum is independent and always processed). |
+| `hotkeys` | `HotkeyMap \| false` | built-in defaults | Keyboard shortcut bindings — see [Hotkeys](#hotkeys). Pass `false` to disable **all** keyboard handling (including viewport nav keys). (one-time) |
+| `interaction` | `{ wheelInertia?: boolean }` | `{ wheelInertia: true }` | Trackpad/wheel inertia for pan + zoom. Disable to stop the synthetic deceleration tail (macOS OS-level momentum is independent and always processed). (one-time) |
 | `showSeriesBadges` | `boolean` | `false` | Render a colored pill on the right price axis for each labeled series, mirroring the candle current-price badge. Multi-channel series get one pill per channel. |
 | `seriesBadgeMode` | `'absolute' \| 'visible'` | `'absolute'` | `'absolute'` shows the latest non-null value in the data array (live "current" value). `'visible'` shows the latest non-null value within the current visible range. |
 
-Options marked "one-time" cannot be changed via `applyOptions()` — a warning is emitted via the `error` event if you try.
+Options marked "one-time" cannot be changed via `applyOptions()` — a warning is emitted via the `error` event if you try, except `hotkeys` and `interaction`, which are currently ignored silently (no warning).
 
 ### Crosshair
 
@@ -266,7 +266,7 @@ destroy(): void
 
 | Field | Type | Description |
 |---|---|---|
-| `pane` | `'main' \| string` | Target pane id. Omit for auto-detection via `__meta`. Pass `'new'` to create a new sub-pane. |
+| `pane` | `'main' \| string` | Target pane id. Omit for auto-detection via `__meta`. Pass `'sub'` to auto-create a new sub-pane; any other custom string creates (or reuses) a pane with that id. |
 | `scaleId` | `'left' \| 'right'` | Which scale to bind to (only relevant for dual-scale panes). Default `'right'`. |
 | `type` | `SeriesType` | Override the auto-detected series type. |
 | `color` | `string` | Primary color for the series. |
@@ -316,7 +316,7 @@ All time values are epoch milliseconds.
 
 | Event | Payload shape |
 |---|---|
-| `crosshairMove` | `CrosshairMoveData = { time, price, x, y, paneId }` |
+| `crosshairMove` | `CrosshairMoveData = { time, index, ohlcv, paneId }` |
 | `click` | `ChartClickData = { x, y, index, time, shiftKey, altKey, metaKey, ctrlKey }` |
 | `visibleRangeChange` | `VisibleRangeChangeData = { startTime, endTime, startIndex, endIndex }` |
 | `resize` | `{ width: number, height: number }` |
@@ -392,7 +392,7 @@ Useful when you want to pass indicator configurations around your app without co
 ```typescript
 function connectLivePrimitives(
   source: LiveSource,
-  specs: readonly LivePrimitiveSpec<unknown>[],
+  specs: readonly LivePrimitiveSpec<any>[], // `any`, not `unknown`: per-spec T varies across the array, and `unknown` would force every handle.update to accept unknown, rejecting strongly-typed plugin handles like connectSrConfluence's
 ): LivePrimitivesConnection
 ```
 
@@ -403,10 +403,10 @@ import { connectIndicators, connectLivePrimitives, connectSrConfluence } from '@
 import { srZones } from 'trendcraft';
 
 const conn = connectIndicators(chart, { presets, candles, live: source });
-const sr = connectSrConfluence(chart, srZones(source.completedCandles));
+const sr = connectSrConfluence(chart, srZones(source.completedCandles).zones);
 
 const liveSr = connectLivePrimitives(source, [
-  { recompute: (candles) => srZones(candles), handle: sr, name: 'sr' },
+  { recompute: (candles) => srZones(candles).zones, handle: sr, name: 'sr' },
 ]);
 
 // later
@@ -537,7 +537,7 @@ import { TrendChart, useTrendChart } from '@trendcraft/chart/react';
 />
 ```
 
-Props mirror `ChartOptions` plus: `candles`, `indicators`, `signals`, `trades`, `drawings`, `timeframes`, `backtest`, `patterns`, `scores`, and event handlers. Expose the underlying `ChartInstance` via ref.
+Props mirror the `useTrendChart` options: `candles`, `indicators`, `signals`, `trades`, `drawings`, `timeframes`, `backtest`, `patterns`, `scores`, `plugins`, `chartType`, `layout`, `theme`, `fitOnLoad`, event handlers (`onCrosshairMove`, `onSeriesAdded`, `onSeriesRemoved`, `onError`), an `options` prop carrying the remaining `ChartOptions`, plus `style` / `className`. Expose the underlying `ChartInstance` via ref.
 
 **Hook** — imperative access to `ChartInstance` for drawing tools, live feeds, custom plugins:
 
@@ -625,7 +625,7 @@ const result = introspect(myIndicatorData);
 //   seriesType: 'band',         // resolved visual type
 //   rule: IntrospectionRule,    // matched rule (or null)
 //   preset: IndicatorPreset,    // matched preset (or null)
-//   pane: 'main' | 'new',       // resolved pane hint
+//   pane: 'main' | 'sub' (or custom pane id),  // resolved pane hint
 //   config: SeriesConfig,       // merged config
 //   yRange?: [number, number],  // from __meta
 //   referenceLines?: number[],  // from __meta
@@ -684,7 +684,7 @@ chart.addRule({
 chart.addPreset('myShape', {
   color: '#FF9800',
   lineWidth: 2,
-  pane: 'new',
+  pane: 'sub',
 });
 ```
 

--- a/packages/chart/docs/GUIDE.md
+++ b/packages/chart/docs/GUIDE.md
@@ -50,7 +50,7 @@ Everything the chart draws is either:
 | **Drawings** | Discriminated union (`hline`, `trendline`, etc.) | User-drawn annotations via `addDrawing()` |
 | **Overlays** | Framework-provided helpers (`addSignals`, `addTrades`, `addBacktest`, `addPatterns`, `addScores`) | Pre-baked visualizations of higher-level trading concepts |
 
-`time` is always epoch milliseconds (matches `trendcraft`'s `TimeValue`). `value` shape varies — see [Auto-detection from `__meta`](#auto-detection-from-__meta).
+`time` is always epoch milliseconds (the chart's `TimeValue` type — the same epoch-ms `time` carried by `trendcraft`'s normalized candles). `value` shape varies — see [Auto-detection from `__meta`](#auto-detection-from-__meta).
 
 ### Compound values
 
@@ -74,15 +74,14 @@ Internally, every point goes through two scales:
 
 `DrawHelper` (exposed to plugins) wraps these with `draw.x(index)` and `draw.y(price)`.
 
-When you read event data, you get **both** the time value and the pixel coordinate:
+Event data is expressed in candle terms — the snapped index and its OHLCV — not pixels:
 
 ```typescript
 chart.on('crosshairMove', (data: CrosshairMoveData) => {
-  data.time   // epoch ms (or null if outside plot area)
-  data.price  // price (or null)
-  data.x      // canvas x in CSS pixels
-  data.y      // canvas y in CSS pixels
-  data.paneId // which pane the pointer is over
+  data.time   // epoch ms of the snapped candle (or null when leaving the plot area)
+  data.index  // candle index (or null)
+  data.ohlcv  // { open, high, low, close, volume } (or null)
+  data.paneId // pane under the pointer (or null)
 });
 ```
 
@@ -144,7 +143,7 @@ chart.addIndicator(mySecondarySeries, { pane: 'main', scaleId: 'left' });
 
 When you pass an indicator series to `addIndicator()`, the chart does two things:
 
-1. **Reads `__meta`** if present. `trendcraft` indicators attach a non-enumerable `__meta: SeriesMeta` describing the indicator's domain characteristics (label, overlay vs. sub-pane, Y-range, reference lines). The chart translates these to pane placement.
+1. **Reads `__meta`** if present. `trendcraft` indicators attach a `__meta: SeriesMeta` property describing the indicator's domain characteristics (label, overlay vs. sub-pane, Y-range, reference lines). The chart translates these to pane placement.
 2. **Falls back to shape introspection.** For untagged data, the chart inspects the first non-null value. A `number` becomes a line, `{ upper, middle, lower }` becomes a band, etc.
 
 This is why you can write `chart.addIndicator(sma(candles))` without passing a pane id — `trendcraft`'s `sma` sets `overlay: true` in its `__meta`, the chart puts it on the price pane, and reads the label for the legend.
@@ -155,7 +154,7 @@ Pass a `SeriesConfig` to override:
 
 ```typescript
 chart.addIndicator(mySeries, {
-  pane: 'new',                   // create a new sub-pane
+  pane: 'sub',                   // auto-generate a fresh sub-pane
   type: 'histogram',             // force a specific renderer
   color: '#FF9800',
   label: 'My Indicator',
@@ -163,14 +162,14 @@ chart.addIndicator(mySeries, {
 });
 ```
 
+`'sub'` mints a new auto-generated sub-pane on every call; any other string is a literal pane id — indicators passing the same id share that pane.
+
 ### Custom introspection rules
 
 If you have custom indicators with a non-standard compound shape, register a rule:
 
 ```typescript
-import { SeriesRegistry } from '@trendcraft/chart';
-
-SeriesRegistry.addRule({
+chart.addRule({
   name: 'myCustomShape',
   test: (value) => typeof value === 'object' && value !== null && 'score' in value,
   seriesType: 'line',
@@ -179,7 +178,9 @@ SeriesRegistry.addRule({
 });
 ```
 
-Rules are consulted in registration order, with built-in rules last. Useful when you want to share conventions across a team without each caller configuring the chart.
+`chart.addRule` delegates to the shared default registry. In headless code, import `defaultRegistry` from `@trendcraft/chart/headless` and call `defaultRegistry.addRule(rule)`.
+
+Custom rules are consulted most-recently-registered first, with built-in rules last — when two custom rules match the same shape, the later-registered rule wins. Useful when you want to share conventions across a team without each caller configuring the chart.
 
 ## Adding indicators: which API?
 
@@ -214,8 +215,8 @@ These three terms appear throughout the API and look similar; they describe diff
 
 | Term | Meaning |
 |---|---|
-| `Series<T>` | The input. A plain array `{ time: number, value: T }[]` returned by every `trendcraft` indicator, optionally tagged with a non-enumerable `__meta`. |
-| `ResolvedSeries` | An internal step. After introspection (auto-detection or your `SeriesConfig` overrides), the chart knows which pane, color, type, and channel layout to use. Not a public type, but referenced in error messages. |
+| `Series<T>` | The input. A plain array `{ time: number, value: T }[]` returned by every `trendcraft` indicator, optionally tagged with a `__meta` property. |
+| `ResolvedSeries` | An intermediate step. After introspection (auto-detection or your `SeriesConfig` overrides), the chart knows which pane, color, type, and channel layout to use. Exported as a type from `@trendcraft/chart/headless` (the computed series rendering info). |
 | `SeriesHandle` | The output of `addIndicator`. The handle you keep to mutate or remove the series later. Stable across `update()` calls; invalidated by `remove()`. |
 
 ### Validation behavior
@@ -281,7 +282,7 @@ The time axis has three navigational modes:
 |---|---|
 | `setVisibleRange(start, end)` | Absolute control — show this time window |
 | `setVisibleRangeByDuration('1M')` | Relative — show the last month |
-| `fitContent()` | Reset to show everything with 20% right padding |
+| `fitContent()` | Reset to show everything (data fills the full plot width; no right padding) |
 
 `fitContent()` locks pan when all data is visible. Once the user zooms back in, pan re-engages.
 
@@ -298,7 +299,7 @@ The chart captures keyboard when focused:
 
 ### Touch
 
-On touch devices: single-finger pan, two-finger pinch-zoom, tap-hold-drag for drawing tools.
+On touch devices: single-finger pan, two-finger pinch-zoom, double-tap to fit content, and long-press to lock the crosshair. Drawing tools place points with discrete taps (two-tap tools show a preview between the first and second tap).
 
 ## Events
 
@@ -306,7 +307,7 @@ Subscribe via `chart.on(event, handler)`. Unsubscribe via `chart.off`. Events ar
 
 | Event | Payload |
 |---|---|
-| `crosshairMove` | `CrosshairMoveData` — time, price, x, y, paneId |
+| `crosshairMove` | `CrosshairMoveData` — time, index, ohlcv, paneId |
 | `visibleRangeChange` | `VisibleRangeChangeData` — startTime, endTime, startIndex, endIndex |
 | `click` | `ChartClickData` — x, y, index, time, shiftKey, altKey, metaKey, ctrlKey; fires on pointer up |
 | `resize` | `{ width, height }` |
@@ -373,7 +374,7 @@ import {
 
 These are the same classes the browser chart uses internally — you can build server-side analytics, static previews, or tests without loading the canvas code.
 
-For Next.js specifically, import `@trendcraft/chart` in a `useEffect` or a dynamic import with `ssr: false`. The React wrapper (`@trendcraft/chart/react`) handles this for you: it mounts in `useLayoutEffect` and skips on the server.
+For Next.js specifically, import `@trendcraft/chart` in a `useEffect` or a dynamic import with `ssr: false`. The React wrapper (`@trendcraft/chart/react`) handles this for you: it mounts in `useEffect`, which does not run during server rendering.
 
 ## Accessibility
 
@@ -381,7 +382,7 @@ Each chart mounts an `aria-live` region (`ChartAria`) that announces crosshair u
 
 > "RSI: 42.5 at 2026-04-15"
 
-Announcements are debounced to once per 250 ms so screen readers don't get spammed. You can disable ARIA entirely by setting `theme.border` to transparent and... actually you can't disable it yet — if you need that, open an issue.
+Announcements are debounced by 300 ms (the announcement fires 300 ms after the crosshair settles) so screen readers don't get spammed. You can disable ARIA entirely by setting `theme.border` to transparent and... actually you can't disable it yet — if you need that, open an issue.
 
 Keyboard navigation works as documented in [Viewport and navigation](#viewport-and-navigation). The chart container itself is focusable (tabindex 0); arrow keys pan only when focused.
 

--- a/packages/chart/src/__tests__/chart-lifecycle-events.test.ts
+++ b/packages/chart/src/__tests__/chart-lifecycle-events.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment happy-dom
+/**
+ * Lifecycle events — `resize`, `paneResize`, `seriesRemoved`.
+ *
+ * These three events were declared in the ChartEvent union and documented,
+ * but never emitted. These tests pin the now-real emission semantics:
+ *
+ * - `resize` `{ width, height }` — fires once per actual CSS-px size change.
+ *   chart.resize(), applyOptions() size changes, and ResizeObserver ticks all
+ *   funnel through the same internal sizing path; same-size calls and
+ *   DPR-only changes stay silent, and the constructor's initial sizing never
+ *   reaches subscribers (none can exist yet).
+ * - `paneResize` `{ paneId, height }` — fires per pointer-move during a user
+ *   divider drag; payload names the pane above the dragged divider with its
+ *   new height in CSS px. Clamped/no-op drags are silent.
+ * - `seriesRemoved` `{ id }` — every removal path funnels through the series
+ *   handle (host `handle.remove()`, connectIndicators teardown). Repeat
+ *   remove() on the same handle is silent, and destroy() emits nothing
+ *   (mirroring `seriesAdded`, which is also silent during teardown).
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createChart } from "../index";
+
+beforeAll(() => {
+  const noop = () => {};
+  const ctx = new Proxy(
+    {},
+    {
+      get: (_t, prop) => {
+        if (prop === "canvas") return null;
+        if (prop === "measureText") return () => ({ width: 0 }) as TextMetrics;
+        return noop;
+      },
+      set: () => true,
+    },
+  ) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as { getContext: () => unknown }).getContext = () => ctx;
+});
+
+function makeContainer(): HTMLElement {
+  const el = document.createElement("div");
+  el.style.width = "800px";
+  el.style.height = "400px";
+  document.body.appendChild(el);
+  return el;
+}
+
+const sampleCandles = Array.from({ length: 50 }, (_, i) => ({
+  time: 1700000000000 + i * 86400000,
+  open: 100 + i,
+  high: 105 + i,
+  low: 95 + i,
+  close: 102 + i,
+  volume: 1000,
+}));
+
+const sampleLine = sampleCandles.map((c) => ({ time: c.time, value: c.close }));
+
+/** Internal layout access — needed to locate the divider gap for drag tests. */
+type LayoutInternals = {
+  _layout: {
+    paneRects: readonly { id: string; y: number; height: number }[];
+  };
+};
+
+describe("resize event", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("emits { width, height } once when chart.resize() changes the size", () => {
+    const chart = createChart(makeContainer(), { width: 800, height: 400 });
+    const handler = vi.fn();
+    chart.on("resize", handler);
+
+    chart.resize(900, 500);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ width: 900, height: 500 });
+    chart.destroy();
+  });
+
+  it("does not emit for a same-size call or a DPR-only change", () => {
+    Object.defineProperty(window, "devicePixelRatio", { configurable: true, value: 1 });
+    const chart = createChart(makeContainer(), { width: 800, height: 400 });
+    const handler = vi.fn();
+    chart.on("resize", handler);
+
+    // Same size — silent.
+    chart.resize(800, 400);
+    expect(handler).not.toHaveBeenCalled();
+
+    // DPR-only change (window dragged to a Retina display) — the canvas
+    // backing store re-scales but the CSS-px size is unchanged, so no emit.
+    Object.defineProperty(window, "devicePixelRatio", { configurable: true, value: 2 });
+    chart.resize(800, 400);
+    expect(handler).not.toHaveBeenCalled();
+
+    chart.destroy();
+  });
+
+  it("emits once when applyOptions changes the size", () => {
+    const chart = createChart(makeContainer(), { width: 800, height: 400 });
+    const handler = vi.fn();
+    chart.on("resize", handler);
+
+    chart.applyOptions({ width: 640 });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ width: 640, height: 400 });
+
+    // Re-applying the same size stays silent.
+    chart.applyOptions({ width: 640, height: 400 });
+    expect(handler).toHaveBeenCalledTimes(1);
+    chart.destroy();
+  });
+});
+
+describe("paneResize event", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  function dragDivider(container: HTMLElement, chart: unknown, deltaY: number): void {
+    const canvas = container.querySelector("canvas") as HTMLCanvasElement;
+    const rects = (chart as LayoutInternals)._layout.paneRects;
+    // The gap sits between pane 0 (main) and pane 1 (volume).
+    const gapY = rects[0].y + rects[0].height + 1;
+    const rect = canvas.getBoundingClientRect();
+    canvas.dispatchEvent(
+      new MouseEvent("mousedown", {
+        clientX: rect.left + 100,
+        clientY: rect.top + gapY,
+        bubbles: true,
+      }),
+    );
+    canvas.dispatchEvent(
+      new MouseEvent("mousemove", {
+        clientX: rect.left + 100,
+        clientY: rect.top + gapY + deltaY,
+        bubbles: true,
+      }),
+    );
+    canvas.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+  }
+
+  it("emits { paneId, height } when the user drags a pane divider", () => {
+    const container = makeContainer();
+    const chart = createChart(container, { width: 800, height: 400 });
+    chart.setCandles(sampleCandles);
+
+    const prevHeight = (chart as unknown as LayoutInternals)._layout.paneRects[0].height;
+    const handler = vi.fn();
+    chart.on("paneResize", handler);
+
+    dragDivider(container, chart, 20);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const payload = handler.mock.calls[0][0] as { paneId: string; height: number };
+    expect(payload.paneId).toBe("main");
+    // Divider moved down 20 CSS px → the main pane grows by ~20 px
+    // (flex re-normalization can shift the result by sub-pixel amounts).
+    expect(payload.height).toBeCloseTo(prevHeight + 20, 0);
+    chart.destroy();
+  });
+
+  it("does not emit when the drag leaves the pane height unchanged", () => {
+    const container = makeContainer();
+    const chart = createChart(container, { width: 800, height: 400 });
+    chart.setCandles(sampleCandles);
+
+    const handler = vi.fn();
+    chart.on("paneResize", handler);
+
+    dragDivider(container, chart, 0);
+
+    expect(handler).not.toHaveBeenCalled();
+    chart.destroy();
+  });
+});
+
+describe("seriesRemoved event", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("emits { id } when a series handle is removed, once per handle", () => {
+    const chart = createChart(makeContainer(), { width: 800, height: 400 });
+    chart.setCandles(sampleCandles);
+    const handle = chart.addIndicator(sampleLine, { label: "SMA(20)" });
+
+    const handler = vi.fn();
+    chart.on("seriesRemoved", handler);
+
+    handle.remove();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ id: handle.id });
+
+    // Repeat remove() on the same handle is idempotent — no second emit.
+    handle.remove();
+    expect(handler).toHaveBeenCalledTimes(1);
+    chart.destroy();
+  });
+
+  it("does not emit during destroy() teardown (mirrors seriesAdded)", () => {
+    const chart = createChart(makeContainer(), { width: 800, height: 400 });
+    chart.setCandles(sampleCandles);
+    chart.addIndicator(sampleLine, { label: "A" });
+    chart.addIndicator(
+      sampleLine.map((p) => ({ ...p, value: p.value + 1 })),
+      { label: "B" },
+    );
+
+    const handler = vi.fn();
+    chart.on("seriesRemoved", handler);
+
+    chart.destroy();
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/chart/src/__tests__/sync-charts.test.ts
+++ b/packages/chart/src/__tests__/sync-charts.test.ts
@@ -40,9 +40,8 @@ describe("syncCharts", () => {
 
     const move: CrosshairMoveData = {
       time: 1609459200000,
-      price: 100,
-      x: 0,
-      y: 0,
+      index: 0,
+      ohlcv: { open: 100, high: 101, low: 99, close: 100, volume: 1000 },
       paneId: "main",
     };
     a.emit("crosshairMove", move);
@@ -57,7 +56,7 @@ describe("syncCharts", () => {
     const b = makeFakeChart();
     syncCharts([a, b] as unknown as ChartInstance[]);
 
-    a.emit("crosshairMove", { time: null, price: null, x: 0, y: 0, paneId: "main" });
+    a.emit("crosshairMove", { time: null, index: null, ohlcv: null, paneId: null });
     expect(b.setCrosshair).toHaveBeenCalledWith(null);
   });
 
@@ -68,7 +67,7 @@ describe("syncCharts", () => {
     const a = makeFakeChart();
     const b = makeFakeChart();
     (b.setCrosshair as ReturnType<typeof vi.fn>).mockImplementation((time) => {
-      b.emit("crosshairMove", { time, price: null, x: 0, y: 0, paneId: "main" });
+      b.emit("crosshairMove", { time, index: null, ohlcv: null, paneId: "main" });
     });
 
     syncCharts([a, b] as unknown as ChartInstance[]);

--- a/packages/chart/src/core/data-layer.ts
+++ b/packages/chart/src/core/data-layer.ts
@@ -37,6 +37,7 @@ export class DataLayer {
   private _onChange: (() => void) | null = null;
   private _onPaneEmpty: ((paneId: string) => void) | null = null;
   private _onWarn: ((message: string) => void) | null = null;
+  private _onSeriesRemoved: ((id: string) => void) | null = null;
 
   /** Register a callback for data changes */
   setOnChange(cb: () => void): void {
@@ -51,6 +52,15 @@ export class DataLayer {
   /** Register a callback for diagnostic warnings (e.g. duplicate timestamps) */
   setOnWarn(cb: (message: string) => void): void {
     this._onWarn = cb;
+  }
+
+  /**
+   * Register a callback fired when a series is removed via its handle.
+   * Every removal path (host `handle.remove()`, connectIndicators teardown,
+   * bulk cleanup) funnels through the handle, so this hook sees them all.
+   */
+  setOnSeriesRemoved(cb: (id: string) => void): void {
+    this._onSeriesRemoved = cb;
   }
 
   /** Set maximum candle count. Older candles are trimmed when exceeded. */
@@ -223,6 +233,10 @@ export class DataLayer {
         const paneId = s?.paneId;
         this._series.delete(id);
         this.markDirty();
+        // Only notify when the series actually existed — repeat remove()
+        // calls on the same handle stay silent (idempotent from the
+        // listener's point of view).
+        if (s) this._onSeriesRemoved?.(id);
         if (paneId) this.checkPaneEmpty(paneId);
       },
     };

--- a/packages/chart/src/core/types/event.ts
+++ b/packages/chart/src/core/types/event.ts
@@ -36,12 +36,23 @@ export type SeriesActionData = {
   anchorEl: HTMLElement;
 };
 
+/**
+ * Payload for the `crosshairMove` event. Fires when the candle the crosshair
+ * snaps to changes. `time`/`index`/`ohlcv` describe the snapped candle;
+ * `paneId` is the pane under the pointer. All fields are `null` in the single
+ * emission fired when the crosshair leaves the data area.
+ */
 export type CrosshairMoveData = {
   time: TimeValue | null;
-  price: number | null;
-  x: number;
-  y: number;
-  paneId: string;
+  index: number | null;
+  ohlcv: {
+    open: number;
+    high: number;
+    low: number;
+    close: number;
+    volume: number;
+  } | null;
+  paneId: string | null;
 };
 
 /**

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -91,8 +91,8 @@ export class CanvasChart implements ChartInstance {
   private _ctx: CanvasRenderingContext2D;
   private _pixelRatio: number;
   /**
-   * `true` when the caller pinned `pixelRatio` via constructor options
-   * (or `applyOptions`). When pinned, we honor the caller's value and
+   * `true` when the caller pinned `pixelRatio` via constructor options.
+   * When pinned, we honor the caller's value and
    * never auto-track `window.devicePixelRatio`. When false, every
    * `_setSize` call re-reads `window.devicePixelRatio` so dragging the
    * window between displays of different DPR (e.g. Retina ↔ external
@@ -262,7 +262,7 @@ export class CanvasChart implements ChartInstance {
     if (idx === this._lastCrosshairIndex) return;
     this._lastCrosshairIndex = idx;
     if (idx === null) {
-      this._emit("crosshairMove", { time: null, index: null, paneId: null });
+      this._emit("crosshairMove", { time: null, index: null, ohlcv: null, paneId: null });
       return;
     }
     const candle = this._data.candles[idx];
@@ -377,6 +377,14 @@ export class CanvasChart implements ChartInstance {
     // Forward data layer warnings
     this._data.setOnWarn((msg) => this._warn(msg));
 
+    // Mirror of `seriesAdded`: every removal path (SeriesHandle.remove(),
+    // connectIndicators teardown, legend-driven host removal) funnels
+    // through the data layer, so this single hook covers them all.
+    this._data.setOnSeriesRemoved((id) => {
+      this._emit("seriesRemoved", { id });
+      this._updateAriaLabel();
+    });
+
     // Auto-remove empty panes when last series is removed
     this._data.setOnPaneEmpty((paneId) => {
       if (this._layout.removePane(paneId)) {
@@ -417,7 +425,17 @@ export class CanvasChart implements ChartInstance {
           : null,
       (y) => this._layout.gapAtY(y),
       (gapIdx, delta) => {
+        const prevHeight = this._layout.paneRects[gapIdx]?.height;
         this._layout.resizePanes(gapIdx, delta);
+        // paneResize fires per pointer-move during a divider drag (the drag
+        // handler streams deltas as the pointer moves — there is no separate
+        // "drag end" callback at this level). Payload identifies the pane
+        // above the dragged divider and its new height in CSS px; skipped
+        // when the drag was clamped away (height unchanged).
+        const rect = this._layout.paneRects[gapIdx];
+        if (rect && rect.height !== prevHeight) {
+          this._emit("paneResize", { paneId: rect.id, height: rect.height });
+        }
         this._needsRender = true;
       },
       options?.scrollSensitivity,
@@ -1279,6 +1297,12 @@ export class CanvasChart implements ChartInstance {
 
     this._layout.setDimensions(w, h, priceAxisWidth, timeAxisHeight);
 
+    // Emit `resize` only when the applied CSS-px size actually changed —
+    // DPR-only updates and repeated same-size calls (e.g. a ResizeObserver
+    // tick after applyOptions already applied the size) stay silent. The
+    // constructor's initial sizing pre-seeds `_sizeState`, so it never emits.
+    const sizeChanged = w !== this._sizeState?.width || h !== this._sizeState?.height;
+
     // Keep last-applied size so applyOptions() can compose partial changes
     this._sizeState = {
       width: w,
@@ -1293,6 +1317,10 @@ export class CanvasChart implements ChartInstance {
     // Re-fit if all data was visible before resize
     if (wasFit && this._timeScale.totalCount > 0) {
       this._timeScale.fitContent();
+    }
+
+    if (sizeChanged) {
+      this._emit("resize", { width: w, height: h });
     }
   }
 


### PR DESCRIPTION
## Summary

An exhaustive docs-vs-source audit surfaced two classes of event-contract drift in `@trendcraft/chart` where the exported types and docs disagreed with what the runtime actually does. Both are fixed here, with CHANGELOG entries under Unreleased.

### 1. `CrosshairMoveData` type now matches the emitted payload

The exported type declared `{ time, price, x, y, paneId }`, but the chart has always emitted `{ time, index, ohlcv, paneId }` from `crosshairMove`. The type (and the API.md/GUIDE.md tables and snippet) now describe the real payload:

- `time: number | null` — epoch ms of the snapped candle
- `index: number | null` — candle index
- `ohlcv: { open, high, low, close, volume } | null`
- `paneId: string | null`

All fields are `null` in the single emission fired when the crosshair leaves the data area (that emission now includes `ohlcv: null` for shape consistency). Runtime behavior is otherwise unchanged — TypeScript consumers who typed handlers against the never-delivered `price`/`x`/`y` fields will get compile errors pointing at fields that never existed at runtime.

### 2. `resize`, `paneResize`, and `seriesRemoved` now actually fire

All three were declared in the `ChartEvent` union, documented with payload shapes, and subscribed to by the React/Vue wrappers — but nothing ever emitted them, so every subscription was a silent no-op:

- **`resize`** `{ width, height }` — once per actual CSS-px size change (covers `chart.resize()`, `applyOptions` size changes, and the container's `ResizeObserver`). Same-size calls and DPR-only changes (dragging between displays) stay silent; initial sizing during `createChart()` does not emit.
- **`paneResize`** `{ paneId, height }` — per pointer-move while the user drags a pane divider, with the pane above the divider and its new height in CSS px; drags clamped by the minimum pane height are silent.
- **`seriesRemoved`** `{ id }` — a single data-layer hook covers every removal path (`SeriesHandle.remove()`, `connectIndicators` teardown, host-driven removal). Repeat `remove()` calls are silent, and `destroy()` emits nothing — matching `seriesAdded`, which is also silent on teardown.

Note: the touched docs files (API.md / GUIDE.md) also carry a handful of unrelated table corrections from the same audit.

## Test plan

- 7 new tests in `chart-lifecycle-events.test.ts` (payload shape per event, plus negative tests: same-size resize silent, zero-delta drag silent, repeat-remove silent, destroy silent) + `sync-charts.test.ts` fixtures updated to the corrected `CrosshairMoveData` shape
- On this branch in isolation: `pnpm test` → **81 files / 924 tests, all pass**; `npx tsc --noEmit` → pass; `pnpm size-check` → all budgets green (Main 40.95/41 kB, Headless 10.86/11 kB, React 32.19/33 kB, Vue 32.45/33 kB, Sparkline 3.79/5 kB, Replay 935 B/3 kB)