### PR TITLE
docs(chart,mcp): correct docs, JSDoc, and tool-description drift (audit round 2)

### DIFF
--- a/packages/chart/docs/COOKBOOK.md
+++ b/packages/chart/docs/COOKBOOK.md
@@ -58,7 +58,7 @@ chart.setCandles(candles);
 chart.addIndicator(sma(candles, { period: 20 }));
 ```
 
-`sma()` returns a `Series<number>` carrying `__meta` describing pane, color, and label. The chart auto-detects all three. No `addIndicator` config needed.
+`sma()` returns a `Series<number>` carrying `__meta` describing pane placement (`overlay`) and label — the chart auto-detects both and assigns a color from its palette. No `addIndicator` config needed.
 
 ---
 
@@ -94,14 +94,14 @@ conn.add("macd");
 
 ```typescript
 chart.addIndicator(rsi(candles, { period: 14 }), {
-  pane: "new",
+  pane: "sub",
   yRange: [0, 100],
   referenceLines: [30, 70],
   color: "#f59e0b",
 });
 ```
 
-`pane: "new"` creates a fresh sub-pane. `pane: "main"` forces the main pane. Omit it to let `__meta` decide.
+`pane: "sub"` creates a fresh sub-pane (each call gets its own auto-generated pane). `pane: "main"` forces the main pane. Omit it to let `__meta` decide.
 
 ---
 
@@ -308,7 +308,7 @@ for (const ticker of tickers) {
 }
 ```
 
-The sparkline subpath has its own bundle budget (see `packages/chart/.size-limit.json`) and does not pull in the main chart code.
+The sparkline subpath has its own bundle budget (see the `size-limit` field in `packages/chart/package.json`) and does not pull in the main chart code.
 
 ---
 

--- a/packages/chart/docs/LIVE.md
+++ b/packages/chart/docs/LIVE.md
@@ -74,10 +74,15 @@ const live = createLiveCandle({
   maxHistory: 2000,         // cap memory for long-running sessions
 });
 
+// initHistory: false — the chart was already primed via chart.setCandles(history).
+// The default (initHistory: true) would replace the chart candles with
+// live.completedCandles, which is empty here because createLiveCandle's
+// `history` option is warm-up-only and never enters completedCandles.
 const conn = connectIndicators(chart, {
   presets: indicatorPresets,
   candles: history,
   live,
+  initHistory: false,
 });
 conn.add('rsi');
 conn.add('sma', { period: 20 });
@@ -191,7 +196,7 @@ Each `add` call:
 | `list()` | All active handles. |
 | `listByPreset(id)` | Handles for a given preset id. |
 | `get(snapshotName)` | Look up a single handle. |
-| `recompute(candles)` | Re-run all indicators with new candle data (static mode). |
+| `recompute(candles)` | Re-run all indicators with new candle data. In live mode this permanently replaces the connection's canonical history — subsequent `candleComplete` bars append onto it and later `add()` calls backfill from it. |
 | `disconnect()` | Unsubscribe events and remove all indicators. Idempotent. |
 | `connected` (readonly) | `true` until `disconnect()` is called. |
 | `mode` (readonly) | `'static'` or `'live'`. |
@@ -200,7 +205,7 @@ Each `add` call:
 
 | Member | Description |
 |---|---|
-| `snapshotName` | Unique key for this instance (e.g. `'sma20'`). |
+| `snapshotName` | Unique key for this instance (e.g. `'sma_close_20'`). |
 | `presetId` | The preset id used to build this instance. |
 | `params` | Effective parameters (defaults merged with overrides). |
 | `series` | Underlying `SeriesHandle` (escape hatch — most users ignore this). |
@@ -224,7 +229,11 @@ connectIndicators(chart, {
   presets: indicatorPresets,
   candles,   // used for:
              //   1. preset.compute(candles, params) → backfill series
-             //   2. chart.setCandles(candles) if initHistory and live.completedCandles is empty
+             //   2. chart.setCandles(live.completedCandles) is called when
+             //      initHistory is not false (live mode) — options.candles is
+             //      never passed to setCandles. Prime the chart yourself with
+             //      chart.setCandles(candles) and pass initHistory: false if
+             //      the live source has no completed candles yet.
   live,
 });
 ```
@@ -265,12 +274,12 @@ handle.setVisible(false);
 handle.setVisible(true);
 ```
 
-For presets where snapshot names depend on params (e.g. `sma` → `sma20`), the chart keys state by snapshot name. This means you can mount multiple instances of the same preset without collision:
+For presets where snapshot names depend on params (e.g. `sma` → `sma_close_20`), the chart keys state by snapshot name. This means you can mount multiple instances of the same preset without collision:
 
 ```typescript
-conn.add('sma', { period: 5 });   // snapshotName: 'sma5'
-conn.add('sma', { period: 20 });  // snapshotName: 'sma20'
-conn.add('sma', { period: 60 });  // snapshotName: 'sma60'
+conn.add('sma', { period: 5 });   // snapshotName: 'sma_close_5'
+conn.add('sma', { period: 20 });  // snapshotName: 'sma_close_20'
+conn.add('sma', { period: 60 });  // snapshotName: 'sma_close_60'
 ```
 
 For presets with static snapshot names (e.g. `emaRibbon`), pass an explicit `snapshotName`:
@@ -291,14 +300,15 @@ let savedState = live.getState();
 
 ws.on('close', () => { savedState = live.getState(); });
 ws.on('open', () => {
-  // restore
+  // restore — disconnect the old connection first
+  conn.disconnect();
   live = createLiveCandle(options, savedState);
   conn = connectIndicators(chart, { presets: indicatorPresets, candles, live });
   for (const indicator of activeIndicators) conn.add(indicator.id, indicator.params);
 });
 ```
 
-This is correct but heavyweight — you rebuild the whole pipeline.
+This works but is heavyweight — you rebuild the whole pipeline, and the `conn.disconnect()` before recreating is required: chart series are only removed via `remove()`/`disconnect()`, so skipping it duplicates every indicator series on each reconnect.
 
 Approach B — keep `LiveCandle` alive, just reconnect the socket:
 
@@ -330,17 +340,17 @@ Without it, TrendCraft-specific shapes (`adaptiveRsi` `{rsi, effectivePeriod, vo
 
 ### Forgetting to call `conn.disconnect()` in cleanup
 
-`disconnect()` unsubscribes event handlers on `live` and removes chart series. Skip it and you leak listeners + series on every route transition. The React / Vue wrappers handle this when the component unmounts — but if you wire the connection inside a `useEffect`, return a cleanup function that calls `disconnect()`.
+`disconnect()` unsubscribes event handlers on `live` and removes chart series. Skip it and you leak listeners + series on every route transition. The React / Vue wrappers do **not** manage an `IndicatorConnection` — `TrendChart` only takes precomputed series props. If you wire `connectIndicators` inside a `useEffect` (React) or `onMounted`/`watchEffect` (Vue), always register a cleanup that calls `conn.disconnect()`.
 
 ### Expecting `live.completedCandles` to include `history`
 
 `createLiveCandle`'s `history` option is for **warm-up context only** — it's used to advance the incremental indicators so they're not stuck in their warm-up period. It does **not** become part of `completedCandles`.
 
-When `connectIndicators` sets up the chart, it uses `candles` for backfill **and** tries to prime the chart with `live.completedCandles` if non-empty. Be explicit about which source drives `setCandles()`.
+When `connectIndicators` sets up the chart, it uses `candles` for indicator backfill **and** — unless you pass `initHistory: false` — calls `chart.setCandles(live.completedCandles)` unconditionally, even when `completedCandles` is empty, which clears any candles you set yourself. Pass `initHistory: false` to keep your own `setCandles()` data.
 
 ### Re-using the same `live` across charts
 
-One `LiveCandle` per data source; one chart per view. If you need the same data on two charts, register indicators on both via `connectIndicators` — they'll share the underlying `live` state.
+One `LiveCandle` per data source; one chart per view. Sharing the same `live` across two `connectIndicators` connections is not supported out of the box: adding the same preset from the second connection derives the same snapshot name, and `LiveCandle.addIndicator` throws `Indicator "<name>" already registered`. Either give the second connection a distinct explicit `snapshotName` per add (this registers a separate indicator instance — incremental state is not shared), or drive the second chart directly from `live.on('tick')`.
 
 ### Forgetting to handle `partial: true`
 

--- a/packages/chart/docs/PLUGINS.md
+++ b/packages/chart/docs/PLUGINS.md
@@ -7,7 +7,7 @@ The chart exposes two plugin surfaces:
 | **Series renderer** | A new series type with its own rendering logic | "I need to draw Renko / Point&Figure / a custom candle style" |
 | **Pane primitive** | A free-form overlay on a pane (not tied to a data series) | "I want to draw support zones / session backgrounds / a watermark per pane" |
 
-Both plugins are plain objects you register on the chart instance. No build step, no magic discovery — the chart just calls your `render` function every frame.
+Both plugins are plain objects you register on the chart instance. No build step, no magic discovery — the chart just calls your `render` function on every invalidated frame.
 
 ## Table of Contents
 
@@ -34,13 +34,14 @@ SeriesRendererPlugin:                       Plugin owns: render, price range,
 
 PrimitivePlugin:                            Plugin owns: state, render
   plugin defines defaultState → chart       Chart owns: pane layout, z-order,
-  calls render(state) every frame           canvas lifecycle
+  calls render(state) on each               canvas lifecycle
+  invalidated frame
 ```
 
 - Pick a **series renderer** when you want per-bar data flowing through the standard `addIndicator` API and the chart to auto-scale around it.
 - Pick a **primitive** when you have a logically flat overlay (zones, bands, markers) that doesn't map cleanly onto a series.
 
-Many of TrendCraft's built-in visualizations (`addBacktest`, `addPatterns`, `addScores`, the regime heatmap, the SMC layer) are primitives.
+Several of TrendCraft's built-in visualizations (the regime heatmap, the SMC layer, and the other modules in `packages/chart/src/plugins/`) are primitives. `addBacktest`, `addPatterns`, and `addScores` are not — they use dedicated internal renderers, not the primitive system.
 
 ## Series renderer plugin
 
@@ -162,7 +163,7 @@ const myPrim = definePrimitive<MyState>({
 | `name` | `string` | Yes | Unique identifier. Used by `chart.removePrimitive(name)`. |
 | `pane` | `string` | Yes | Target pane: `'main'`, a specific pane id, or `'all'` to render on every pane. |
 | `zOrder` | `'below' \| 'above'` | Yes | Render order relative to series. `'below'` = backgrounds, `'above'` = annotations. |
-| `defaultState` | `TState` | Yes | Initial state object. The chart holds a mutable reference. |
+| `defaultState` | `TState` | Yes | Initial state object. The chart takes a shallow copy at registration, so later mutations of your original object are not seen — change state via the `update` hook or by re-registering under the same `name`. |
 | `render` | `(ctx, state) => void` | Yes | Draw the primitive. Called once per frame per matched pane. |
 | `update` | `(state) => state` | No | Optional state transform called before each render. Return a new state to replace the current one. |
 | `destroy` | `() => void` | No | Called on `chart.destroy()`. |
@@ -296,7 +297,7 @@ registerPrimitive(plugin)
 
 ### Primitive with external state
 
-If your primitive's state comes from outside the chart (e.g., a reactive store), keep a reference in the closure and read from it in `render`. The chart calls `render` every frame, so changes show up on the next tick.
+If your primitive's state comes from outside the chart (e.g., a reactive store), keep a reference in the closure and read from it in `render`. Rendering is invalidation-driven, not per-frame — after mutating the closure state, trigger a repaint (the simplest way is to re-register the primitive via `chart.registerPrimitive(...)`, which marks the chart dirty; any other chart mutation also works).
 
 ```typescript
 let currentZones: Zone[] = [];
@@ -315,7 +316,7 @@ const srZones = definePrimitive({
 export function setZones(zones: Zone[]) { currentZones = zones; }
 ```
 
-The built-in `connectRegimeHeatmap`, `connectSmcLayer`, etc. use this pattern — they return a handle that lets you push new state without re-registering.
+The built-in `connectRegimeHeatmap`, `connectSmcLayer`, etc. take a different approach: their handle's `update()` builds a fresh primitive with the new state baked into `defaultState` and calls `chart.registerPrimitive(...)` again — re-registering under the same name replaces the prior entry (and runs its `destroy`), which also marks the chart dirty so the update paints.
 
 ### Connect-style helpers
 

--- a/packages/chart/docs/assets/README.md
+++ b/packages/chart/docs/assets/README.md
@@ -8,10 +8,10 @@ Screenshots referenced from `packages/chart/README.md` and the docs under `packa
 |---|---|---|
 | `hero.png` | `hero` | README (top) — mountain base for a clean first impression |
 | `hero-candle.png` | `hero-candle` | GUIDE — candlestick variant with the same indicator stack |
-| `auto-detection.png` | `auto-detection` | README "Series Auto-Detection" section |
-| `chart-types.png` | `chart-types` | README "Chart Types" table |
-| `plugin-regime.png` | `plugin-regime` | README "Plugin System" section |
-| `backtest.png` | `backtest` | README "Backtest Visualization" section |
+| `auto-detection.png` | `auto-detection` | README "With TrendCraft — zero-config indicators" section + GUIDE "Auto-detection from `__meta`" section |
+| `chart-types.png` | `chart-types` | llms-full.txt "Chart Types" section |
+| `plugin-regime.png` | `plugin-regime` | llms-full.txt "Plugin System" section |
+| `backtest.png` | `backtest` | llms-full.txt "Backtest Visualization" section |
 
 Each image is 2560×1440 (2x Retina-class), dark theme, pinned font (`"Helvetica Neue", Arial, sans-serif`). File sizes typically land in the 150–500 KB range. Prefer PNG; WebP is fine if you need smaller files for a specific image.
 

--- a/packages/chart/examples/docs-screenshots/README.md
+++ b/packages/chart/examples/docs-screenshots/README.md
@@ -45,8 +45,8 @@ Runs the Vite dev server on port 5175 in the background, then drives `agent-brow
 
 | id | purpose | indicators |
 |---|---|---|
-| `hero` | README top, mountain base | SMA 5 / 20 / 60 + RSI + MACD |
-| `hero-candle` | GUIDE, candlestick variant | same |
+| `hero` | README top, clean candlestick beauty shot (~170-bar window) | Bollinger Bands + SMA 50 |
+| `hero-candle` | GUIDE, candlestick variant | SMA 5 / 20 / 60 + RSI + MACD |
 | `auto-detection` | show five distinct shape types | SMA + Bollinger + RSI + Stochastics + MACD |
 | `chart-types` | 2×2 of candle / line / mountain / ohlc | — |
 | `plugin-regime` | plugin showcase | HMM regime heatmap on SMA 20 |

--- a/packages/chart/examples/docs-screenshots/src/scenes/hero-candle.ts
+++ b/packages/chart/examples/docs-screenshots/src/scenes/hero-candle.ts
@@ -1,7 +1,8 @@
 /**
  * Candlestick-based hero variant, for docs pages that want the trader
  * signal rather than the cleaner mountain base.
- * Same indicator stack as hero.ts.
+ * Uses an SMA 5/20/60 ribbon plus RSI and MACD panes (hero.ts uses
+ * Bollinger Bands + SMA 50 instead).
  */
 
 import type { CandleData } from "@trendcraft/chart";

--- a/packages/chart/examples/indicator-showcase/README.md
+++ b/packages/chart/examples/indicator-showcase/README.md
@@ -1,8 +1,9 @@
 # indicator-showcase
 
-Catalog demo for `@trendcraft/chart`. Every preset registered with
-`registerTrendCraftPresets` (104+ entries) is exposed via a categorized sidebar
-with parameter controls, live mode, signal panel, and plugin panel.
+Catalog demo for `@trendcraft/chart`. Every preset in `indicatorPresets` from
+`trendcraft` (104+ entries) is exposed via a categorized sidebar with parameter
+controls, live mode, signal panel, and plugin panel; `registerTrendCraftPresets`
+wires up their TrendCraft-specific rendering.
 
 ## Setup
 
@@ -27,7 +28,7 @@ pnpm dev
 - **Plugins panel** — toggle Regime Heatmap, SMC Layer, Wyckoff Phase, etc.
 - **Last-value badges** — `Badges` and `Mode` toolbar buttons exercise
   `showSeriesBadges` / `seriesBadgeMode` (absolute vs visible).
-- **Theme + PNG export** — light/dark and `chart.exportPng()`.
+- **Theme + PNG export** — light/dark and `chart.toImage("image/png")`.
 
 ## When to read this code
 

--- a/packages/chart/examples/strategy-studio/README.md
+++ b/packages/chart/examples/strategy-studio/README.md
@@ -2,7 +2,7 @@
 
 A 1-screen React example that aims to be the **flagship integration demo** of TrendCraft — the place where you can touch every layer (indicator, chart, signal, backtest, risk, meta-strategy, portfolio, MCP) without setting up your own project.
 
-The studio runs **fully offline with no LLM key**. It uses `detectMarketRegime` and `suggestForRegime` from `trendcraft/manifest` rule-based, so anyone can launch it and see a regime-aware setup immediately.
+The studio runs **fully offline with no LLM key**. It uses `detectMarketRegime` from `trendcraft` and `suggestForRegime` from `trendcraft/manifest`, rule-based, so anyone can launch it and see a regime-aware setup immediately.
 
 ## Why a third example?
 
@@ -42,9 +42,9 @@ The studio now spans every feature surface from the original plan; remaining roa
 
 ## Architecture notes
 
-- **`registerTrendCraftPresets(chart)` is required**, not optional. Calling `connectIndicators` with `indicatorPresets` without it leaves TrendCraft-specific shapes (`adaptiveRsi`, `connorsRsi`, `klinger`, `vsa`) silently rendering as generic "Indicator"/"Series". See `src/App.tsx` and `packages/chart/docs/COOKBOOK.md` Recipe 1.
+- **`registerTrendCraftPresets(chart)` is required**, not optional. Calling `connectIndicators` with `indicatorPresets` without it leaves TrendCraft-specific shapes (`adaptiveRsi`, `connorsRsi`, `klinger`, `vsa`) silently rendering as generic "Indicator"/"Series". See `src/App.tsx` and `packages/chart/docs/COOKBOOK.md` Recipe 2.
 - **Phase 2 seam**: all domain calls go through `lib/studio-api.ts`'s `StudioAPI` interface. PR2 ships `localStudioAPI` (calls trendcraft directly). A future `mcpStudioAPI` will let LLM tool-use drive the same surface unchanged.
-- **kind ↔ preset key alias**: `trendcraft/manifest` uses long names (`bollingerBands`); `indicatorPresets` uses short keys (`bb`). 13 mappings in `KIND_TO_PRESET_KEY`. Manifest entries with no preset (`hmmRegimes`, `liquiditySweep`) render as disabled.
+- **kind ↔ preset key alias**: `trendcraft/manifest` uses long names (`bollingerBands`); `indicatorPresets` uses short keys (`bb`). 15 mappings live in core's `KIND_ALIASES` table, consumed via `getIndicatorPreset` / `getIndicatorPresetKey` from `trendcraft` (single owner — the studio keeps no table of its own). Manifest entries with no preset (`hmmRegimes`, `liquiditySweep`) render as disabled.
 
 ## How to run
 

--- a/packages/chart/src/core/format.ts
+++ b/packages/chart/src/core/format.ts
@@ -9,11 +9,12 @@
 
 /**
  * Auto-format price based on magnitude.
- * - >= 10000 → "12,345" (0 decimals)
+ * - >= 10000 → "12345" (0 decimals)
  * - >= 100   → "234.56" (2 decimals)
  * - >= 1     → "1.234" (3 decimals)
  * - >= 0.01  → "0.0456" (4 decimals)
- * - < 0.01   → "0.00001234" (8 decimals)
+ * - >= 0.0001 → "0.000123" (6 decimals)
+ * - < 0.0001 → "0.00001234" (8 decimals)
  */
 export function autoFormatPrice(price: number): string {
   const abs = Math.abs(price);

--- a/packages/chart/src/core/scale.ts
+++ b/packages/chart/src/core/scale.ts
@@ -559,7 +559,8 @@ function localDayKey(time: number): number {
 
 /**
  * Maps price values to y-pixel positions within a pane.
- * Supports linear, logarithmic, and percent scaling.
+ * Supports linear and logarithmic scaling. ("percent" is accepted by the
+ * ScaleMode type but is not yet implemented and currently renders as linear.)
  */
 export class PriceScale {
   private _mode: ScaleMode = "linear";

--- a/packages/chart/src/core/types/config.ts
+++ b/packages/chart/src/core/types/config.ts
@@ -17,7 +17,7 @@ export type ChartOptions = {
   pixelRatio?: number;
   /** Right margin for price axis in pixels (default: 60) */
   priceAxisWidth?: number;
-  /** Bottom margin for time axis in pixels (default: 24) */
+  /** Bottom margin for time axis in pixels (default: 32) */
   timeAxisHeight?: number;
   /** Font family (default: system) */
   fontFamily?: string;
@@ -94,7 +94,7 @@ export type SessionGapsOptions = {
   /**
    * Detection mode:
    * - `"timeGap"` (default): insert a gap whenever the time delta between
-   *   consecutive bars exceeds `gapThresholdMs` (or 2 × median when unset).
+   *   consecutive bars exceeds `gapThresholdMs` (or 4 hours when unset).
    *   Works correctly regardless of data timezone.
    * - `"dayBoundary"`: insert a gap whenever the UTC calendar day changes
    *   between consecutive bars. Useful for 24×7 data (crypto / FX) where
@@ -106,7 +106,7 @@ export type SessionGapsOptions = {
   sizeBars?: number;
   /** Only enable if median bar interval ≤ this many ms (default: 6h). */
   intradayThresholdMs?: number;
-  /** For `"timeGap"` mode: the minimum delta to count as a session gap (default: 2 × median). */
+  /** For `"timeGap"` mode: the minimum delta to count as a session gap (default: 4 hours). */
   gapThresholdMs?: number;
 };
 

--- a/packages/chart/src/integration/connect-indicators.ts
+++ b/packages/chart/src/integration/connect-indicators.ts
@@ -26,8 +26,8 @@
  * conn.add(sma5);
  *
  * // Individual and bulk removal
- * conn.remove("sma5");  // remove just one instance (snapshotName match)
- * conn.remove("sma");   // remove all remaining sma instances (preset id fallback)
+ * conn.remove("sma_close_5"); // remove just one instance (snapshotName match)
+ * conn.remove("sma");         // remove all remaining sma instances (preset id fallback)
  *
  * conn.disconnect();
  * ```
@@ -179,7 +179,7 @@ export type IndicatorConnection = {
   /**
    * Remove indicator(s). Accepts:
    * - an `IndicatorHandle` → removes that instance
-   * - a snapshot name (e.g. `"sma5"`) → removes that single instance
+   * - a snapshot name (e.g. `"sma_close_5"`) → removes that single instance
    * - a preset id (e.g. `"sma"`) with no matching snapshot name → removes all instances of that preset
    */
   remove(target: string | IndicatorHandle): void;

--- a/packages/chart/src/integration/connect-live-primitives.ts
+++ b/packages/chart/src/integration/connect-live-primitives.ts
@@ -12,13 +12,14 @@
  *
  * @example
  * ```ts
- * import { connectIndicators, connectLivePrimitives, connectSrConfluence, srZones } from "@trendcraft/chart";
+ * import { connectIndicators, connectLivePrimitives, connectSrConfluence } from "@trendcraft/chart";
+ * import { srZones } from "trendcraft";
  *
  * const conn = connectIndicators(chart, { presets, candles, live: source });
- * const sr = connectSrConfluence(chart, srZones(source.completedCandles));
+ * const sr = connectSrConfluence(chart, srZones(source.completedCandles).zones);
  *
  * const live = connectLivePrimitives(source, [
- *   { recompute: (candles) => srZones(candles), handle: sr, name: "sr" },
+ *   { recompute: (candles) => srZones(candles).zones, handle: sr, name: "sr" },
  * ]);
  *
  * // later

--- a/packages/chart/src/plugins/sr-confluence.ts
+++ b/packages/chart/src/plugins/sr-confluence.ts
@@ -2,7 +2,8 @@
  * S/R Zone Confluence Plugin — Visualizes multi-source support/resistance zones
  * as strength-colored horizontal bands.
  *
- * Zone opacity and width scale with strength score (0-100).
+ * Zone opacity scales with strength score (0-100); the band height comes
+ * from the zone's low/high prices.
  * Sources are labeled: swing, pivot, VWAP, round, volumeProfile, custom.
  *
  * @example

--- a/packages/chart/src/plugins/trade-analysis.ts
+++ b/packages/chart/src/plugins/trade-analysis.ts
@@ -13,7 +13,7 @@
  *
  * const chart = createChart(el);
  * chart.setCandles(candles);
- * const result = runBacktest(candles, entry, exit);
+ * const result = runBacktest(candles, entry, exit, { capital: 1_000_000 });
  * const handle = connectTradeAnalysis(chart, result.trades, candles);
  * ```
  */

--- a/packages/chart/src/renderer/backtest-renderer.ts
+++ b/packages/chart/src/renderer/backtest-renderer.ts
@@ -196,7 +196,7 @@ export function renderEquityCurve(
 }
 
 /**
- * Render backtest summary bar at bottom of equity pane.
+ * Render backtest summary bar at the top of the equity pane.
  */
 export function renderBacktestSummary(
   ctx: CanvasRenderingContext2D,

--- a/packages/chart/src/renderer/render-pipeline.ts
+++ b/packages/chart/src/renderer/render-pipeline.ts
@@ -624,8 +624,9 @@ export function renderFrame(rc: RenderContext): RenderResult {
     rc.crosshair,
   );
 
-  // Crosshair event emission is handled by CanvasChart._render() with
-  // change-detection so it only fires when the index actually moves.
+  // Crosshair event emission is handled by CanvasChart's viewport interaction
+  // callback (_maybeEmitCrosshair) with change-detection so it only fires
+  // when the index actually moves.
   // Emitting every frame (as this used to) broke syncCharts: the
   // round-trip A→B→A crosses a requestAnimationFrame boundary, so the
   // synchronous re-entry guard can't stop the echo.

--- a/packages/chart/src/sparkline/types.ts
+++ b/packages/chart/src/sparkline/types.ts
@@ -41,7 +41,7 @@ export type HoverPayload = {
   type: "line" | "candle";
   /** For line mode: the close value at index. For candle: candle.close. */
   value: number;
-  /** Present when underlying data is OHLC. */
+  /** Present only when rendering in candle mode (omitted in line mode — including the density fallback — even when the underlying data is OHLC). */
   candle?: SparklineCandle;
 };
 

--- a/packages/mcp/src/dispatcher/signal-map.ts
+++ b/packages/mcp/src/dispatcher/signal-map.ts
@@ -101,7 +101,7 @@ const REGISTRY: Record<string, SignalDescriptor> = {
     shape: "events",
     oneLiner: "Bullish/bearish divergence between price and RSI swings.",
     paramsHint:
-      "DivergenceOptions — see trendcraft signals docs (period, lookback, swingThreshold, ...)",
+      "{ swingLookback?: number = 5, minSwingDistance?: number = 5, maxSwingDistance?: number = 60, kinds?: ('regular'|'hidden')[] = ['regular'] } — RSI period is fixed at 14",
     fn: (c, o) => rsiDivergence(c, o as Parameters<typeof rsiDivergence>[1]),
   },
   macdDivergence: {
@@ -119,7 +119,8 @@ const REGISTRY: Record<string, SignalDescriptor> = {
   },
   volumeBreakout: {
     shape: "events",
-    oneLiner: "Volume exceeds N-period MA × ratio — breakout volume confirmation.",
+    oneLiner:
+      "Volume exceeds the highest volume of the prior N bars (ratio vs previous high >= minRatio) — breakout volume confirmation.",
     paramsHint: "{ period?: number = 20, minRatio?: number = 1.0 }",
     usesVolume: true,
     fn: (c, o) => volumeBreakout(c, o as Parameters<typeof volumeBreakout>[1]),

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -136,7 +136,7 @@ export function createServer(): McpServer {
         "Cache OHLCV candles in the session and return an opaque `handle`. Pass that handle as `candlesRef` on subsequent `calc_indicator` / `detect_signal` calls instead of re-sending the candle array. " +
         "Designed for multi-tool screens: 5 parallel indicator calls against the same 124-bar series transmits the bars 1× total instead of 5×. " +
         "Inputs: provide either `candles` (canonical `[{time,open,high,low,close,volume?}]`) or `candlesArray` (compact tuple form `[[time,open,high,low,close,volume?], ...]`, ~40% smaller). Optional `symbol` and `hint` are stored as metadata for your own bookkeeping. " +
-        "Output: `{ handle, count, span: { from, to }, symbol?, hint? }`. " +
+        "Output: `{ handle, count, span: { from, to }, symbol?, hint?, storeSize, capacity }` — `storeSize` is the number of handles currently held (including this one), `capacity` is the LRU limit. " +
         "Lifetime: handles live for the duration of the stdio MCP process only — no persistence, no cross-session sharing. Capacity is 50 handles; oldest is silently evicted. Reload is cheap.",
       inputSchema: loadCandlesInputShape,
     },
@@ -153,9 +153,9 @@ export function createServer(): McpServer {
     "detect_signal",
     {
       description:
-        "Detect a trading signal from caller-supplied OHLCV candles. Single-tool dispatcher across crossovers (goldenCross, deadCross), multi-MA alignment (perfectOrder), divergence (rsiDivergence, macdDivergence, obvDivergence), volatility squeeze (bollingerSqueeze), and volume signals (volumeBreakout, volumeAccumulation, volumeMaCross, volumeAboveAverage). " +
+        "Detect a trading signal from caller-supplied OHLCV candles. Single-tool dispatcher across crossovers (goldenCross, deadCross), multi-MA alignment (perfectOrder), divergence (rsiDivergence, macdDivergence, obvDivergence), volatility squeeze (bollingerSqueeze), volume signals (volumeBreakout, volumeAccumulation, volumeMaCross, volumeAboveAverage), and candlestick patterns (candlestickPatterns). " +
         "Candle input: provide exactly one of `candles` (canonical), `candlesArray` (compact tuple form), or `candlesRef` (handle from `load_candles` — cheapest for repeated calls). " +
-        'Output envelope: `{ kind, shape, output, firedAt, count, totalLength, truncated }`. `firedAt` is a token-cheap list of times where the signal triggered — ideal for screening ("did goldenCross fire in the last 5 bars on this symbol?"). `shape` is `series` (boolean per bar) or `events` (sparse event objects). ' +
+        'Output envelope: `{ kind, shape, output, firedAt, count, totalLength, truncated, processedBars, symbol? }`. `firedAt` is a token-cheap list of times where the signal triggered — ideal for screening ("did goldenCross fire in the last 5 bars on this symbol?"). `shape` is `series` (boolean/state value per bar) or `events` (sparse event objects). `processedBars` is the number of input candle bars evaluated; `symbol` is echoed when `candlesRef` is used. ' +
         "Errors: INVALID_INPUT, INVALID_HANDLE, INVALID_PARAMETER, INSUFFICIENT_DATA, UNSUPPORTED_SIGNAL, SIGNAL_ERROR. " +
         "Note: signal kinds are NOT the same set as calc_indicator kinds — call detect_signal with an unknown kind to see the supported list.",
       inputSchema: detectSignalInputShape,


### PR DESCRIPTION
## Summary

Companion to #305 (core) — the chart and MCP portions of the second exhaustive docs-vs-source consistency sweep. Every corrected fact was verified against the implementation and adversarially re-verified by an independent pass before editing. **No runtime behavior changes** — all `.ts` edits are JSDoc comments or description strings.

### Chart

- **docs**: COOKBOOK / LIVE / PLUGINS corrections; `docs/assets/README.md` capture notes
- **example READMEs**: docs-screenshots (stale "same indicator stack as hero.ts" claim — the candle hero uses an SMA 5/20/60 ribbon + RSI + MACD, not hero.ts's BB + SMA 50), indicator-showcase, strategy-studio
- **src JSDoc**: `autoFormatPrice` tier list matched to the actual thresholds (format.ts), `PriceScale` class doc no longer claims a percent mode the scaler doesn't implement (scale.ts), `SessionGapsOptions.gapThresholdMs` semantics (config.ts), `connectIndicators` module `@example` uses the real snapshot name (`sma_close_5`), `connectSrConfluence` `@example` passes `SrZoneData[]` (not the `SrZonesResult` wrapper), `trade-analysis` `@example` calls `runBacktest` with its required options argument, backtest summary renders at the top of the equity pane (backtest-renderer), crosshair emission comment (render-pipeline), sparkline `HoverPayload.candle` presence condition

### MCP

- `server.ts`: the `detect_signal` tool description now enumerates the `candlestickPatterns` kind and the actual result fields (`processedBars`, optional `symbol`)
- `signal-map.ts`: `rsiDivergence` `paramsHint` lists the real `DivergenceOptions` keys and notes the RSI period is fixed at 14; `volumeBreakout` hint describes the prior-N-bars-max comparison the implementation performs

## Test plan

- On this branch in isolation: chart `pnpm test` → **80 files / 917 tests, all pass**; mcp `pnpm test` → **8 files / 80 tests, all pass**
- On the full working tree (all four audit PRs together): `pnpm build` passes; core 6281 / chart 924 / mcp 80 / strategy-studio 108 all pass