### PR TITLE
test(core): Tier 1.5 doc-correctness harnesses (docs typecheck, type mirror, JSDoc examples, options-key wiring, EN/JA parity)

### DIFF
--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -10,11 +10,15 @@
   - [出来高](#出来高)
   - [相対強度（RS）](#相対強度rs)
   - [価格](#価格)
+  - [S/Rゾーンクラスタリング](#srゾーンクラスタリング)
   - [フィボナッチリトレースメント](#フィボナッチリトレースメント)
   - [スマートマネーコンセプト (SMC)](#スマートマネーコンセプト-smc)
+  - [セッション / キルゾーン](#セッション--キルゾーン)
+  - [HMMレジーム検出](#hmmレジーム検出)
 - [シグナル](#シグナル)
   - [クロス検出](#クロス検出)
   - [ダイバージェンス検出](#ダイバージェンス検出)
+  - [CVDダイバージェンス](#cvdダイバージェンス)
   - [スクイーズ検出](#スクイーズ検出)
   - [レンジ相場検出](#レンジ相場検出)
   - [価格パターン](#価格パターン)
@@ -198,7 +202,7 @@ McGinley Dynamic — 市場速度に自動適応するMA。速い市場でのラ
 
 ```typescript
 const result = mcginleyDynamic(candles);
-const custom = mcginleyDynamic(candles, { period: 20, k: 0.6, source: 'close' });
+const custom = mcginleyDynamic(candles, { period: 14, k: 0.6 });
 ```
 
 **オプション:**
@@ -222,7 +226,7 @@ EMAリボン — 複数EMAの束でトレンド強度・方向を可視化。
 
 ```typescript
 const result = emaRibbon(candles);
-const custom = emaRibbon(candles, { periods: [8, 13, 21, 34, 55], source: 'close' });
+const custom = emaRibbon(candles, { periods: [8, 13, 21, 34, 55] });
 ```
 
 **オプション:**
@@ -391,7 +395,7 @@ interface MacdValue {
 
 ```typescript
 // ストキャスティクス（デフォルト slowing: 3 = スロー相当）
-const raw = stochastics(candles, { kPeriod: 14, dPeriod: 3 });
+const result = stochastics(candles, { kPeriod: 14, dPeriod: 3 });
 // 生（未平滑）にする場合は slowing: 1 を明示
 // const fastRaw = stochastics(candles, { kPeriod: 14, dPeriod: 3, slowing: 1 });
 
@@ -777,7 +781,10 @@ interface VwapValue {
   lower: number | null;  // 下バンド（VWAP - 標準偏差）
   bands?: VwapBand[];    // bandMultipliers指定時の追加バンド
 }
-interface VwapBand { upper: number; lower: number; }
+interface VwapBand {
+  upper: number;  // 上バンド値
+  lower: number;  // 下バンド値
+}
 ```
 
 ---
@@ -1077,7 +1084,7 @@ TWAP（時間加重平均価格） — セッション内のTypical Priceの均�
 
 ```typescript
 const result = twap(candles);
-const custom = twap(candles, { sessionResetPeriod: 'session' });
+const fixed = twap(candles, { sessionResetPeriod: 30 });
 ```
 
 **オプション:**
@@ -1095,7 +1102,7 @@ Weis Wave Volume — 波動方向ごとにボリュームを累積。
 
 ```typescript
 const result = weisWave(candles);
-const custom = weisWave(candles, { method: 'close', threshold: 0 });
+const custom = weisWave(candles, { method: 'highlow', threshold: 0.5 });
 ```
 
 **オプション:**
@@ -1109,7 +1116,7 @@ const custom = weisWave(candles, { method: 'close', threshold: 0 });
 ```typescript
 interface WeisWaveValue {
   waveVolume: number;          // 波動の累積ボリューム
-  direction: "up" | "down";    // 波動の方向
+  direction: 'up' | 'down';    // 波動の方向
 }
 ```
 
@@ -1121,11 +1128,7 @@ Market Profile / TPO — 価格帯ごとの滞在時間分析。POC・Value Area
 
 ```typescript
 const result = marketProfile(candles);
-const custom = marketProfile(candles, {
-  tickSize: 0.01,
-  sessionResetPeriod: 'session',
-  valueAreaPercent: 0.70
-});
+const custom = marketProfile(candles, { tickSize: 0.5, valueAreaPercent: 0.70 });
 ```
 
 **オプション:**
@@ -1148,6 +1151,137 @@ interface MarketProfileValue {
 
 ---
 
+#### `cvd(candles)`
+
+Cumulative Volume Delta（累積出来高デルタ） — 各バーのレンジ内で終値がどこに位置するかから買い圧力・売り圧力を推定し、デルタを累積します。
+
+```typescript
+const cvdData = cvd(candles);
+const current = cvdData[cvdData.length - 1].value;
+const previous = cvdData[cvdData.length - 2].value;
+
+// CVD上昇 = 買い圧力優勢
+if (current !== null && previous !== null && current > previous) {
+  // 買い圧力が優勢
+}
+```
+
+**計算方法:**
+- `buyVolume = volume × (close - low) / (high - low)`
+- `sellVolume = volume - buyVolume`
+- `delta = buyVolume - sellVolume`
+- `CVD = デルタの累積和`
+
+**戻り値:** `Series<number>`
+
+**解釈:**
+- CVD上昇: 買い圧力優勢（アキュミュレーション）
+- CVD下降: 売り圧力優勢（ディストリビューション）
+- CVDと価格のダイバージェンスは反転の可能性を示唆
+- 同事線（レンジ = 0）: delta = 0
+
+---
+
+#### `cvdWithSignal(candles, options)`
+
+EMA平滑化とシグナルラインをオプションで付加したCVD。
+
+```typescript
+const data = cvdWithSignal(candles, { smoothing: 5, signalPeriod: 9 });
+const last = data[data.length - 1].value;
+
+// CVDがシグナルを上抜け = 強気
+if (last.cvd > last.signal!) {
+  // 強気モメンタム
+}
+```
+
+**オプション:**
+| オプション | 型 | デフォルト | 説明 |
+|-----------|------|-----------|------|
+| `smoothing` | `number` | `1` | CVDのEMA平滑化期間（1 = 平滑化なし） |
+| `signalPeriod` | `number` | `9` | シグナルラインのEMA期間 |
+
+**戻り値:** `Series<CvdWithSignalValue>`
+
+```typescript
+interface CvdWithSignalValue {
+  cvd: number;              // CVD値（平滑化されている場合あり）
+  signal: number | null;    // シグナルライン（CVDのEMA）、ウォームアップ中はnull
+}
+```
+
+---
+
+### S/Rゾーンクラスタリング
+
+#### `srZones(candles, options)`
+
+複数のソースから価格レベルを収集し、K-means++でクラスタリングしてサポート/レジスタンスゾーンを特定します。各ゾーンはタッチ回数・ソース多様性・新しさでスコアリングされます。
+
+```typescript
+const result = srZones(candles);
+console.log(result.zones[0]);
+// { price: 100.5, low: 99.8, high: 101.2, touchCount: 5,
+//   sourceDiversity: 3, sources: ['swing', 'pivot', 'round'], strength: 85 }
+```
+
+**収集されるソース:**
+- **スイングポイント**: スイングハイ・スイングロー
+- **ピボットポイント**: PP、R1、R2、S1、S2
+- **VWAP**: 直近のVWAP値
+- **ボリュームプロファイル**: POC、Value Area上限/下限
+- **ラウンドナンバー**: 価格レンジに基づく自動検出間隔
+- **カスタムレベル**: ユーザー指定の価格レベル
+
+**オプション:**
+| オプション | 型 | デフォルト | 説明 |
+|-----------|------|-----------|------|
+| `numZones` | `number` | `auto` | ゾーン数（auto: `min(max(3, levels/3), 15)`） |
+| `zoneWidth` | `number` | `0.5` | ゾーン幅のATR倍率 |
+| `includeRoundNumbers` | `boolean` | `true` | ラウンドナンバーを含める |
+| `includeSwingPoints` | `boolean` | `true` | スイングポイントを含める |
+| `includePivotPoints` | `boolean` | `true` | ピボットポイントを含める |
+| `includeVwap` | `boolean` | `true` | VWAPレベルを含める |
+| `includeVolumeProfile` | `boolean` | `true` | ボリュームプロファイルレベルを含める |
+| `customLevels` | `number[]` | `[]` | カスタム価格レベル |
+| `swingLookback` | `number` | `5` | スイングポイントのルックバック本数 |
+| `maxIterations` | `number` | `50` | K-meansの最大反復回数 |
+
+**戻り値:** `SrZonesResult`
+
+```typescript
+interface SrZonesResult {
+  zones: SrZone[];              // 強度の降順でソートされたゾーン
+  rawLevels: PriceLevelSource[];  // クラスタリング前の全生レベル
+}
+
+interface SrZone {
+  price: number;          // 加重セントロイド
+  low: number;            // 下限（セントロイド − zoneWidth × ATR）
+  high: number;           // 上限（セントロイド + zoneWidth × ATR）
+  touchCount: number;     // クラスタ内の生レベル数
+  sourceDiversity: number; // ユニークなソース種別数
+  sources: string[];      // ユニークなソース種別のリスト
+  strength: number;       // スコア0-100（touchCount 40% + 多様性 40% + 新しさ 20%）
+}
+```
+
+---
+
+#### `srZonesSeries(candles, options)`
+
+`srZones`のローリング版 — ルックバックウィンドウを使って各バーでゾーンを計算します。
+
+```typescript
+const series = srZonesSeries(candles, { numZones: 5 });
+const currentZones = series[series.length - 1].value;
+```
+
+**戻り値:** `Series<SrZone[]>`
+
+---
+
 ### 相対強度（RS）
 
 #### `benchmarkRS(candles, benchmark, options)`
@@ -1162,7 +1296,7 @@ const rs = benchmarkRS(stockCandles, sp500Candles, { period: 52 });
 
 // アウトパフォームしている銘柄を探す
 const latest = rs[rs.length - 1];
-if (latest.value.rsRating > 80 && latest.value.trend === 'up') {
+if (latest.value.rsRating !== null && latest.value.rsRating > 80 && latest.value.trend === 'up') {
   console.log('相対強度が強い！');
 }
 ```
@@ -1226,13 +1360,13 @@ import { rankByRS, topByRS, filterByRSPercentile } from 'trendcraft';
 
 // 全銘柄をRSでランキング
 const symbolsData = new Map([
-  ['トヨタ', toyotaCandles],
-  ['ソニー', sonyCandles],
-  ['任天堂', nintendoCandles],
+  ['AAPL', aaplCandles],
+  ['GOOGL', googlCandles],
+  ['MSFT', msftCandles],
 ]);
 
 const rankings = rankByRS(symbolsData, { period: 52 });
-// [{ symbol: 'トヨタ', rs: 1.18, rank: 1, percentile: 100, performance: 18 }, ...]
+// [{ symbol: 'AAPL', rank: 1, percentile: 92, ... }, ...]
 
 // 上位5銘柄を取得
 const top5 = topByRS(symbolsData, 5);
@@ -1757,6 +1891,261 @@ if (hasRecentSweepSignal(candles, "bullish")) {
 
 ---
 
+### セッション / キルゾーン
+
+ICT標準のセッション検出、キルゾーン特定、セッション統計、セッションブレイクアウト検出。時刻はすべてUTC（ET = UTC-5、DSTは無視）。
+
+#### `getIctSessions()`
+
+UTCでの標準ICTセッション4つを返します。
+
+```typescript
+const sessions = getIctSessions();
+// [{ name: 'Asia', startHour: 0, startMinute: 0, endHour: 5, endMinute: 0 },
+//  { name: 'London', startHour: 7, ... }, { name: 'NY AM', ... }, { name: 'NY PM', ... }]
+```
+
+| セッション | UTC時刻 | ET時刻 | 特徴 |
+|-----------|----------|---------|----------------|
+| Asia | 00:00-05:00 | 19:00-00:00 | 低流動性、レンジ形成 |
+| London | 07:00-10:00 | 02:00-05:00 | 欧州勢参入、だまし |
+| NY AM | 13:30-16:00 | 08:30-11:00 | 最大流動性 |
+| NY PM | 18:30-21:00 | 13:30-16:00 | 反転が起きやすい |
+
+---
+
+#### `defineSession(name, startHour, startMinute, endHour, endMinute)`
+
+カスタムセッション定義を作成するファクトリ関数。
+
+```typescript
+const preMarket = defineSession('Pre-Market', 9, 0, 13, 30);
+```
+
+---
+
+#### `detectSessions(candles, sessions?)`
+
+各ローソク足がどのセッションに属するかを判定し、セッションOHLCを追跡します。
+
+```typescript
+const sessionData = detectSessions(candles);
+const i = sessionData.length - 1; // 現在バーのインデックス
+const bar = sessionData[i].value;
+if (bar.inSession) {
+  console.log(`セッション ${bar.session}、ここまでの高値: ${bar.sessionHigh}`);
+}
+```
+
+**戻り値:** `Series<SessionInfo>`
+
+```typescript
+interface SessionInfo {
+  session: string | null;       // セッション名（全セッション外はnull）
+  inSession: boolean;           // 定義されたセッション内かどうか
+  barIndex: number;             // 現在セッション内のバーインデックス（0始まり）
+  sessionOpen: number | null;   // セッション始値
+  sessionHigh: number | null;   // ここまでのセッション高値
+  sessionLow: number | null;    // ここまでのセッション安値
+}
+```
+
+---
+
+#### `sessionStats(candles, options?)`
+
+ルックバック期間にわたるセッション別の集計統計を計算します。
+
+```typescript
+const stats = sessionStats(candles, { lookback: 20 });
+stats.forEach(s => {
+  console.log(`${s.session}: avgRange=${s.avgRange.toFixed(2)}, bullish=${(s.bullishPercent * 100).toFixed(0)}%`);
+});
+```
+
+**オプション:**
+| オプション | 型 | デフォルト | 説明 |
+|-----------|------|-----------|------|
+| `sessions` | `SessionDefinition[]` | ICTセッション | セッション定義 |
+| `lookback` | `number` | `20` | 分析するセッション出現回数 |
+
+**戻り値:** `SessionStatsValue[]`
+
+```typescript
+interface SessionStatsValue {
+  session: string;        // セッション名
+  avgRange: number;       // セッション出現あたりの平均レンジ
+  avgVolume: number;      // セッション出現あたりの平均出来高
+  bullishPercent: number; // 陽線（close > open）の割合
+  barCount: number;       // 全出現通算のバー数
+}
+```
+
+---
+
+#### `getIctKillZones()`
+
+UTCでの標準ICTキルゾーン4つを特徴説明付きで返します。
+
+```typescript
+const zones = getIctKillZones();
+// [{ name: 'Asian KZ', ..., characteristic: 'Range formation, accumulation' }, ...]
+```
+
+| キルゾーン | UTC時刻 | 特徴 |
+|-----------|----------|---------------|
+| Asian KZ | 00:00-05:00 | レンジ形成、アキュミュレーション |
+| London Open KZ | 07:00-09:00 | だまし、ストップ狩り、初動 |
+| NY Open KZ | 12:00-14:00 | 最大流動性、最も強い値動き |
+| London Close KZ | 15:00-17:00 | 反転、利益確定 |
+
+---
+
+#### `killZones(candles, zones?)`
+
+各ローソク足がキルゾーン内かどうかを判定します。
+
+```typescript
+const kz = killZones(candles);
+const i = kz.length - 1; // 現在バーのインデックス
+if (kz[i].value.inKillZone) {
+  console.log(`${kz[i].value.zone} 内: ${kz[i].value.characteristic}`);
+}
+```
+
+**戻り値:** `Series<KillZoneValue>`
+
+```typescript
+interface KillZoneValue {
+  zone: string | null;             // キルゾーン名（外ならnull）
+  inKillZone: boolean;             // いずれかのキルゾーン内かどうか
+  characteristic: string | null;   // 期待される値動きの説明
+}
+```
+
+---
+
+#### `sessionBreakout(candles, options?)`
+
+直近の完了セッションのレンジ上抜け/下抜けを検出します。
+
+```typescript
+const breakouts = sessionBreakout(candles);
+const i = breakouts.length - 1; // 現在バーのインデックス
+if (breakouts[i].value.breakout === 'above') {
+  console.log(`${breakouts[i].value.fromSession} の高値 ${breakouts[i].value.rangeHigh} を上抜け`);
+}
+```
+
+**戻り値:** `Series<SessionBreakoutValue>`
+
+```typescript
+interface SessionBreakoutValue {
+  fromSession: string | null;             // 直前セッション名
+  breakout: 'above' | 'below' | null;    // ブレイクアウト方向
+  rangeHigh: number | null;              // 直前セッション高値
+  rangeLow: number | null;               // 直前セッション安値
+}
+```
+
+---
+
+### HMMレジーム検出
+
+確率的な市場レジーム分類のための隠れマルコフモデル。外部依存ゼロの純TypeScript実装（Baum-Welch / Viterbi）。
+
+#### `hmmRegimes(candles, options?)`
+
+ガウシアンHMMで市場レジームを検出。特徴量（リターン、ボラティリティ、出来高比率、レンジ、実体比率）を抽出し、EMでモデルをフィットして最尤状態系列をデコードします。
+
+```typescript
+const regimes = hmmRegimes(candles, { numStates: 3, seed: 42 });
+const current = regimes[regimes.length - 1].value;
+console.log(`レジーム: ${current.label}, P=${current.probabilities}`);
+// レジーム: "trending-up", P=[0.02, 0.08, 0.90]
+```
+
+**オプション:**
+| オプション | 型 | デフォルト | 説明 |
+|-----------|------|-----------|------|
+| `numStates` | `number` | `3` | レジーム状態数 |
+| `maxIterations` | `number` | `100` | EMの最大反復回数 |
+| `seed` | `number` | `42` | 再現性のための乱数シード |
+| `numRestarts` | `number` | `5` | 局所最適回避のランダム再スタート回数 |
+| `featureOptions` | `FeatureOptions` | `{}` | 特徴量抽出の設定 |
+
+**特徴量オプション:**
+| オプション | 型 | デフォルト | 説明 |
+|-----------|------|-----------|------|
+| `returnLookback` | `number` | `1` | リターン計算のルックバック |
+| `volatilityWindow` | `number` | `20` | ローリングボラティリティのウィンドウ |
+| `volumeWindow` | `number` | `20` | 出来高比率のウィンドウ |
+
+**戻り値:** `Series<HmmRegimeValue>`
+
+```typescript
+interface HmmRegimeValue {
+  regime: number;           // レジームインデックス（0始まり）
+  label: string;            // "trending-up" | "ranging" | "trending-down"（3状態時）
+  probabilities: number[];  // この時点での状態確率
+  logLikelihood: number;    // フィット済みモデルの対数尤度
+}
+```
+
+**ラベル（3状態モデル）:** 状態は平均リターンでソート — 最低 = "trending-down"、中間 = "ranging"、最高 = "trending-up"。N ≠ 3 の場合、ラベルは "state-0"、"state-1" など。
+
+---
+
+#### `fitHmm(candles, options?)`
+
+デコードせずにHMMをフィット — 分析用の学習済みモデルを返します。
+
+```typescript
+const model = fitHmm(candles, { numStates: 3 });
+console.log(`対数尤度: ${model.logLikelihood}`);
+console.log(`収束: ${model.converged}`);
+```
+
+**戻り値:** `HmmModel`
+
+```typescript
+interface HmmModel {
+  numStates: number;
+  pi: number[];                    // 初期状態確率
+  transitionMatrix: number[][];    // A[i][j] = P(state j | state i)
+  emissionMeans: number[][];       // means[state][feature]
+  emissionVariances: number[][];   // variances[state][feature]
+  logLikelihood: number;
+  converged: boolean;
+}
+```
+
+---
+
+#### `regimeTransitionMatrix(model, labels?)`
+
+フィット済みモデルから遷移分析を抽出します。
+
+```typescript
+const model = fitHmm(candles);
+const info = regimeTransitionMatrix(model);
+console.log(`期待継続期間: ${info.expectedDurations}`);
+console.log(`定常分布: ${info.stationaryDistribution}`);
+```
+
+**戻り値:** `RegimeTransitionInfo`
+
+```typescript
+interface RegimeTransitionInfo {
+  matrix: number[][];             // 遷移確率行列
+  labels: string[];               // 各状態のラベル
+  expectedDurations: number[];    // 各状態の期待滞在バー数: 1 / (1 - 自己遷移確率)
+  stationaryDistribution: number[]; // 長期的な状態確率
+}
+```
+
+---
+
 ## シグナル
 
 ### クロス検出
@@ -1769,11 +2158,7 @@ if (hasRecentSweepSignal(candles, "bullish")) {
 const crosses = crossOver(shortMA, longMA);
 ```
 
-**戻り値:** `Series<boolean>`
-
-```typescript
-// crossOver/crossUnder return Series<boolean> ({ time, value: boolean }) — true at the bar where the cross occurs.
-```
+**戻り値:** `Series<boolean>`（クロスが発生したバーでtrue）
 
 ---
 
@@ -1861,6 +2246,22 @@ const signals = macdDivergence(candles);
 
 ---
 
+### CVDダイバージェンス
+
+#### `cvdDivergence(candles, options)`
+
+価格とCumulative Volume Delta（CVD）のダイバージェンスを検出。内部で `detectDivergence()` を使用します。
+
+```typescript
+const signals = cvdDivergence(candles);
+const bullish = signals.filter(s => s.type === 'bullish');
+// 強気: 価格は安値更新、CVDは安値切り上げ → 買い圧力の蓄積
+const bearish = signals.filter(s => s.type === 'bearish');
+// 弱気: 価格は高値更新、CVDは高値切り下げ → 売り圧力の蓄積
+```
+
+---
+
 **オプション（全ダイバージェンス関数共通）:**
 | オプション | 型 | デフォルト | 説明 |
 |------------|------|---------|------|
@@ -1918,108 +2319,106 @@ interface SqueezeSignal {
 
 ### レンジ相場検出
 
-#### `rangeBound(candles, options)`
+#### `rangeBound(candles, options?)`
 
 レンジ相場（ボックス相場）を検出。複数の指標を組み合わせて、トレンドのない横ばい期間を識別します。
 
 ```typescript
-const result = rangeBound(candles);
-const custom = rangeBound(candles, {
-  dmiPeriod: 14,
-  adxTrendThreshold: 25,
-  donchianPeriod: 20,
-  persistBars: 3,
-});
+const rb = rangeBound(candles, { persistBars: 3 });
 ```
 
 **オプション:**
+
 | オプション | 型 | デフォルト | 説明 |
 |------------|------|---------|------|
-| `dmiPeriod` | `number` | `14` | DMI/ADX計算期間 |
-| `adxTrendThreshold` | `number` | `25` | トレンド判定のADX閾値 |
+| `dmiPeriod` | `number` | `14` | DMI/ADX期間 |
+| `bbPeriod` | `number` | `20` | ボリンジャーバンド期間 |
 | `donchianPeriod` | `number` | `20` | ドンチャンチャネル期間 |
-| `atrPeriod` | `number` | `14` | ATR計算期間 |
-| `tightRangeThreshold` | `number` | `85` | タイトレンジ判定のスコア閾値 |
+| `atrPeriod` | `number` | `14` | ATR期間 |
+| `adxWeight` | `number` | `0.50` | ADXスコアの重み |
+| `bandwidthWeight` | `number` | `0.20` | バンド幅スコアの重み |
+| `donchianWeight` | `number` | `0.20` | ドンチャン幅スコアの重み |
+| `atrWeight` | `number` | `0.10` | ATRスコアの重み |
+| `adxThreshold` | `number` | `20` | この値未満のADX = レンジ |
+| `adxTrendThreshold` | `number` | `25` | この値超のADX = トレンド |
 | `rangeScoreThreshold` | `number` | `70` | レンジ検出のスコア閾値 |
-| `breakoutRiskZone` | `number` | `0.1` | レンジ境界付近のブレイクアウトリスクゾーン（10%） |
-| `persistBars` | `number` | `3` | 状態維持の最小バー数 |
-| `adxWeight` | `number` | `0.5` | ADXスコアの重み |
-| `bandwidthWeight` | `number` | `0.2` | バンド幅スコアの重み |
-| `donchianWeight` | `number` | `0.2` | ドンチャン幅スコアの重み |
-| `atrWeight` | `number` | `0.1` | ATRスコアの重み |
-| `diDifferenceThreshold` | `number` | `10` | +DI/-DI差分閾値 |
-| `slopeThreshold` | `number` | `0.15` | 線形回帰傾き閾値（ATR比） |
-| `consecutiveHHLLThreshold` | `number` | `3` | 連続HH/LL回数閾値 |
-| `hhllLookback` | `number` | `10` | HH/LL判定の参照期間 |
-| `priceMovementThreshold` | `number` | `0.05` | 価格変動閾値（5%） |
-| `priceMovementPeriod` | `number` | `20` | 価格変動判定期間 |
+| `tightRangeThreshold` | `number` | `85` | タイトレンジ判定のスコア閾値 |
+| `breakoutRiskZone` | `number` | `0.1` | 境界付近のブレイクアウトリスクゾーン（10%） |
+| `persistBars` | `number` | `3` | 確定に必要なバー数 |
+| `lookbackPeriod` | `number` | `100` | パーセンタイル計算のルックバック |
+| `priceMovementPeriod` | `number` | `20` | 価格変動計算の期間 |
+| `priceMovementThreshold` | `number` | `0.05` | 5%の価格変動 = トレンド |
+| `diDifferenceThreshold` | `number` | `10` | トレンド判定の+DI/-DI差分 |
+| `slopeThreshold` | `number` | `0.15` | 回帰傾き閾値（ATR比） |
+| `consecutiveHHLLThreshold` | `number` | `3` | トレンド判定の連続HH/LL回数 |
+| `hhllLookback` | `number` | `10` | HH/LL検出のルックバック |
 
 **戻り値:** `Series<RangeBoundValue>`
 
+**RangeBoundValueのプロパティ:**
+
+| プロパティ | 型 | 説明 |
+|----------|------|-------------|
+| `state` | `RangeBoundState` | 現在の状態 |
+| `rangeScore` | `number` | 複合スコア（0-100） |
+| `confidence` | `number` | 信頼度（0-1） |
+| `persistCount` | `number` | 現在の状態の連続バー数 |
+| `isConfirmed` | `boolean` | persistCount >= persistBars でtrue |
+| `rangeDetected` | `boolean` | イベント: レンジ条件を初検出 |
+| `rangeConfirmed` | `boolean` | イベント: レンジを初確定 |
+| `breakoutRiskDetected` | `boolean` | イベント: ブレイクアウトリスクを初検出 |
+| `rangeBroken` | `boolean` | イベント: レンジからトレンドへの転換 |
+| `adx` | `number \| null` | ADX値 |
+| `rangeHigh` | `number \| null` | レンジ上限 |
+| `rangeLow` | `number \| null` | レンジ下限 |
+| `pricePosition` | `number \| null` | レンジ内の位置（0=下限、1=上限） |
+| `trendReason` | `TrendReason` | トレンド判定の理由（デバッグ用） |
+
+**RangeBoundStateの値:**
+
+| 状態 | 説明 |
+|-------|-------------|
+| `NEUTRAL` | データ不足または混在シグナル |
+| `RANGE_FORMING` | レンジ条件が出始めた |
+| `RANGE_CONFIRMED` | persistBars経過後にレンジ確定 |
+| `RANGE_TIGHT` | 非常にタイトなレンジ |
+| `BREAKOUT_RISK_UP` | 価格が上限付近 |
+| `BREAKOUT_RISK_DOWN` | 価格が下限付近 |
+| `TRENDING` | トレンド中 |
+
+**TrendReasonの値:**
+
+| 理由 | 説明 |
+|--------|-------------|
+| `adx_high` | ADX >= adxTrendThreshold |
+| `price_movement` | 価格変動 >= 閾値 |
+| `di_diff` | +DI/-DI差分 >= 閾値 |
+| `slope` | 回帰傾き >= 閾値 |
+| `hhll` | 連続HHまたはLL >= 閾値 |
+| `null` | トレンドではない |
+
+**例:**
+
 ```typescript
-interface RangeBoundValue {
-  state: RangeBoundState;     // 現在の状態
-  rangeScore: number;         // レンジスコア (0-100)
-  rangeHigh: number | null;   // レンジ上限
-  rangeLow: number | null;    // レンジ下限
-  adx: number | null;         // ADX値
-  donchianWidth: number | null;  // ドンチャンチャネル幅（中値比）
-  atrRatio: number | null;    // 終値比のATR
-  adxScore: number;           // ADXスコア成分 (0-100)
-  bandwidthScore: number;     // バンド幅スコア成分 (0-100)
-  donchianScore: number;      // ドンチャン幅スコア成分 (0-100)
-  atrScore: number;           // ATR比スコア成分 (0-100)
-  rangeBroken: boolean;       // レンジブレイク検出
-  trendReason: TrendReason;   // トレンド判定理由
+import { rangeBound } from 'trendcraft';
+
+const rb = rangeBound(candles);
+const latest = rb[rb.length - 1].value;
+
+// 現在の状態をチェック
+console.log(`状態: ${latest.state}`);
+console.log(`スコア: ${latest.rangeScore}/100`);
+
+// レンジ境界をチェック
+if (latest.rangeHigh && latest.rangeLow && latest.pricePosition !== null) {
+  console.log(`レンジ: ${latest.rangeLow} - ${latest.rangeHigh}`);
+  console.log(`位置: ${(latest.pricePosition * 100).toFixed(0)}%`);
 }
 
-type RangeBoundState =
-  | 'NEUTRAL'           // 中立
-  | 'RANGE_FORMING'     // レンジ形成中
-  | 'RANGE_CONFIRMED'   // レンジ確定
-  | 'RANGE_TIGHT'       // タイトレンジ
-  | 'BREAKOUT_RISK_UP'  // 上方ブレイクアウトリスク
-  | 'BREAKOUT_RISK_DOWN'// 下方ブレイクアウトリスク
-  | 'TRENDING';         // トレンド中
-
-type TrendReason =
-  | 'adx_high'          // ADX >= 25
-  | 'price_movement'    // 20日で5%以上の価格変動
-  | 'di_diff'           // +DI/-DI差分 >= 10
-  | 'slope'             // 線形回帰傾き >= 0.15 ATR
-  | 'hhll'              // 連続HH/LL >= 3
-  | null;               // トレンドではない
-```
-
-#### レンジ相場条件（バックテスト用）
-
-```typescript
-// レンジ状態（任意のレンジ）
-inRangeBound()
-
-// レンジ形成中
-rangeForming()
-
-// レンジ確定
-rangeConfirmed()
-
-// レンジからトレンドへの転換（ブレイクアウト）
-rangeBreakout()
-
-// タイトレンジ検出
-tightRange()
-
-// 上方ブレイクアウトリスク（上限付近）
-breakoutRiskUp()
-
-// 下方ブレイクアウトリスク（下限付近）
-breakoutRiskDown()
-
-// レンジスコアが閾値超
-rangeScoreAbove(70)
-
-// レンジ相場ではない時のみ（フィルター）
-not(inRangeBound())
+// トレンド判定のデバッグ
+if (latest.trendReason) {
+  console.log(`トレンド理由: ${latest.trendReason}`);
+}
 ```
 
 ---
@@ -2207,7 +2606,7 @@ const bearish = headAndShoulders(candles);
 const bullish = inverseHeadAndShoulders(candles);
 
 bearish.forEach(p => {
-  console.log(`H&S発生 ${new Date(p.time)}, ネックライン: ${p.pattern.neckline.currentPrice}`);
+  console.log(`H&S発生 ${new Date(p.time)}, ネックライン: ${p.pattern.neckline?.currentPrice}`);
 });
 ```
 
@@ -2531,11 +2930,23 @@ interface BacktestResult {
   winRate: number;                   // 勝率 (%)
   maxDrawdown: number;               // 最大ドローダウン (%)
   sharpeRatio: number;               // シャープレシオ（年率化）
+  sortinoRatio: number;              // ソルティノレシオ（年率化・下方偏差ベース）
+  calmarRatio: number;               // CAGR ÷ 最大ドローダウン
+  cagrPercent: number;               // 年平均成長率 (%)
+  expectancyPercent: number;         // 1取引あたり平均リターン (%)
+  exposurePercent: number;           // 市場エクスポージャー: ポジション保有時間比率 (%)
+  avgWinPercent: number;             // 平均勝ちトレード (%)
+  avgLossPercent: number;            // 平均負けトレード (%, 正の値)
+  largestWinPercent: number;         // 最大勝ちトレード (%)
+  largestLossPercent: number;        // 最大負けトレード (%, 正の値)
+  firstBarTime: number;              // 最初のローソク足時刻 (エポックms)
+  lastBarTime: number;               // 最後のローソク足時刻 (エポックms)
   profitFactor: number;              // プロフィットファクター
   avgHoldingDays: number;            // 平均保有日数
   trades: Trade[];                   // 取引詳細
   settings: BacktestSettings;        // 使用した設定（再現性のため）
   drawdownPeriods: DrawdownPeriod[]; // 個別ドローダウン期間
+  equityCurve?: number[];            // ローソク足終値ごとの時価評価資産額
 }
 
 interface DrawdownPeriod {
@@ -2552,12 +2963,15 @@ interface DrawdownPeriod {
 interface BacktestSettings {
   fillMode: FillMode;          // 約定タイミングモード
   slTpMode: SlTpMode;          // SL/TP判定モード
+  direction?: PositionDirection; // ポジション方向（デフォルト: "long"）
   stopLoss?: number;           // ストップロス (%)
   takeProfit?: number;         // 利確 (%)
   trailingStop?: number;       // トレーリングストップ (%)
   slippage: number;            // スリッページ (%)
   commission: number;          // 固定手数料/取引
   commissionRate: number;      // 手数料率 (%)
+  taxRate: number;             // 利益への税率 (%)
+  sizing?: BacktestSizingConfigJSON | { method: "custom" }; // 使用したサイジング設定
 }
 
 interface Trade {
@@ -2568,6 +2982,13 @@ interface Trade {
   return: number;
   returnPercent: number;
   holdingDays: number;
+  direction?: PositionDirection; // ポジション方向（デフォルト: "long"）
+  isPartial?: boolean;           // 部分利確による決済の場合 true
+  exitPercent?: number;          // 元ポジションのうち今回売却した割合 (%)
+  exitReason?: ExitReason;       // 決済理由
+  mfe?: number;                  // 最大含み益 (%)
+  mae?: number;                  // 最大含み損 (%)
+  mfeUtilization?: number;       // 実現リターン ÷ MFE
 }
 ```
 
@@ -2769,13 +3190,13 @@ monthlyTrendStrong(adxThreshold = 25)  // 月足ADX > 閾値
 mtfTrendStrong(timeframe, adxThreshold = 25)  // MTF ADX > 閾値
 
 // カスタムMTF条件
-mtfCondition(requiredTimeframes, name, evaluateFn)  // MTFデータでのカスタム条件（例: mtfCondition(['weekly', 'monthly'], 'weeklyAboveMonthly', (mtf, indicators, candle, index, candles) => ...)）
+mtfCondition(requiredTimeframes, name, evaluate)  // MTFデータでのカスタム条件（例: mtfCondition(['weekly'], 'myCond', (mtf, indicators, candle, index, candles) => boolean)）
 ```
 
 **Fluent APIでの使用:**
 
 ```typescript
-import { TrendCraft, weeklyRsiAbove, goldenCrossCondition, and } from 'trendcraft';
+import { TrendCraft, weeklyRsiAbove, goldenCrossCondition, deadCrossCondition, and } from 'trendcraft';
 
 const result = TrendCraft.from(dailyCandles)
   .withMtf(['weekly'])  // 週足タイムフレームを有効化
@@ -2992,10 +3413,7 @@ const monthly = resample(dailyCandles, 'monthly');
 **サポートされるタイムフレーム:**
 - ショートハンド: `'1m'` / `'5m'` / `'15m'` / `'30m'` / `'1h'` / `'4h'` / `'1d'`（`'daily'`）/ `'1w'`（`'weekly'`）/ `'1M'`（`'monthly'`）
 - または `{ value, unit }` 形式の `Timeframe` オブジェクト（unit: `'minute' | 'hour' | 'day' | 'week' | 'month'`）
-
-```typescript
-const fourHour = resample(hourlyCandles, '4h');  // 1時間足 → 4時間足
-```
+- 例: `resample(hourlyCandles, '4h')` で1時間足 → 4時間足
 
 ---
 
@@ -3087,6 +3505,35 @@ for (const c of breakdown.contributions) {
 }
 ```
 
+**戻り値:** `ScoreBreakdown`
+
+```typescript
+interface ScoreBreakdown extends ScoreResult {
+  contributions: SignalContribution[];
+}
+
+interface SignalContribution {
+  name: string;
+  displayName: string;
+  rawValue: number;     // 0-1
+  score: number;        // rawValue * weight
+  weight: number;
+  isActive: boolean;
+  category?: string;
+}
+```
+
+---
+
+#### `calculateScoreSeries(candles, config, startIndex?, context?)`
+
+全ローソク足のスコアを計算（チャート表示に便利）。
+
+```typescript
+const series = calculateScoreSeries(candles, config);
+// [{ time: 1234567890, score: ScoreResult }, ...]
+```
+
 ---
 
 ### スコアリングプリセット
@@ -3108,6 +3555,19 @@ const available = listPresets();  // ['momentum', 'meanReversion', 'trendFollowi
 | `balanced` | 混合 | 70/50/30 | バランス型 |
 | `aggressive` | 低閾値 | 60/40/25 | 積極型（低スコア閾値） |
 | `conservative` | 高閾値 | 80/60/40 | 保守型（高スコア閾値） |
+
+**ファクトリ関数:**
+
+```typescript
+import {
+  createMomentumPreset,
+  createMeanReversionPreset,
+  createTrendFollowingPreset,
+  createBalancedPreset,
+  createAggressivePreset,      // 低閾値: 60/40/25
+  createConservativePreset,    // 高閾値: 80/60/40
+} from 'trendcraft';
+```
 
 ---
 
@@ -3151,10 +3611,21 @@ const result = riskBasedSize({
   entryPrice: 50,
   stopLossPrice: 48,
   riskPercent: 1,           // 口座の1%をリスク
-  maxPositionPercent: 25,   // 最大25%
+  maxPositionPercent: 25,   // 口座の最大25%
+  minShares: 1,
+  roundShares: true,
+  direction: 'long',        // 'long' | 'short'
 });
 
-// 結果: { shares: 500, positionValue: 25000, riskAmount: 1000, ... }
+// 結果:
+// {
+//   shares: 500,
+//   positionValue: 25000,
+//   riskAmount: 1000,
+//   riskPercent: 1,
+//   stopPrice: 48,
+//   method: 'risk-based'
+// }
 ```
 
 **計算式:** `株数 = リスク額 / ストップ幅`
@@ -3174,8 +3645,20 @@ const result = atrBasedSize({
   atrValue: 2.5,
   atrMultiplier: 2,     // 2倍ATRでストップ
   riskPercent: 1,
+  direction: 'long',
 });
-// stopPrice: 45, shares: 200
+
+// stopPrice: 45 (50 - 2.5 * 2)
+// shares: 200 (1000 / 5)
+```
+
+**ユーティリティ関数:**
+
+```typescript
+import { calculateAtrStopDistance, recommendedAtrMultiplier } from 'trendcraft';
+
+const stopDistance = calculateAtrStopDistance(2.5, 2);  // 5
+const multiplier = recommendedAtrMultiplier('conservative');  // 3
 ```
 
 ---
@@ -3187,14 +3670,17 @@ const result = atrBasedSize({
 ```typescript
 import { kellySize, calculateKellyPercent } from 'trendcraft';
 
-const kellyPct = calculateKellyPercent(0.6, 1.5);  // 33.3%
+// 最適Kellyパーセンテージを計算
+const kellyPct = calculateKellyPercent(0.6, 1.5);  // 勝率60%、勝敗比1.5
+// 33.3%（Kelly = winRate - (1 - winRate) / winLossRatio）
 
 const result = kellySize({
   accountSize: 100000,
   entryPrice: 50,
   winRate: 0.6,
   winLossRatio: 1.5,
-  kellyFraction: 0.5,     // ハーフKelly
+  kellyFraction: 0.5,     // ハーフKelly（より安全）
+  maxKellyPercent: 25,    // 上限25%
 });
 ```
 
@@ -3205,13 +3691,18 @@ const result = kellySize({
 シンプルな固定比率配分。
 
 ```typescript
-import { fixedFractionalSize } from 'trendcraft';
+import { fixedFractionalSize, maxPositions, fractionForPositionCount } from 'trendcraft';
 
 const result = fixedFractionalSize({
   accountSize: 100000,
   entryPrice: 50,
   fractionPercent: 10,      // 1ポジションあたり10%
+  maxPositionPercent: 20,   // 上限
 });
+
+// ユーティリティ関数
+const positions = maxPositions(100000, 10);  // 10%で10ポジション
+const fraction = fractionForPositionCount(5);  // 5ポジションなら20%
 ```
 
 ---
@@ -3275,6 +3766,8 @@ const result = runBacktest(candles, entry, exit, {
     atrPeriod: 14,
     atrStopMultiplier: 2.5,
     atrTakeProfitMultiplier: 4.0,
+    atrTrailingMultiplier: 2.0,
+    useEntryAtr: true,  // エントリー時ATRを使用（動的でなく）
   },
 });
 ```
@@ -3347,22 +3840,25 @@ interface VolatilityRegimeValue {
 **使用例:**
 
 ```typescript
-import { regimeIs, regimeNot, atrPercentAbove, and, goldenCrossCondition } from 'trendcraft';
+import {
+  regimeIs, regimeNot, atrPercentAbove, and,
+  goldenCrossCondition, rsiBelow, perfectOrderBullish,
+} from 'trendcraft';
 
 // 低ボラティリティ環境でのみエントリー
-const entry = and(
+const lowVolEntry = and(
   regimeIs('low'),
   rsiBelow(30)
 );
 
 // 極端なボラティリティを避ける
-const entry = and(
+const calmEntry = and(
   regimeNot('extreme'),
   goldenCrossCondition()
 );
 
 // トレンドフォロー用にATR%でフィルタ（ボラタイルな銘柄のみ）
-const entry = and(
+const volatileEntry = and(
   atrPercentAbove(2.3),
   perfectOrderBullish()
 );
@@ -3476,8 +3972,8 @@ CSCV（組合せ対称交差検証）によるバックテスト過学習確率�
 ```typescript
 import { pbo } from 'trendcraft';
 
-// returns[t][n] = n番目のパラメーター組み合わせの期間tのリターン
-const result = pbo(returns, { blocks: 10 });
+// comboReturns[t][n] = n番目のパラメーター組み合わせの期間tのリターン
+const result = pbo(comboReturns, { blocks: 10 });
 
 console.log(`PBO: ${(result.pbo * 100).toFixed(1)}%`);   // 50%以上 → 選択は偶然と同等
 console.log(`評価したsplit数: ${result.combinations}`);   // C(10, 5) = 252
@@ -3532,11 +4028,11 @@ const ranges: PathParameterRange[] = [
   { path: 'entry.0.params.period', min: 10, max: 30, step: 5 },
 ];
 
-const grid = gridSearchFromJSON(candles, strategy, ranges, backtestRegistry, {
+const grid = gridSearchFromJSON(candles, strategyJson, ranges, backtestRegistry, {
   metric: 'sharpe',
 });
 
-const wf = walkForwardAnalysisFromJSON(candles, strategy, ranges, backtestRegistry, {
+const wf = walkForwardAnalysisFromJSON(candles, strategyJson, ranges, backtestRegistry, {
   windowSize: 252,
   stepSize: 63,
   testSize: 63,
@@ -3626,7 +4122,7 @@ import {
 } from 'trendcraft';
 
 // 個別メトリクスを計算
-const sharpe = calculateSharpeRatio(returns, riskFreeRate);
+const sharpe = calculateSharpeRatio(dailyReturns, riskFreeRate);
 const calmar = calculateCalmarRatio(annualizedReturnPercent, maxDrawdownPercent);
 const recovery = calculateRecoveryFactor(netProfit, maxDrawdown);
 
@@ -3760,16 +4256,18 @@ interface MetricStatistics {
 **ヘルパー関数:**
 
 ```typescript
-// 結果のフォーマット
-const formatted = formatMonteCarloResult(mcResult);
+import { summarizeMonteCarloResult, calculateStatistics } from 'trendcraft';
 
 // サマリー取得
 const summary = summarizeMonteCarloResult(mcResult);
-// => { probProfit, probLoss, riskOfRuin, expectedSharpe, sharpe95CI, originalSharpe }
+console.log(summary.probProfit);   // 0.92（利益となったリサンプルの割合）
+console.log(summary.riskOfRuin);   // 0.03（破産しきい値に達した割合）
+console.log(summary.sharpe95CI);   // { lower: 0.4, upper: 1.8 }
 
-// 統計値の計算（直接使用可能）
+// 任意の配列の統計値を計算
 const stats = calculateStatistics([1, 2, 3, 4, 5]);
-// => { mean: 3, median: 3, stdDev: 1.41, ... }
+console.log(stats.mean);    // 3
+console.log(stats.median);  // 3
 ```
 
 ---
@@ -3781,23 +4279,15 @@ const stats = calculateStatistics([1, 2, 3, 4, 5]);
 固定起点から訓練期間を拡張するウォークフォワード分析。長期的な戦略の堅牢性を検証します。
 
 ```typescript
-import {
-  anchoredWalkForwardAnalysis,
-  formatAWFResult,
-  createEntryConditionPool,
-  createExitConditionPool
-} from 'trendcraft';
-
-const entryPool = createEntryConditionPool();
-const exitPool = createExitConditionPool();
+import { anchoredWalkForwardAnalysis, formatAWFResult } from 'trendcraft';
 
 const awfResult = anchoredWalkForwardAnalysis(
   candles,
-  entryPool,
-  exitPool,
+  entryConditions,
+  exitConditions,
   {
     anchorDate: new Date('2015-01-01').getTime(),
-    initialTrainSize: 500,   // 約2年
+    initialTrainSize: 504,   // 約2年
     expansionStep: 252,      // 1年ずつ拡張
     testSize: 252,           // 1年テスト
     metric: 'sharpe',
@@ -3805,7 +4295,6 @@ const awfResult = anchoredWalkForwardAnalysis(
 );
 
 console.log(formatAWFResult(awfResult));
-// => Stability: 72%, Recommended: GC + Stoch↑ / VolDiv
 ```
 
 **期間分割の例:**
@@ -3877,23 +4366,31 @@ interface AWFPeriod {
 **ヘルパー関数:**
 
 ```typescript
-// 結果のフォーマット
-const formatted = formatAWFResult(awfResult);
-
-// サマリー取得
-const summary = summarizeAWFResult(awfResult);
+import {
+  generateAWFBoundaries,
+  calculateAWFPeriodCount,
+  summarizeAWFResult,
+  getAWFEquityCurve
+} from 'trendcraft';
 
 // 期間数の事前計算（位置引数）
 const anchorDate = new Date('2015-01-01').getTime();
 const anchorIndex = candles.findIndex((c) => c.time >= anchorDate);
-const count = calculateAWFPeriodCount(candles.length, anchorIndex, 500, 252, 252);
-// オプションオブジェクトから求める場合: generateAWFBoundaries(candles, options).length
+const count = calculateAWFPeriodCount(candles.length, anchorIndex, 504, 252, 252);
+// オプションオブジェクトから求める場合: generateAWFBoundaries(candles, awfOptions).length
 
-// 期間境界の生成
-const boundaries = generateAWFBoundaries(candles, options);
+// フル分析を実行せずに期間境界を取得
+const boundaries = generateAWFBoundaries(candles, awfOptions);
 
-// エクイティカーブの取得
-const equity = getAWFEquityCurve(awfResult, 1000000);
+// サマリー取得
+const summary = summarizeAWFResult(awfResult);
+console.log(summary.stabilityRatio);        // 0.72（ISパフォーマンスの72%）
+console.log(summary.profitablePeriods);     // 4（5期間中）
+console.log(summary.recommendedEntry);      // ['gc', 'stochUp']
+
+// OOS結果からエクイティカーブを取得
+const curve = getAWFEquityCurve(awfResult, 1000000);
+// [{ time: ..., equity: 1050000, periodNumber: 1 }, ...]
 ```
 
 ---
@@ -4258,8 +4755,13 @@ const isEntry = evaluateStreamingCondition(entryCondition, snapshot, candle);
 プレーンな関数を条件として渡すこともできます:
 
 ```typescript
-const customCondition = (snapshot, candle) => {
-  return candle.close > 100 && snapshot.rsi < 50;
+import { streaming } from "trendcraft";
+
+// スナップショットの値は `unknown`（各インジケーターの snapshot 名がキー）
+// のため、比較前にナローイングする。
+const customCondition: streaming.StreamingConditionFn = (snapshot, candle) => {
+  const rsi = snapshot.rsi as number | null;
+  return candle.close > 100 && rsi !== null && rsi < 50;
 };
 ```
 
@@ -4799,7 +5301,7 @@ const tradeSignals = patterns.map(p => fromPatternSignal(p, 100));
 ```typescript
 import { fromScoreResult } from 'trendcraft';
 
-const breakdown = calculateScoreBreakdown(candles, i, config); // config: ScoringConfig（例: { signals: [...] }）
+const breakdown = calculateScoreBreakdown(candles, candles.length - 1, config); // config: ScoringConfig（例: { signals: [...] }）
 const signal = fromScoreResult(breakdown, candle.time, { minScore: 50, entryPrice: 100 });
 ```
 
@@ -4829,14 +5331,15 @@ const signal = fromPipelineResult(result, candle.time, candle.close);
 #### `createSignalEmitter(options)`
 
 ```typescript
-import { streaming, incremental } from 'trendcraft';
+import { streaming } from 'trendcraft';
+import { createRsi } from 'trendcraft/incremental';
 
 const { createSignalEmitter, rsiBelow, rsiAbove } = streaming;
 
 const emitter = createSignalEmitter({
   intervalMs: 60000,
   pipeline: {
-    indicators: [{ name: 'rsi14', create: () => incremental.createRsi({ period: 14 }) }],
+    indicators: [{ name: 'rsi14', create: () => createRsi({ period: 14 }) }],
     entry: rsiBelow(30),
     exit: rsiAbove(70),
   },
@@ -4926,9 +5429,9 @@ const restored = createSignalManager(options, state);
 シグナル配列にライフサイクルルールを一括適用。バックテスト後のポスト処理に便利。
 
 ```typescript
-import { processSignalsBatch } from 'trendcraft';
+import { processSignalsBatch, type TradeSignal } from 'trendcraft';
 
-const allSignals = [/* バックテストのシグナル */];
+const allSignals: TradeSignal[] = [/* バックテストのシグナル */];
 const filtered = processSignalsBatch(allSignals, { cooldown: { bars: 3 } });
 // 3バー以内の重複シグナルを除去
 ```
@@ -5373,11 +5876,15 @@ import { TrendCraft, plugins } from "trendcraft";
 // .sma(50) と同等
 TrendCraft.from(candles).use(plugins.sma, { period: 50 });
 
-// 動的なプラグイン選択
-const selected = [plugins.sma, plugins.rsi];
-let tc = TrendCraft.from(candles);
-for (const p of selected) {
-  tc = tc.use(p);
+// 動的なプラグイン選択 — 各ステップが自身のプラグインをクロージャで保持する
+// ため、異種リストでもプラグインごとのオプション型チェックが維持される
+const steps = [
+  (t: TrendCraft) => t.use(plugins.sma),
+  (t: TrendCraft) => t.use(plugins.rsi),
+];
+let tc: TrendCraft = TrendCraft.from(candles);
+for (const step of steps) {
+  tc = step(tc);
 }
 const result = tc.compute();
 ```
@@ -5424,6 +5931,7 @@ console.log(explanation.fired);          // true/false
 console.log(explanation.signalType);     // "entry" | "exit"
 console.log(explanation.narrative);      // 人間が読めるテキスト
 console.log(explanation.contributions);  // リーフ条件の詳細
+console.log(explanation.trace);          // 完全な条件ツリー
 ```
 
 **オプション:**
@@ -5495,6 +6003,16 @@ const bbOfHist = pipe(
 
 複数の変換を単一の関数に合成します（右から左の順序）。
 
+```typescript
+import { compose, applyIndicator, rsi, ema } from "trendcraft";
+
+const smoothedRsi = compose(
+  (s: Series<number|null>) => applyIndicator(s, ema, { period: 9 }),
+  (c: NormalizedCandle[]) => rsi(c, { period: 14 }),
+);
+const result = smoothedRsi(candles);
+```
+
 ### `through(indicator, options?)`
 
 `pipe()`で使用するインジケーターステップを作成します。Seriesをローソク足に変換してインジケーターを適用します。
@@ -5519,9 +6037,19 @@ const histogram = extractField(macd(candles), "histogram");
 
 シリーズの値を変換関数でマッピングします。
 
+```typescript
+const normalized = mapValues(rsiSeries, v => v !== null ? v / 100 : null);
+```
+
 ### `combineSeries(a, b, fn)`
 
 2つのシリーズをインデックスごとにポイント単位で結合します。
+
+```typescript
+const spread = combineSeries(seriesA, seriesB, (a, b) =>
+  a !== null && b !== null ? a - b : null
+);
+```
 
 ---
 
@@ -5543,6 +6071,9 @@ console.log(decay.assessment.status);      // "healthy" | "warning" | "degraded"
 console.log(decay.assessment.reason);      // 人間が読める評価
 console.log(decay.assessment.currentIC);   // 現在の情報係数
 console.log(decay.assessment.halfLife);     // 推定半減期（バー数、またはnull）
+console.log(decay.rollingIC);              // ローリングICシリーズ
+console.log(decay.rollingHitRate);         // ローリングヒットレートシリーズ
+console.log(decay.breaks);                 // CUSUM構造的ブレークポイント
 ```
 
 **オプション:**
@@ -5559,6 +6090,11 @@ console.log(decay.assessment.halfLife);     // 推定半減期（バー数、ま
 ### `createObservationsFromScores(scores, candles, forwardBars?)`
 
 シグナルスコアとローソク足データからの実際の先行リターンをペアリングします。
+
+```typescript
+const observations = createObservationsFromScores(scoreSeries, candles, 5);
+const decay = analyzeAlphaDecay(observations);
+```
 
 ### `spearmanCorrelation(x, y)`
 
@@ -5668,6 +6204,7 @@ const robustness = quickRobustnessScore(result);
 console.log(`Grade: ${robustness.grade} (${robustness.compositeScore}/100)`);
 console.log(robustness.assessment);
 console.log(robustness.recommendations);
+console.log(robustness.dimensions); // { monteCarlo, tradeConsistency, drawdownResilience }
 ```
 
 **オプション:**
@@ -5699,6 +6236,7 @@ const robustness = calculateRobustnessScore(
     { name: "longMA", min: 20, max: 40, step: 5 },
   ],
 );
+console.log(`Grade: ${robustness.grade}`);
 ```
 
 **戻り値:** `RobustnessResult`（`compositeScore`、`grade`、`dimensions`、`assessment`、`recommendations` を含む）
@@ -5706,6 +6244,12 @@ const robustness = calculateRobustnessScore(
 ### `scoreToGrade(score)`
 
 数値スコア（0-100）をレターグレードに変換します。
+
+```typescript
+scoreToGrade(92); // "A+"
+scoreToGrade(75); // "B+"
+scoreToGrade(30); // "D"
+```
 
 グレードスケール: A+（90+）、A（80+）、B+（70+）、B（60+）、C+（50+）、C（40+）、D（25+）、F（<25）
 
@@ -5750,6 +6294,13 @@ if (result.cointegration.isCointegrated) {
 
 拡張Dickey-Fuller検定（定常性検定）。
 
+```typescript
+const result = adfTest(residuals);
+if (result.adfStatistic < result.criticalValues["5%"]) {
+  console.log("5%有意水準で定常です");
+}
+```
+
 **戻り値:** `{ adfStatistic, pValue, criticalValues: { "1%", "5%", "10%" }, lag }`
 
 ### `calculateSpread(seriesY, seriesX, hedgeRatio, intercept, times, options?)`
@@ -5791,6 +6342,7 @@ const analysis = analyzeCorrelation(
 console.log(`Average correlation: ${analysis.summary.avgCorrelation}`);
 console.log(`Current regime: ${analysis.summary.currentRegime}`);
 console.log(`Lead-lag: ${analysis.leadLag.assessment}`);
+console.log(`Divergences: ${analysis.divergences.length}`);
 ```
 
 **オプション:**
@@ -5831,6 +6383,11 @@ Spearman順位相関係数。
 ### `analyzeLeadLag(returnsA, returnsB, options?)`
 
 クロス相関を使用したリードラグ関係の分析。正の最適ラグはAがBをリード、負はBがAをリードすることを意味します。
+
+```typescript
+const result = analyzeLeadLag(returnsA, returnsB, { maxLag: 5 });
+console.log(`Optimal lag: ${result.optimalLag}`);
+```
 
 **戻り値:** `LeadLagResult`（`optimalLag`、`crossCorrelation`、`maxCorrelation`、`assessment` を含む）
 
@@ -5916,7 +6473,7 @@ const sma = livePresets.sma;
 
 // レジストリから指標をインスタンス化
 const factory = sma.createFactory({ period: 50 });
-const indicator = factory(undefined); // 既存 state なし
+const rsiIndicator = factory(undefined); // 既存 state なし
 ```
 
 **エントリー形式 (`LivePreset`):**
@@ -5937,11 +6494,12 @@ import { indicatorPresets } from "trendcraft";
 
 const rsi = indicatorPresets.rsi;
 
-// 静的モード — 一括計算
-const series = rsi.compute(candles, { period: 14 });
+// 静的モード — 一括計算。型上 `compute` はオプショナル（組み込みエントリーはすべて定義済み）
+const series = rsi.compute!(candles, { period: 14 });
 
-// ストリーミングモード — 同じレジストリから createFactory でインクリメンタル指標を生成
-const factory = rsi.createFactory({ period: 14 });
+// ストリーミングモード — バッチ専用エントリーには `createFactory` がないため
+// オプショナル呼び出し（または存在チェック）を使う
+const factory = rsi.createFactory?.({ period: 14 });
 ```
 
 **エントリー形式 (`IndicatorPreset`):** LivePreset と同形の `meta` / `defaultParams` / `snapshotName` を持つ独立型。`compute?` と `createFactory?` はともにオプショナル（少なくとも一方は定義。インクリメンタル未対応の指標は `compute` のみで、104 エントリー中 25 個は `createFactory` を持たない）。
@@ -5960,10 +6518,12 @@ const factory = rsi.createFactory({ period: 14 });
 任意の `Series<T>` に `__meta` プロパティを付与してドメインメタデータを載せます。組み込み指標はすべて既に tag 済み。自作指標でも下流の利用者（レンダラー、UI ジェネレーター等）に同じ規約で解釈させたい場合に `tagSeries` を使います。
 
 ```typescript
-import { tagSeries, rsi, type SeriesMeta } from "trendcraft";
+import { tagSeries, rsi, type SeriesMeta, type TaggedSeries } from "trendcraft";
 
 const r = rsi(candles, { period: 14 });
-r.__meta;
+// 指標のシグネチャ上の型は Series<T>。実行時に付与されるメタデータを読むには
+// TaggedSeries<T> にキャストします。
+(r as TaggedSeries<number | null>).__meta;
 // {
 //   kind: "rsi",
 //   label: "RSI(14)",
@@ -6063,7 +6623,8 @@ import { rsi, sma } from "trendcraft";
 try {
   const result = rsi(candles, { period: 14 });
 } catch (error) {
-  console.error(error.message);
+  // strict 設定では `error` は `unknown` — 使用前にナローイングする
+  console.error((error as Error).message);
 }
 ```
 
@@ -6115,6 +6676,202 @@ const result = toResult(() => someThrowingFunction(), "INDICATOR_ERROR");
 
 - **ライブラリ利用者**: 堅牢性のためSafeバージョンを推奨
 - **内部 / パフォーマンス重視のコード**: Throwバージョンを直接使用
+
+---
+
+## ワイコフ分析（VSA + フェーズ検出）
+
+### `vsa(candles, options?)`
+
+Volume Spread Analysis（出来高スプレッド分析） — 出来高・スプレッド・終値位置の関係から各バーを分類します。
+
+```typescript
+import { vsa } from "trendcraft";
+
+const vsaBars = vsa(candles, { volumeMaPeriod: 20, atrPeriod: 14 });
+const last = vsaBars[vsaBars.length - 1].value;
+// last.barType: 'noSupply' | 'noDemand' | 'stoppingVolume' | 'climacticAction'
+//             | 'test' | 'upthrust' | 'spring' | 'absorption'
+//             | 'effortUp' | 'effortDown' | 'normal'
+// last.spreadRelative: number（1.0 = 平均）
+// last.closePosition: number（0 = 安値、1 = 高値）
+// last.volumeRelative: number（1.0 = 平均）
+// last.isEffortDivergence: boolean
+```
+
+| オプション | デフォルト | 説明 |
+|--------|---------|-------------|
+| `volumeMaPeriod` | `20` | 出来高MA期間 |
+| `atrPeriod` | `14` | スプレッド正規化のATR期間 |
+| `highVolumeThreshold` | `1.5` | 「高出来高」の相対出来高閾値 |
+| `lowVolumeThreshold` | `0.7` | 「低出来高」の相対出来高閾値 |
+| `wideSpreadThreshold` | `1.2` | 「ワイドスプレッド」の相対スプレッド閾値 |
+| `narrowSpreadThreshold` | `0.7` | 「ナロースプレッド」の相対スプレッド閾値 |
+
+### `wyckoffPhases(candles, options?)`
+
+ワイコフフェーズ検出 — VSA・スイングポイント・BOS/CHoCHで駆動されるステートマシンにより、アキュミュレーション/ディストリビューションのフェーズとスキマティックイベントを特定します。
+
+```typescript
+import { wyckoffPhases } from "trendcraft";
+
+const phases = wyckoffPhases(candles, { swingPeriod: 5, minRangeBars: 20 });
+const last = phases[phases.length - 1].value;
+// last.phase: 'accumulation' | 'markup' | 'distribution' | 'markdown' | 'unknown'
+// last.event: 'PS' | 'SC' | 'AR' | 'ST' | 'spring' | 'SOS' | 'LPS' | ... | null
+// last.confidence: 0-100
+// last.eventsDetected: WyckoffEvent[]
+// last.rangeHigh / last.rangeLow: レンジ境界
+```
+
+| オプション | デフォルト | 説明 |
+|--------|---------|-------------|
+| `swingPeriod` | `5` | スイングポイント検出期間 |
+| `minRangeBars` | `20` | トレーディングレンジの最小バー数 |
+| `atrPeriod` | `14` | ATR期間 |
+| `volumeMaPeriod` | `20` | 出来高MA期間 |
+| `rangeTolerance` | `0.5` | レンジ境界許容のATR倍率 |
+
+---
+
+## メタ戦略（エクイティカーブトレーディング）
+
+### `applyEquityCurveFilter(result, options?)`
+
+エクイティカーブの健全性を分析してバックテスト結果をフィルタリングします。エクイティがMAを下回る、過大なドローダウン中、勝率が低い場合にトレードをスキップまたは縮小します。
+
+```typescript
+import { runBacktest, applyEquityCurveFilter } from "trendcraft";
+
+const result = runBacktest(candles, entry, exit, { capital: 100000 });
+const analysis = applyEquityCurveFilter(result, {
+  type: 'ma',
+  maPeriod: 10,
+  filteredSizeFactor: 0, // 0 = スキップ、0.5 = 半分のサイズ
+});
+console.log(analysis.tradesSkipped);
+console.log(analysis.improvement.maxDrawdown); // 正の値 = 改善
+```
+
+| オプション | デフォルト | 説明 |
+|--------|---------|-------------|
+| `type` | `'ma'` | フィルタータイプ: `'ma'`、`'drawdown'`、`'winRate'`、`'combined'` |
+| `maPeriod` | `20` | MA期間（トレード数単位） |
+| `maType` | `'sma'` | `'sma'` または `'ema'` |
+| `maxDrawdown` | `15` | 一時停止するドローダウン閾値（%、15 = 15%） |
+| `winRateWindow` | `20` | 勝率のローリングウィンドウ |
+| `minWinRate` | `40` | 継続に必要な最小勝率（%、40 = 40%） |
+| `filteredSizeFactor` | `0` | フィルター時のサイズ係数（0 = スキップ） |
+
+### `equityCurveHealth(result, options?)`
+
+戦略のエクイティカーブの現在の健全性を評価します。
+
+```typescript
+import { equityCurveHealth } from "trendcraft";
+
+const health = equityCurveHealth(result, { maPeriod: 10 });
+// health.aboveMa: boolean
+// health.currentDrawdown: 0-100（%、BacktestResult.maxDrawdownと同じ単位）
+// health.rollingWinRate: 0-100（%、BacktestResult.winRateと同じ単位）
+// health.healthScore: 0-100
+```
+
+### `rotateStrategies(results, options?)`
+
+複数の戦略を直近パフォーマンスでランク付けし、資金を配分します。
+
+```typescript
+import { rotateStrategies } from "trendcraft";
+
+const rotation = rotateStrategies([resultA, resultB, resultC], {
+  lookbackTrades: 20,
+  rankingMetric: 'returnPercent',
+  allocationMethod: 'proportional',
+});
+// rotation.allocations: [{ strategyIndex, weight, metricValue }]
+// rotation.rankings: [bestIdx, ..., worstIdx]
+```
+
+| オプション | デフォルト | 説明 |
+|--------|---------|-------------|
+| `lookbackTrades` | `20` | ランク付けに使う直近トレード数 |
+| `rankingMetric` | `'returnPercent'` | `'returnPercent'`、`'sharpeRatio'`、`'profitFactor'`、`'winRate'` |
+| `maxActiveStrategies` | 全戦略 | 配分する最大戦略数 |
+| `minAllocation` | `0.05` | 戦略あたりの最小配分 |
+| `allocationMethod` | `'proportional'` | `'equal'`、`'proportional'`、`'topN'` |
+
+---
+
+## リスク分析（VaR / CVaR / リスクパリティ）
+
+### `calculateVaR(returns, options?)`
+
+Value at Risk と Conditional VaR（期待ショートフォール）を計算します。
+
+```typescript
+import { calculateVaR } from "trendcraft";
+
+const result = calculateVaR(dailyReturns, {
+  confidence: 0.95,
+  method: 'historical', // 'historical' | 'parametric' | 'cornishFisher'
+});
+// result.var: 0.025（2.5%の潜在損失）
+// result.cvar: 0.035（VaR超過時の平均損失3.5%）
+// result.skewness, result.kurtosis
+```
+
+| オプション | デフォルト | 説明 |
+|--------|---------|-------------|
+| `confidence` | `0.95` | 信頼水準 |
+| `method` | `'historical'` | `'historical'`、`'parametric'`、`'cornishFisher'` |
+
+### `rollingVaR(returns, options?)`
+
+ローリングウィンドウでのVaR/CVaR計算。
+
+```typescript
+import { rollingVaR } from "trendcraft";
+
+const rolling = rollingVaR(dailyReturns, { window: 60, confidence: 0.95 });
+// rolling[i]: { var: number, cvar: number }
+```
+
+### `riskParityAllocation(returnsSeries, options?)`
+
+資産間のリスク寄与を均等化するリスクパリティ配分ウェイトを計算します。
+
+```typescript
+import { riskParityAllocation } from "trendcraft";
+
+const result = riskParityAllocation({
+  SPY: spyReturns,
+  TLT: tltReturns,
+  GLD: gldReturns,
+});
+// result.weights: { SPY: 0.20, TLT: 0.45, GLD: 0.35 }
+// result.riskContributions: ほぼ均等
+// result.portfolioVolatility: number
+// result.correlationMatrix: number[][]
+```
+
+### `correlationAdjustedSize(currentReturns, portfolioReturns, options)`
+
+既存ポートフォリオとの相関に基づいてポジションサイズを調整します。
+
+```typescript
+import { correlationAdjustedSize } from "trendcraft";
+
+const result = correlationAdjustedSize(stockReturns, [pos1Returns, pos2Returns], {
+  baseSize: 10000,
+  lowCorrelationThreshold: 0.3,
+  highCorrelationThreshold: 0.7,
+  minSizeFactor: 0.25,
+});
+// result.adjustedSize: 7500
+// result.sizeFactor: 0.75
+// result.averageCorrelation: 0.5
+```
 
 ---
 
@@ -6304,8 +7061,16 @@ import {
   CRYPTO_CALENDAR,     // 365
   FX_CALENDAR,         // 260
   annualizationFactor,
+  stressTest,
+  PRESET_SCENARIOS,
 } from "trendcraft";
 
+// 日本株戦略のSharpeは年245バーで計算
+const result = stressTest(dailyReturns, PRESET_SCENARIOS.covidCrash2020, 100_000, {
+  calendar: JPX_CALENDAR,
+});
+
+// 単一の情報源 — ボラティリティにはsqrt(N)、リターン指数にはN
 const N = annualizationFactor({ calendar: JPX_CALENDAR }); // 245
 ```
 
@@ -6622,13 +7387,13 @@ type ConditionSpec =
   | { op: "and" | "or" | "not"; conditions: ConditionSpec[] };
 
 // 例: and(goldenCrossCondition(5,25), rsiBelow(30))
-{
+const example: ConditionSpec = {
   "op": "and",
   "conditions": [
     { "name": "goldenCross", "params": { "shortPeriod": 5, "longPeriod": 25 } },
     { "name": "rsiBelow", "params": { "threshold": 30 } }
   ]
-}
+};
 ```
 
 ### 型

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -1186,10 +1186,11 @@ Cumulative Volume Delta — estimates buying vs selling pressure by measuring wh
 
 ```typescript
 const cvdData = cvd(candles);
-const currentCvd = cvdData[i].value;
+const current = cvdData[cvdData.length - 1].value;
+const previous = cvdData[cvdData.length - 2].value;
 
 // CVD increasing = net buying pressure
-if (cvdData[i].value > cvdData[i - 1].value) {
+if (current !== null && previous !== null && current > previous) {
   // Buying pressure dominant
 }
 ```
@@ -1324,7 +1325,7 @@ const rs = benchmarkRS(stockCandles, sp500Candles, { period: 52 });
 
 // Find outperforming stocks
 const latest = rs[rs.length - 1];
-if (latest.value.rsRating > 80 && latest.value.trend === 'up') {
+if (latest.value.rsRating !== null && latest.value.rsRating > 80 && latest.value.trend === 'up') {
   console.log('Strong relative strength!');
 }
 ```
@@ -1953,6 +1954,7 @@ For each candle, determine which session it belongs to and track session OHLC.
 
 ```typescript
 const sessionData = detectSessions(candles);
+const i = sessionData.length - 1; // current bar index
 const bar = sessionData[i].value;
 if (bar.inSession) {
   console.log(`In ${bar.session}, high so far: ${bar.sessionHigh}`);
@@ -2029,6 +2031,7 @@ For each candle, determine if it falls within a kill zone.
 
 ```typescript
 const kz = killZones(candles);
+const i = kz.length - 1; // current bar index
 if (kz[i].value.inKillZone) {
   console.log(`In ${kz[i].value.zone}: ${kz[i].value.characteristic}`);
 }
@@ -2052,6 +2055,7 @@ Detect breakouts above/below the most recently completed session's range.
 
 ```typescript
 const breakouts = sessionBreakout(candles);
+const i = breakouts.length - 1; // current bar index
 if (breakouts[i].value.breakout === 'above') {
   console.log(`Broke above ${breakouts[i].value.fromSession} high at ${breakouts[i].value.rangeHigh}`);
 }
@@ -2430,7 +2434,7 @@ console.log(`State: ${latest.state}`);
 console.log(`Score: ${latest.rangeScore}/100`);
 
 // Check range boundaries
-if (latest.rangeHigh && latest.rangeLow) {
+if (latest.rangeHigh && latest.rangeLow && latest.pricePosition !== null) {
   console.log(`Range: ${latest.rangeLow} - ${latest.rangeHigh}`);
   console.log(`Position: ${(latest.pricePosition * 100).toFixed(0)}%`);
 }
@@ -2624,7 +2628,7 @@ const bearish = headAndShoulders(candles);
 const bullish = inverseHeadAndShoulders(candles);
 
 bearish.forEach(p => {
-  console.log(`H&S at ${new Date(p.time)}, neckline: ${p.pattern.neckline.currentPrice}`);
+  console.log(`H&S at ${new Date(p.time)}, neckline: ${p.pattern.neckline?.currentPrice}`);
 });
 ```
 
@@ -2948,11 +2952,23 @@ interface BacktestResult {
   winRate: number;                   // Win rate (%)
   maxDrawdown: number;               // Maximum drawdown (%)
   sharpeRatio: number;               // Sharpe ratio (annualized)
+  sortinoRatio: number;              // Sortino ratio (annualized, downside deviation)
+  calmarRatio: number;               // CAGR / max drawdown
+  cagrPercent: number;               // Compound annual growth rate (%)
+  expectancyPercent: number;         // Average per-trade return (%)
+  exposurePercent: number;           // Market exposure: time in position (%)
+  avgWinPercent: number;             // Average winning trade (%)
+  avgLossPercent: number;            // Average losing trade (%, positive value)
+  largestWinPercent: number;         // Largest winning trade (%)
+  largestLossPercent: number;        // Largest losing trade (%, positive value)
+  firstBarTime: number;              // First candle time (epoch ms)
+  lastBarTime: number;               // Last candle time (epoch ms)
   profitFactor: number;              // Profit factor
   avgHoldingDays: number;            // Average holding days
   trades: Trade[];                   // Trade details
   settings: BacktestSettings;        // Settings used (for reproducibility)
   drawdownPeriods: DrawdownPeriod[]; // Individual drawdown periods
+  equityCurve?: number[];            // Mark-to-market equity per candle close
 }
 
 interface DrawdownPeriod {
@@ -2969,12 +2985,15 @@ interface DrawdownPeriod {
 interface BacktestSettings {
   fillMode: FillMode;          // Order fill timing mode
   slTpMode: SlTpMode;          // SL/TP evaluation mode
+  direction?: PositionDirection; // Position direction (default: "long")
   stopLoss?: number;           // Stop loss percentage
   takeProfit?: number;         // Take profit percentage
   trailingStop?: number;       // Trailing stop percentage
   slippage: number;            // Slippage percentage
   commission: number;          // Fixed commission per trade
   commissionRate: number;      // Commission rate (%)
+  taxRate: number;             // Tax rate on profits (%)
+  sizing?: BacktestSizingConfigJSON | { method: "custom" }; // Sizing config used
 }
 
 interface Trade {
@@ -2985,6 +3004,13 @@ interface Trade {
   return: number;
   returnPercent: number;
   holdingDays: number;
+  direction?: PositionDirection; // Position direction (default: "long")
+  isPartial?: boolean;           // True when this row is a partial exit
+  exitPercent?: number;          // % of the original position sold in this exit
+  exitReason?: ExitReason;       // Why the trade was closed
+  mfe?: number;                  // Maximum favorable excursion (%)
+  mae?: number;                  // Maximum adverse excursion (%)
+  mfeUtilization?: number;       // Actual return / MFE
 }
 ```
 
@@ -3849,22 +3875,25 @@ Use these conditions to filter trades by market volatility environment.
 **Example:**
 
 ```typescript
-import { regimeIs, regimeNot, atrPercentAbove, and, goldenCrossCondition } from 'trendcraft';
+import {
+  regimeIs, regimeNot, atrPercentAbove, and,
+  goldenCrossCondition, rsiBelow, perfectOrderBullish,
+} from 'trendcraft';
 
 // Only enter trades in low volatility environment
-const entry = and(
+const lowVolEntry = and(
   regimeIs('low'),
   rsiBelow(30)
 );
 
 // Avoid extreme volatility
-const entry = and(
+const calmEntry = and(
   regimeNot('extreme'),
   goldenCrossCondition()
 );
 
 // Filter by ATR% for trend-following (volatile stocks only)
-const entry = and(
+const volatileEntry = and(
   atrPercentAbove(2.3),
   perfectOrderBullish()
 );
@@ -3978,9 +4007,9 @@ an exactly-median winner counts as neutral rather than overfit.)
 ```typescript
 import { pbo } from 'trendcraft';
 
-// returns[t][n] = period-t return of the n-th parameter combination,
+// comboReturns[t][n] = period-t return of the n-th parameter combination,
 // e.g. per-bar or per-week returns collected for every grid-search combo
-const result = pbo(returns, { blocks: 10 });
+const result = pbo(comboReturns, { blocks: 10 });
 
 console.log(`PBO: ${(result.pbo * 100).toFixed(1)}%`);   // ≥50% → selection is chance
 console.log(`Splits evaluated: ${result.combinations}`);  // C(10, 5) = 252
@@ -4037,11 +4066,11 @@ const ranges: PathParameterRange[] = [
   { path: 'entry.0.params.period', min: 10, max: 30, step: 5 },
 ];
 
-const grid = gridSearchFromJSON(candles, strategy, ranges, backtestRegistry, {
+const grid = gridSearchFromJSON(candles, strategyJson, ranges, backtestRegistry, {
   metric: 'sharpe',
 });
 
-const wf = walkForwardAnalysisFromJSON(candles, strategy, ranges, backtestRegistry, {
+const wf = walkForwardAnalysisFromJSON(candles, strategyJson, ranges, backtestRegistry, {
   windowSize: 252,
   stepSize: 63,
   testSize: 63,
@@ -4131,7 +4160,7 @@ import {
 } from 'trendcraft';
 
 // Calculate individual metrics
-const sharpe = calculateSharpeRatio(returns, riskFreeRate);
+const sharpe = calculateSharpeRatio(dailyReturns, riskFreeRate);
 const calmar = calculateCalmarRatio(annualizedReturnPercent, maxDrawdownPercent);
 const recovery = calculateRecoveryFactor(netProfit, maxDrawdown);
 
@@ -4189,6 +4218,10 @@ const mcResult = runMonteCarloSimulation(backtestResult, {
 });
 
 console.log(formatMonteCarloResult(mcResult));
+
+// Check downside risk
+console.log('Prob. of profit:', mcResult.downside.probProfit);
+console.log('Risk of ruin:', mcResult.downside.riskOfRuin);
 ```
 
 **How it works:**
@@ -4275,7 +4308,7 @@ console.log(stats.median);  // 3
 
 ---
 
-### `anchoredWalkForwardAnalysis(candles, entryPool, exitPool, options)`
+### `anchoredWalkForwardAnalysis(candles, entryConditions, exitConditions, options)`
 
 Anchored Walk-Forward (AWF) analysis for robust strategy validation. Unlike rolling walk-forward, AWF keeps the training start date fixed and progressively expands the training period.
 
@@ -4374,11 +4407,14 @@ import {
   getAWFEquityCurve
 } from 'trendcraft';
 
-// Calculate how many periods will be generated
-const count = calculateAWFPeriodCount(candles.length, 0, 504, 252, 252);
+// Calculate how many periods will be generated (positional args)
+const anchorDate = new Date('2015-01-01').getTime();
+const anchorIndex = candles.findIndex((c) => c.time >= anchorDate);
+const count = calculateAWFPeriodCount(candles.length, anchorIndex, 504, 252, 252);
+// From an options object instead: generateAWFBoundaries(candles, awfOptions).length
 
 // Get boundaries without running full analysis
-const boundaries = generateAWFBoundaries(candles, options);
+const boundaries = generateAWFBoundaries(candles, awfOptions);
 
 // Get summary
 const summary = summarizeAWFResult(awfResult);
@@ -4762,8 +4798,13 @@ const isEntry = evaluateStreamingCondition(entryCondition, snapshot, candle);
 You can also pass a plain function as a condition:
 
 ```typescript
-const customCondition = (snapshot, candle) => {
-  return candle.close > 100 && snapshot.rsi < 50;
+import { streaming } from "trendcraft";
+
+// Snapshot values are `unknown` (keyed by each indicator's snapshot name), so
+// narrow them before comparing.
+const customCondition: streaming.StreamingConditionFn = (snapshot, candle) => {
+  const rsi = snapshot.rsi as number | null;
+  return candle.close > 100 && rsi !== null && rsi < 50;
 };
 ```
 
@@ -5305,7 +5346,7 @@ Converts a `ScoreBreakdown` to a `TradeSignal`. Returns `null` if below threshol
 ```typescript
 import { fromScoreResult } from 'trendcraft';
 
-const breakdown = calculateScoreBreakdown(candles, i, config); // config: ScoringConfig, e.g. { signals: [...] }
+const breakdown = calculateScoreBreakdown(candles, candles.length - 1, config); // config: ScoringConfig, e.g. { signals: [...] }
 const signal = fromScoreResult(breakdown, candle.time, { minScore: 50, entryPrice: 100 });
 ```
 
@@ -5433,9 +5474,9 @@ const restored = createSignalManager(options, state);
 Applies lifecycle rules to an array of signals at once. Useful for backtest post-processing.
 
 ```typescript
-import { processSignalsBatch } from 'trendcraft';
+import { processSignalsBatch, type TradeSignal } from 'trendcraft';
 
-const allSignals = [/* signals from backtest */];
+const allSignals: TradeSignal[] = [/* signals from backtest */];
 const filtered = processSignalsBatch(allSignals, { cooldown: { bars: 3 } });
 // Removes duplicate signals within 3-bar windows
 ```
@@ -5654,7 +5695,7 @@ console.log(`5% hit rate: ${projection.hitRates.find(h => h.threshold === 5)?.ra
 Convenience wrapper for `PatternSignal[]`. Automatically detects direction from pattern type (double_top/head_shoulders → bearish, others → bullish).
 
 ```typescript
-import { projectFromPatterns, doubleTop, doubleBottom } from 'trendcraft';
+import { projectFromPatterns, doubleTop } from 'trendcraft';
 
 const tops = doubleTop(candles);
 const projection = projectFromPatterns(candles, tops); // auto bearish
@@ -5880,11 +5921,15 @@ import { TrendCraft, plugins } from "trendcraft";
 // Equivalent to .sma(50)
 TrendCraft.from(candles).use(plugins.sma, { period: 50 });
 
-// Dynamic plugin selection
-const selected = [plugins.sma, plugins.rsi];
-let tc = TrendCraft.from(candles);
-for (const p of selected) {
-  tc = tc.use(p);
+// Dynamic plugin selection — each step closes over its own plugin so the
+// per-plugin option types stay checked across a heterogeneous list
+const steps = [
+  (t: TrendCraft) => t.use(plugins.sma),
+  (t: TrendCraft) => t.use(plugins.rsi),
+];
+let tc: TrendCraft = TrendCraft.from(candles);
+for (const step of steps) {
+  tc = step(tc);
 }
 const result = tc.compute();
 ```
@@ -6498,11 +6543,13 @@ import { indicatorPresets } from "trendcraft";
 
 const rsi = indicatorPresets.rsi;
 
-// Static mode — one-shot computation
-const series = rsi.compute(candles, { period: 14 });
+// Static mode — one-shot computation. `compute` is optional in the entry
+// type; every built-in entry defines it.
+const series = rsi.compute!(candles, { period: 14 });
 
-// Streaming mode — use createFactory for incremental updates
-const factory = rsi.createFactory({ period: 14 });
+// Streaming mode — `createFactory` is absent on batch-only entries, so use
+// an optional call (or check for its presence first).
+const factory = rsi.createFactory?.({ period: 14 });
 ```
 
 **Entry shape (`IndicatorPreset` extends `LivePreset`):**
@@ -6522,10 +6569,12 @@ At least one of `compute` or `createFactory` is always defined. All 104 entries 
 Attach domain metadata to any `Series<T>` via a `__meta` property. Every built-in indicator already tags its output. Use `tagSeries` on your own indicators if you want downstream consumers (renderers, UI generators, etc.) to pick up the same conventions.
 
 ```typescript
-import { tagSeries, rsi, type SeriesMeta } from "trendcraft";
+import { tagSeries, rsi, type SeriesMeta, type TaggedSeries } from "trendcraft";
 
 const r = rsi(candles, { period: 14 });
-r.__meta;
+// Indicator signatures are typed as Series<T>; cast to TaggedSeries<T> to read
+// the runtime-attached metadata.
+(r as TaggedSeries<number | null>).__meta;
 // {
 //   kind: "rsi",
 //   label: "RSI(14)",
@@ -6625,7 +6674,8 @@ import { rsi, sma } from "trendcraft";
 try {
   const result = rsi(candles, { period: 14 });
 } catch (error) {
-  console.error(error.message);
+  // `error` is `unknown` under strict settings — narrow before use
+  console.error((error as Error).message);
 }
 ```
 
@@ -7391,13 +7441,13 @@ type ConditionSpec =
   | { op: "and" | "or" | "not"; conditions: ConditionSpec[] };
 
 // Example: and(goldenCrossCondition(5,25), rsiBelow(30))
-{
+const example: ConditionSpec = {
   "op": "and",
   "conditions": [
     { "name": "goldenCross", "params": { "shortPeriod": 5, "longPeriod": 25 } },
     { "name": "rsiBelow", "params": { "threshold": 30 } }
   ]
-}
+};
 ```
 
 ### Types

--- a/packages/core/docs/COOKBOOK.md
+++ b/packages/core/docs/COOKBOOK.md
@@ -421,10 +421,11 @@ const result = runBacktest(
 console.log(`Return: ${result.totalReturnPercent.toFixed(2)}%`);
 console.log(`Trades: ${result.tradeCount}`);
 
-// Check exit reasons
+// Check exit reasons (`exitReason` is undefined for still-open trades)
 const byReason = result.trades.reduce(
   (acc, t) => {
-    acc[t.exitReason] = (acc[t.exitReason] ?? 0) + 1;
+    const reason = t.exitReason ?? "open";
+    acc[reason] = (acc[reason] ?? 0) + 1;
     return acc;
   },
   {} as Record<string, number>,
@@ -473,17 +474,19 @@ console.log(result.indicators.rsi14);
 console.log(result.indicators.smaSpread_10_50);
 
 // Step 3: Dynamic plugin selection from config
+// Each entry closes over its own plugin + options, so the per-plugin option
+// types stay fully checked even though the list is heterogeneous.
 import { plugins } from "trendcraft";
 
 const pipeline = [
-  { plugin: plugins.sma, options: { period: 50 } },
-  { plugin: plugins.rsi, options: { period: 14 } },
-  { plugin: smaSpread, options: { fastPeriod: 5, slowPeriod: 20 } },
+  (t: TrendCraft) => t.use(plugins.sma, { period: 50 }),
+  (t: TrendCraft) => t.use(plugins.rsi, { period: 14 }),
+  (t: TrendCraft) => t.use(smaSpread, { fastPeriod: 5, slowPeriod: 20 }),
 ];
 
-let tc = TrendCraft.from(candles);
-for (const { plugin, options } of pipeline) {
-  tc = tc.use(plugin, options);
+let tc: TrendCraft = TrendCraft.from(candles);
+for (const step of pipeline) {
+  tc = step(tc);
 }
 const dynamicResult = tc.compute();
 console.log(Object.keys(dynamicResult.indicators));
@@ -609,14 +612,16 @@ import {
 
 const candles = normalizeCandles(rawCandles);
 
-// Transform: Normalize RSI to 0-1 range
+// Transform: Normalize RSI to 0-1 range (values are null during warm-up)
 const rsi14 = rsi(candles);
-const normalizedRsi = mapSeries(rsi14, (val) => val / 100);
+const normalizedRsi = mapSeries(rsi14, (val) => (val === null ? null : val / 100));
 
 // Combine: SMA spread
 const sma5 = sma(candles, { period: 5 });
 const sma25 = sma(candles, { period: 25 });
-const spread = zipSeries(sma5, sma25, (fast, slow) => fast - slow);
+const spread = zipSeries(sma5, sma25, (fast, slow) =>
+  fast !== null && slow !== null ? fast - slow : null,
+);
 
 // Complex merge: Create a composite signal
 const bb = bollingerBands(candles);
@@ -624,15 +629,15 @@ const composite = zipSeries(rsi14, bb, (rsiVal, bbVal) => ({
   rsi: rsiVal,
   percentB: bbVal.percentB,
   signal:
-    rsiVal < 30 && bbVal.percentB !== null && bbVal.percentB < 0
+    rsiVal !== null && rsiVal < 30 && bbVal.percentB !== null && bbVal.percentB < 0
       ? "strong_buy"
-      : rsiVal > 70 && bbVal.percentB !== null && bbVal.percentB > 1
+      : rsiVal !== null && rsiVal > 70 && bbVal.percentB !== null && bbVal.percentB > 1
         ? "strong_sell"
         : "neutral",
 }));
 
 // Filter: Find oversold moments
-const oversold = filterSeries(rsi14, (val) => val < 30);
+const oversold = filterSeries(rsi14, (val) => val !== null && val < 30);
 console.log(`Oversold points: ${oversold.length}`);
 
 // Align: Higher timeframe indicator to daily data

--- a/packages/core/docs/GUIDE.ja.md
+++ b/packages/core/docs/GUIDE.ja.md
@@ -971,7 +971,7 @@ Mansfield RS < 0  →  RS弱まっている
 import { benchmarkRS, isOutperforming, rankByRS } from 'trendcraft';
 
 // ベンチマークに対するRS計算
-const rs = benchmarkRS(stockCandles, nikkei225Candles, { period: 52 });
+const rs = benchmarkRS(stockCandles, sp500Candles, { period: 52 });
 
 const latest = rs[rs.length - 1].value;
 console.log(`RS Rating: ${latest.rsRating}`);        // パーセンタイル（0-100）
@@ -1015,7 +1015,7 @@ const entry = and(
 // ベンチマーク付きバックテスト実行 — `benchmark` オプションでベンチマークのローソク足を渡す
 runBacktest(candles, entry, exit, {
   capital: 1000000,
-  benchmark: nikkei225Candles,
+  benchmark: sp500Candles,
 });
 ```
 
@@ -1266,29 +1266,27 @@ console.log(`勝率: ${result.winRate}%`);
 ```typescript
 import { rangeBound } from 'trendcraft';
 
-const rbData = rangeBound(candles);
+const rb = rangeBound(candles);
+const latest = rb[rb.length - 1].value;
 
-rbData.forEach(({ time, value }) => {
-  const { state, rangeScore, rangeHigh, rangeLow, trendReason } = value;
-
-  switch (state) {
-    case 'RANGE_CONFIRMED':
-      console.log(`${time}: レンジ確定 (${rangeLow} - ${rangeHigh})`);
-      break;
-    case 'RANGE_TIGHT':
-      console.log(`${time}: タイトレンジ - ブレイクアウト注意`);
-      break;
-    case 'BREAKOUT_RISK_UP':
-      console.log(`${time}: 上方ブレイクアウトリスク`);
-      break;
-    case 'BREAKOUT_RISK_DOWN':
-      console.log(`${time}: 下方ブレイクアウトリスク`);
-      break;
-    case 'TRENDING':
-      console.log(`${time}: トレンド中 (理由: ${trendReason})`);
-      break;
+// 現在の状態をチェック
+if (latest.state === 'RANGE_CONFIRMED') {
+  console.log('レンジ相場です');
+  console.log(`レンジ: ${latest.rangeLow} - ${latest.rangeHigh}`);
+  if (latest.pricePosition !== null) {
+    console.log(`ポジション: ${(latest.pricePosition * 100).toFixed(0)}%`);
   }
-});
+}
+
+// ブレイクアウトリスクに反応
+if (latest.state === 'BREAKOUT_RISK_UP') {
+  console.log('上方ブレイクアウトに注意！');
+}
+
+// トレンド判定の理由をデバッグ
+if (latest.trendReason === 'hhll') {
+  console.log('連続する高値切り上げ/安値切り上げによりトレンド中');
+}
 ```
 
 ### Range Score
@@ -1304,11 +1302,38 @@ rangeScore >= 85（tightRangeThreshold）かつ ADX <= 15 → RANGE_TIGHT（非�
 ### トレード戦略
 
 #### レンジトレード戦略
+
+サポート付近（pricePosition ≈ 0）で買い、レジスタンス付近（pricePosition ≈ 1）で売り：
+
+```typescript
+import { rangeBound, inRangeBound } from 'trendcraft';
+
+// 確定レンジの下限でエントリー
+const rb = rangeBound(candles);
+const last = rb[rb.length - 1].value;
+const isGoodEntry = last.state === 'RANGE_CONFIRMED'
+  && last.pricePosition !== null && last.pricePosition < 0.2;
+```
+
 - レンジ下限（`rangeLow`）で買い、上限（`rangeHigh`）で売り
 - レンジ幅の50%以上の利益目標
 - レンジ外に逃げた場合はストップロス
 
 #### ブレイクアウト戦略
+
+レンジ形成を待ち、ブレイクアウトを取引：
+
+```typescript
+import { rangeBreakout } from 'trendcraft';
+
+// バックテストのエントリー条件として使用
+const result = TrendCraft.from(candles)
+  .strategy()
+    .entry(rangeBreakout())  // レンジブレイクでエントリー
+    .exit(deadCrossCondition())
+  .backtest({ capital: 1000000 });
+```
+
 - `RANGE_TIGHT`または`BREAKOUT_RISK_*`で警戒態勢
 - ブレイクアウト方向にエントリー
 - 出来高増加で確認
@@ -1322,24 +1347,6 @@ rangeScore >= 85（tightRangeThreshold）かつ ADX <= 15 → RANGE_TIGHT（非�
 | `rangeBreakout()` | レンジからのブレイクアウトでエントリー |
 | `not(inRangeBound())` | レンジ相場ではない時のみエントリー（フィルター） |
 | `rangeForming()` | レンジ形成中にイグジット |
-
-```typescript
-import { TrendCraft, and, goldenCrossCondition, deadCrossCondition, rangeBreakout, inRangeBound, not } from 'trendcraft';
-
-// ブレイクアウト戦略
-const result1 = TrendCraft.from(candles)
-  .strategy()
-    .entry(rangeBreakout())
-    .exit(deadCrossCondition())
-  .backtest({ capital: 1000000 });
-
-// レンジ相場を避けるフィルター
-const result2 = TrendCraft.from(candles)
-  .strategy()
-    .entry(and(goldenCrossCondition(), not(inRangeBound())))
-    .exit(deadCrossCondition())
-  .backtest({ capital: 1000000 });
-```
 
 ### ポイント
 
@@ -1391,8 +1398,13 @@ chop.forEach(({ value }) => {
 ```typescript
 import { vwap } from 'trendcraft';
 
+// ±2σ、±3σバンドを追加
 const result = vwap(candles, { bandMultipliers: [2, 3] });
-// result[i].value.bands で ±2σ、±3σバンドにアクセス
+result.forEach(({ value }) => {
+  console.log(value.vwap);           // VWAP
+  console.log(value.upper, value.lower);  // ±1σバンド（常に含まれる）
+  console.log(value.bands);          // 2σ・3σの [{upper, lower}, {upper, lower}]
+});
 ```
 
 ### アンカードVWAP
@@ -1867,7 +1879,9 @@ import {
 
 // ATRを計算
 const atrValues = atr(candles, { period: 14 });
+// ウォームアップ期間中の ATR は null — 十分なデータが揃うまで処理を中断
 const currentAtr = atrValues[atrValues.length - 1].value;
+if (currentAtr === null) throw new Error('ATR の計算に十分なローソク足がありません');
 
 // ポジションサイズを計算
 const position = atrBasedSize({
@@ -2267,8 +2281,9 @@ import { livePresets, indicatorPresets } from 'trendcraft';
 const smaFactory = livePresets.sma.createFactory({ period: 50 });
 const smaIndicator = smaFactory(undefined);
 
-// `indicatorPresets` は一括計算用の `compute` も持つ
-const rsiSeries = indicatorPresets.rsi.compute(candles, { period: 14 });
+// `indicatorPresets` は一括計算用の `compute` も持つ。
+// 型上は `compute` はオプショナル（組み込みエントリーはすべて定義済み）。
+const rsiSeries = indicatorPresets.rsi.compute!(candles, { period: 14 });
 ```
 
 `livePresets` はストリーミング向け 84 エントリー、`indicatorPresets` はストリーミング + バッチ両対応の 104 エントリーです。
@@ -2278,10 +2293,12 @@ const rsiSeries = indicatorPresets.rsi.compute(candles, { period: 14 });
 組み込み指標の出力はすべて、表示規約（ラベル、価格スケールに重ねるか、Y 軸レンジ、参照線）を示す `__meta` プロパティを持ちます:
 
 ```typescript
-import { rsi } from 'trendcraft';
+import { rsi, type TaggedSeries } from 'trendcraft';
 
 const r = rsi(candles, { period: 14 });
-r.__meta; // { kind: 'rsi', label: 'RSI(14)', overlay: false, yRange: [0, 100], referenceLines: [30, 70] }
+// 指標のシグネチャ上の型は Series<T>。実行時に付与されるメタデータを読むには
+// TaggedSeries<T> にキャストします。
+(r as TaggedSeries<number | null>).__meta; // { kind: 'rsi', label: 'RSI(14)', overlay: false, yRange: [0, 100], referenceLines: [30, 70] }
 ```
 
 `kind` はパラメータ非依存の安定した識別子（`indicatorPresets` のキーと一致）— フィルタ用に `s.__meta?.kind === 'rsi'` のように使います。`label` は表示用で、パラメータで変化します。

--- a/packages/core/docs/GUIDE.md
+++ b/packages/core/docs/GUIDE.md
@@ -1289,7 +1289,9 @@ const latest = rb[rb.length - 1].value;
 if (latest.state === 'RANGE_CONFIRMED') {
   console.log('Market is range-bound');
   console.log(`Range: ${latest.rangeLow} - ${latest.rangeHigh}`);
-  console.log(`Position: ${(latest.pricePosition * 100).toFixed(0)}%`);
+  if (latest.pricePosition !== null) {
+    console.log(`Position: ${(latest.pricePosition * 100).toFixed(0)}%`);
+  }
 }
 
 // React to breakout risk
@@ -1314,8 +1316,9 @@ import { rangeBound, inRangeBound } from 'trendcraft';
 
 // Entry when price at bottom of confirmed range
 const rb = rangeBound(candles);
-const isGoodEntry = rb[rb.length - 1].value.state === 'RANGE_CONFIRMED'
-  && rb[rb.length - 1].value.pricePosition < 0.2;
+const last = rb[rb.length - 1].value;
+const isGoodEntry = last.state === 'RANGE_CONFIRMED'
+  && last.pricePosition !== null && last.pricePosition < 0.2;
 ```
 
 #### Breakout Trading
@@ -1514,7 +1517,7 @@ const result = runBacktest(
 ### Combining Conditions
 
 ```typescript
-import { and, or, not } from 'trendcraft';
+import { and, or, not, goldenCrossCondition, deadCrossCondition } from 'trendcraft';
 
 // Golden Cross AND RSI < 30
 const entry = and(goldenCrossCondition(), rsiBelow(30));
@@ -1881,7 +1884,9 @@ import {
 
 // Calculate ATR
 const atrValues = atr(candles, { period: 14 });
+// ATR is null during the warm-up window — bail out until enough data exists
 const currentAtr = atrValues[atrValues.length - 1].value;
+if (currentAtr === null) throw new Error('not enough candles for ATR');
 
 // Calculate position size
 const position = atrBasedSize({
@@ -2281,8 +2286,9 @@ import { livePresets, indicatorPresets } from 'trendcraft';
 const smaFactory = livePresets.sma.createFactory({ period: 50 });
 const smaIndicator = smaFactory(undefined);
 
-// `indicatorPresets` adds a batch `compute` for one-shot static calculation
-const rsiSeries = indicatorPresets.rsi.compute(candles, { period: 14 });
+// `indicatorPresets` adds a batch `compute` for one-shot static calculation.
+// `compute` is optional in the entry type; every built-in entry defines it.
+const rsiSeries = indicatorPresets.rsi.compute!(candles, { period: 14 });
 ```
 
 `livePresets` ships 84 entries (streaming-focused); `indicatorPresets` ships 104 with both streaming and batch paths.
@@ -2292,10 +2298,12 @@ const rsiSeries = indicatorPresets.rsi.compute(candles, { period: 14 });
 Every built-in indicator output carries a `__meta` property with display conventions — label, whether it belongs on the price scale, Y-range, reference lines:
 
 ```typescript
-import { rsi } from 'trendcraft';
+import { rsi, type TaggedSeries } from 'trendcraft';
 
 const r = rsi(candles, { period: 14 });
-r.__meta; // { kind: 'rsi', label: 'RSI(14)', overlay: false, yRange: [0, 100], referenceLines: [30, 70] }
+// Indicator signatures are typed as Series<T>; cast to TaggedSeries<T> to read
+// the runtime-attached metadata.
+(r as TaggedSeries<number | null>).__meta; // { kind: 'rsi', label: 'RSI(14)', overlay: false, yRange: [0, 100], referenceLines: [30, 70] }
 ```
 
 `kind` is the stable, parameter-independent identifier (matches `indicatorPresets` keys) — use it for filtering (`s.__meta?.kind === 'rsi'`). `label` is for display and changes with parameters.

--- a/packages/core/src/__tests__/docs-ja-parity.test.ts
+++ b/packages/core/src/__tests__/docs-ja-parity.test.ts
@@ -1,0 +1,276 @@
+// @vitest-environment node
+/**
+ * EN/JA doc parity check.
+ *
+ * The package keeps English/Japanese twin docs (API.md ↔ API.ja.md,
+ * GUIDE.md ↔ GUIDE.ja.md, README.md ↔ README.ja.md). Audits repeatedly found
+ * the twins drifting independently — a fix lands in one language and not the
+ * other, or code examples diverge. This test pins the twins together at the
+ * code-fence level:
+ *
+ *   1. Fence-count parity — both files of a pair must contain the same number
+ *      of `ts`/`typescript` fences, in the same order (cheapest drift signal).
+ *   2. Normalized content parity — each fence pair must be identical after
+ *      stripping comments, collapsing whitespace, and replacing string-literal
+ *      CONTENTS with a placeholder. Japanese docs legitimately translate
+ *      comments and string literals, but the code itself — identifiers, option
+ *      keys, call shapes, and NUMBERS — must match exactly. (Numbers are
+ *      deliberately NOT normalized away: a wrong documented default, e.g. 20
+ *      vs "all candles", was a real bug class in past audits.)
+ *
+ * Escape hatch: place `<!-- ja-parity-skip -->` on its own line before a fence
+ * to exempt that fence from parity (it is removed from the sequence on that
+ * side, so a one-sided extra fence can also be excused). Skips are counted in
+ * an assertion so every exemption stays deliberate.
+ *
+ * Note: `@trendcraft/chart` has no Japanese doc twins (verified 2026-07 —
+ * packages/chart ships English-only docs), so this check is core-only.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pkgRoot = path.resolve(here, "../..");
+
+// Every EN doc that has a Japanese twin (paths relative to the package root).
+const DOC_PAIRS: Array<{ en: string; ja: string }> = [
+  { en: "docs/API.md", ja: "docs/API.ja.md" },
+  { en: "docs/GUIDE.md", ja: "docs/GUIDE.ja.md" },
+  { en: "README.md", ja: "README.ja.md" },
+];
+
+const SKIP_MARKER = "<!-- ja-parity-skip -->";
+
+// Total `ja-parity-skip` markers expected across all pairs. Bump this number
+// in the same commit that adds a marker, with a reason — the assertion exists
+// so exemptions cannot accumulate silently.
+const EXPECTED_SKIPS = 0;
+
+interface Fence {
+  /** 0-based position among the ts fences of the file (before skip removal). */
+  index: number;
+  /** Nearest markdown heading above the fence, for orientation in reports. */
+  heading: string;
+  /** 1-based line number of the opening ``` in the source file. */
+  line: number;
+  code: string;
+  skipped: boolean;
+}
+
+/**
+ * Extract `ts`/`typescript` fenced code plus orientation metadata. Fence
+ * detection mirrors docs-import-check.test.ts (` ```ts `/` ```typescript `
+ * opener, bare ` ``` ` closer); other-language fences are consumed so their
+ * bodies can't produce false headings or markers.
+ */
+function extractFences(relPath: string): Fence[] {
+  const lines = readFileSync(path.join(pkgRoot, relPath), "utf8").split("\n");
+  const fences: Fence[] = [];
+  let heading = "(top of file)";
+  let pendingSkip = false;
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (/^#{1,6}\s/.test(line)) {
+      heading = line.trim();
+      pendingSkip = false; // a marker must sit under the same heading as its fence
+      i++;
+      continue;
+    }
+    if (line.trim() === SKIP_MARKER) {
+      pendingSkip = true;
+      i++;
+      continue;
+    }
+    if (/^```(ts|typescript)\s*$/.test(line)) {
+      const start = i + 1;
+      const body: string[] = [];
+      i++;
+      while (i < lines.length && !/^```\s*$/.test(lines[i])) body.push(lines[i++]);
+      fences.push({
+        index: fences.length,
+        heading,
+        line: start,
+        code: body.join("\n"),
+        skipped: pendingSkip,
+      });
+      pendingSkip = false;
+    } else if (/^```/.test(line)) {
+      // Non-ts fence: consume its body so nothing inside is misread.
+      i++;
+      while (i < lines.length && !/^```\s*$/.test(lines[i])) i++;
+    }
+    i++;
+  }
+  return fences;
+}
+
+/**
+ * Normalize a fence for cross-language comparison: strip `//` and `/* *​/`
+ * comments, replace string-literal contents with a placeholder (quote style
+ * is kept; template-literal `${…}` interpolations are code and are preserved),
+ * then collapse whitespace per line and drop blank lines. Identifiers, option
+ * keys, call shapes, and numeric literals all survive normalization.
+ */
+function normalizeFence(code: string): string[] {
+  let out = "";
+  let i = 0;
+  const n = code.length;
+  while (i < n) {
+    const c = code[i];
+    if (c === "/" && code[i + 1] === "/") {
+      while (i < n && code[i] !== "\n") i++;
+      continue;
+    }
+    if (c === "/" && code[i + 1] === "*") {
+      i += 2;
+      while (i < n && !(code[i] === "*" && code[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      out += `${c}S${c}`;
+      i++;
+      while (i < n && code[i] !== c) i += code[i] === "\\" ? 2 : 1;
+      i++; // closing quote
+      continue;
+    }
+    if (c === "`") {
+      // Template literal: text segments are translatable (dropped entirely —
+      // translation reshapes text around interpolations, so even a placeholder
+      // per segment would be position-sensitive), but `${…}` interpolations
+      // are code and are kept verbatim (brace-balanced).
+      out += "`";
+      i++;
+      while (i < n && code[i] !== "`") {
+        if (code[i] === "\\") {
+          i += 2;
+          continue;
+        }
+        if (code[i] === "$" && code[i + 1] === "{") {
+          let depth = 1;
+          let j = i + 2;
+          while (j < n && depth > 0) {
+            if (code[j] === "{") depth++;
+            else if (code[j] === "}") depth--;
+            if (depth > 0) j++;
+          }
+          out += `\${${code.slice(i + 2, j)}}`;
+          i = j + 1;
+          continue;
+        }
+        i++;
+      }
+      out += "`";
+      i++;
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out
+    .split("\n")
+    .map((l) => l.replace(/\s+/g, " ").trim())
+    .filter((l) => l.length > 0);
+}
+
+function active(fences: Fence[]): Fence[] {
+  return fences.filter((f) => !f.skipped);
+}
+
+function describeFence(file: string, f: Fence): string {
+  return `${file}:${f.line} (fence #${f.index + 1}, under "${f.heading}")`;
+}
+
+const extracted = DOC_PAIRS.map((pair) => ({
+  pair,
+  en: extractFences(pair.en),
+  ja: extractFences(pair.ja),
+}));
+
+describe("doc snippets — EN/JA parity", () => {
+  it("found fences to compare in every pair", () => {
+    for (const { pair, en, ja } of extracted) {
+      expect(en.length, `${pair.en} has no ts fences`).toBeGreaterThan(0);
+      expect(ja.length, `${pair.ja} has no ts fences`).toBeGreaterThan(0);
+    }
+  });
+
+  it.each(
+    extracted.map((e) => [`${e.pair.en} ↔ ${e.pair.ja}`, e] as const),
+  )("fence count parity: %s", (_label, { pair, en, ja }) => {
+    const enA = active(en);
+    const jaA = active(ja);
+    if (enA.length === jaA.length) return;
+
+    // Locate the first index where normalized content diverges — the extra
+    // fence(s) are at or after this point — and report the longer side's
+    // tail from there for orientation.
+    let firstDiff = Math.min(enA.length, jaA.length);
+    for (let k = 0; k < firstDiff; k++) {
+      const a = normalizeFence(enA[k].code).join("\n");
+      const b = normalizeFence(jaA[k].code).join("\n");
+      if (a !== b) {
+        firstDiff = k;
+        break;
+      }
+    }
+    const [longSide, longFile] = enA.length > jaA.length ? [enA, pair.en] : [jaA, pair.ja];
+    const tail = longSide
+      .slice(firstDiff)
+      .map((f) => `  ${describeFence(longFile, f)}`)
+      .join("\n");
+    expect.fail(
+      `Fence count mismatch: ${pair.en} has ${enA.length} ts fences, ${pair.ja} has ${jaA.length} ` +
+        `(after excluding ${SKIP_MARKER}).\n` +
+        `Sequences first diverge at fence pair #${firstDiff + 1}. ` +
+        `Fences on the longer side (${longFile}) from that point:\n${tail}`,
+    );
+  });
+
+  it.each(
+    extracted.map((e) => [`${e.pair.en} ↔ ${e.pair.ja}`, e] as const),
+  )("fence content parity (normalized): %s", (_label, { pair, en, ja }) => {
+    const enA = active(en);
+    const jaA = active(ja);
+    const len = Math.min(enA.length, jaA.length);
+    const reports: string[] = [];
+    for (let k = 0; k < len; k++) {
+      const a = normalizeFence(enA[k].code);
+      const b = normalizeFence(jaA[k].code);
+      if (a.join("\n") === b.join("\n")) continue;
+      let d = 0;
+      while (d < a.length && d < b.length && a[d] === b[d]) d++;
+      reports.push(
+        [
+          `Pair #${k + 1}:`,
+          `  EN ${describeFence(pair.en, enA[k])}`,
+          `  JA ${describeFence(pair.ja, jaA[k])}`,
+          `  first differing normalized line (#${d + 1}):`,
+          `    EN: ${a[d] ?? "(no line — fence ends here)"}`,
+          `    JA: ${b[d] ?? "(no line — fence ends here)"}`,
+        ].join("\n"),
+      );
+    }
+    expect(
+      reports.length,
+      `Normalized fence divergence in ${pair.en} ↔ ${pair.ja} — the twins must show ` +
+        `identical code (comments/string contents may be translated):\n${reports.join("\n")}`,
+    ).toBe(0);
+  });
+
+  it(`ja-parity-skip markers are deliberate (expected: ${EXPECTED_SKIPS})`, () => {
+    const skips = extracted.flatMap(({ pair, en, ja }) => [
+      ...en.filter((f) => f.skipped).map((f) => describeFence(pair.en, f)),
+      ...ja.filter((f) => f.skipped).map((f) => describeFence(pair.ja, f)),
+    ]);
+    expect(
+      skips.length,
+      `Update EXPECTED_SKIPS (with a reason) when adding/removing ${SKIP_MARKER}.\nCurrent skips:\n${skips
+        .map((s) => `  ${s}`)
+        .join("\n")}`,
+    ).toBe(EXPECTED_SKIPS);
+  });
+});

--- a/packages/core/src/__tests__/docs-typecheck.test.ts
+++ b/packages/core/src/__tests__/docs-typecheck.test.ts
@@ -1,0 +1,744 @@
+// @vitest-environment node
+/**
+ * Doc-snippet harness (Tier 1.5 — type-check).
+ *
+ * Compiles EVERY fenced `ts`/`typescript` block in the package docs with the
+ * real TypeScript compiler against the in-repo source, in ONE virtual program:
+ *
+ *   Layer A — every fence must type-check. Catches wrong option-object keys,
+ *   wrong return-field access, wrong signatures, out-of-scope variables, and
+ *   nullability the docs ignore — the classes both the import check (Tier 1)
+ *   and the executed subset (Tier 2) are blind to.
+ *
+ *   Layer B — every fence that re-declares an interface / object type alias
+ *   whose name is also exported from the main entry is mirrored against the
+ *   real type: the key sets must match exactly and the two shapes must be
+ *   mutually assignable. Catches reference-doc shape drift (e.g. a doc block
+ *   listing stale field names for a result type).
+ *
+ * Design notes:
+ *   - Reference-style fences (API.md) intentionally omit imports; free
+ *     identifiers that are real package exports are auto-imported with their
+ *     REAL types, so calls and member access are still fully checked. Fences
+ *     that DO show imports have those imports checked as written.
+ *   - Free identifiers that are doc context variables ("candles", "wf", …) are
+ *     declared from the typed FIXTURES dictionary below. A new context variable
+ *     in the docs fails the suite until it is added here (or the doc declares
+ *     it) — that is deliberate: the dictionary is the allowlist.
+ *   - Signature-template arguments (`rsiBelow(threshold = 30)`) are rewritten
+ *     to their default value so the documented default is checked against the
+ *     real parameter type.
+ *   - `<!-- doctest-notypecheck: reason -->` on the line before a fence opts it
+ *     out (for pseudo-syntax summaries). Opt-outs and auto-skips are counted
+ *     and bounded by constants below so silent-skip creep is visible.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pkgRoot = path.resolve(here, "../..");
+const SRC = path.join(pkgRoot, "src");
+
+// Same doc surface as the Tier-1 import check.
+const DOC_FILES = [
+  "docs/COOKBOOK.md",
+  "docs/GUIDE.md",
+  "docs/API.md",
+  "docs/GUIDE.ja.md",
+  "docs/API.ja.md",
+  "README.md",
+  "README.ja.md",
+];
+
+// Published specifier → absolute in-repo source entry (mirrors Tier 1/2 maps).
+const ENTRIES: Record<string, string> = {
+  trendcraft: path.join(SRC, "index.ts"),
+  "trendcraft/screening": path.join(SRC, "screening/index.ts"),
+  "trendcraft/incremental": path.join(SRC, "indicators/incremental/index.ts"),
+  "trendcraft/safe": path.join(SRC, "indicators/safe.ts"),
+  "trendcraft/manifest": path.join(SRC, "manifest/index.ts"),
+};
+const AUTO_IMPORT_ORDER = Object.keys(ENTRIES);
+const MIRROR_ENTRY = "trendcraft";
+
+// If a fence auto-skips beyond these bounds, a doc change introduced a new
+// non-compilable fence shape — either fix the fence or raise the bound
+// deliberately (with a review of why the fence cannot compile).
+const MAX_AUTO_SKIPPED = 2; // bare `...` placeholder fragments
+const MAX_OPTED_OUT = 0; // explicit <!-- doctest-notypecheck --> markers
+
+// ---------------------------------------------------------------- fixtures
+// Typed declarations for the docs' free context variables. Types are REAL
+// package types (via `import("<abs source>")`), so member access and argument
+// passing on fixtures is still verified. `{core}` / `{incr}` expand to entries.
+const N = 'import("{core}").NormalizedCandle';
+const C = 'import("{core}").Candle';
+const T = (name: string) => `import("{core}").${name}`;
+const F = (fn: string) => `typeof import("{core}").${fn}`;
+const FIXTURES: Record<string, string> = {
+  // candle arrays (normalized)
+  ...Object.fromEntries(
+    [
+      "candles",
+      "dailyCandles",
+      "weeklyCandles",
+      "hourlyCandles",
+      "intradayCandles",
+      "historicalCandles",
+      "stockCandles",
+      "sp500Candles",
+      "benchmarkCandles",
+      "nikkei225Candles",
+      "aaplCandles",
+      "googlCandles",
+      "msftCandles",
+      "toyotaCandles",
+      "sonyCandles",
+      "nintendoCandles",
+      "candlesGOOG",
+      "candlesMSFT",
+      "candlesSPY",
+      "candlesQQQ",
+      "stream",
+    ].map((n) => [n, `${N}[]`]),
+  ),
+  // raw (pre-normalization) candle arrays
+  ...Object.fromEntries(
+    [
+      "rawCandles",
+      "rawDailyCandles",
+      "aaplRaw",
+      "msftRaw",
+      "googRaw",
+      "amznRaw",
+      "toyotaRaw",
+      "sonyRaw",
+      "softbankRaw",
+    ].map((n) => [n, `${C}[]`]),
+  ),
+  stockData: `Record<string, ${C}[]>`,
+  // single bars
+  ...Object.fromEntries(
+    ["candle", "bar", "formingBar", "formedCandle", "partialCandle"].map((n) => [n, N]),
+  ),
+  // numeric arrays
+  ...Object.fromEntries(
+    [
+      "dailyReturns",
+      "returnsA",
+      "returnsB",
+      "spyReturns",
+      "tltReturns",
+      "gldReturns",
+      "stockReturns",
+      "pos1Returns",
+      "pos2Returns",
+      "residuals",
+      "trialSharpes",
+    ].map((n) => [n, "number[]"]),
+  ),
+  // scalar pseudo-params used by signature-catalog fences
+  ...Object.fromEntries(
+    [
+      "period",
+      "threshold",
+      "adxThreshold",
+      "shortPeriod",
+      "longPeriod",
+      "stdDev",
+      "ratio",
+      "minConfidence",
+      "riskFreeRate",
+      "annualizedReturnPercent",
+      "maxDrawdownPercent",
+      "netProfit",
+      "maxDrawdown",
+      "atrValue",
+      "barTime",
+      "currentTime",
+      "index",
+      "fast",
+      "slow",
+    ].map((n) => [n, "number"]),
+  ),
+  name: "string",
+  csvString: "string",
+  timeframe: T("TimeframeShorthand"),
+  requiredTimeframes: `${T("TimeframeShorthand")}[]`,
+  entry: T("Condition"),
+  exit: T("Condition"),
+  entryConditions: `Parameters<${F("combinationSearch")}>[1]`,
+  exitConditions: `Parameters<${F("combinationSearch")}>[2]`,
+  result: T("BacktestResult"),
+  backtestResult: T("BacktestResult"),
+  resultA: T("BacktestResult"),
+  resultB: T("BacktestResult"),
+  resultC: T("BacktestResult"),
+  bestResult: T("BacktestResult"),
+  wf: T("WalkForwardResult"),
+  mcResult: T("MonteCarloResult"),
+  awfResult: `Parameters<${F("summarizeAWFResult")}>[0]`,
+  awfOptions: `Parameters<${F("generateAWFBoundaries")}>[1]`,
+  strategyFactory: T("StrategyFactory"),
+  paramRanges: `${T("ParameterRange")}[]`,
+  datasets: `Parameters<${F("batchBacktest")}>[0]`,
+  symbolsMap: `Map<string, ${N}[]>`,
+  ws: "{ on(event: string, handler: (data: any) => void): void }",
+  config: T("ScoringConfig"),
+  strategyJson: T("StrategyJSON"),
+  trace: `Parameters<${F("generateNarrative")}>[0]`,
+  myData: `${T("Series")}<number | null>`,
+  scoreSeries: `Parameters<${F("createObservationsFromScores")}>[0]`,
+  rsiSeries: `${T("Series")}<number | null>`,
+  seriesA: `${T("Series")}<number | null>`,
+  seriesB: `${T("Series")}<number | null>`,
+  shortMA: `${T("Series")}<number | null>`,
+  longMA: `${T("Series")}<number | null>`,
+  tickStream: `${T("streaming")}.Trade[]`,
+  trades: `${T("streaming")}.Trade[]`,
+  rsiIndicator: `ReturnType<typeof import("{incr}").createRsi>`,
+  entryCondition: `Parameters<typeof import("{core}").streaming.evaluateStreamingCondition>[0]`,
+  snapshot: `Parameters<typeof import("{core}").streaming.evaluateStreamingCondition>[1]`,
+  pipeline: `{ next(candle: ${N}): Parameters<${F("fromPipelineResult")}>[0] }`,
+  manager: `ReturnType<${F("createSignalManager")}>`,
+  incomingSignals: `Parameters<ReturnType<${F("createSignalManager")}>["onBar"]>[0]`,
+  signal: `Parameters<ReturnType<${F("createSignalManager")}>["onBar"]>[0][number]`,
+  myConditionFactory: `(period: number) => ${T("Condition")}`,
+  someThrowingFunction: "() => unknown",
+  updateChart: "(...args: unknown[]) => void",
+  placeOrder: "(...args: unknown[]) => void",
+  closeAllPositions: "() => void",
+  evaluate: `Parameters<${F("mtfCondition")}>[2]`,
+  evaluateFn: `Parameters<${F("mtfCondition")}>[2]`,
+  options: T("SignalManagerOptions"),
+  comboReturns: "number[][]",
+  // external data vendors (the docs' stated payload shapes)
+  exchange:
+    "{ fetchOHLCV(symbol: string, timeframe: string, since?: number, limit?: number): Promise<Array<[number, number, number, number, number, number]>> }",
+  alpaca:
+    "{ getBars(opts: { symbol: string; timeframe: string; limit?: number }): Promise<Array<{ t: string; o: number; h: number; l: number; c: number; v: number }>> }",
+  yahooFinance:
+    "{ chart(symbol: string, opts: { period1: string }): Promise<{ quotes: Array<{ date: Date; open: number; high: number; low: number; close: number; volume: number }> }> }",
+};
+// Fixtures the docs re-assign (none in core docs today).
+const MUTABLE_FIXTURES = new Set<string>();
+// Placeholder TYPE fixtures (doc narrative types); none needed for core docs.
+const TYPE_FIXTURES: Record<string, string> = {};
+
+function substituteFixturePaths(type: string): string {
+  return type
+    .replaceAll("{core}", ENTRIES.trendcraft)
+    .replaceAll("{incr}", ENTRIES["trendcraft/incremental"]);
+}
+
+// ---------------------------------------------------------------- fences
+type Fence = {
+  file: string;
+  index: number;
+  lang: string;
+  mdLine: number; // 1-based line of the first fence body line
+  code: string;
+  noTypecheck: boolean;
+};
+
+const FENCE_OPEN_RE = /^```(ts|typescript)\s*$/;
+const NOTYPECHECK_RE = /<!--\s*doctest-notypecheck\b[^>]*-->/;
+
+function extractFences(relFile: string): Fence[] {
+  const lines = readFileSync(path.join(pkgRoot, relFile), "utf8").split("\n");
+  const out: Fence[] = [];
+  let i = 0;
+  let idx = 0;
+  while (i < lines.length) {
+    const m = lines[i].match(FENCE_OPEN_RE);
+    if (!m) {
+      i++;
+      continue;
+    }
+    const lookback = lines.slice(Math.max(0, i - 3), i).join("\n");
+    const noTypecheck = NOTYPECHECK_RE.test(lookback);
+    const bodyStart = i + 2;
+    const body: string[] = [];
+    i++;
+    while (i < lines.length && !/^```\s*$/.test(lines[i])) body.push(lines[i++]);
+    i++;
+    out.push({
+      file: relFile,
+      index: idx++,
+      lang: m[1],
+      mdLine: bodyStart,
+      code: body.join("\n"),
+      noTypecheck,
+    });
+  }
+  return out;
+}
+
+// A bare `...`/`…` placeholder (not a spread `...expr`) marks a fragment.
+function hasBareEllipsis(code: string): boolean {
+  const stripped = code.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+  return /\.\.\.(?![A-Za-z_$([{'"`0-9])/.test(stripped) || /…/.test(stripped);
+}
+
+// ---------------------------------------------------------- compiler setup
+const compilerOptions: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  lib: ["lib.es2022.d.ts", "lib.dom.d.ts", "lib.dom.iterable.d.ts"],
+  strict: true,
+  noEmit: true,
+  esModuleInterop: true,
+  skipLibCheck: true,
+  allowImportingTsExtensions: true,
+  types: [],
+};
+
+// ---------------------------------------------------------- name analysis
+/**
+ * Collect FILE-scope declared names and referenced identifiers. Only file-scope
+ * declarations suppress auto-import/fixtures — a nested function parameter
+ * named `candles` must not hide the fixture the top-level statements rely on
+ * (references inside the nested scope still resolve to the parameter).
+ */
+function analyzeNames(sourceFile: ts.SourceFile): {
+  declared: Set<string>;
+  referenced: Set<string>;
+} {
+  const declared = new Set<string>();
+  const referenced = new Set<string>();
+  function visit(node: ts.Node): void {
+    if (ts.isIdentifier(node)) {
+      const p = node.parent;
+      if (!p) return;
+      const isDecl =
+        ((ts.isVariableDeclaration(p) ||
+          ts.isFunctionDeclaration(p) ||
+          ts.isClassDeclaration(p) ||
+          ts.isInterfaceDeclaration(p) ||
+          ts.isTypeAliasDeclaration(p) ||
+          ts.isEnumDeclaration(p) ||
+          ts.isModuleDeclaration(p) ||
+          ts.isParameter(p) ||
+          ts.isBindingElement(p) ||
+          ts.isImportClause(p) ||
+          ts.isNamespaceImport(p) ||
+          ts.isImportSpecifier(p) ||
+          ts.isTypeParameterDeclaration(p)) &&
+          p.name === node) ||
+        (ts.isImportSpecifier(p) && p.propertyName === node);
+      if (isDecl) {
+        let scope: ts.Node | undefined = p.parent;
+        while (
+          scope &&
+          !ts.isSourceFile(scope) &&
+          !ts.isFunctionLike(scope) &&
+          !ts.isClassLike(scope) &&
+          !ts.isInterfaceDeclaration(scope) &&
+          !ts.isTypeAliasDeclaration(scope)
+        ) {
+          scope = scope.parent;
+        }
+        if (scope && ts.isSourceFile(scope)) declared.add(node.text);
+        return;
+      }
+      const skip =
+        (ts.isPropertyAccessExpression(p) && p.name === node) ||
+        (ts.isQualifiedName(p) && p.right === node) ||
+        (ts.isPropertyAssignment(p) && p.name === node) ||
+        (ts.isPropertySignature(p) && p.name === node) ||
+        (ts.isMethodSignature(p) && p.name === node) ||
+        (ts.isPropertyDeclaration(p) && p.name === node) ||
+        (ts.isMethodDeclaration(p) && p.name === node) ||
+        (ts.isGetAccessorDeclaration(p) && p.name === node) ||
+        (ts.isSetAccessorDeclaration(p) && p.name === node) ||
+        (ts.isBindingElement(p) && p.propertyName === node) ||
+        ts.isExportSpecifier(p) ||
+        (ts.isEnumMember(p) && p.name === node) ||
+        (ts.isLabeledStatement(p) && p.label === node) ||
+        (ts.isBreakOrContinueStatement(p) && p.label === node);
+      if (!skip) referenced.add(node.text);
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  return { declared, referenced };
+}
+
+// -------------------------------------------------- per-fence preprocessing
+const SPEC_RE = /(['"])(trendcraft(?:\/[\w-]+)?)\1/g;
+
+function rewriteSpecifiers(code: string): string {
+  return code.replace(SPEC_RE, (m, q, spec) => (ENTRIES[spec] ? `${q}${ENTRIES[spec]}${q}` : m));
+}
+
+type Prepared = { code: string; sf: ts.SourceFile; wrapped: boolean };
+
+function parse(code: string): ts.SourceFile {
+  return ts.createSourceFile("fence.ts", code, ts.ScriptTarget.ES2022, true, ts.ScriptKind.TS);
+}
+
+/** Syntax errors of a standalone SourceFile (`parseDiagnostics` is not on the public type). */
+function parseErrors(sf: ts.SourceFile): readonly ts.Diagnostic[] {
+  return (sf as unknown as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ?? [];
+}
+
+function prepare(fence: Fence): Prepared {
+  let code = rewriteSpecifiers(fence.code);
+  let sf = parse(code);
+
+  // Signature-template call arguments: `rsiBelow(threshold = 30)` documents a
+  // default. Rewrite `ident = expr` (ident undeclared) to bare `expr` so the
+  // documented default is checked against the real parameter type.
+  {
+    const declaredQuick = new Set<string>();
+    const collectDecl = (n: ts.Node): void => {
+      if (
+        (ts.isVariableDeclaration(n) || ts.isParameter(n) || ts.isFunctionDeclaration(n)) &&
+        n.name &&
+        ts.isIdentifier(n.name)
+      ) {
+        declaredQuick.add(n.name.text);
+      }
+      ts.forEachChild(n, collectDecl);
+    };
+    collectDecl(sf);
+    const edits: Array<[number, number]> = [];
+    const findTemplateArgs = (n: ts.Node): void => {
+      if (ts.isCallExpression(n)) {
+        for (const arg of n.arguments) {
+          if (
+            ts.isBinaryExpression(arg) &&
+            arg.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+            ts.isIdentifier(arg.left) &&
+            !declaredQuick.has(arg.left.text)
+          ) {
+            edits.push([arg.getStart(sf), arg.right.getStart(sf)]);
+          }
+        }
+      }
+      ts.forEachChild(n, findTemplateArgs);
+    };
+    findTemplateArgs(sf);
+    if (edits.length) {
+      for (const [s, e] of edits.sort((a, b) => b[0] - a[0]))
+        code = code.slice(0, s) + code.slice(e);
+      sf = parse(code);
+    }
+  }
+
+  // Declare-ify top-level body-less function declarations (signature docs).
+  {
+    const inserts: number[] = [];
+    for (const st of sf.statements) {
+      if (
+        ts.isFunctionDeclaration(st) &&
+        !st.body &&
+        !st.modifiers?.some((mod) => mod.kind === ts.SyntaxKind.DeclareKeyword)
+      ) {
+        inserts.push(st.getStart(sf));
+      }
+    }
+    if (inserts.length) {
+      for (const pos of inserts.sort((a, b) => b - a))
+        code = `${code.slice(0, pos)}declare ${code.slice(pos)}`;
+      sf = parse(code);
+    }
+  }
+
+  // Bare method-signature fences (`setCandles(candles: CandleData[]): void`)
+  // don't parse as statements; they DO parse as interface members. Wrapping
+  // still type-checks every referenced parameter/return type.
+  let wrapped = false;
+  if (parseErrors(sf).length > 0) {
+    const wrappedCode = `interface __DocMemberSignatures {\n${code}\n}`;
+    const sf2 = parse(wrappedCode);
+    if (parseErrors(sf2).length === 0) {
+      code = wrappedCode;
+      sf = sf2;
+      wrapped = true;
+    }
+  }
+  return { code, sf, wrapped };
+}
+
+// ---------------------------------------------------------------- assembly
+type Checked = {
+  fence: Fence;
+  vpath: string;
+  preambleLines: number;
+  layer: "A" | "B";
+  mirrorNames?: string[];
+};
+
+type Harness = {
+  fences: Fence[];
+  checked: Checked[];
+  autoSkipped: Array<{ fence: Fence; reason: string }>;
+  optedOut: Fence[];
+  mirrorCount: number;
+  findings: string[];
+};
+
+let harnessCache: Harness | null = null;
+
+function buildHarness(): Harness {
+  if (harnessCache) return harnessCache;
+
+  const virtualFiles = new Map<string, string>();
+  const sourceFileCache = new Map<string, ts.SourceFile | undefined>();
+  const baseHost = ts.createCompilerHost(compilerOptions, true);
+  const host: ts.CompilerHost = {
+    ...baseHost,
+    fileExists: (f) => virtualFiles.has(f) || baseHost.fileExists(f),
+    readFile: (f) => virtualFiles.get(f) ?? baseHost.readFile(f),
+    getSourceFile: (f, lang, onError, shouldCreate) => {
+      const v = virtualFiles.get(f);
+      if (v !== undefined) {
+        let sf = sourceFileCache.get(f);
+        if (!sf || sf.text !== v) {
+          sf = ts.createSourceFile(f, v, compilerOptions.target ?? ts.ScriptTarget.ES2022, true);
+          sourceFileCache.set(f, sf);
+        }
+        return sf;
+      }
+      let sf = sourceFileCache.get(f);
+      if (!sf) {
+        sf = baseHost.getSourceFile(f, lang, onError, shouldCreate);
+        sourceFileCache.set(f, sf);
+      }
+      return sf;
+    },
+  };
+
+  // Phase 0: parse the entry graph once to learn every export name (values AND
+  // types — the runtime import used by Tier 1 cannot see type-only exports).
+  const programZero = ts.createProgram({
+    rootNames: Object.values(ENTRIES),
+    options: compilerOptions,
+    host,
+  });
+  const checker0 = programZero.getTypeChecker();
+  const exportsByEntry = new Map<string, Set<string>>();
+  for (const [spec, entry] of Object.entries(ENTRIES)) {
+    const sf = programZero.getSourceFile(entry);
+    const names = new Set<string>();
+    const sym = sf && checker0.getSymbolAtLocation(sf);
+    if (sym) for (const e of checker0.getExportsOfModule(sym)) names.add(e.getName());
+    exportsByEntry.set(spec, names);
+  }
+
+  function computePreamble(declared: Set<string>, referenced: Set<string>): string {
+    const free = [...referenced].filter((n) => !declared.has(n));
+    const bySpec = new Map<string, string[]>();
+    for (const n of free) {
+      for (const spec of AUTO_IMPORT_ORDER) {
+        if (exportsByEntry.get(spec)?.has(n)) {
+          if (!bySpec.has(spec)) bySpec.set(spec, []);
+          bySpec.get(spec)?.push(n);
+          break;
+        }
+      }
+    }
+    const parts: string[] = [];
+    const imported = new Set<string>();
+    for (const [spec, names] of bySpec) {
+      parts.push(`import { ${names.join(", ")} } from "${ENTRIES[spec]}";`);
+      for (const n of names) imported.add(n);
+    }
+    const fixtureDecls: string[] = [];
+    for (const [fname, ftype] of Object.entries(FIXTURES)) {
+      if (!declared.has(fname) && !imported.has(fname) && referenced.has(fname)) {
+        const kw = MUTABLE_FIXTURES.has(fname) ? "let" : "const";
+        fixtureDecls.push(`declare ${kw} ${fname}: ${substituteFixturePaths(ftype)};`);
+      }
+    }
+    for (const [tname, decl] of Object.entries(TYPE_FIXTURES)) {
+      const needed =
+        (!declared.has(tname) && !imported.has(tname) && referenced.has(tname)) ||
+        fixtureDecls.some((d) => new RegExp(`\\b${tname}\\b`).test(d));
+      if (needed && !declared.has(tname) && !imported.has(tname)) parts.push(decl);
+    }
+    parts.push(...fixtureDecls);
+    // Single line: keeps the md-line mapping offset at exactly one line.
+    return parts.join(" ");
+  }
+
+  function buildVirtual(prep: Prepared): { text: string; preambleLines: number } {
+    const { declared, referenced } = analyzeNames(prep.sf);
+    const preamble = computePreamble(declared, referenced);
+    const hasModuleSyntax =
+      /(^|\n)\s*(import|export)\b/.test(prep.code) || preamble.includes("import ");
+    const text =
+      (preamble ? `${preamble}\n` : "") + prep.code + (hasModuleSyntax ? "" : "\nexport {};");
+    return { text, preambleLines: preamble ? 1 : 0 };
+  }
+
+  // Layer B: mirror doc-declared interfaces / object type aliases against the
+  // real exported type of the same name.
+  function buildMirrors(prep: Prepared): { text: string; names: string[] } | null {
+    const entryExports = exportsByEntry.get(MIRROR_ENTRY);
+    const mirrors: string[] = [];
+    for (const st of prep.sf.statements) {
+      let mirrorName: string | null = null;
+      let generic = false;
+      if (ts.isInterfaceDeclaration(st)) {
+        mirrorName = st.name.text;
+        generic = (st.typeParameters?.length ?? 0) > 0;
+      } else if (ts.isTypeAliasDeclaration(st) && ts.isTypeLiteralNode(st.type)) {
+        mirrorName = st.name.text;
+        generic = (st.typeParameters?.length ?? 0) > 0;
+      }
+      if (!mirrorName || generic || !entryExports?.has(mirrorName)) continue;
+      mirrors.push(mirrorName);
+    }
+    if (mirrors.length === 0) return null;
+
+    let code = prep.code;
+    for (const mirrorName of mirrors) {
+      code = code.replace(new RegExp(`\\b${mirrorName}\\b`, "g"), `${mirrorName}__doc`);
+    }
+    const { declared, referenced } = analyzeNames(prep.sf);
+    for (const n of mirrors) referenced.delete(n); // renamed & declared locally
+    const preamble = computePreamble(declared, referenced);
+    const header =
+      (preamble ? `${preamble} ` : "") +
+      `import type { ${mirrors.map((n) => `${n} as ${n}__real`).join(", ")} } from "${ENTRIES[MIRROR_ENTRY]}";`;
+    const tail: string[] = [];
+    for (const n of mirrors) {
+      tail.push(
+        `type __MissingInDoc_${n} = Exclude<keyof ${n}__real, keyof ${n}__doc>;`,
+        `type __ExtraInDoc_${n} = Exclude<keyof ${n}__doc, keyof ${n}__real>;`,
+        `const __keys_${n}: [__MissingInDoc_${n} | __ExtraInDoc_${n}] extends [never] ? "ok" : { docIsMissing: __MissingInDoc_${n}[]; docHasExtra: __ExtraInDoc_${n}[] } = "ok";`,
+        `declare const __docV_${n}: ${n}__doc; declare const __realV_${n}: ${n}__real;`,
+        `const __docAssignable_${n}: ${n}__real = __docV_${n};`,
+        `const __realAssignable_${n}: ${n}__doc = __realV_${n};`,
+        `void __keys_${n}; void __docAssignable_${n}; void __realAssignable_${n};`,
+      );
+    }
+    return { text: `${header}\n${code}\n${tail.join("\n")}\nexport {};`, names: mirrors };
+  }
+
+  const fences = DOC_FILES.flatMap(extractFences);
+  const autoSkipped: Array<{ fence: Fence; reason: string }> = [];
+  const optedOut: Fence[] = [];
+  const checked: Checked[] = [];
+  const VDIR = path.join(here, "__doc_typecheck_virtual__");
+
+  for (const fence of fences) {
+    if (fence.noTypecheck) {
+      optedOut.push(fence);
+      continue;
+    }
+    if (hasBareEllipsis(fence.code)) {
+      autoSkipped.push({ fence, reason: "ellipsis-placeholder" });
+      continue;
+    }
+    const prep = prepare(fence);
+    const id = `${fence.file.replace(/\W/g, "_")}_${fence.index}`;
+    const v = buildVirtual(prep);
+    const vpath = path.join(VDIR, `${id}.ts`);
+    virtualFiles.set(vpath, v.text);
+    checked.push({
+      fence,
+      vpath,
+      preambleLines: v.preambleLines + (prep.wrapped ? 1 : 0),
+      layer: "A",
+    });
+
+    const mirror = buildMirrors(prep);
+    if (mirror) {
+      const mpath = path.join(VDIR, `${id}.mirror.ts`);
+      virtualFiles.set(mpath, mirror.text);
+      checked.push({
+        fence,
+        vpath: mpath,
+        preambleLines: 1,
+        layer: "B",
+        mirrorNames: mirror.names,
+      });
+    }
+  }
+
+  const program = ts.createProgram({
+    rootNames: [...virtualFiles.keys()],
+    options: compilerOptions,
+    host,
+    oldProgram: programZero,
+  });
+
+  const findings: string[] = [];
+  for (const c of checked) {
+    const sf = program.getSourceFile(c.vpath);
+    if (!sf) continue;
+    const diags = [...program.getSyntacticDiagnostics(sf), ...program.getSemanticDiagnostics(sf)];
+    for (const d of diags) {
+      const pos = d.start !== undefined ? sf.getLineAndCharacterOfPosition(d.start) : { line: 0 };
+      const mdLine = c.fence.mdLine + Math.max(0, pos.line - c.preambleLines);
+      const layerTag = c.layer === "B" ? ` [type-mirror: ${c.mirrorNames?.join(", ")}]` : "";
+      findings.push(
+        `  ${c.fence.file}:${mdLine}${layerTag} TS${d.code}: ${ts.flattenDiagnosticMessageText(d.messageText, " | ")}`,
+      );
+    }
+  }
+
+  harnessCache = {
+    fences,
+    checked,
+    autoSkipped,
+    optedOut,
+    mirrorCount: checked.filter((c) => c.layer === "B").length,
+    findings,
+  };
+  return harnessCache;
+}
+
+// ---------------------------------------------------------------- tests
+const TIMEOUT_MS = 60_000;
+
+describe("doc snippets — type-check (Tier 1.5)", () => {
+  it(
+    "found ts fences to type-check",
+    () => {
+      const h = buildHarness();
+      expect(h.checked.filter((c) => c.layer === "A").length).toBeGreaterThan(500);
+      expect(h.mirrorCount).toBeGreaterThan(50);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "every documented snippet type-checks against the real API",
+    () => {
+      const h = buildHarness();
+      expect(
+        h.findings.length,
+        `Doc snippet type errors (fix the doc, or opt out with <!-- doctest-notypecheck: reason -->):\n${h.findings.join("\n")}`,
+      ).toBe(0);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "auto-skips and opt-outs stay within recorded bounds",
+    () => {
+      const h = buildHarness();
+      const skipReport = h.autoSkipped
+        .map((s) => `  ${s.fence.file}#${s.fence.index}: ${s.reason}`)
+        .join("\n");
+      expect(
+        h.autoSkipped.length,
+        `Auto-skipped fences exceeded the recorded bound (${MAX_AUTO_SKIPPED}). If the new fragment is intentional, raise MAX_AUTO_SKIPPED deliberately.\n${skipReport}`,
+      ).toBeLessThanOrEqual(MAX_AUTO_SKIPPED);
+      const optReport = h.optedOut.map((f) => `  ${f.file}#${f.index}`).join("\n");
+      expect(
+        h.optedOut.length,
+        `Opted-out fences exceeded the recorded bound (${MAX_OPTED_OUT}). If the new opt-out is justified, raise MAX_OPTED_OUT deliberately.\n${optReport}`,
+      ).toBeLessThanOrEqual(MAX_OPTED_OUT);
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/core/src/__tests__/jsdoc-examples-typecheck.test.ts
+++ b/packages/core/src/__tests__/jsdoc-examples-typecheck.test.ts
@@ -1,0 +1,681 @@
+// @vitest-environment node
+/**
+ * JSDoc @example type-check harness.
+ *
+ * Sweeps every non-test `src/**` source file for JSDoc `@example` blocks and
+ * type-checks the extracted code in ONE virtual TypeScript program, so stale
+ * examples (wrong signatures, removed helpers, renamed exports) fail CI the
+ * same way stale doc fences do in `docs-import-check` / `docs-snippets`.
+ *
+ * Leniency model — JSDoc examples conventionally omit imports and fixtures,
+ * so unlike the docs-fence harnesses the whole public surface is put in scope:
+ *   - Every runtime export / exported type of the package entries (main,
+ *     screening, incremental, safe, manifest, plus the `streaming` module so
+ *     its members resolve bare) is ambient-declared.
+ *   - Exported namespaces (e.g. `execution`, `streaming`, `safe`) also get a
+ *     global `namespace` declaration carrying their exported TYPES, so
+ *     qualified type references like `execution.PositionSnapshot` resolve.
+ *   - The exports of the module each example lives in are declared per
+ *     example (examples often use their own file's non-root-exported helpers).
+ *   - Examples under `src/streaming/` additionally get the streaming entry's
+ *     exports, shadowing same-named root exports: bare `rsiBelow` in a
+ *     streaming example means `streaming.rsiBelow`, not the backtest one.
+ *   - Conventional fixtures (`candles`, `stream`, `result`, …) are declared
+ *     with their real types — see FIXTURE_TYPES / FIXTURE_FAMILIES below.
+ *   - The ellipsis placeholder convention is tolerated: `[1, 2, ...]` /
+ *     `{ a, ... }` become a spread of `any`, and a fully-elided call
+ *     `fn(...)` is checked as `(fn as any)()` (arity intentionally unchecked).
+ *   - `import ... from "trendcraft[/sub]"` statements are rewritten to the
+ *     in-repo source entries (same mapping as docs-import-check).
+ *
+ * Suppressed diagnostics (documented noise, not stale-docs signal):
+ *   - TS6133/TS6196/TS6198/TS6205 — unused locals; examples assign results
+ *     without consuming them.
+ *   - TS2451/TS2393 — redeclarations; one example often shows several
+ *     alternative snippets reusing the same `const entry = …` name.
+ *   - TS7006/TS7031 — implicit-any callback params / binding elements;
+ *     illustrative fragments omit param types real code gets from context.
+ *   - TS2531/TS18047/TS18048 — strict-null elision; examples intentionally
+ *     skip the null guards on `Series<T | null>` values.
+ *
+ * Opt-out: an example whose first code line starts with `// notypecheck` is
+ * skipped (for intentionally partial pseudo-code that cannot type-check).
+ * The skip count is pinned below so opt-outs stay deliberate.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const srcRoot = path.resolve(here, "..");
+const INDEX = path.join(srcRoot, "index.ts");
+
+/** Number of examples deliberately opted out via `// notypecheck`. */
+const EXPECTED_SKIPS = 3;
+
+// Entries whose exports become ambient globals (first entry wins on name
+// clashes, so the main entry's meaning of a name is authoritative).
+// `streaming` is not a published subpath but its members appear bare in
+// streaming examples, so its surface is included last.
+const AMBIENT_ENTRIES = [
+  INDEX,
+  path.join(srcRoot, "screening/index.ts"),
+  path.join(srcRoot, "indicators/incremental/index.ts"),
+  path.join(srcRoot, "indicators/safe/index.ts"),
+  path.join(srcRoot, "manifest/index.ts"),
+  path.join(srcRoot, "streaming/index.ts"),
+];
+
+// `import ... from "trendcraft[/sub]"` → in-repo source entry (mirrors
+// docs-import-check's SUBPATH_TO_SOURCE). Absolute paths keep resolution
+// independent of where the virtual example file lives.
+const IMPORT_REWRITES: Array<[RegExp, string]> = [
+  [
+    /(["'])trendcraft\/incremental\1/g,
+    JSON.stringify(path.join(srcRoot, "indicators/incremental/index.ts")),
+  ],
+  [/(["'])trendcraft\/screening\1/g, JSON.stringify(path.join(srcRoot, "screening/index.ts"))],
+  [/(["'])trendcraft\/safe\1/g, JSON.stringify(path.join(srcRoot, "indicators/safe/index.ts"))],
+  [/(["'])trendcraft\/manifest\1/g, JSON.stringify(path.join(srcRoot, "manifest/index.ts"))],
+  [/(["'])trendcraft\1/g, JSON.stringify(INDEX)],
+];
+
+// Conventional free variables JSDoc examples assume from context, declared
+// with their REAL types so calls against them are genuinely checked. `any` is
+// used only for opaque placeholders (resume tokens, "your options here",
+// external broker/API pseudo-objects) where no single real type exists.
+const T = (t: string) => `import(${JSON.stringify(INDEX)}).${t}`;
+const FIXTURE_TYPES: Record<string, string> = {
+  // market data
+  candles: `${T("NormalizedCandle")}[]`,
+  rawCandles: `${T("Candle")}[]`,
+  candle: T("NormalizedCandle"),
+  currentCandle: T("NormalizedCandle"),
+  oneMinCandle: T("NormalizedCandle"),
+  stream: `Iterable<${T("NormalizedCandle")}>`,
+  series: `${T("Series")}<number | null>`,
+  tickStream: "Iterable<{ time: number; price: number; volume: number }>",
+  // scalars
+  i: "number",
+  index: "number",
+  endIndex: "number",
+  timestamp: "number",
+  price: "number",
+  currentPrice: "number",
+  bestScore: "number",
+  // backtest
+  result: T("BacktestResult"),
+  backtestResult: T("BacktestResult"),
+  bestResult: T("BacktestResult"),
+  resultA: T("BacktestResult"),
+  resultB: T("BacktestResult"),
+  resultC: T("BacktestResult"),
+  trades: `${T("Trade")}[]`,
+  entry: T("Condition"),
+  exit: T("Condition"),
+  entryConditions: `${T("ConditionDefinition")}[]`,
+  exitConditions: `${T("ConditionDefinition")}[]`,
+  datasets: `${T("SymbolData")}[]`,
+  // optimization
+  createStrategy: T("StrategyFactory"),
+  parameterRanges: `${T("ParameterRange")}[]`,
+  ranges: `${T("ParameterRange")}[]`,
+  pathRanges: `${T("PathParameterRange")}[]`,
+  gridResult: T("GridSearchResult"),
+  walkForwardResult: T("WalkForwardResult"),
+  monteCarloResult: T("MonteCarloResult"),
+  paretoResult: T("ParetoResult"),
+  entries: `${T("OptimizationResultEntry")}[]`,
+  objectives: `${T("ParetoObjective")}[]`,
+  fronts: "number[][]",
+  // numeric arrays
+  returns: "number[]",
+  returnsMatrix: "number[][]",
+  equity: "number[]",
+  prices: "number[]",
+  weights: "number[]",
+  times: "number[]",
+  scores: "number[]",
+  drawdowns: "number[]",
+  residuals: "number[]",
+  volatilities: "number[]",
+  // HMM
+  obs: "number[][]",
+  model: T("HmmModel"),
+  // strategy JSON / serialization
+  strategyJson: T("StrategyJSON"),
+  strategyDefinition: T("StrategyDefinition"),
+  jsonString: "string",
+  csvContent: "string",
+  // signals / patterns
+  swingHighs: `import(${JSON.stringify(path.join(srcRoot, "signals/patterns/double-pattern-utils.ts"))}).SwingPoint[]`,
+  swingLows: `import(${JSON.stringify(path.join(srcRoot, "signals/patterns/double-pattern-utils.ts"))}).SwingPoint[]`,
+  upper: T("TrendlineFit"),
+  lower: T("TrendlineFit"),
+  pair: `{ upper: ${T("TrendlineFit")}; lower: ${T("TrendlineFit")} }`,
+  convertedSignals: `${T("TradeSignal")}[]`,
+  newSignals: `${T("TradeSignal")}[]`,
+  incomingSignals: `${T("TradeSignal")}[]`,
+  pipeline: `ReturnType<typeof import(${JSON.stringify(path.join(srcRoot, "streaming/index.ts"))}).createPipeline>`,
+  // analysis / misc domain objects
+  fundamentals: `${T("FundamentalMetrics")}[]`,
+  rollingCorr: `${T("CorrelationPoint")}[]`,
+  trace: T("ConditionTrace"),
+  criteria: T("ScreeningCriteria"),
+  internalPositions: `import(${JSON.stringify(path.join(srcRoot, "execution/index.ts"))}).PositionSnapshot[]`,
+  brokerPositions: `import(${JSON.stringify(path.join(srcRoot, "execution/index.ts"))}).PositionSnapshot[]`,
+  // streaming
+  completedCandle: T("NormalizedCandle"),
+  formingCandle: T("NormalizedCandle"),
+  trade: "{ time: number; price: number; volume: number }",
+  baseShares: "number",
+  rsiValue: "number | null",
+  smaIndicator: `ReturnType<typeof import(${JSON.stringify(path.join(srcRoot, "indicators/incremental/index.ts"))}).createSma>`,
+  emaIndicator: `ReturnType<typeof import(${JSON.stringify(path.join(srcRoot, "indicators/incremental/index.ts"))}).createEma>`,
+  rsiIndicator: `ReturnType<typeof import(${JSON.stringify(path.join(srcRoot, "indicators/incremental/index.ts"))}).createRsi>`,
+  bbIndicator: `ReturnType<typeof import(${JSON.stringify(path.join(srcRoot, "indicators/incremental/index.ts"))}).createBollingerBands>`,
+  // ML
+  modelWeights: T("CandleFormerWeights"),
+  // misc scalars/strings
+  input: "string",
+  // incremental resume token (opaque; each createX has its own snapshot type)
+  snapshot: "any",
+  // generic placeholders (documented leniency: "your X here")
+  options: "any",
+  config: "any",
+  warmUpOptions: "any",
+  conn: "any",
+  pipelineOptions: "any",
+  // external broker/API pseudo-objects in execution examples (structural, so
+  // downstream generic inference stays typed)
+  api: "{ submitOrder: (order: unknown) => Promise<{ status: string }>; getOrder: (id: string) => Promise<{ status: string }> }",
+  broker: "{ getOrder: (id: string) => Promise<{ status: string }> }",
+  ws: "any",
+  order: "any",
+  pendingOrder: "any",
+  orderId: "string",
+  NetworkError: "new (...args: any[]) => Error",
+  // fire-and-forget callback placeholders
+  processCandle: `(candle: ${T("NormalizedCandle")}) => void`,
+  updateChart: "(...args: any[]) => void",
+  placeOrder: "(...args: any[]) => void",
+  closeAllPositions: "(...args: any[]) => void",
+};
+
+// Conventional fixture-name PATTERNS (open-ended families like sp500Candles /
+// candlesSPY / dailyReturns / rsiValues / seriesA), injected per example for
+// identifiers the example uses but does not bind itself.
+const FIXTURE_FAMILIES: Array<[RegExp, string]> = [
+  [
+    /^(?:[a-z_$][\w$]*)?Candles(?:[A-Z0-9][\w$]*)?$|^candles[A-Z0-9][\w$]*$/,
+    `${T("NormalizedCandle")}[]`,
+  ],
+  [/^(?:[a-z_$][\w$]*)?Returns$|^returns[A-Z0-9][\w$]*$/, "number[]"],
+  [/^(?:[a-z_$][\w$]*)?Prices$|^prices[A-Z0-9][\w$]*$/, "number[]"],
+  [/^(?:[a-z_$][\w$]*)?Values$/, "number[]"],
+  [/^series[A-Z0-9][\w$]*$|^[a-z_$][\w$]*Series$/, `${T("Series")}<number | null>`],
+  // placeholder unified conditions in the condition-DSL examples
+  [/^[a-z_$][\w$]*Cond$/, T("UnifiedCondition")],
+];
+
+// Names that must never be ambient-declared because they'd collide with
+// DOM/ES globals from the default libs.
+const GLOBAL_NAME_SKIP = new Set([
+  "Event",
+  "Range",
+  "Node",
+  "Window",
+  "Position",
+  "History",
+  "Selection",
+  "Screen",
+]);
+
+// Diagnostic codes suppressed as documented noise (see file header).
+const SUPPRESSED_CODES = new Set([
+  6133,
+  6196,
+  6198,
+  6205, // unused locals/types
+  2451,
+  2393, // redeclared alternative-variant consts / functions
+  7006,
+  7031, // implicit-any example callback params / binding elements
+  2531,
+  18047,
+  18048, // strict-null elision on Series values
+]);
+
+// ---------------------------------------------------------------------------
+// 1. Sweep + extraction
+// ---------------------------------------------------------------------------
+
+type Example = { file: string; line: number; code: string; skip: boolean };
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (e.name === "__tests__" || e.name === "node_modules") continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, out);
+    else if (e.name.endsWith(".ts") && !e.name.endsWith(".d.ts")) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Extract `@example` blocks from a source file's JSDoc comments. A block's
+ * code runs from the line after the `@example` tag (any caption on the tag
+ * line is ignored) to the next `@tag` or the end of the comment, with the
+ * leading `* ` stripped. When the block contains fenced code, only
+ * inside-fence lines are kept (captions/prose outside fences are blanked, not
+ * removed, so line numbers keep mapping back to the source file).
+ */
+function extractExamples(file: string): Example[] {
+  const text = fs.readFileSync(file, "utf8");
+  const raw: Array<{ line: number; body: string[] }> = [];
+  const re = /\/\*\*[\s\S]*?\*\//g;
+  let m: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
+  while ((m = re.exec(text)) !== null) {
+    const startLine = text.slice(0, m.index).split("\n").length; // 1-based
+    const lines = m[0].split("\n");
+    let cur: { line: number; body: string[] } | null = null;
+    const flush = () => {
+      if (cur) raw.push(cur);
+      cur = null;
+    };
+    for (let i = 0; i < lines.length; i++) {
+      // Strip the trailing "*/" first so the closing line leaves no stray "/".
+      const stripped = lines[i].replace(/\s*\*\/\s*$/, "").replace(/^\s*\/?\*+ ?/, "");
+      if (/^@example\b/.test(stripped)) {
+        flush();
+        cur = { line: startLine + i + 1, body: [] };
+        continue;
+      }
+      if (cur && /^@[a-zA-Z]/.test(stripped)) {
+        flush();
+        continue;
+      }
+      if (cur) cur.body.push(stripped);
+    }
+    flush();
+  }
+  const out: Example[] = [];
+  for (const b of raw) {
+    let { line } = b;
+    let body = b.body;
+    while (body.length && body[0].trim() === "") {
+      body = body.slice(1);
+      line++;
+    }
+    while (body.length && body[body.length - 1].trim() === "") body = body.slice(0, -1);
+    if (body.some((l) => /^```/.test(l.trim()))) {
+      let inside = false;
+      body = body.map((l) => {
+        if (/^```/.test(l.trim())) {
+          inside = !inside;
+          return "";
+        }
+        return inside ? l : "";
+      });
+    }
+    const code = body.join("\n");
+    if (code.trim() === "") continue;
+    const firstLine = body.find((l) => l.trim() !== "")?.trim() ?? "";
+    out.push({ file, line, code, skip: firstLine.startsWith("// notypecheck") });
+  }
+  return out;
+}
+
+const allFiles = walk(srcRoot);
+const examples = allFiles.flatMap(extractExamples);
+const checked = examples.filter((e) => !e.skip);
+const skipped = examples.filter((e) => e.skip);
+
+// ---------------------------------------------------------------------------
+// 2. Virtual compiler host (shared SourceFile cache across both programs)
+// ---------------------------------------------------------------------------
+
+const compilerOptions: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  lib: ["lib.es2022.d.ts", "lib.dom.d.ts"],
+  strict: true,
+  noEmit: true,
+  // Rewritten imports point at .ts source files; top-level await in examples
+  // is valid under module: ESNext + target: ES2022.
+  allowImportingTsExtensions: true,
+  skipLibCheck: true,
+  esModuleInterop: true,
+};
+
+const virtualFiles = new Map<string, string>();
+const sourceFileCache = new Map<string, ts.SourceFile>();
+const baseHost = ts.createCompilerHost(compilerOptions, true);
+const host: ts.CompilerHost = {
+  ...baseHost,
+  fileExists: (f) => virtualFiles.has(f) || baseHost.fileExists(f),
+  readFile: (f) => virtualFiles.get(f) ?? baseHost.readFile(f),
+  getSourceFile: (f, lang, onError, shouldCreate) => {
+    const v = virtualFiles.get(f);
+    if (v !== undefined) {
+      let sf = sourceFileCache.get(f);
+      if (!sf || sf.text !== v) {
+        sf = ts.createSourceFile(f, v, compilerOptions.target ?? ts.ScriptTarget.ES2022, true);
+        sourceFileCache.set(f, sf);
+      }
+      return sf;
+    }
+    let sf = sourceFileCache.get(f);
+    if (!sf) {
+      sf = baseHost.getSourceFile(f, lang, onError, shouldCreate);
+      if (sf) sourceFileCache.set(f, sf);
+    }
+    return sf;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 3. Export enumeration (phase-1 program) + ambient declaration generation
+// ---------------------------------------------------------------------------
+
+type ExportInfo = {
+  name: string;
+  isValue: boolean;
+  isType: boolean;
+  isNamespace: boolean;
+  typeParams: { text: string; names: string } | null;
+};
+
+function buildAmbient(): {
+  ambientPath: string;
+  declared: Set<string>;
+  exportsOf: (f: string) => ExportInfo[];
+} {
+  const hostModules = [...new Set(checked.map((e) => e.file))];
+  const phase1 = ts.createProgram({
+    rootNames: [...AMBIENT_ENTRIES, ...hostModules],
+    options: compilerOptions,
+    host,
+  });
+  const checker = phase1.getTypeChecker();
+
+  const exportsCache = new Map<string, ExportInfo[]>();
+  function exportsOf(fileAbs: string): ExportInfo[] {
+    const cached = exportsCache.get(fileAbs);
+    if (cached) return cached;
+    const out: ExportInfo[] = [];
+    const sf = phase1.getSourceFile(fileAbs);
+    const sym = sf ? checker.getSymbolAtLocation(sf) : undefined;
+    if (sym) {
+      for (const ex of checker.getExportsOfModule(sym)) {
+        const name = ex.getName();
+        if (!/^[A-Za-z_$][\w$]*$/.test(name)) continue;
+        let resolved = ex;
+        try {
+          if (ex.flags & ts.SymbolFlags.Alias) resolved = checker.getAliasedSymbol(ex);
+        } catch {
+          // keep the alias symbol if resolution fails
+        }
+        const isValue = (resolved.flags & ts.SymbolFlags.Value) !== 0;
+        const isType =
+          (resolved.flags &
+            (ts.SymbolFlags.Interface |
+              ts.SymbolFlags.TypeAlias |
+              ts.SymbolFlags.Class |
+              ts.SymbolFlags.Enum)) !==
+          0;
+        const isNamespace = (resolved.flags & ts.SymbolFlags.Module) !== 0;
+        // Generic types need their type-parameter list replicated on the
+        // alias: `type Series = import(...).Series` would reject
+        // `Series<number>` with TS2314.
+        let typeParams: ExportInfo["typeParams"] = null;
+        if (isType) {
+          const decl = (resolved.declarations ?? []).find(
+            (
+              d,
+            ): d is ts.DeclarationStatement & {
+              typeParameters: ts.NodeArray<ts.TypeParameterDeclaration>;
+            } =>
+              (d as { typeParameters?: ts.NodeArray<ts.TypeParameterDeclaration> })
+                .typeParameters !== undefined &&
+              ((d as { typeParameters?: ts.NodeArray<ts.TypeParameterDeclaration> }).typeParameters
+                ?.length ?? 0) > 0,
+          );
+          if (decl) {
+            typeParams = {
+              text: decl.typeParameters.map((p) => p.getText()).join(", "),
+              names: decl.typeParameters.map((p) => p.name.text).join(", "),
+            };
+          }
+        }
+        out.push({ name, isValue, isType, isNamespace, typeParams });
+      }
+    }
+    exportsCache.set(fileAbs, out);
+    return out;
+  }
+
+  function typeAliasLine(name: string, spec: string, typeParams: ExportInfo["typeParams"]): string {
+    return typeParams
+      ? `type ${name}<${typeParams.text}> = import(${spec}).${name}<${typeParams.names}>;`
+      : `type ${name} = import(${spec}).${name};`;
+  }
+
+  const ambientLines: string[] = [];
+  const declared = new Set<string>();
+  for (const entry of AMBIENT_ENTRIES) {
+    const spec = JSON.stringify(entry);
+    for (const { name, isValue, isType, isNamespace, typeParams } of exportsOf(entry)) {
+      if (declared.has(name) || GLOBAL_NAME_SKIP.has(name)) continue;
+      declared.add(name);
+      if (isValue) ambientLines.push(`declare const ${name}: typeof import(${spec}).${name};`);
+      if (isType) ambientLines.push(typeAliasLine(name, spec, typeParams));
+      if (isNamespace && entry === INDEX) {
+        // Re-exported module namespaces (execution, streaming, safe, …): the
+        // const above covers VALUE access; a merged global namespace carries
+        // the TYPES so `execution.PositionSnapshot` works in type position.
+        const nsModule = checker.getSymbolAtLocation(phase1.getSourceFile(entry)!);
+        const nsSym = nsModule
+          ? checker.getExportsOfModule(nsModule).find((s) => s.getName() === name)
+          : undefined;
+        const resolvedNs =
+          nsSym && nsSym.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(nsSym) : nsSym;
+        const nsSource = resolvedNs?.declarations?.[0]?.getSourceFile().fileName;
+        if (nsSource) {
+          const nsSpec = JSON.stringify(nsSource);
+          const typeLines = exportsOf(nsSource)
+            .filter((e) => e.isType)
+            .map((e) => `  export ${typeAliasLine(e.name, nsSpec, e.typeParams)}`);
+          if (typeLines.length) ambientLines.push(`declare namespace ${name} {`, ...typeLines, `}`);
+        }
+      }
+    }
+  }
+  const fixtureLines = Object.entries(FIXTURE_TYPES)
+    .filter(([name]) => !declared.has(name))
+    .map(([name, type]) => `declare const ${name}: ${type};`);
+  const ambientPath = path.join(srcRoot, "__jsdoc_examples_ambient__.d.ts");
+  virtualFiles.set(ambientPath, [...ambientLines, ...fixtureLines].join("\n") + "\n");
+  return { ambientPath, declared, exportsOf };
+}
+
+// ---------------------------------------------------------------------------
+// 4. Virtual example files
+// ---------------------------------------------------------------------------
+
+function rewriteImports(code: string): string {
+  let out = code;
+  for (const [re, repl] of IMPORT_REWRITES) out = out.replace(re, repl);
+  return out;
+}
+
+/**
+ * Tolerate the ellipsis placeholder convention: a bare `...` before a closing
+ * delimiter becomes a spread of `any` (arrays/objects), and a fully-elided
+ * call `fn(...)` is checked as `(fn as any)()` since its arguments are
+ * intentionally unspecified.
+ */
+function fillEllipsisHoles(code: string): string {
+  return code
+    .replace(/=>\s*\{\s*\.\.\.\s*\}/g, "=> {}") // elided function body
+    .replace(/([A-Za-z_$][\w$]*)\s*\(\s*\.\.\.\s*\)/g, "($1 as any)()")
+    .replace(/\.\.\.(?=\s*[,)\]}]|\s*$)/gm, "...(null as any)");
+}
+
+/** Names the example itself binds at top level (imports + declarations). */
+function boundNames(code: string): Set<string> {
+  const names = new Set<string>();
+  for (const m of code.matchAll(/import\s+([^;]*?)\s+from/g)) {
+    const clause = m[1];
+    const brace = clause.match(/\{([^}]*)\}/);
+    if (brace) {
+      for (const s of brace[1].split(",")) {
+        const p = s
+          .trim()
+          .replace(/^type\s+/, "")
+          .split(/\s+as\s+/);
+        const local = (p[1] ?? p[0]).trim();
+        if (local) names.add(local);
+      }
+    }
+    const star = clause.match(/\*\s+as\s+([A-Za-z_$][\w$]*)/);
+    if (star) names.add(star[1]);
+    const def = clause.match(/^([A-Za-z_$][\w$]*)\s*(,|$)/);
+    if (def) names.add(def[1]);
+  }
+  for (const m of code.matchAll(
+    /^\s*(?:const|let|var|function|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/gm,
+  )) {
+    names.add(m[1]);
+  }
+  // destructuring declarations: const { a, b: c } = … / const [a, b] = …
+  for (const m of code.matchAll(/^\s*(?:const|let|var)\s*[{[]([^}\]]*)[}\]]/gm)) {
+    for (const part of m[1].split(",")) {
+      const p = part.trim();
+      if (!p) continue;
+      const alias = p.includes(":") ? p.split(":")[1] : p;
+      const name = alias.trim().split(/[=\s]/)[0];
+      if (/^[A-Za-z_$][\w$]*$/.test(name)) names.add(name);
+    }
+  }
+  return names;
+}
+
+// ---------------------------------------------------------------------------
+// 5. Diagnostics
+// ---------------------------------------------------------------------------
+
+type Finding = string;
+
+function collectFindings(): { findings: Finding[]; elapsedMs: number } {
+  const started = Date.now();
+  const { ambientPath, declared, exportsOf } = buildAmbient();
+
+  type Meta = { file: string; line: number; headerLines: number };
+  const exampleMeta = new Map<string, Meta>();
+  let counter = 0;
+  const streamingEntry = path.join(srcRoot, "streaming/index.ts");
+  for (const ex of checked) {
+    const bound = boundNames(ex.code);
+    const header: string[] = [];
+    const headerNames = new Set<string>();
+    // Own module first (authoritative for the example), then the streaming
+    // subsystem entry for examples living under src/streaming/.
+    const contextModules = [ex.file];
+    if (
+      ex.file.startsWith(path.join(srcRoot, "streaming") + path.sep) &&
+      ex.file !== streamingEntry
+    ) {
+      contextModules.push(streamingEntry);
+    }
+    for (const mod of contextModules) {
+      const spec = JSON.stringify(mod);
+      for (const { name, isValue, isType, typeParams } of exportsOf(mod)) {
+        if (bound.has(name) || GLOBAL_NAME_SKIP.has(name) || headerNames.has(name)) continue;
+        headerNames.add(name);
+        if (isValue) header.push(`declare const ${name}: typeof import(${spec}).${name};`);
+        if (isType) {
+          header.push(
+            typeParams
+              ? `type ${name}<${typeParams.text}> = import(${spec}).${name}<${typeParams.names}>;`
+              : `type ${name} = import(${spec}).${name};`,
+          );
+        }
+      }
+    }
+    // family-pattern fixtures for identifiers this example uses but doesn't
+    // bind. Called identifiers are excluded — families describe data values,
+    // so a call like `fooValues(...)` should surface as a real finding.
+    const injected = new Set<string>();
+    for (const tok of ex.code.matchAll(/[A-Za-z_$][\w$]*/g)) {
+      const name = tok[0];
+      if (bound.has(name) || declared.has(name) || injected.has(name) || FIXTURE_TYPES[name])
+        continue;
+      if (new RegExp(`\\b${name}\\s*\\(`).test(ex.code)) continue;
+      const fam = FIXTURE_FAMILIES.find(([re]) => re.test(name));
+      if (fam) {
+        injected.add(name);
+        header.push(`declare const ${name}: ${fam[1]};`);
+      }
+    }
+    const headerText = header.length ? `${header.join("\n")}\n` : "";
+    // `export {}` forces module scope so examples don't clash in global scope.
+    const content = `${headerText}${fillEllipsisHoles(rewriteImports(ex.code))}\nexport {};\n`;
+    const vpath = path.join(path.dirname(ex.file), `__jsdoc_example_${counter++}__.ts`);
+    virtualFiles.set(vpath, content);
+    exampleMeta.set(vpath, { file: ex.file, line: ex.line, headerLines: header.length });
+  }
+
+  const program = ts.createProgram({
+    rootNames: [ambientPath, ...exampleMeta.keys()],
+    options: compilerOptions,
+    host,
+  });
+
+  const findings: Finding[] = [];
+  for (const [vpath, meta] of exampleMeta) {
+    const sf = program.getSourceFile(vpath);
+    if (!sf) continue;
+    const diags = [...program.getSyntacticDiagnostics(sf), ...program.getSemanticDiagnostics(sf)];
+    for (const d of diags) {
+      if (SUPPRESSED_CODES.has(d.code)) continue;
+      const pos =
+        d.file && d.start !== undefined ? ts.getLineAndCharacterOfPosition(d.file, d.start) : null;
+      const origLine = pos ? meta.line + (pos.line - meta.headerLines) : meta.line;
+      const msg = ts.flattenDiagnosticMessageText(d.messageText, " ");
+      findings.push(`${path.relative(srcRoot, meta.file)}:${origLine} TS${d.code}: ${msg}`);
+    }
+  }
+  return { findings, elapsedMs: Date.now() - started };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("JSDoc @example blocks — type check", () => {
+  it("found @example blocks to check", () => {
+    expect(checked.length).toBeGreaterThan(0);
+  });
+
+  it("notypecheck opt-outs stay deliberate", () => {
+    const list = skipped.map((s) => `  ${path.relative(srcRoot, s.file)}:${s.line}`).join("\n");
+    expect(
+      skipped.length,
+      `Expected exactly ${EXPECTED_SKIPS} '// notypecheck' example(s); found ${skipped.length}:\n${list}\n` +
+        "Update EXPECTED_SKIPS if the change is intentional.",
+    ).toBe(EXPECTED_SKIPS);
+  });
+
+  it("every @example type-checks against the current API", { timeout: 120_000 }, () => {
+    const { findings } = collectFindings();
+    expect(
+      findings.length,
+      `Stale JSDoc @example code (${findings.length} diagnostic(s)):\n${findings.map((f) => `  ${f}`).join("\n")}`,
+    ).toBe(0);
+  });
+});

--- a/packages/core/src/__tests__/options-key-usage.test.ts
+++ b/packages/core/src/__tests__/options-key-usage.test.ts
@@ -1,0 +1,592 @@
+// @vitest-environment node
+/**
+ * Contract-wiring guard: every declared `*Options` key must be read somewhere.
+ *
+ * Motivation: an audit found options keys that were DECLARED (typed, documented,
+ * accepted by the compiler) but never WIRED — `GarchOptions.p` / `.q` and
+ * `SeriesToCandlesOptions.fillMode` were silently ignored by the
+ * implementations. This test makes that class of bug fail loudly:
+ *
+ * For every exported `interface`/`type` whose name ends in `Options` under
+ * src/ (tests excluded), it extracts the literal property keys via the
+ * TypeScript AST, then asserts each key's identifier appears in RUNTIME code
+ * (type declarations, type annotations, imports/exports and comments are all
+ * excluded from the usage corpus) of the modules that consume the type:
+ *
+ *   - the declaring module,
+ *   - every module that references the type name,
+ *   - plus modules the options object is forwarded to whole (e.g. garch()
+ *     passes its whole options object to annualizationFactor() — the callee's
+ *     module joins the corpus instead of the type being skipped, so locally
+ *     declared keys still have to be consumed somewhere reachable).
+ *
+ * This is a word-level heuristic: it proves the key participates in runtime
+ * code near the type, not that it is read from this exact object. That is
+ * precisely enough to catch the observed bug class — a key that appears
+ * NOWHERE outside its declaration — with near-zero false negatives (see the
+ * synthetic self-tests at the bottom, which re-create the garch-style bug and
+ * assert the analyzer flags it).
+ *
+ * Notes on the corpus rules:
+ *   - Intersections contribute only their literal members; referenced parts
+ *     (e.g. the AnnualizationOptions half of GarchOptions) are validated at
+ *     their own declaration site.
+ *   - Union-typed aliases have no literal members of their own and are skipped.
+ *   - Inherited interface members are validated at the base declaration.
+ *   - String literals count as usage (covers `options["key"]` bracket access
+ *     and schema/registry key tables).
+ *   - Rest-destructuring an Options-typed binding (`const { a, ...rest } = o`)
+ *     marks the type opaque (remaining keys unverifiable without dataflow).
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const SRC_ROOT = path.resolve(here, ".."); // packages/core/src
+
+// ---------------------------------------------------------------------------
+// Allowlist — keys that are declared but intentionally not consumed in core
+// src, or not verifiable by this heuristic. EVERY entry needs a justification;
+// an entry that is actually a latent bug must be fixed in runtime code and
+// removed from here, not parked forever.
+// ---------------------------------------------------------------------------
+const ALLOWLIST: Record<string, string[]> = {
+  // LATENT BUG (flagged 2026-07): parseFundamentals() takes an already-decoded
+  // string, so `encoding` ("default: utf-8") is never read. Wire it up (accept
+  // a Buffer) or remove the key.
+  ParseFundamentalsOptions: ["encoding"],
+  // LATENT BUG (flagged 2026-07): documented as "softmax temperature for
+  // inference (default: 1.0)" but trainCandleFormer() never reads it and does
+  // not propagate it into the trained model/config; inference uses predict()'s
+  // own parameter. Setting it in train options silently does nothing.
+  CandleFormerTrainOptions: ["temperature"],
+  // LATENT BUG (flagged 2026-07): documented "(default: 10)" but runScreening
+  // is fully synchronous and never reads `concurrency`. Remove or implement.
+  ScreeningOptions: ["concurrency"],
+  // LATENT BUG (flagged 2026-07): highestLowest() always reads candle
+  // high/low; `source?: "high" | "low" | "close"` is never consulted, so
+  // callers asking for close-based extremes silently get high/low behavior.
+  HighestLowestOptions: ["source"],
+  // LATENT BUG (flagged 2026-07): documented "(default: 10)" but
+  // robustness/full.ts never reads `perturbationSamples` (unlike its sibling
+  // perturbationPercent, which is wired). Remove or implement.
+  RobustnessOptions: ["perturbationSamples"],
+  // Known-dead, documented in source: "Unused — reserved for future use;
+  // riskParityAllocation does not read this option". Kept for API compat.
+  RiskParityOptions: ["riskFreeRate"],
+  // Known-dead, documented in source: `@deprecated Was never wired into the
+  // engine. Use tradeOptions.sizing`. Kept for backward compatibility.
+  PortfolioBacktestOptions: ["positionSizing"],
+  // Heuristic gap, key IS consumed: incremental indicators accept
+  // structurally-identical inline `{ warmUp?: NormalizedCandle[]; … }` params
+  // without ever referencing the WarmUpOptions name (e.g.
+  // indicators/incremental/momentum/dmi.ts reads warmUpOptions.warmUp), so
+  // the name-based consumer search cannot see the usage.
+  WarmUpOptions: ["warmUp"],
+};
+
+// ---------------------------------------------------------------------------
+// AST analysis
+// ---------------------------------------------------------------------------
+
+type OptionTypeDecl = {
+  name: string;
+  file: string;
+  props: string[];
+  /**
+   * Other *Options type names referenced inside this declaration (intersection
+   * parts, heritage clauses, property types). Used to propagate consumers:
+   * code that handles `RiskBasedSizingOptions` (= PositionSizingBaseOptions &
+   * {…}) consumes the base's keys without ever naming the base type.
+   */
+  refs: string[];
+};
+
+type FileAnalysis = {
+  file: string;
+  /** Every identifier anywhere in the file (consumer detection). */
+  allIdents: Set<string>;
+  /** Identifiers + string-literal texts in runtime positions only. */
+  usage: Set<string>;
+  /** Exported *Options declarations found in this file. */
+  optionTypes: OptionTypeDecl[];
+  /** Options type name -> absolute files its whole value is forwarded to. */
+  forwardTargets: Map<string, Set<string>>;
+  /** Options type names rest-destructured (unverifiable remaining keys). */
+  opaqueTypes: Set<string>;
+};
+
+function walkTsFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "__tests__" || entry.name === "__benchmarks__") continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkTsFiles(full, out);
+    else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) out.push(full);
+  }
+  return out;
+}
+
+function hasExportModifier(node: ts.HasModifiers): boolean {
+  return ts.getModifiers(node)?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) ?? false;
+}
+
+function propName(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) return name.text;
+  return null;
+}
+
+/** Collect literal property keys of a type node (intersections included). */
+function literalProps(type: ts.TypeNode, out: string[]): void {
+  if (ts.isParenthesizedTypeNode(type)) {
+    literalProps(type.type, out);
+  } else if (ts.isIntersectionTypeNode(type)) {
+    for (const part of type.types) literalProps(part, out);
+  } else if (ts.isTypeLiteralNode(type)) {
+    for (const member of type.members) {
+      if ((ts.isPropertySignature(member) || ts.isMethodSignature(member)) && member.name) {
+        const n = propName(member.name);
+        if (n) out.push(n);
+      }
+    }
+  }
+  // Unions, mapped types, references (incl. Omit<…>) contribute nothing here —
+  // referenced shapes are validated at their own declaration sites.
+}
+
+/** All TypeReference names ending in "Options" inside a type annotation. */
+function optionsRefsInAnnotation(type: ts.TypeNode, out: Set<string>): void {
+  const visit = (t: ts.Node): void => {
+    if (ts.isTypeReferenceNode(t) && ts.isIdentifier(t.typeName)) {
+      if (t.typeName.text.endsWith("Options")) out.add(t.typeName.text);
+    }
+    t.forEachChild(visit);
+  };
+  visit(type);
+}
+
+/** Resolve a relative import specifier to an absolute .ts file, if possible. */
+function resolveRelativeImport(fromFile: string, spec: string): string | null {
+  if (!spec.startsWith(".")) return null;
+  const base = path.resolve(path.dirname(fromFile), spec);
+  for (const candidate of [`${base}.ts`, path.join(base, "index.ts")]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+type ImportResolver = (fromFile: string, spec: string) => string | null;
+
+function analyzeSource(
+  fileName: string,
+  text: string,
+  resolveImport: ImportResolver = resolveRelativeImport,
+): FileAnalysis {
+  const sf = ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true);
+
+  const allIdents = new Set<string>();
+  const usage = new Set<string>();
+  const optionTypes: OptionTypeDecl[] = [];
+  /** local import binding -> resolved absolute file. */
+  const importSources = new Map<string, string>();
+  /** binding name -> Options type names in its annotation. */
+  const annotated = new Map<string, Set<string>>();
+  /** binding names whose whole value escapes into a call, keyed by callee expr. */
+  const escapes: Array<{ binding: string; callee: ts.Expression }> = [];
+  const opaqueTypes = new Set<string>();
+  /** identifiers rest-destructured later (`const { a, ...rest } = options`). */
+  const restDestructured = new Set<string>();
+
+  // Pass 1: every identifier (consumer detection) + imports.
+  const collectAll = (node: ts.Node): void => {
+    if (ts.isIdentifier(node)) allIdents.add(node.text);
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      const resolved = resolveImport(fileName, node.moduleSpecifier.text);
+      if (resolved && node.importClause) {
+        const { name, namedBindings } = node.importClause;
+        if (name) importSources.set(name.text, resolved);
+        if (namedBindings) {
+          if (ts.isNamespaceImport(namedBindings)) {
+            importSources.set(namedBindings.name.text, resolved);
+          } else {
+            for (const spec of namedBindings.elements) {
+              importSources.set(spec.name.text, resolved);
+            }
+          }
+        }
+      }
+    }
+    node.forEachChild(collectAll);
+  };
+  collectAll(sf);
+
+  // Record an Options-typed binding: plain identifier -> annotated map;
+  // rest-destructured pattern -> the type becomes opaque.
+  const recordBinding = (name: ts.BindingName, type: ts.TypeNode | undefined): void => {
+    if (!type) return;
+    const refs = new Set<string>();
+    optionsRefsInAnnotation(type, refs);
+    if (refs.size === 0) return;
+    if (ts.isIdentifier(name)) {
+      const set = annotated.get(name.text) ?? new Set<string>();
+      for (const r of refs) set.add(r);
+      annotated.set(name.text, set);
+    } else if (ts.isObjectBindingPattern(name)) {
+      if (name.elements.some((el) => el.dotDotDotToken)) {
+        for (const r of refs) opaqueTypes.add(r);
+      }
+    }
+  };
+
+  // Record whole-value escapes of an identifier into a call/new expression:
+  // bare argument, spread argument, object-literal spread / property value.
+  const recordEscapes = (call: ts.CallExpression | ts.NewExpression): void => {
+    const args = call.arguments ?? [];
+    // Unwrap common non-transforming wrappers so `helper(options ?? {})`,
+    // `helper((options))` and `helper(options as Foo)` still count as
+    // whole-value escapes of `options`.
+    const note = (expr: ts.Expression): void => {
+      if (ts.isIdentifier(expr)) {
+        escapes.push({ binding: expr.text, callee: call.expression });
+      } else if (ts.isParenthesizedExpression(expr) || ts.isAsExpression(expr)) {
+        note(expr.expression);
+      } else if (
+        ts.isBinaryExpression(expr) &&
+        (expr.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken ||
+          expr.operatorToken.kind === ts.SyntaxKind.BarBarToken)
+      ) {
+        note(expr.left);
+        note(expr.right);
+      } else if (ts.isConditionalExpression(expr)) {
+        note(expr.whenTrue);
+        note(expr.whenFalse);
+      } else if (ts.isSpreadElement(expr)) {
+        note(expr.expression);
+      } else if (ts.isObjectLiteralExpression(expr)) {
+        for (const prop of expr.properties) {
+          if (ts.isSpreadAssignment(prop)) note(prop.expression);
+          if (ts.isPropertyAssignment(prop)) note(prop.initializer);
+          if (ts.isShorthandPropertyAssignment(prop)) {
+            escapes.push({ binding: prop.name.text, callee: call.expression });
+          }
+        }
+      }
+    };
+    for (const arg of args) note(arg);
+  };
+
+  // Pass 2: runtime-usage corpus + declarations + forwarding.
+  const collectRuntime = (node: ts.Node): void => {
+    // --- declarations of *Options types (excluded from the usage corpus) ---
+    if (ts.isInterfaceDeclaration(node)) {
+      if (hasExportModifier(node) && node.name.text.endsWith("Options")) {
+        const props: string[] = [];
+        const refs = new Set<string>();
+        for (const member of node.members) {
+          if ((ts.isPropertySignature(member) || ts.isMethodSignature(member)) && member.name) {
+            const n = propName(member.name);
+            if (n) props.push(n);
+          }
+          if (ts.isPropertySignature(member) && member.type) {
+            optionsRefsInAnnotation(member.type, refs);
+          }
+        }
+        for (const heritage of node.heritageClauses ?? []) {
+          for (const t of heritage.types) {
+            if (ts.isIdentifier(t.expression) && t.expression.text.endsWith("Options")) {
+              refs.add(t.expression.text);
+            }
+          }
+        }
+        refs.delete(node.name.text);
+        optionTypes.push({ name: node.name.text, file: fileName, props, refs: [...refs] });
+      }
+      return; // do not descend — declaration text is not usage
+    }
+    if (ts.isTypeAliasDeclaration(node)) {
+      if (hasExportModifier(node) && node.name.text.endsWith("Options")) {
+        const props: string[] = [];
+        literalProps(node.type, props);
+        const refs = new Set<string>();
+        optionsRefsInAnnotation(node.type, refs);
+        refs.delete(node.name.text);
+        optionTypes.push({ name: node.name.text, file: fileName, props, refs: [...refs] });
+      }
+      return;
+    }
+    // --- non-usage regions ---
+    if (
+      ts.isImportDeclaration(node) ||
+      ts.isExportDeclaration(node) ||
+      ts.isImportEqualsDeclaration(node)
+    ) {
+      return;
+    }
+    if (ts.isTypeNode(node)) return; // annotations, `as T`, type args, …
+
+    // --- usage corpus ---
+    if (ts.isIdentifier(node)) usage.add(node.text);
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+      usage.add(node.text);
+    }
+
+    // --- Options-typed bindings + forwarding ---
+    if (ts.isParameter(node) || ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node)) {
+      recordBinding(node.name as ts.BindingName, node.type);
+      // Un-annotated rest-destructure of an identifier: if the identifier is
+      // (or becomes) Options-typed, the type must go opaque — the rest binding
+      // can carry any remaining key without its name ever appearing.
+      const name = node.name as ts.BindingName;
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isObjectBindingPattern(name) &&
+        name.elements.some((el) => el.dotDotDotToken) &&
+        node.initializer !== undefined &&
+        ts.isIdentifier(node.initializer)
+      ) {
+        restDestructured.add(node.initializer.text);
+      }
+    }
+    if (ts.isCallExpression(node) || ts.isNewExpression(node)) recordEscapes(node);
+
+    node.forEachChild(collectRuntime);
+  };
+  collectRuntime(sf);
+
+  // Join rest-destructures with annotated bindings (post-walk: declaration
+  // order between the annotation and the destructure does not matter).
+  for (const binding of restDestructured) {
+    for (const t of annotated.get(binding) ?? []) opaqueTypes.add(t);
+  }
+
+  // Join escapes with annotated bindings -> forward targets per Options type.
+  const forwardTargets = new Map<string, Set<string>>();
+  for (const { binding, callee } of escapes) {
+    const types = annotated.get(binding);
+    if (!types) continue;
+    // Resolve callee to a module: imported identifier or namespace member.
+    let target: string | null = null;
+    if (ts.isIdentifier(callee)) {
+      target = importSources.get(callee.text) ?? null;
+    } else if (ts.isPropertyAccessExpression(callee) && ts.isIdentifier(callee.expression)) {
+      target = importSources.get(callee.expression.text) ?? null;
+    }
+    if (!target) continue; // local / unresolvable callee — same-file corpus already applies
+    for (const t of types) {
+      const set = forwardTargets.get(t) ?? new Set<string>();
+      set.add(target);
+      forwardTargets.set(t, set);
+    }
+  }
+
+  return { file: fileName, allIdents, usage, optionTypes, forwardTargets, opaqueTypes };
+}
+
+type Violation = { type: string; declaredIn: string; missing: string[] };
+
+/** Cross-file join: per Options type, verify every literal key is used. */
+function findViolations(
+  analyses: FileAnalysis[],
+  allowlist: Record<string, string[]> = ALLOWLIST,
+): {
+  violations: Violation[];
+  optionTypes: OptionTypeDecl[];
+  opaque: string[];
+} {
+  const byFile = new Map(analyses.map((a) => [a.file, a]));
+  const optionTypes = analyses.flatMap((a) => a.optionTypes);
+  const violations: Violation[] = [];
+  const opaque = new Set<string>();
+
+  // Reverse reference graph: base type name -> types whose declarations
+  // reference it. Consumers of a derived type also consume the base's keys.
+  const referencedBy = new Map<string, Set<string>>();
+  for (const decl of optionTypes) {
+    for (const ref of decl.refs) {
+      const set = referencedBy.get(ref) ?? new Set<string>();
+      set.add(decl.name);
+      referencedBy.set(ref, set);
+    }
+  }
+
+  /** The type itself plus every type transitively referencing it. */
+  function nameClosure(name: string): Set<string> {
+    const closure = new Set<string>([name]);
+    const queue = [name];
+    while (queue.length > 0) {
+      const current = queue.pop() as string;
+      for (const dependent of referencedBy.get(current) ?? []) {
+        if (!closure.has(dependent)) {
+          closure.add(dependent);
+          queue.push(dependent);
+        }
+      }
+    }
+    return closure;
+  }
+
+  for (const decl of optionTypes) {
+    if (decl.props.length === 0) continue;
+
+    // Consumers: every file whose identifiers mention the type name — or the
+    // name of a type that (transitively) embeds this one in its declaration.
+    const closure = nameClosure(decl.name);
+    const consumers = analyses.filter((a) => [...closure].some((n) => a.allIdents.has(n)));
+    const corpus = new Set<string>();
+    let isOpaque = false;
+    for (const consumer of consumers) {
+      // Opaqueness intentionally does NOT propagate through the closure: a
+      // rest-destructure of a derived type should not silence checks on a
+      // widely shared base.
+      if (consumer.opaqueTypes.has(decl.name)) isOpaque = true;
+      for (const word of consumer.usage) corpus.add(word);
+      for (const name of closure) {
+        for (const target of consumer.forwardTargets.get(name) ?? []) {
+          const targetAnalysis = byFile.get(target);
+          if (targetAnalysis) for (const word of targetAnalysis.usage) corpus.add(word);
+        }
+      }
+    }
+    if (isOpaque) {
+      opaque.add(decl.name);
+      continue;
+    }
+
+    const allowed = new Set(allowlist[decl.name] ?? []);
+    const missing = decl.props.filter((p) => !corpus.has(p) && !allowed.has(p));
+    if (missing.length > 0) {
+      violations.push({ type: decl.name, declaredIn: decl.file, missing });
+    }
+  }
+  return { violations, optionTypes, opaque: [...opaque] };
+}
+
+// ---------------------------------------------------------------------------
+// Analysis of the real source tree (computed once)
+// ---------------------------------------------------------------------------
+
+const analyses = walkTsFiles(SRC_ROOT).map((file) =>
+  analyzeSource(file, readFileSync(file, "utf8")),
+);
+const result = findViolations(analyses, ALLOWLIST);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("*Options contract wiring (declared keys must be read)", () => {
+  it("discovers a plausible number of exported Options types (sanity)", () => {
+    expect(result.optionTypes.length).toBeGreaterThanOrEqual(150);
+  });
+
+  it("regression sentinels: previously-buggy keys are now detected as used", () => {
+    // GarchOptions.p/.q and SeriesToCandlesOptions.fillMode were declared but
+    // unread until fixed; assert the analyzer sees both the declarations and
+    // their (now-existing) usage, so this harness cannot rot into always-pass.
+    const garch = result.optionTypes.find((t) => t.name === "GarchOptions");
+    expect(garch?.props).toEqual(expect.arrayContaining(["p", "q"]));
+    const s2c = result.optionTypes.find((t) => t.name === "SeriesToCandlesOptions");
+    expect(s2c?.props).toContain("fillMode");
+    expect(result.opaque).not.toContain("GarchOptions");
+    expect(result.opaque).not.toContain("SeriesToCandlesOptions");
+    const names = result.violations.map((v) => v.type);
+    expect(names).not.toContain("GarchOptions");
+    expect(names).not.toContain("SeriesToCandlesOptions");
+  });
+
+  it("every declared Options key is consumed by runtime code", () => {
+    const report = result.violations
+      .map((v) => `  ${v.type} (${path.relative(SRC_ROOT, v.declaredIn)}): ${v.missing.join(", ")}`)
+      .join("\n");
+    expect(
+      result.violations,
+      `Options key(s) declared but never read anywhere in src/ ` +
+        `(dead contract surface — callers can set them, nothing happens). ` +
+        `Wire the key up, remove it, or add an allowlist entry WITH justification:\n${report}`,
+    ).toEqual([]);
+  });
+
+  it("allowlist entries are still needed (no stale entries)", () => {
+    // Re-run the join without the allowlist; every allowlisted key must still
+    // be genuinely unread. When a key gets wired up (or removed), its
+    // allowlist entry must be deleted so it cannot mask a future regression.
+    const raw = findViolations(analyses, {});
+    const rawMissing = new Map(raw.violations.map((v) => [v.type, new Set(v.missing)]));
+    const stale: string[] = [];
+    for (const [type, keys] of Object.entries(ALLOWLIST)) {
+      for (const key of keys) {
+        if (!rawMissing.get(type)?.has(key)) stale.push(`${type}.${key}`);
+      }
+    }
+    expect(
+      stale,
+      `Stale allowlist entr(ies) — the key is now consumed (or gone); ` +
+        `remove from ALLOWLIST:\n  ${stale.join("\n  ")}`,
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Synthetic self-tests — prove the analyzer catches the original bug class.
+// These re-create the pre-fix shapes in memory and assert they are flagged.
+// ---------------------------------------------------------------------------
+
+describe("analyzer self-tests (garch-class bugs are caught)", () => {
+  it("flags a declared-but-unread key in the declaring module", () => {
+    // Pre-fix SeriesToCandlesOptions.fillMode shape: key declared, never read.
+    const src = `
+      export type FakeOptions = { used?: number; ghost?: string };
+      export function fake(o: FakeOptions = {}): number {
+        return o.used ?? 0;
+      }
+    `;
+    const { violations } = findViolations([analyzeSource("/virtual/fake.ts", src)], {});
+    expect(violations).toEqual([
+      { type: "FakeOptions", declaredIn: "/virtual/fake.ts", missing: ["ghost"] },
+    ]);
+  });
+
+  it("whole-object forwarding extends the corpus instead of skipping the type", () => {
+    // Pre-fix GarchOptions shape: options forwarded whole to a helper in
+    // another module (garch() calls annualizationFactor(options)). The forward
+    // must NOT excuse locally declared keys — `p` unread anywhere still fails —
+    // while a key read only by the forward target (`rate`) passes because the
+    // target module joins the usage corpus.
+    const helper = `
+      export function helper(o: { rate?: number }): number { return o.rate ?? 1; }
+    `;
+    const main = `
+      import { helper } from "./helper";
+      export type FwdOptions = { rate?: number; p?: number; tol?: number };
+      export function fwd(options?: FwdOptions): number {
+        const tol = options?.tol ?? 1e-6;
+        return helper(options ?? {}) + tol;
+      }
+    `;
+    const virtualResolver: ImportResolver = (_from, spec) =>
+      spec === "./helper" ? "/virtual/helper.ts" : null;
+    const analyses = [
+      analyzeSource("/virtual/helper.ts", helper, virtualResolver),
+      analyzeSource("/virtual/main.ts", main, virtualResolver),
+    ];
+    const { violations } = findViolations(analyses, {});
+    expect(violations).toEqual([
+      { type: "FwdOptions", declaredIn: "/virtual/main.ts", missing: ["p"] },
+    ]);
+  });
+
+  it("rest-destructuring marks a type opaque rather than reporting noise", () => {
+    const src = `
+      export type RestOptions = { a?: number; b?: number };
+      export function rest(options: RestOptions = {}): unknown {
+        const { a, ...others } = options;
+        return { a, others };
+      }
+    `;
+    const { violations, opaque } = findViolations([analyzeSource("/virtual/rest.ts", src)], {});
+    expect(violations).toEqual([]);
+    expect(opaque).toContain("RestOptions");
+  });
+});

--- a/packages/core/src/__tests__/streaming-event-wiring.test.ts
+++ b/packages/core/src/__tests__/streaming-event-wiring.test.ts
@@ -1,0 +1,216 @@
+// @vitest-environment node
+/**
+ * Contract-wiring guard for core's streaming event contracts.
+ *
+ * Same bug class as the chart's ChartEvent guard: an event that is DECLARED
+ * (typed, documented, subscribable) but never EMITTED is dead contract
+ * surface — subscribers compile fine and wait forever. Core has two clean
+ * declared-event contracts in the streaming layer:
+ *
+ *   1. `LiveCandleEventMap` (streaming/types.ts) — a name -> payload map for
+ *      LiveCandle.on(). Both directions are checked: every key must have an
+ *      `emit("<key>", …)` site in streaming/, and every literal emit name
+ *      must be a declared key.
+ *   2. `SessionEvent` (streaming/types.ts) and `PositionEvent`
+ *      (streaming/position-manager/types.ts) — discriminated unions returned
+ *      from onTrade()/close(). Forward direction only: every declared
+ *      `type: "<discriminant>"` variant must be constructed somewhere in
+ *      streaming/ runtime code. The reverse guard is intentionally omitted:
+ *      `type: "<string>"` object keys are a generic pattern in core (e.g.
+ *      indicator preset param descriptors use `type: "number"`), so an
+ *      "every constructed literal must be declared" check would be all noise.
+ *
+ * All extraction is AST-based so string literals in comments/JSDoc examples
+ * (`live.on("candleComplete", …)` appears in doc comments) cannot skew either
+ * direction.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const STREAMING_ROOT = path.resolve(here, "../streaming");
+const STREAMING_TYPES = path.join(STREAMING_ROOT, "types.ts");
+const POSITION_TYPES = path.join(STREAMING_ROOT, "position-manager/types.ts");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function walkTsFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "__tests__" || entry.name === "__benchmarks__") continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkTsFiles(full, out);
+    else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) out.push(full);
+  }
+  return out;
+}
+
+function parseFile(file: string): ts.SourceFile {
+  return ts.createSourceFile(file, readFileSync(file, "utf8"), ts.ScriptTarget.Latest, true);
+}
+
+/** Property-name keys of a type-literal alias (e.g. LiveCandleEventMap). */
+function mapKeysOfAlias(sf: ts.SourceFile, aliasName: string): string[] {
+  let keys: string[] | null = null;
+  sf.forEachChild((node) => {
+    if (!ts.isTypeAliasDeclaration(node) || node.name.text !== aliasName) return;
+    if (!ts.isTypeLiteralNode(node.type)) return;
+    keys = node.type.members
+      .filter(ts.isPropertySignature)
+      .map((m) => (ts.isIdentifier(m.name) || ts.isStringLiteral(m.name) ? m.name.text : null))
+      .filter((n): n is string => n !== null);
+  });
+  if (!keys) throw new Error(`Type-literal alias ${aliasName} not found in ${sf.fileName}`);
+  return keys;
+}
+
+/** `type: "<literal>"` discriminants of a discriminated-union alias. */
+function discriminantsOfUnion(sf: ts.SourceFile, aliasName: string): string[] {
+  let found: string[] | null = null;
+  sf.forEachChild((node) => {
+    if (!ts.isTypeAliasDeclaration(node) || node.name.text !== aliasName) return;
+    if (!ts.isUnionTypeNode(node.type)) return;
+    const out: string[] = [];
+    for (const member of node.type.types) {
+      if (!ts.isTypeLiteralNode(member)) continue;
+      for (const prop of member.members) {
+        if (
+          ts.isPropertySignature(prop) &&
+          ts.isIdentifier(prop.name) &&
+          prop.name.text === "type" &&
+          prop.type &&
+          ts.isLiteralTypeNode(prop.type) &&
+          ts.isStringLiteral(prop.type.literal)
+        ) {
+          out.push(prop.type.literal.text);
+        }
+      }
+    }
+    found = out;
+  });
+  if (!found) throw new Error(`Discriminated union ${aliasName} not found in ${sf.fileName}`);
+  return found;
+}
+
+type Site = { file: string; name: string; line: number };
+
+/** Literal `emit("<name>", …)` call sites (bare or property access). */
+function collectEmitSites(sf: ts.SourceFile, out: Site[]): void {
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && node.arguments.length > 0) {
+      const callee = node.expression;
+      const calleeName = ts.isIdentifier(callee)
+        ? callee.text
+        : ts.isPropertyAccessExpression(callee)
+          ? callee.name.text
+          : null;
+      if (calleeName === "emit" && ts.isStringLiteral(node.arguments[0])) {
+        const { line } = sf.getLineAndCharacterOfPosition(node.arguments[0].getStart(sf));
+        out.push({
+          file: path.relative(STREAMING_ROOT, sf.fileName),
+          name: node.arguments[0].text,
+          line: line + 1,
+        });
+      }
+    }
+    node.forEachChild(visit);
+  };
+  visit(sf);
+}
+
+/** Runtime object literals carrying `type: "<literal>"` (construction sites). */
+function collectTypeDiscriminantConstructions(sf: ts.SourceFile, out: Set<string>): void {
+  const visit = (node: ts.Node): void => {
+    // Type declarations spell variants as PropertySignatures, not object
+    // literals, so they cannot leak into this set — but skip them anyway so
+    // a `satisfies`-style refactor cannot change that invariant silently.
+    if (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) return;
+    if (ts.isObjectLiteralExpression(node)) {
+      for (const prop of node.properties) {
+        if (
+          ts.isPropertyAssignment(prop) &&
+          (ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name)) &&
+          prop.name.text === "type" &&
+          ts.isStringLiteral(prop.initializer)
+        ) {
+          out.add(prop.initializer.text);
+        }
+      }
+    }
+    node.forEachChild(visit);
+  };
+  visit(sf);
+}
+
+// ---------------------------------------------------------------------------
+// Analysis (computed once)
+// ---------------------------------------------------------------------------
+
+const liveCandleEvents = mapKeysOfAlias(parseFile(STREAMING_TYPES), "LiveCandleEventMap");
+const sessionEvents = discriminantsOfUnion(parseFile(STREAMING_TYPES), "SessionEvent");
+const positionEvents = discriminantsOfUnion(parseFile(POSITION_TYPES), "PositionEvent");
+
+const emitSites: Site[] = [];
+const constructedDiscriminants = new Set<string>();
+for (const file of walkTsFiles(STREAMING_ROOT)) {
+  const sf = parseFile(file);
+  collectEmitSites(sf, emitSites);
+  collectTypeDiscriminantConstructions(sf, constructedDiscriminants);
+}
+const emittedNames = new Set(emitSites.map((s) => s.name));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("streaming event contract wiring", () => {
+  it("parses the declared contracts (sanity)", () => {
+    expect(liveCandleEvents).toContain("tick");
+    expect(liveCandleEvents).toContain("candleComplete");
+    expect(sessionEvents.length).toBeGreaterThanOrEqual(5);
+    expect(positionEvents.length).toBeGreaterThanOrEqual(3);
+    expect(emitSites.length).toBeGreaterThan(0);
+    expect(constructedDiscriminants.size).toBeGreaterThan(0);
+  });
+
+  it("every LiveCandleEventMap key is emitted somewhere in streaming/", () => {
+    const dead = liveCandleEvents.filter((name) => !emittedNames.has(name));
+    expect(
+      dead,
+      `LiveCandleEventMap key(s) declared but never emitted ` +
+        `(subscribers can register but the event never fires):\n  ${dead.join("\n  ")}`,
+    ).toEqual([]);
+  });
+
+  it("every literal emit name in streaming/ is a declared LiveCandleEventMap key", () => {
+    const undeclared = emitSites.filter((s) => !liveCandleEvents.includes(s.name));
+    const report = undeclared.map((s) => `  ${s.file}:${s.line} emits "${s.name}"`).join("\n");
+    expect(
+      undeclared,
+      `emit() call(s) using an event name missing from LiveCandleEventMap ` +
+        `(no subscriber can type-safely listen for these):\n${report}`,
+    ).toEqual([]);
+  });
+
+  it("every SessionEvent variant is constructed somewhere in streaming/", () => {
+    const dead = sessionEvents.filter((name) => !constructedDiscriminants.has(name));
+    expect(
+      dead,
+      `SessionEvent variant(s) declared in streaming/types.ts but never ` +
+        `constructed (consumers can switch on them but they never occur):\n  ${dead.join("\n  ")}`,
+    ).toEqual([]);
+  });
+
+  it("every PositionEvent variant is constructed somewhere in streaming/", () => {
+    const dead = positionEvents.filter((name) => !constructedDiscriminants.has(name));
+    expect(
+      dead,
+      `PositionEvent variant(s) declared in position-manager/types.ts but never ` +
+        `constructed (consumers can switch on them but they never occur):\n  ${dead.join("\n  ")}`,
+    ).toEqual([]);
+  });
+});

--- a/packages/core/src/backtest/conditions/mtf.ts
+++ b/packages/core/src/backtest/conditions/mtf.ts
@@ -29,7 +29,7 @@ import type {
  * @example
  * ```ts
  * // Buy when weekly RSI > 50 and daily golden cross
- * const entry = and(weeklyRsiAbove(50), goldenCross());
+ * const entry = and(weeklyRsiAbove(50), goldenCrossCondition());
  * ```
  */
 export function weeklyRsiAbove(threshold = 50, period = 14): MtfPresetCondition {
@@ -454,7 +454,7 @@ export function mtfDowntrend(timeframe: TimeframeShorthand, adxThreshold = 20): 
  *     const monthlyIdx = mtf.indices.get("monthly");
  *     const weekly = mtf.datasets.get("weekly")?.candles[weeklyIdx!];
  *     const monthly = mtf.datasets.get("monthly")?.candles[monthlyIdx!];
- *     return weekly && monthly && weekly.close > monthly.close;
+ *     return weekly !== undefined && monthly !== undefined && weekly.close > monthly.close;
  *   }
  * );
  * ```

--- a/packages/core/src/backtest/conditions/relative-strength.ts
+++ b/packages/core/src/backtest/conditions/relative-strength.ts
@@ -159,7 +159,7 @@ export function rsBelow(threshold = 1.0, options: RSConditionOptions = {}): Pres
  * @example
  * ```ts
  * // Buy when stock is gaining relative strength
- * const entry = and(goldenCross(), rsRising());
+ * const entry = and(goldenCrossCondition(), rsRising());
  * ```
  */
 export function rsRising(options: RSConditionOptions = {}): PresetCondition {

--- a/packages/core/src/backtest/conditions/volatility.ts
+++ b/packages/core/src/backtest/conditions/volatility.ts
@@ -54,7 +54,7 @@ function getRegimeSeries(
  * const entry = and(
  *   regimeNot('high'),
  *   regimeNot('extreme'),
- *   goldenCross()
+ *   goldenCrossCondition()
  * );
  * ```
  */

--- a/packages/core/src/backtest/conditions/volume-anomaly-profile.ts
+++ b/packages/core/src/backtest/conditions/volume-anomaly-profile.ts
@@ -23,7 +23,7 @@ import type { PresetCondition, VolumeAnomalyValue, VolumeProfileValue } from "..
  * @example
  * ```ts
  * // Buy on golden cross with high volume
- * const entry = and(goldenCross(), volumeAnomalyCondition(2.0));
+ * const entry = and(goldenCrossCondition(), volumeAnomalyCondition(2.0));
  * ```
  */
 export function volumeAnomalyCondition(threshold = 2.0, period = 20): PresetCondition {

--- a/packages/core/src/backtest/order-types.ts
+++ b/packages/core/src/backtest/order-types.ts
@@ -36,10 +36,18 @@ export type StopPriceFunc = (entryCandle: NormalizedCandle, atr: number) => numb
  * @example
  * ```ts
  * // Limit order valid for today only
- * { orderType: { type: "limit", price: 100 }, timeInForce: "day" }
+ * const dayOrder: BacktestOptions = {
+ *   capital: 1_000_000,
+ *   orderType: { type: "limit", price: 100 },
+ *   timeInForce: "day",
+ * };
  *
  * // Fill or kill — all shares or nothing
- * { orderType: { type: "limit", price: 100 }, timeInForce: "fok" }
+ * const fokOrder: BacktestOptions = {
+ *   capital: 1_000_000,
+ *   orderType: { type: "limit", price: 100 },
+ *   timeInForce: "fok",
+ * };
  * ```
  */
 export type TimeInForce = "day" | "gtc" | "ioc" | "fok" | "opg" | "cls";

--- a/packages/core/src/conditions/unified.ts
+++ b/packages/core/src/conditions/unified.ts
@@ -152,7 +152,8 @@ export function defineUnifiedCondition(def: UnifiedConditionDef): UnifiedConditi
  *
  * @example
  * ```ts
- * const entry = unifiedAnd(rsiOversold, volumeSpike);
+ * // oversoldCond / volumeSpikeCond: conditions from defineUnifiedCondition
+ * const entry = unifiedAnd(oversoldCond, volumeSpikeCond);
  * const bt = entry.toBacktestCondition();
  * const st = entry.toStreamingCondition();
  * ```
@@ -175,7 +176,7 @@ export function unifiedAnd(...conditions: UnifiedCondition[]): UnifiedCondition 
  *
  * @example
  * ```ts
- * const exit = unifiedOr(rsiOverbought, stopLossHit);
+ * const exit = unifiedOr(overboughtCond, stopLossCond);
  * ```
  */
 export function unifiedOr(...conditions: UnifiedCondition[]): UnifiedCondition {
@@ -196,7 +197,7 @@ export function unifiedOr(...conditions: UnifiedCondition[]): UnifiedCondition {
  *
  * @example
  * ```ts
- * const notOverbought = unifiedNot(rsiOverbought);
+ * const notOverbought = unifiedNot(overboughtCond);
  * ```
  */
 export function unifiedNot(condition: UnifiedCondition): UnifiedCondition {

--- a/packages/core/src/core/tag-series.ts
+++ b/packages/core/src/core/tag-series.ts
@@ -7,8 +7,8 @@
  * ```ts
  * import { tagSeries } from './tag-series';
  *
- * const result = computeIndicator(candles);
- * return tagSeries(result, { pane: 'main', label: 'SMA(20)' });
+ * const result = sma(candles, { period: 20 });
+ * const tagged = tagSeries(result, { overlay: true, label: 'SMA(20)' });
  * ```
  */
 

--- a/packages/core/src/core/trendcraft.ts
+++ b/packages/core/src/core/trendcraft.ts
@@ -388,10 +388,10 @@ export class TrendCraft<TIndicators extends Record<string, unknown> = {}> {
    * const result = TrendCraft.from(candles)
    *   .strategy()
    *   .entry((indicators, candle, i) => {
-   *     return indicators.goldenCross && indicators.rsi < 30;
+   *     return indicators.goldenCross === true && (indicators.rsi as number) < 30;
    *   })
    *   .exit((indicators, candle, i) => {
-   *     return indicators.deadCross || indicators.rsi > 70;
+   *     return indicators.deadCross === true || (indicators.rsi as number) > 70;
    *   })
    *   .backtest({ capital: 1000000 });
    * ```

--- a/packages/core/src/execution/reconciler.ts
+++ b/packages/core/src/execution/reconciler.ts
@@ -44,10 +44,10 @@ export type ReconcileOptions = {
  *
  * @example
  * ```ts
- * const internal: PositionSnapshot[] = [
+ * const internal: execution.PositionSnapshot[] = [
  *   { symbol: "AAPL", quantity: 10, avgEntryPrice: 150 },
  * ];
- * const external: PositionSnapshot[] = [
+ * const external: execution.PositionSnapshot[] = [
  *   { symbol: "AAPL", quantity: 8, avgEntryPrice: 150.5 },
  *   { symbol: "TSLA", quantity: 5, avgEntryPrice: 200 },
  * ];

--- a/packages/core/src/explainability/narrative.ts
+++ b/packages/core/src/explainability/narrative.ts
@@ -130,6 +130,7 @@ function buildJaDetails(trace: ConditionTrace): string {
  *
  * @example
  * ```ts
+ * // notypecheck — module-private helper, not importable
  * formatIndicatorValues({ rsi14: 28.5, sma5: 102.3 })
  * // => "rsi14 = 28.5, sma5 = 102.3"
  * ```

--- a/packages/core/src/indicators/incremental/state-contract.ts
+++ b/packages/core/src/indicators/incremental/state-contract.ts
@@ -304,7 +304,8 @@ export function makeSnapshot<TState>(
  *
  * @example
  * ```ts
- * const { params } = resolveResume<SmaParams, SmaState>({
+ * type SmaParams = { period?: number; source?: string };
+ * const { params } = resolveResume<SmaParams, unknown>({
  *   indicator: "sma",
  *   defaults: { source: "close" }, // no `period` default
  *   ...
@@ -313,7 +314,7 @@ export function makeSnapshot<TState>(
  *   "sma",
  *   params,
  *   "period",
- *   (v): v is number => Number.isInteger(v) && v >= 1,
+ *   (v) => Number.isInteger(v) && v >= 1,
  *   "must be a positive integer",
  * );
  * ```

--- a/packages/core/src/ml/conditions.ts
+++ b/packages/core/src/ml/conditions.ts
@@ -36,7 +36,7 @@ function getCachedPredictions(
  *
  * @example
  * ```ts
- * const entry = candleFormerBullish(weights, 60);
+ * const entry = candleFormerBullish(modelWeights, 60);
  * const result = runBacktest(candles, entry, rsiAbove(70), { capital: 100_000 });
  * ```
  */
@@ -66,7 +66,7 @@ export function candleFormerBullish(
  *
  * @example
  * ```ts
- * const exit = candleFormerBearish(weights, 60);
+ * const exit = candleFormerBearish(modelWeights, 60);
  * const result = runBacktest(candles, rsiBelow(30), exit, { capital: 100_000 });
  * ```
  */

--- a/packages/core/src/optimization/grid-search-json.ts
+++ b/packages/core/src/optimization/grid-search-json.ts
@@ -93,7 +93,7 @@ export function gridSearchFromJSON(
  *
  * @example
  * ```ts
- * const result = gridSearchFromJSONSafe(candles, strategy, ranges, registry);
+ * const result = gridSearchFromJSONSafe(candles, strategyJson, pathRanges, backtestRegistry);
  * if (result.ok) {
  *   console.log(result.value.bestParams);
  * } else {

--- a/packages/core/src/optimization/pareto.ts
+++ b/packages/core/src/optimization/pareto.ts
@@ -387,7 +387,7 @@ export function paretoOptimizationSafe(
  *
  * @example
  * ```ts
- * console.log(summarizeParetoResult(result));
+ * console.log(summarizeParetoResult(paretoResult));
  * ```
  */
 export function summarizeParetoResult(result: ParetoResult): string {

--- a/packages/core/src/optimization/pbo.ts
+++ b/packages/core/src/optimization/pbo.ts
@@ -113,8 +113,8 @@ function binomial(n: number, k: number): number {
  * ```ts
  * import { pbo } from "trendcraft";
  *
- * // returns[t][n]: period-t return of the n-th parameter combination
- * const { pbo: probability, combinations } = pbo(returns, { blocks: 10 });
+ * // returnsMatrix[t][n]: period-t return of the n-th parameter combination
+ * const { pbo: probability, combinations } = pbo(returnsMatrix, { blocks: 10 });
  * console.log(`PBO ${(probability * 100).toFixed(1)}% over ${combinations} splits`);
  * // PBO ≥ ~50% → the in-sample winner is indistinguishable from chance OOS
  * ```

--- a/packages/core/src/optimization/walkforward-json.ts
+++ b/packages/core/src/optimization/walkforward-json.ts
@@ -97,7 +97,7 @@ export function walkForwardAnalysisFromJSON(
  *
  * @example
  * ```ts
- * const result = walkForwardAnalysisFromJSONSafe(candles, strategy, ranges, registry);
+ * const result = walkForwardAnalysisFromJSONSafe(candles, strategyJson, pathRanges, backtestRegistry);
  * if (result.ok) {
  *   console.log(result.value.recommendation);
  * } else {

--- a/packages/core/src/risk/drawdown-analysis.ts
+++ b/packages/core/src/risk/drawdown-analysis.ts
@@ -170,7 +170,7 @@ export function drawdownDistribution(drawdownDepths: number[], numBins = 10): Dr
  * ```ts
  * import { conditionalDrawdown } from "trendcraft";
  *
- * const result = conditionalDrawdown(returns, drawdowns, volatilities);
+ * const result = conditionalDrawdown(dailyReturns, drawdowns, volatilities);
  * console.log(`High-vol avg DD: ${result.highVolatility.avgDepth}%`);
  * console.log(`Trending avg DD: ${result.trending.avgDepth}%`);
  * ```

--- a/packages/core/src/risk/var.ts
+++ b/packages/core/src/risk/var.ts
@@ -67,6 +67,7 @@ export type RollingVarValue = {
  *
  * @example
  * ```ts
+ * // notypecheck — module-private helper, not importable
  * normalPdf(0); // ~0.3989
  * ```
  */
@@ -80,6 +81,7 @@ function normalPdf(x: number): number {
  *
  * @example
  * ```ts
+ * // notypecheck — module-private helper, not importable
  * normalInverseCdf(0.95); // ~1.6449
  * ```
  */

--- a/packages/core/src/scoring/calculator.ts
+++ b/packages/core/src/scoring/calculator.ts
@@ -159,8 +159,8 @@ function precomputeIndicators(
  * ```ts
  * const config: ScoringConfig = {
  *   signals: [
- *     { name: "rsi", displayName: "RSI Oversold", weight: 2, evaluate: rsiOversoldEvaluator },
- *     { name: "macd", displayName: "MACD Bullish", weight: 1.5, evaluate: macdBullishEvaluator },
+ *     { name: "rsi", displayName: "RSI Oversold", weight: 2, evaluate: createRsiOversoldEvaluator() },
+ *     { name: "macd", displayName: "MACD Bullish", weight: 1.5, evaluate: createMacdBullishEvaluator() },
  *   ],
  * };
  *

--- a/packages/core/src/scoring/signals/momentum.ts
+++ b/packages/core/src/scoring/signals/momentum.ts
@@ -260,7 +260,7 @@ export function createMacdBearishEvaluator(
  * @param dPeriod - %D period (default: 3)
  * @example
  * ```ts
- * import { ScoreBuilder, createStochOversoldEvaluator } from "trendcraft";
+ * import { ScoreBuilder } from "trendcraft";
  *
  * const config = ScoreBuilder.create()
  *   .addSignal({ name: "stochOS", displayName: "Stoch < 20", weight: 2.0, evaluate: createStochOversoldEvaluator(20) })
@@ -364,7 +364,7 @@ export function createStochOverboughtEvaluator(
  * Returns 1 when %K crosses above %D in oversold territory.
  * @example
  * ```ts
- * import { ScoreBuilder, createStochBullishCrossEvaluator } from "trendcraft";
+ * import { ScoreBuilder } from "trendcraft";
  *
  * const config = ScoreBuilder.create()
  *   .addSignal({ name: "stochCross", displayName: "Stoch Bull Cross", weight: 2.5, evaluate: createStochBullishCrossEvaluator(20) })

--- a/packages/core/src/scoring/signals/trend.ts
+++ b/packages/core/src/scoring/signals/trend.ts
@@ -247,7 +247,7 @@ export function createPullbackEntryEvaluator(
  * Returns 1 when short MA crosses above long MA.
  * @example
  * ```ts
- * import { ScoreBuilder, createGoldenCrossEvaluator } from "trendcraft";
+ * import { ScoreBuilder } from "trendcraft";
  *
  * const config = ScoreBuilder.create()
  *   .addSignal({ name: "gc", displayName: "Golden Cross (50/200)", weight: 2.0, evaluate: createGoldenCrossEvaluator(50, 200) })

--- a/packages/core/src/signals/trade-signal/converters.ts
+++ b/packages/core/src/signals/trade-signal/converters.ts
@@ -194,7 +194,7 @@ export function fromPatternSignal(signal: PatternSignal, entryPrice?: number): T
  *
  * @example
  * ```ts
- * const breakdown = calculateScoreBreakdown(candles, signals, i);
+ * const breakdown = calculateScoreBreakdown(candles, i, config);
  * const signal = fromScoreResult(breakdown, candle.time, { minScore: 50 });
  * ```
  */

--- a/packages/core/src/strategy/factory.ts
+++ b/packages/core/src/strategy/factory.ts
@@ -7,7 +7,7 @@
  * ```ts
  * import { createSessionFromStrategy } from "trendcraft";
  *
- * const session = createSessionFromStrategy(strategy, {
+ * const session = createSessionFromStrategy(strategyDefinition, {
  *   capital: 500_000,
  * });
  *
@@ -31,14 +31,14 @@ import type { SessionOverrides, StrategyDefinition } from "./types";
  *
  * @example
  * ```ts
- * import { createSessionFromStrategy, type StrategyDefinition } from "trendcraft";
+ * import { createSessionFromStrategy, streaming, type StrategyDefinition } from "trendcraft";
  *
  * const strategy: StrategyDefinition = {
  *   id: "my-strategy",
  *   name: "My Strategy",
  *   intervalMs: 60_000,
  *   symbols: ["AAPL"],
- *   pipeline: { indicators: [...], entry: rsiBelow(30), exit: rsiAbove(70) },
+ *   pipeline: { indicators: [...], entry: streaming.rsiBelow(30), exit: streaming.rsiAbove(70) },
  *   position: { capital: 100_000, stopLoss: 2 },
  * };
  *

--- a/packages/core/src/strategy/hydrate.ts
+++ b/packages/core/src/strategy/hydrate.ts
@@ -12,9 +12,12 @@
  *   backtestRegistry,
  * );
  *
- * // Load a full strategy
+ * // Load a full strategy (backtestOptions is partial — supply required fields)
  * const { entry, exit, backtestOptions } = loadStrategy(strategyJson, backtestRegistry);
- * const result = runBacktest(candles, entry, exit, backtestOptions);
+ * const result = runBacktest(candles, entry, exit, {
+ *   ...backtestOptions,
+ *   capital: backtestOptions.capital ?? 1_000_000,
+ * });
  * ```
  */
 
@@ -61,7 +64,7 @@ export function hydrateCondition(
  *
  * @example
  * ```ts
- * const { entry, exit, backtestOptions, metadata } = loadStrategy(json, backtestRegistry);
+ * const { entry, exit, backtestOptions, metadata } = loadStrategy(strategyJson, backtestRegistry);
  * const result = runBacktest(candles, entry, exit, { capital: 1_000_000, ...backtestOptions });
  * ```
  */

--- a/packages/core/src/strategy/registry.ts
+++ b/packages/core/src/strategy/registry.ts
@@ -8,9 +8,9 @@
  *
  * @example
  * ```ts
- * import { ConditionRegistry, and, or, not } from "trendcraft";
+ * import { ConditionRegistry, and, or, not, goldenCrossCondition, type Condition } from "trendcraft";
  *
- * const registry = new ConditionRegistry();
+ * const registry = new ConditionRegistry<Condition>();
  * registry.register({
  *   name: "goldenCross",
  *   displayName: "Golden Cross",
@@ -19,7 +19,7 @@
  *     shortPeriod: { type: "number", default: 5, min: 1 },
  *     longPeriod: { type: "number", default: 25, min: 1 },
  *   },
- *   create: (p) => goldenCross(
+ *   create: (p) => goldenCrossCondition(
  *     (p.shortPeriod as number) ?? 5,
  *     (p.longPeriod as number) ?? 25,
  *   ),

--- a/packages/core/src/strategy/serialize.ts
+++ b/packages/core/src/strategy/serialize.ts
@@ -5,7 +5,7 @@
  * ```ts
  * import { serializeStrategy, parseStrategy } from "trendcraft";
  *
- * const json = serializeStrategy(strategy);
+ * const json = serializeStrategy(strategyJson);
  * const parsed = parseStrategy(json);
  * ```
  */

--- a/packages/core/src/strategy/tunables.ts
+++ b/packages/core/src/strategy/tunables.ts
@@ -69,7 +69,7 @@ export type Tunable = {
  *
  * @example
  * ```ts
- * const tunables = listTunables(strategy);
+ * const tunables = listTunables(strategyJson);
  * for (const t of tunables) {
  *   console.log(t.key, t.paramName, t.schema.default);
  * }

--- a/packages/core/src/strategy/walker.ts
+++ b/packages/core/src/strategy/walker.ts
@@ -21,10 +21,10 @@
  * ```ts
  * import { flattenStrategyLeaves, applyParamOverrides } from "trendcraft";
  *
- * const leaves = flattenStrategyLeaves(strategy);
+ * const leaves = flattenStrategyLeaves(strategyJson);
  * // [{ bucket: "entry", leafIndex: 0, name: "goldenCross", params: {...} }, ...]
  *
- * const tuned = applyParamOverrides(strategy, {
+ * const tuned = applyParamOverrides(strategyJson, {
  *   "entry.0.shortPeriod": 10,
  *   "entry.0.longPeriod": 50,
  * });

--- a/packages/core/src/streaming/conditions/core.ts
+++ b/packages/core/src/streaming/conditions/core.ts
@@ -73,6 +73,7 @@ export function not(condition: StreamingCondition): StreamingCombinedCondition {
  *
  * @example
  * ```ts
+ * const entryCondition = and(rsiBelow(30), smaGoldenCross());
  * const isEntry = evaluateStreamingCondition(entryCondition, snapshot, candle);
  * ```
  */

--- a/packages/core/src/streaming/indicator-presets.ts
+++ b/packages/core/src/streaming/indicator-presets.ts
@@ -10,11 +10,11 @@
  *
  * const rsi = indicatorPresets.rsi;
  *
- * // Static mode — one-shot batch computation
- * const series = rsi.compute(candles, { period: 14 });
+ * // Static mode — one-shot batch computation (`compute` is optional per entry)
+ * const series = rsi.compute?.(candles, { period: 14 });
  *
  * // Streaming mode — build an incremental indicator from the same entry
- * const factory = rsi.createFactory({ period: 14 });
+ * const factory = rsi.createFactory?.({ period: 14 });
  * ```
  */
 

--- a/packages/core/src/streaming/signal-emitter.ts
+++ b/packages/core/src/streaming/signal-emitter.ts
@@ -69,7 +69,7 @@ export type SignalEmitter = {
  *   onSignal: (signal) => console.log(signal),
  * });
  *
- * for (const trade of trades) {
+ * for (const trade of tickStream) {
  *   emitter.onTrade(trade);
  * }
  * emitter.close();

--- a/packages/core/src/types/backtest.ts
+++ b/packages/core/src/types/backtest.ts
@@ -110,10 +110,10 @@ export type PartialTakeProfitConfig = {
  * @example
  * ```ts
  * // Move stop to breakeven after +3% gain
- * breakevenStop: { threshold: 3 }
+ * const breakeven: BreakevenStopConfig = { threshold: 3 };
  *
  * // Move stop to +0.5% above entry after +3% gain
- * breakevenStop: { threshold: 3, buffer: 0.5 }
+ * const breakevenBuffered: BreakevenStopConfig = { threshold: 3, buffer: 0.5 };
  * ```
  */
 export type BreakevenStopConfig = {
@@ -158,10 +158,10 @@ export type ScaleOutConfig = {
  * @example
  * ```ts
  * // Exit after 20 days regardless of P&L
- * timeExit: { maxHoldDays: 20 }
+ * const timeExit: TimeExitConfig = { maxHoldDays: 20 };
  *
  * // Exit after 20 days only if P&L is within ±2%
- * timeExit: { maxHoldDays: 20, onlyIfFlat: { threshold: 2 } }
+ * const timeExitFlat: TimeExitConfig = { maxHoldDays: 20, onlyIfFlat: { threshold: 2 } };
  * ```
  */
 export type TimeExitConfig = {

--- a/packages/core/src/types/candle.ts
+++ b/packages/core/src/types/candle.ts
@@ -79,7 +79,7 @@ export type SeriesMeta = {
  *
  * @example
  * ```ts
- * const result = sma(candles, { period: 20 });
+ * const result = sma(candles, { period: 20 }) as TaggedSeries<number | null>;
  * result.__meta // { overlay: true, label: 'SMA 20' }
  * ```
  */

--- a/packages/core/src/types/portfolio.ts
+++ b/packages/core/src/types/portfolio.ts
@@ -58,7 +58,11 @@ export type BatchBacktestOptions = Omit<BacktestOptions, "capital"> & {
    *
    * @example
    * ```ts
-   * allocations: { AAPL: 0.4, MSFT: 0.3, GOOG: 0.3 }
+   * const options: BatchBacktestOptions = {
+   *   capital: 3_000_000,
+   *   allocation: "custom",
+   *   allocations: { AAPL: 0.4, MSFT: 0.3, GOOG: 0.3 },
+   * };
    * ```
    */
   allocations?: Record<string, number>;

--- a/packages/core/src/utils/series.ts
+++ b/packages/core/src/utils/series.ts
@@ -220,6 +220,7 @@ export function filterSeries<T>(
  *
  * const weeklyCandles = resample(dailyCandles, { value: 1, unit: "week" });
  * const weeklySma = sma(weeklyCandles, { period: 20 });
+ * const dailySma = sma(dailyCandles, { period: 20 });
  *
  * // Align weekly SMA to daily timestamps
  * const dailyAlignedWeeklySma = alignSeries(weeklySma, dailySma);


### PR DESCRIPTION
## Summary

The recent docs-vs-source audits (#301, #305) fixed hundreds of drifted sites, but the existing gates could not have prevented them: the import-check validates only imports, and the snippet harness executes only tagged recipes. This PR adds five CI gates that close those gaps for the core package. Combined added wall-time: **~4s** inside `pnpm test`.

### New gates

1. **`docs-typecheck.test.ts`** — type-checks **every** `ts` fence in the docs (737 fences) in one virtual TypeScript program against the real source types (same family as the twoslash approach used by the TypeScript handbook, zero new dependencies). Reference-doc fences that omit imports get typed auto-imports for identifiers that are real exports; narrative context variables (`wf`, `snapshot`, …) resolve through a typed fixture dictionary, so a new undeclared variable fails until added deliberately. **Layer B**: any fence that declares an `interface`/`type` whose name is exported gets mirrored against the real type with exact-key + mutual-assignability assertions — this is the layer that catches "docs show a shape that drifted from the export". Opt-out is `<!-- doctest-notypecheck: reason -->` and both skip counts are pinned by constants so silent-skip creep fails the suite.
2. **`jsdoc-examples-typecheck.test.ts`** — type-checks all **708 `@example` blocks** in `src/`. Examples conventionally omit imports, so the package surface is ambient-declared; ellipsis placeholders are hole-filled; `// notypecheck` opt-outs are pinned (currently 3, all module-private helpers).
3. **`docs-ja-parity.test.ts`** — the EN/JA twin docs must carry an identical sequence of code fences (comments and string contents are normalized away; identifiers, option keys, and numbers must match). Catches the "fixed in one language only" class.
4. **`options-key-usage.test.ts`** — every property key of every exported `*Options` type (226 types) must be read by runtime code; whole-object forwarding is followed into the callee's module. Synthetic self-tests prove the analyzer flags the previously-fixed `garch p/q` and `seriesToCandles fillMode` classes. A documented allowlist quarantines the currently-known declared-but-unused keys (see below) and a staleness guard forces entries to be deleted once wired.
5. **`streaming-event-wiring.test.ts`** — `LiveCandleEventMap` keys must be emitted (and every emitted literal must be declared); `SessionEvent`/`PositionEvent` variants must actually be constructed in `streaming/`.

### What the first run caught (all fixed here; docs + JSDoc comments only, no runtime changes)

- **API.ja.md was missing three entire sections** (Wyckoff Analysis, Meta-Strategy, Risk Analytics) plus the Session/Kill Zones and HMM examples — the TOC linked to them but the bodies were never translated. 41 fences backfilled; both files now carry 314 fences. Five sites where the **English** side was the stale one were also synced.
- Doc-declared shapes had drifted: `BacktestResult` (12 missing fields), `Trade` (7), `BacktestSettings` (3).
- JSDoc `@example`s using the `goldenCross`/`deadCross` **signal detectors** as backtest conditions (5 sites — the condition aliases are `goldenCrossCondition`/`deadCrossCondition`), a stale `calculateScoreBreakdown` argument order, placeholder variables shadowing real exports, and several non-compiling fragments made self-contained.

### Known latent issues quarantined for a follow-up fix PR

`options-key-usage` found five genuinely declared-but-never-read option keys (same class as the garch `p`/`q` bug fixed in #304): `HighestLowestOptions.source`, `ScreeningOptions.concurrency`, `CandleFormerTrainOptions.temperature`, `RobustnessOptions.perturbationSamples`, `ParseFundamentalsOptions.encoding`. They are listed in the test's allowlist with justifications rather than silently passing; fixing the implementations is deliberately out of scope here.

## Test plan

- On this branch in isolation: `pnpm test` (core) → **340 files / 6189 tests, all pass**; `npx tsc --noEmit --ignoreDeprecations 6.0` → pass
- On the full working tree (with the chart/mcp companion): core **6307**, chart 934, mcp 83, strategy-studio 108 — all pass; `pnpm build` passes