### PR TITLE
test(chart,mcp): Tier 1.5 doc-correctness harnesses (docs typecheck, JSDoc examples, event wiring)

### DIFF
--- a/packages/chart/docs/API.md
+++ b/packages/chart/docs/API.md
@@ -98,6 +98,7 @@ Options marked "one-time" cannot be changed via `applyOptions()` — a warning i
 type CrosshairOptions = {
   mode?: 'normal' | 'magnet' | 'magnetOHLC';
   snapThreshold?: number; // px, default 12, only used by 'magnetOHLC'
+  lockOnLongPress?: boolean; // long-press crosshair lock on touch devices, default true
 };
 ```
 
@@ -285,6 +286,7 @@ Returned by `addIndicator`. Keep the reference if you need to manipulate the ser
 ```typescript
 type SeriesHandle = {
   readonly id: string;
+  readonly config: Readonly<SeriesConfig>;        // resolved config (read back auto-assigned color etc.)
   update(point: DataPoint<unknown>): void;       // streaming update — append or patch last point
   setData<T>(data: DataPoint<T>[]): void;         // replace all data
   setVisible(visible: boolean): void;
@@ -403,10 +405,11 @@ import { connectIndicators, connectLivePrimitives, connectSrConfluence } from '@
 import { srZones } from 'trendcraft';
 
 const conn = connectIndicators(chart, { presets, candles, live: source });
-const sr = connectSrConfluence(chart, srZones(source.completedCandles).zones);
+// completedCandles is readonly — copy before passing to trendcraft's mutable-array APIs
+const sr = connectSrConfluence(chart, srZones([...source.completedCandles]).zones);
 
 const liveSr = connectLivePrimitives(source, [
-  { recompute: (candles) => srZones(candles).zones, handle: sr, name: 'sr' },
+  { recompute: (candles) => srZones([...candles]).zones, handle: sr, name: 'sr' },
 ]);
 
 // later
@@ -480,20 +483,23 @@ definePrimitive<TState>(plugin: PrimitivePlugin<TState>): PrimitivePlugin<TState
 Identity functions that give you type inference. See [PLUGINS.md](./PLUGINS.md).
 
 ```typescript
-class DrawHelper {
+declare class DrawHelper {
   x(index: number): number;
   y(price: number): number;
   readonly startIndex: number;
   readonly endIndex: number;
   readonly barSpacing: number;
 
-  line(values, style): void;
-  hline(price, style): void;
-  rect(index, priceTop, widthBars, priceBottom, fill, stroke?): void;
-  fillBetween(upper, lower, fill): void;
-  circle(index, price, radius, fill): void;
-  text(label, index, price, options?): void;
-  scope(fn: (ctx) => void): void;
+  line(values: readonly (number | null)[], style: StrokeStyle): void;
+  hline(price: number, style: StrokeStyle): void;
+  rect(index: number, priceTop: number, widthBars: number, priceBottom: number,
+       fill: FillStyle, stroke?: StrokeStyle): void;
+  fillBetween(upper: readonly (number | null)[], lower: readonly (number | null)[],
+              fill: FillStyle): void;
+  circle(index: number, price: number, radius: number, fill: FillStyle): void;
+  text(label: string, index: number, price: number,
+       options?: { color?: string; font?: string; align?: CanvasTextAlign; baseline?: CanvasTextBaseline }): void;
+  scope(fn: (ctx: CanvasRenderingContext2D) => void): void;
 }
 ```
 
@@ -542,7 +548,7 @@ Props mirror the `useTrendChart` options: `candles`, `indicators`, `signals`, `t
 **Hook** — imperative access to `ChartInstance` for drawing tools, live feeds, custom plugins:
 
 ```tsx
-function MyChart({ candles }) {
+function MyChart({ candles }: { candles: CandleData[] }) {
   const { containerRef, chart } = useTrendChart({ candles, theme: 'dark' });
   useEffect(() => {
     if (!chart) return;

--- a/packages/chart/docs/COOKBOOK.md
+++ b/packages/chart/docs/COOKBOOK.md
@@ -235,9 +235,10 @@ See [LIVE.md](./LIVE.md) for backfill, reconnect, and pre-formed candle inputs.
 
 ```tsx
 import { TrendChart } from "@trendcraft/chart/react";
-import { sma, rsi } from "trendcraft";
+import { sma, rsi, type NormalizedCandle } from "trendcraft";
 
-export function ChartView({ candles }: { candles: Candle[] }) {
+// NormalizedCandle (numeric time) satisfies both trendcraft indicators and the chart
+export function ChartView({ candles }: { candles: NormalizedCandle[] }) {
   const indicators = [
     sma(candles, { period: 20 }),
     sma(candles, { period: 50 }),

--- a/packages/chart/docs/GUIDE.md
+++ b/packages/chart/docs/GUIDE.md
@@ -57,10 +57,10 @@ Everything the chart draws is either:
 `trendcraft` indicators often return compound objects:
 
 ```typescript
-rsi(candles)          // [{ time, value: number | null }]
-bollingerBands(c)     // [{ time, value: { upper, middle, lower, percentB, bandwidth } }]
-ichimoku(c)           // [{ time, value: { tenkan, kijun, senkouA, senkouB, chikou } }]
-macd(c)               // [{ time, value: { macd, signal, histogram } }]
+rsi(candles)             // [{ time, value: number | null }]
+bollingerBands(candles)  // [{ time, value: { upper, middle, lower, percentB, bandwidth } }]
+ichimoku(candles)        // [{ time, value: { tenkan, kijun, senkouA, senkouB, chikou } }]
+macd(candles)            // [{ time, value: { macd, signal, histogram } }]
 ```
 
 The chart introspects the first non-null value to pick a series type and pane. You never have to split a compound object into separate line series yourself.
@@ -77,11 +77,13 @@ Internally, every point goes through two scales:
 Event data is expressed in candle terms — the snapped index and its OHLCV — not pixels:
 
 ```typescript
-chart.on('crosshairMove', (data: CrosshairMoveData) => {
-  data.time   // epoch ms of the snapped candle (or null when leaving the plot area)
-  data.index  // candle index (or null)
-  data.ohlcv  // { open, high, low, close, volume } (or null)
-  data.paneId // pane under the pointer (or null)
+chart.on('crosshairMove', (data) => {
+  // `on` handlers receive `unknown` — narrow to the event's payload type
+  const move = data as CrosshairMoveData;
+  move.time;   // epoch ms of the snapped candle (or null when leaving the plot area)
+  move.index;  // candle index (or null)
+  move.ohlcv;  // { open, high, low, close, volume } (or null)
+  move.paneId; // pane under the pointer (or null)
 });
 ```
 

--- a/packages/chart/docs/LIVE.md
+++ b/packages/chart/docs/LIVE.md
@@ -141,7 +141,10 @@ ws.on('bar', (bar) => {
 
 // Optional: forming bar updates (Alpaca minute-in-progress, etc.)
 ws.on('bar-partial', (bar) => {
-  live.addCandle({ /* ... */ }, { partial: true });
+  live.addCandle(
+    { time: bar.t, open: bar.o, high: bar.h, low: bar.l, close: bar.c, volume: bar.v },
+    { partial: true },
+  );
 });
 ```
 
@@ -150,7 +153,7 @@ ws.on('bar-partial', (bar) => {
 ## `connectIndicators` — one API for static and live
 
 ```typescript
-connectIndicators(chart, options): IndicatorConnection
+function connectIndicators(chart: ChartInstance, options: ConnectIndicatorsOptions): IndicatorConnection
 ```
 
 ### Static mode (no `live` option)
@@ -302,7 +305,7 @@ ws.on('close', () => { savedState = live.getState(); });
 ws.on('open', () => {
   // restore — disconnect the old connection first
   conn.disconnect();
-  live = createLiveCandle(options, savedState);
+  live = createLiveCandle(liveOptions, savedState);
   conn = connectIndicators(chart, { presets: indicatorPresets, candles, live });
   for (const indicator of activeIndicators) conn.add(indicator.id, indicator.params);
 });
@@ -312,6 +315,7 @@ This works but is heavyweight — you rebuild the whole pipeline, and the `conn.
 
 Approach B — keep `LiveCandle` alive, just reconnect the socket:
 
+<!-- doctest-notypecheck: vendor-socket pseudo-code — the browser WebSocket has no node-style `.on` -->
 ```typescript
 // `live` persists across reconnects
 ws = new WebSocket(url);

--- a/packages/chart/docs/PLUGINS.md
+++ b/packages/chart/docs/PLUGINS.md
@@ -181,6 +181,7 @@ const myPrim = definePrimitive<MyState>({
 
 ### Coordinate conversion
 
+<!-- doctest-notypecheck: member-signature summary in `object.method(param: type): ret` pseudo-syntax -->
 ```typescript
 draw.x(index: number): number     // bar index → x pixel
 draw.y(price: number): number     // price → y pixel
@@ -191,6 +192,7 @@ draw.barSpacing                   // pixels per bar (readonly)
 
 ### Primitive shapes
 
+<!-- doctest-notypecheck: parameter-name summary in pseudo-syntax; the typed signatures live in API.md's DrawHelper block -->
 ```typescript
 draw.line(values, { color, lineWidth?, dash? })
 // Draw a polyline over an array indexed by bar. Null entries break the line.
@@ -228,6 +230,7 @@ Prefer `draw.scope` over manual `ctx.save() / ctx.restore()` — a bug where you
 
 `ctx` is always available on the context if you need methods `DrawHelper` doesn't cover:
 
+<!-- doctest-notypecheck: bare `render:` field fragment shown outside its plugin object -->
 ```typescript
 render: ({ ctx, draw, theme }) => {
   // DrawHelper for the common case
@@ -348,25 +351,25 @@ This keeps call sites clean and hides registration details.
 
 ```typescript
 // ✗ bad — allocates a new array every frame
-render: ({ draw, series }) => {
-  const values = series.data.map(d => d.value);  // allocation
+const badRender: SeriesRendererPlugin<unknown>['render'] = ({ draw, series }) => {
+  const values = series.data.map(d => d.value as number | null);  // allocation
   draw.line(values, { color: '#fff' });
-}
+};
 
 // ✓ good — precompute and cache, invalidating on the series data version.
 // `_dataVersion` bumps on every data mutation — including a same-length
 // live update that replaces the last candle in place — so keying on it
 // (not on `data.length`) avoids drawing stale values.
-const valuesCache = new WeakMap<InternalSeries, { version: number; values: number[] }>();
-render: ({ draw, series }) => {
+const valuesCache = new WeakMap<InternalSeries, { version: number; values: (number | null)[] }>();
+const goodRender: SeriesRendererPlugin<unknown>['render'] = ({ draw, series }) => {
   const version = series._dataVersion ?? 0;
   let entry = valuesCache.get(series);
   if (!entry || entry.version !== version) {
-    entry = { version, values: series.data.map(d => d.value) };
+    entry = { version, values: series.data.map(d => d.value as number | null) };
     valuesCache.set(series, entry);
   }
   draw.line(entry.values, { color: '#fff' });
-}
+};
 ```
 
 For series renderers, precompute or cache derived values (see the `WeakMap` example above) instead of re-mapping `series.data` on every frame.
@@ -375,6 +378,7 @@ For series renderers, precompute or cache derived values (see the `WeakMap` exam
 
 Early-out when there's nothing to draw:
 
+<!-- doctest-notypecheck: bare `render:` field fragment shown outside its plugin object -->
 ```typescript
 render: ({ draw }, state) => {
   if (state.zones.length === 0) return;
@@ -405,6 +409,7 @@ my-plugin/
 └── tsconfig.json
 ```
 
+<!-- doctest-notypecheck: package-layout sketch — imports the hypothetical package's own './connect' / './state' modules -->
 ```typescript
 // src/index.ts
 import { definePrimitive, type PrimitivePlugin } from '@trendcraft/chart';

--- a/packages/chart/src/__tests__/docs-typecheck.test.ts
+++ b/packages/chart/src/__tests__/docs-typecheck.test.ts
@@ -1,0 +1,658 @@
+// @vitest-environment node
+/**
+ * Doc-snippet harness (Tier 1.5 — type-check) for @trendcraft/chart.
+ *
+ * Compiles EVERY fenced `ts`/`typescript`/`tsx`/`vue` block in the package
+ * docs with the real TypeScript compiler against the in-repo source, in ONE
+ * virtual program:
+ *
+ *   Layer A — every fence must type-check. Catches wrong option-object keys,
+ *   wrong return-field access, wrong signatures, out-of-scope variables, and
+ *   nullability the docs ignore — the classes both the import check (Tier 1)
+ *   and the executed subset (Tier 2) are blind to.
+ *
+ *   Layer B — every fence that re-declares an interface / object type alias
+ *   whose name is also exported from the main entry is mirrored against the
+ *   real type: key sets must match exactly and the shapes must be mutually
+ *   assignable (this is what catches a doc block listing stale field names).
+ *
+ * `trendcraft` imports resolve to the core package SOURCE (like the Tier-1
+ * import check) so the suite stays build-order-independent. `tsx` fences
+ * compile with the react-jsx transform; `vue` fences compile their <script>
+ * block. See docs-typecheck.test.ts in packages/core for the full design
+ * notes (auto-import of reference-doc identifiers, typed fixture dictionary,
+ * signature-template rewriting, `<!-- doctest-notypecheck: reason -->`).
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pkgRoot = path.resolve(here, "../..");
+const CORE_SRC = path.resolve(pkgRoot, "../core/src");
+
+// Same doc surface as the Tier-1 import check.
+const DOC_FILES = [
+  "docs/API.md",
+  "docs/COOKBOOK.md",
+  "docs/GUIDE.md",
+  "docs/LIVE.md",
+  "docs/PLUGINS.md",
+  "README.md",
+];
+
+// Documented specifier → absolute in-repo source entry. `trendcraft` maps to
+// the core SOURCE entry for build-order independence (Tier-1 precedent).
+const ENTRIES: Record<string, string> = {
+  "@trendcraft/chart": path.join(pkgRoot, "src/index.ts"),
+  "@trendcraft/chart/headless": path.join(pkgRoot, "src/headless.ts"),
+  "@trendcraft/chart/presets": path.join(pkgRoot, "src/presets.ts"),
+  "@trendcraft/chart/replay": path.join(pkgRoot, "src/replay.ts"),
+  "@trendcraft/chart/sparkline": path.join(pkgRoot, "src/sparkline/index.ts"),
+  "@trendcraft/chart/react": path.join(pkgRoot, "react/index.ts"),
+  "@trendcraft/chart/react/sparkline": path.join(pkgRoot, "react/sparkline.tsx"),
+  "@trendcraft/chart/vue": path.join(pkgRoot, "vue/index.ts"),
+  "@trendcraft/chart/vue/sparkline": path.join(pkgRoot, "vue/sparkline.ts"),
+  trendcraft: path.join(CORE_SRC, "index.ts"),
+};
+// Entries searched when auto-importing a reference-doc's free identifiers.
+const AUTO_IMPORT_ORDER = [
+  "@trendcraft/chart",
+  "@trendcraft/chart/headless",
+  "@trendcraft/chart/presets",
+  "@trendcraft/chart/replay",
+  "@trendcraft/chart/sparkline",
+  "@trendcraft/chart/react",
+  "@trendcraft/chart/vue",
+  "trendcraft",
+];
+const MIRROR_ENTRY = "@trendcraft/chart";
+
+// Bounds for skip-creep visibility — raise deliberately when a doc change
+// legitimately adds a new non-compilable fence.
+const MAX_AUTO_SKIPPED = 1; // template-only vue fence (no <script> block)
+const MAX_OPTED_OUT = 6; // <!-- doctest-notypecheck --> pseudo-syntax fences
+
+// ---------------------------------------------------------------- fixtures
+// Typed declarations for the docs' free context variables (see core's
+// docs-typecheck.test.ts for rationale). `{chart}`/`{core}`/… expand to the
+// absolute source entries above.
+const CH = (name: string) => `import("{chart}").${name}`;
+const FIXTURES: Record<string, string> = {
+  container: "HTMLElement",
+  chart: CH("ChartInstance"),
+  candles: 'import("{core}").NormalizedCandle[]',
+  history: 'import("{core}").NormalizedCandle[]',
+  initialBars: 'import("{core}").NormalizedCandle[]',
+  bar: 'import("{core}").NormalizedCandle',
+  conn: 'ReturnType<typeof import("{chart}").connectIndicators>',
+  live: 'ReturnType<typeof import("{core}").createLiveCandle>',
+  liveOptions: 'Parameters<typeof import("{core}").createLiveCandle>[0]',
+  ws: "{ on(event: string, handler: (data: any) => void): void; close(): void }",
+  url: "string",
+  source: CH("LiveSource"),
+  presets: 'typeof import("{core}").indicatorPresets',
+  backtestResult: CH("BacktestResultData"),
+  mySeries: `${CH("DataPoint")}<number | null>[]`,
+  mySecondarySeries: `${CH("DataPoint")}<number | null>[]`,
+  series: `${CH("DataPoint")}<number | null>[]`,
+  myIndicatorData: 'Parameters<typeof import("{headless}").introspect>[0]',
+  renkoData: `${CH("DataPoint")}<unknown>[]`,
+  draw: CH("DrawHelper"),
+  render: "(...args: unknown[]) => void",
+  initialState: "MyState",
+  root: "HTMLElement",
+  rowEl: "HTMLElement",
+  el: "HTMLElement",
+  tickers: 'Array<{ symbol: string; candles: import("{sparkline}").SparklineCandle[] }>',
+  showPatterns: "boolean",
+  options: CH("ChartOptions"),
+  activeIndicators: "Array<{ id: string; params?: Record<string, unknown> }>",
+  useEffect: 'typeof import("react").useEffect',
+  props: '{ candles: import("{chart}").CandleData[] }',
+  ...Object.fromEntries(["nowMs", "index", "price", "x", "y", "w", "h"].map((n) => [n, "number"])),
+};
+// Fixtures the docs re-assign (reconnect recipes in LIVE.md).
+const MUTABLE_FIXTURES = new Set(["conn", "live", "ws"]);
+// Placeholder TYPE fixtures for doc narrative types.
+const TYPE_FIXTURES: Record<string, string> = {
+  MyState: "type MyState = { tick: number };",
+  Zone: "type Zone = { price: number };",
+};
+
+function substituteFixturePaths(type: string): string {
+  return type
+    .replaceAll("{chart}", ENTRIES["@trendcraft/chart"])
+    .replaceAll("{headless}", ENTRIES["@trendcraft/chart/headless"])
+    .replaceAll("{sparkline}", ENTRIES["@trendcraft/chart/sparkline"])
+    .replaceAll("{core}", ENTRIES.trendcraft);
+}
+
+// ---------------------------------------------------------------- fences
+type Fence = {
+  file: string;
+  index: number;
+  lang: string;
+  mdLine: number;
+  code: string;
+  noTypecheck: boolean;
+};
+
+const FENCE_OPEN_RE = /^```(tsx?|typescript|vue)\s*$/;
+const NOTYPECHECK_RE = /<!--\s*doctest-notypecheck\b[^>]*-->/;
+
+function extractFences(relFile: string): Fence[] {
+  const lines = readFileSync(path.join(pkgRoot, relFile), "utf8").split("\n");
+  const out: Fence[] = [];
+  let i = 0;
+  let idx = 0;
+  while (i < lines.length) {
+    const m = lines[i].match(FENCE_OPEN_RE);
+    if (!m) {
+      i++;
+      continue;
+    }
+    const lookback = lines.slice(Math.max(0, i - 3), i).join("\n");
+    const noTypecheck = NOTYPECHECK_RE.test(lookback);
+    const bodyStart = i + 2;
+    const body: string[] = [];
+    i++;
+    while (i < lines.length && !/^```\s*$/.test(lines[i])) body.push(lines[i++]);
+    i++;
+    out.push({
+      file: relFile,
+      index: idx++,
+      lang: m[1],
+      mdLine: bodyStart,
+      code: body.join("\n"),
+      noTypecheck,
+    });
+  }
+  return out;
+}
+
+function hasBareEllipsis(code: string): boolean {
+  const stripped = code.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+  return /\.\.\.(?![A-Za-z_$([{'"`0-9])/.test(stripped) || /…/.test(stripped);
+}
+
+// ---------------------------------------------------------- compiler setup
+const compilerOptions: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  lib: ["lib.es2022.d.ts", "lib.dom.d.ts", "lib.dom.iterable.d.ts"],
+  strict: true,
+  noEmit: true,
+  esModuleInterop: true,
+  skipLibCheck: true,
+  allowImportingTsExtensions: true,
+  types: [],
+  jsx: ts.JsxEmit.ReactJSX,
+};
+
+// ---------------------------------------------------------- name analysis
+/** See core's docs-typecheck.test.ts — file-scope declarations only. */
+function analyzeNames(sourceFile: ts.SourceFile): {
+  declared: Set<string>;
+  referenced: Set<string>;
+} {
+  const declared = new Set<string>();
+  const referenced = new Set<string>();
+  function visit(node: ts.Node): void {
+    if (ts.isIdentifier(node)) {
+      const p = node.parent;
+      if (!p) return;
+      const isDecl =
+        ((ts.isVariableDeclaration(p) ||
+          ts.isFunctionDeclaration(p) ||
+          ts.isClassDeclaration(p) ||
+          ts.isInterfaceDeclaration(p) ||
+          ts.isTypeAliasDeclaration(p) ||
+          ts.isEnumDeclaration(p) ||
+          ts.isModuleDeclaration(p) ||
+          ts.isParameter(p) ||
+          ts.isBindingElement(p) ||
+          ts.isImportClause(p) ||
+          ts.isNamespaceImport(p) ||
+          ts.isImportSpecifier(p) ||
+          ts.isTypeParameterDeclaration(p)) &&
+          p.name === node) ||
+        (ts.isImportSpecifier(p) && p.propertyName === node);
+      if (isDecl) {
+        let scope: ts.Node | undefined = p.parent;
+        while (
+          scope &&
+          !ts.isSourceFile(scope) &&
+          !ts.isFunctionLike(scope) &&
+          !ts.isClassLike(scope) &&
+          !ts.isInterfaceDeclaration(scope) &&
+          !ts.isTypeAliasDeclaration(scope)
+        ) {
+          scope = scope.parent;
+        }
+        if (scope && ts.isSourceFile(scope)) declared.add(node.text);
+        return;
+      }
+      const skip =
+        (ts.isPropertyAccessExpression(p) && p.name === node) ||
+        (ts.isQualifiedName(p) && p.right === node) ||
+        (ts.isPropertyAssignment(p) && p.name === node) ||
+        (ts.isPropertySignature(p) && p.name === node) ||
+        (ts.isMethodSignature(p) && p.name === node) ||
+        (ts.isPropertyDeclaration(p) && p.name === node) ||
+        (ts.isMethodDeclaration(p) && p.name === node) ||
+        (ts.isGetAccessorDeclaration(p) && p.name === node) ||
+        (ts.isSetAccessorDeclaration(p) && p.name === node) ||
+        (ts.isBindingElement(p) && p.propertyName === node) ||
+        ts.isExportSpecifier(p) ||
+        (ts.isEnumMember(p) && p.name === node) ||
+        (ts.isLabeledStatement(p) && p.label === node) ||
+        (ts.isBreakOrContinueStatement(p) && p.label === node) ||
+        (ts.isJsxAttribute(p) && p.name === node);
+      if (!skip) referenced.add(node.text);
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  return { declared, referenced };
+}
+
+// -------------------------------------------------- per-fence preprocessing
+const SPEC_RE = /(['"])(@trendcraft\/chart(?:\/[\w-]+)*|trendcraft(?:\/[\w-]+)?)\1/g;
+
+function rewriteSpecifiers(code: string): string {
+  return code.replace(SPEC_RE, (m, q, spec) => (ENTRIES[spec] ? `${q}${ENTRIES[spec]}${q}` : m));
+}
+
+function extractVueScript(code: string): string | null {
+  const m = code.match(/<script[^>]*>([\s\S]*?)<\/script>/);
+  return m ? m[1] : null;
+}
+
+type Prepared = { code: string; sf: ts.SourceFile; wrapped: boolean; scriptKind: ts.ScriptKind };
+
+function prepare(fence: Fence): Prepared | { skip: string } {
+  let code = fence.code;
+  if (fence.lang === "vue") {
+    const script = extractVueScript(code);
+    if (script === null) return { skip: "vue-template-only" };
+    code = script;
+  }
+  code = rewriteSpecifiers(code);
+
+  const scriptKind = fence.lang === "tsx" ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+  const parse = (text: string) =>
+    ts.createSourceFile("fence.ts", text, ts.ScriptTarget.ES2022, true, scriptKind);
+  // Syntax errors of a standalone SourceFile (`parseDiagnostics` is not public).
+  const parseErrors = (sf2: ts.SourceFile): readonly ts.Diagnostic[] =>
+    (sf2 as unknown as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ?? [];
+  let sf = parse(code);
+
+  // Signature-template call arguments: `f(param = 30)` → `f(30)`.
+  {
+    const declaredQuick = new Set<string>();
+    const collectDecl = (n: ts.Node): void => {
+      if (
+        (ts.isVariableDeclaration(n) || ts.isParameter(n) || ts.isFunctionDeclaration(n)) &&
+        n.name &&
+        ts.isIdentifier(n.name)
+      ) {
+        declaredQuick.add(n.name.text);
+      }
+      ts.forEachChild(n, collectDecl);
+    };
+    collectDecl(sf);
+    const edits: Array<[number, number]> = [];
+    const findTemplateArgs = (n: ts.Node): void => {
+      if (ts.isCallExpression(n)) {
+        for (const arg of n.arguments) {
+          if (
+            ts.isBinaryExpression(arg) &&
+            arg.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+            ts.isIdentifier(arg.left) &&
+            !declaredQuick.has(arg.left.text)
+          ) {
+            edits.push([arg.getStart(sf), arg.right.getStart(sf)]);
+          }
+        }
+      }
+      ts.forEachChild(n, findTemplateArgs);
+    };
+    findTemplateArgs(sf);
+    if (edits.length) {
+      for (const [s, e] of edits.sort((a, b) => b[0] - a[0]))
+        code = code.slice(0, s) + code.slice(e);
+      sf = parse(code);
+    }
+  }
+
+  // Declare-ify top-level body-less function declarations (signature docs).
+  {
+    const inserts: number[] = [];
+    for (const st of sf.statements) {
+      if (
+        ts.isFunctionDeclaration(st) &&
+        !st.body &&
+        !st.modifiers?.some((mod) => mod.kind === ts.SyntaxKind.DeclareKeyword)
+      ) {
+        inserts.push(st.getStart(sf));
+      }
+    }
+    if (inserts.length) {
+      for (const pos of inserts.sort((a, b) => b - a))
+        code = `${code.slice(0, pos)}declare ${code.slice(pos)}`;
+      sf = parse(code);
+    }
+  }
+
+  // Bare method-signature fences parse as interface members; wrapping still
+  // type-checks every referenced parameter/return type.
+  let wrapped = false;
+  if (parseErrors(sf).length > 0) {
+    const wrappedCode = `interface __DocMemberSignatures {\n${code}\n}`;
+    const sf2 = parse(wrappedCode);
+    if (parseErrors(sf2).length === 0) {
+      code = wrappedCode;
+      sf = sf2;
+      wrapped = true;
+    }
+  }
+  return { code, sf, wrapped, scriptKind };
+}
+
+// ---------------------------------------------------------------- assembly
+type Checked = {
+  fence: Fence;
+  vpath: string;
+  preambleLines: number;
+  layer: "A" | "B";
+  mirrorNames?: string[];
+};
+
+type Harness = {
+  checked: Checked[];
+  autoSkipped: Array<{ fence: Fence; reason: string }>;
+  optedOut: Fence[];
+  mirrorCount: number;
+  findings: string[];
+};
+
+let harnessCache: Harness | null = null;
+
+function buildHarness(): Harness {
+  if (harnessCache) return harnessCache;
+
+  const virtualFiles = new Map<string, string>();
+  const sourceFileCache = new Map<string, ts.SourceFile | undefined>();
+  const baseHost = ts.createCompilerHost(compilerOptions, true);
+  const host: ts.CompilerHost = {
+    ...baseHost,
+    fileExists: (f) => virtualFiles.has(f) || baseHost.fileExists(f),
+    readFile: (f) => virtualFiles.get(f) ?? baseHost.readFile(f),
+    getSourceFile: (f, lang, onError, shouldCreate) => {
+      const v = virtualFiles.get(f);
+      if (v !== undefined) {
+        let sf = sourceFileCache.get(f);
+        if (!sf || sf.text !== v) {
+          sf = ts.createSourceFile(
+            f,
+            v,
+            compilerOptions.target ?? ts.ScriptTarget.ES2022,
+            true,
+            f.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+          );
+          sourceFileCache.set(f, sf);
+        }
+        return sf;
+      }
+      let sf = sourceFileCache.get(f);
+      if (!sf) {
+        sf = baseHost.getSourceFile(f, lang, onError, shouldCreate);
+        sourceFileCache.set(f, sf);
+      }
+      return sf;
+    },
+  };
+
+  // Phase 0: parse the entry graph once to learn every export name (values AND types).
+  const programZero = ts.createProgram({
+    rootNames: Object.values(ENTRIES),
+    options: compilerOptions,
+    host,
+  });
+  const checker0 = programZero.getTypeChecker();
+  const exportsByEntry = new Map<string, Set<string>>();
+  for (const [spec, entry] of Object.entries(ENTRIES)) {
+    const sf = programZero.getSourceFile(entry);
+    const names = new Set<string>();
+    const sym = sf && checker0.getSymbolAtLocation(sf);
+    if (sym) for (const e of checker0.getExportsOfModule(sym)) names.add(e.getName());
+    exportsByEntry.set(spec, names);
+  }
+
+  function computePreamble(declared: Set<string>, referenced: Set<string>, lang: string): string {
+    const free = [...referenced].filter((n) => !declared.has(n));
+    // Vue SFC fences resolve wrapper names (TrendChart, useTrendChart) against
+    // the vue entry first; tsx and ts fences prefer the earlier entries.
+    let order = AUTO_IMPORT_ORDER;
+    if (lang === "vue") {
+      order = [
+        ...order.filter((s) => s.includes("/vue")),
+        ...order.filter((s) => !s.includes("/vue")),
+      ];
+    }
+    const bySpec = new Map<string, string[]>();
+    for (const n of free) {
+      for (const spec of order) {
+        if (exportsByEntry.get(spec)?.has(n)) {
+          if (!bySpec.has(spec)) bySpec.set(spec, []);
+          bySpec.get(spec)?.push(n);
+          break;
+        }
+      }
+    }
+    const parts: string[] = [];
+    const imported = new Set<string>();
+    for (const [spec, names] of bySpec) {
+      parts.push(`import { ${names.join(", ")} } from "${ENTRIES[spec]}";`);
+      for (const n of names) imported.add(n);
+    }
+    const fixtureDecls: string[] = [];
+    for (const [fname, ftype] of Object.entries(FIXTURES)) {
+      if (!declared.has(fname) && !imported.has(fname) && referenced.has(fname)) {
+        const kw = MUTABLE_FIXTURES.has(fname) ? "let" : "const";
+        fixtureDecls.push(`declare ${kw} ${fname}: ${substituteFixturePaths(ftype)};`);
+      }
+    }
+    for (const [tname, decl] of Object.entries(TYPE_FIXTURES)) {
+      const needed =
+        (!declared.has(tname) && !imported.has(tname) && referenced.has(tname)) ||
+        fixtureDecls.some((d) => new RegExp(`\\b${tname}\\b`).test(d));
+      if (needed && !declared.has(tname) && !imported.has(tname)) parts.push(decl);
+    }
+    parts.push(...fixtureDecls);
+    return parts.join(" ");
+  }
+
+  function buildVirtual(fence: Fence, prep: Prepared): { text: string; preambleLines: number } {
+    const { declared, referenced } = analyzeNames(prep.sf);
+    const preamble = computePreamble(declared, referenced, fence.lang);
+    const hasModuleSyntax =
+      /(^|\n)\s*(import|export)\b/.test(prep.code) || preamble.includes("import ");
+    const text =
+      (preamble ? `${preamble}\n` : "") + prep.code + (hasModuleSyntax ? "" : "\nexport {};");
+    return { text, preambleLines: preamble ? 1 : 0 };
+  }
+
+  function buildMirrors(fence: Fence, prep: Prepared): { text: string; names: string[] } | null {
+    const entryExports = exportsByEntry.get(MIRROR_ENTRY);
+    const mirrors: string[] = [];
+    for (const st of prep.sf.statements) {
+      let mirrorName: string | null = null;
+      let generic = false;
+      if (ts.isInterfaceDeclaration(st)) {
+        mirrorName = st.name.text;
+        generic = (st.typeParameters?.length ?? 0) > 0;
+      } else if (ts.isTypeAliasDeclaration(st) && ts.isTypeLiteralNode(st.type)) {
+        mirrorName = st.name.text;
+        generic = (st.typeParameters?.length ?? 0) > 0;
+      }
+      if (!mirrorName || generic || !entryExports?.has(mirrorName)) continue;
+      mirrors.push(mirrorName);
+    }
+    if (mirrors.length === 0) return null;
+
+    let code = prep.code;
+    for (const mirrorName of mirrors) {
+      code = code.replace(new RegExp(`\\b${mirrorName}\\b`, "g"), `${mirrorName}__doc`);
+    }
+    const { declared, referenced } = analyzeNames(prep.sf);
+    for (const n of mirrors) referenced.delete(n);
+    const preamble = computePreamble(declared, referenced, fence.lang);
+    const header =
+      (preamble ? `${preamble} ` : "") +
+      `import type { ${mirrors.map((n) => `${n} as ${n}__real`).join(", ")} } from "${ENTRIES[MIRROR_ENTRY]}";`;
+    const tail: string[] = [];
+    for (const n of mirrors) {
+      tail.push(
+        `type __MissingInDoc_${n} = Exclude<keyof ${n}__real, keyof ${n}__doc>;`,
+        `type __ExtraInDoc_${n} = Exclude<keyof ${n}__doc, keyof ${n}__real>;`,
+        `const __keys_${n}: [__MissingInDoc_${n} | __ExtraInDoc_${n}] extends [never] ? "ok" : { docIsMissing: __MissingInDoc_${n}[]; docHasExtra: __ExtraInDoc_${n}[] } = "ok";`,
+        `declare const __docV_${n}: ${n}__doc; declare const __realV_${n}: ${n}__real;`,
+        `const __docAssignable_${n}: ${n}__real = __docV_${n};`,
+        `const __realAssignable_${n}: ${n}__doc = __realV_${n};`,
+        `void __keys_${n}; void __docAssignable_${n}; void __realAssignable_${n};`,
+      );
+    }
+    return { text: `${header}\n${code}\n${tail.join("\n")}\nexport {};`, names: mirrors };
+  }
+
+  const fences = DOC_FILES.flatMap(extractFences);
+  const autoSkipped: Array<{ fence: Fence; reason: string }> = [];
+  const optedOut: Fence[] = [];
+  const checked: Checked[] = [];
+  const VDIR = path.join(here, "__doc_typecheck_virtual__");
+
+  for (const fence of fences) {
+    if (fence.noTypecheck) {
+      optedOut.push(fence);
+      continue;
+    }
+    if (hasBareEllipsis(fence.code)) {
+      autoSkipped.push({ fence, reason: "ellipsis-placeholder" });
+      continue;
+    }
+    const prep = prepare(fence);
+    if ("skip" in prep) {
+      autoSkipped.push({ fence, reason: prep.skip });
+      continue;
+    }
+    const id = `${fence.file.replace(/\W/g, "_")}_${fence.index}`;
+    const ext = fence.lang === "tsx" ? ".tsx" : ".ts";
+    const v = buildVirtual(fence, prep);
+    const vpath = path.join(VDIR, `${id}${ext}`);
+    virtualFiles.set(vpath, v.text);
+    checked.push({
+      fence,
+      vpath,
+      preambleLines: v.preambleLines + (prep.wrapped ? 1 : 0),
+      layer: "A",
+    });
+
+    const mirror = buildMirrors(fence, prep);
+    if (mirror) {
+      const mpath = path.join(VDIR, `${id}.mirror${ext}`);
+      virtualFiles.set(mpath, mirror.text);
+      checked.push({
+        fence,
+        vpath: mpath,
+        preambleLines: 1,
+        layer: "B",
+        mirrorNames: mirror.names,
+      });
+    }
+  }
+
+  const program = ts.createProgram({
+    rootNames: [...virtualFiles.keys()],
+    options: compilerOptions,
+    host,
+    oldProgram: programZero,
+  });
+
+  const findings: string[] = [];
+  for (const c of checked) {
+    const sf = program.getSourceFile(c.vpath);
+    if (!sf) continue;
+    const diags = [...program.getSyntacticDiagnostics(sf), ...program.getSemanticDiagnostics(sf)];
+    for (const d of diags) {
+      const pos = d.start !== undefined ? sf.getLineAndCharacterOfPosition(d.start) : { line: 0 };
+      const mdLine = c.fence.mdLine + Math.max(0, pos.line - c.preambleLines);
+      const layerTag = c.layer === "B" ? ` [type-mirror: ${c.mirrorNames?.join(", ")}]` : "";
+      findings.push(
+        `  ${c.fence.file}:${mdLine}${layerTag} TS${d.code}: ${ts.flattenDiagnosticMessageText(d.messageText, " | ")}`,
+      );
+    }
+  }
+
+  harnessCache = {
+    checked,
+    autoSkipped,
+    optedOut,
+    mirrorCount: checked.filter((c) => c.layer === "B").length,
+    findings,
+  };
+  return harnessCache;
+}
+
+// ---------------------------------------------------------------- tests
+// The harness parses the whole chart AND core source graphs; give it the same
+// headroom as the Tier-1 import check.
+const TIMEOUT_MS = 60_000;
+
+describe("doc snippets — type-check (Tier 1.5)", () => {
+  it(
+    "found ts/tsx/vue fences to type-check",
+    () => {
+      const h = buildHarness();
+      expect(h.checked.filter((c) => c.layer === "A").length).toBeGreaterThan(80);
+      expect(h.mirrorCount).toBeGreaterThan(2);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "every documented snippet type-checks against the real API",
+    () => {
+      const h = buildHarness();
+      expect(
+        h.findings.length,
+        `Doc snippet type errors (fix the doc, or opt out with <!-- doctest-notypecheck: reason -->):\n${h.findings.join("\n")}`,
+      ).toBe(0);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "auto-skips and opt-outs stay within recorded bounds",
+    () => {
+      const h = buildHarness();
+      const skipReport = h.autoSkipped
+        .map((s) => `  ${s.fence.file}#${s.fence.index}: ${s.reason}`)
+        .join("\n");
+      expect(
+        h.autoSkipped.length,
+        `Auto-skipped fences exceeded the recorded bound (${MAX_AUTO_SKIPPED}). If the new fragment is intentional, raise MAX_AUTO_SKIPPED deliberately.\n${skipReport}`,
+      ).toBeLessThanOrEqual(MAX_AUTO_SKIPPED);
+      const optReport = h.optedOut.map((f) => `  ${f.file}#${f.index}`).join("\n");
+      expect(
+        h.optedOut.length,
+        `Opted-out fences exceeded the recorded bound (${MAX_OPTED_OUT}). If the new opt-out is justified, raise MAX_OPTED_OUT deliberately.\n${optReport}`,
+      ).toBeLessThanOrEqual(MAX_OPTED_OUT);
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/chart/src/__tests__/event-wiring.test.ts
+++ b/packages/chart/src/__tests__/event-wiring.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment node
+/**
+ * Contract-wiring guard for the ChartEvent union.
+ *
+ * Motivation: an audit found event names that were DECLARED in the ChartEvent
+ * union (and documented / subscribed to) but never EMITTED anywhere in the
+ * renderer — `resize`, `paneResize`, `seriesRemoved` shipped as dead contract
+ * surface until they were wired up. This test makes the whole class of bug
+ * impossible to reintroduce silently:
+ *
+ *   1. Forward guard — every member of the ChartEvent union must have at
+ *      least one emission site (`_emit("<name>", …)` / `emit("<name>", …)`)
+ *      somewhere in packages/chart/src (tests excluded).
+ *   2. Reverse guard — every event-name string literal passed to an emit
+ *      call must be a declared member of the union (catches emitting an
+ *      event no subscriber can ever type-safely listen for).
+ *
+ * Both sides are extracted with the TypeScript AST (not regex) so string
+ * literals in comments or unrelated code cannot create false hits, and
+ * dynamic emits (`emit(event as ChartEvent, …)`) are ignored — only literal
+ * event names are checkable, and all intentional emission sites use literals.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const SRC_ROOT = path.resolve(here, ".."); // packages/chart/src
+const EVENT_TYPES_FILE = path.join(SRC_ROOT, "core/types/event.ts");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function walkTsFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "__tests__" || entry.name === "node_modules") continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkTsFiles(full, out);
+    else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) out.push(full);
+  }
+  return out;
+}
+
+function parseFile(file: string): ts.SourceFile {
+  return ts.createSourceFile(file, readFileSync(file, "utf8"), ts.ScriptTarget.Latest, true);
+}
+
+/** Extract the string-literal members of the `ChartEvent` union type alias. */
+function extractChartEventUnion(): string[] {
+  const sf = parseFile(EVENT_TYPES_FILE);
+  let members: string[] | null = null;
+  sf.forEachChild((node) => {
+    if (!ts.isTypeAliasDeclaration(node) || node.name.text !== "ChartEvent") return;
+    const collected: string[] = [];
+    const collect = (t: ts.TypeNode): void => {
+      if (ts.isUnionTypeNode(t)) {
+        for (const part of t.types) collect(part);
+      } else if (ts.isLiteralTypeNode(t) && ts.isStringLiteral(t.literal)) {
+        collected.push(t.literal.text);
+      }
+    };
+    collect(node.type);
+    members = collected;
+  });
+  if (!members) throw new Error(`ChartEvent type alias not found in ${EVENT_TYPES_FILE}`);
+  return members;
+}
+
+type EmitSite = { file: string; name: string; line: number };
+
+/**
+ * Collect every `emit("<literal>", …)` / `_emit("<literal>", …)` call.
+ * Matches both bare identifiers (`_emit(…)` is rare) and property access
+ * (`this._emit(…)`, `this._deps.emit(…)`, `rc.emit(…)`).
+ */
+function collectEmitSites(sf: ts.SourceFile, out: EmitSite[]): void {
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && node.arguments.length > 0) {
+      const callee = node.expression;
+      const calleeName = ts.isIdentifier(callee)
+        ? callee.text
+        : ts.isPropertyAccessExpression(callee)
+          ? callee.name.text
+          : null;
+      if (calleeName === "emit" || calleeName === "_emit") {
+        const arg0 = node.arguments[0];
+        if (ts.isStringLiteral(arg0)) {
+          const { line } = sf.getLineAndCharacterOfPosition(arg0.getStart(sf));
+          out.push({
+            file: path.relative(SRC_ROOT, sf.fileName),
+            name: arg0.text,
+            line: line + 1,
+          });
+        }
+      }
+    }
+    node.forEachChild(visit);
+  };
+  visit(sf);
+}
+
+// ---------------------------------------------------------------------------
+// Analysis (computed once — pure fs + AST, no DOM)
+// ---------------------------------------------------------------------------
+
+const unionMembers = extractChartEventUnion();
+const emitSites: EmitSite[] = [];
+for (const file of walkTsFiles(SRC_ROOT)) {
+  collectEmitSites(parseFile(file), emitSites);
+}
+const emittedNames = new Set(emitSites.map((s) => s.name));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ChartEvent contract wiring", () => {
+  it("parses the ChartEvent union (sanity)", () => {
+    // If the union moves or is renamed this fails loudly instead of the
+    // wiring checks silently passing on an empty list.
+    expect(unionMembers.length).toBeGreaterThanOrEqual(10);
+    expect(unionMembers).toContain("crosshairMove");
+  });
+
+  it("finds literal emit sites in src (sanity)", () => {
+    expect(emitSites.length).toBeGreaterThan(0);
+  });
+
+  it("every declared ChartEvent member is emitted somewhere in src", () => {
+    const dead = unionMembers.filter((name) => !emittedNames.has(name));
+    expect(
+      dead,
+      `ChartEvent member(s) declared in core/types/event.ts but never emitted in src/ ` +
+        `(dead contract surface — subscribers can register but the event never fires). ` +
+        `Either wire an emission site or remove the member from the union:\n  ${dead.join("\n  ")}`,
+    ).toEqual([]);
+  });
+
+  it("every emitted event name is a declared ChartEvent member", () => {
+    const undeclared = emitSites.filter((s) => !unionMembers.includes(s.name));
+    const report = undeclared.map((s) => `  ${s.file}:${s.line} emits "${s.name}"`).join("\n");
+    expect(
+      undeclared,
+      `Emit site(s) using an event name that is not in the ChartEvent union ` +
+        `(no subscriber can type-safely listen for these). Add the name to the union ` +
+        `in core/types/event.ts or fix the emit call:\n${report}`,
+    ).toEqual([]);
+  });
+});

--- a/packages/chart/src/__tests__/jsdoc-examples-typecheck.test.ts
+++ b/packages/chart/src/__tests__/jsdoc-examples-typecheck.test.ts
@@ -1,0 +1,592 @@
+// @vitest-environment node
+/**
+ * JSDoc @example type-check harness for @trendcraft/chart.
+ *
+ * Sweeps every non-test source file in `src/`, `react/` and `vue/` for JSDoc
+ * `@example` blocks and type-checks the extracted code in ONE virtual
+ * TypeScript program, so stale examples (wrong signatures, removed helpers,
+ * renamed exports) fail CI the same way stale doc fences do in
+ * `docs-import-check` / `docs-snippets`.
+ *
+ * Leniency model — JSDoc examples conventionally omit imports and fixtures:
+ *   - Every runtime export / exported type of the chart entries (main,
+ *     headless, presets, replay, sparkline) is ambient-declared.
+ *   - The exports of the module each example lives in are declared per
+ *     example. Examples under `react/` / `vue/` additionally get their
+ *     wrapper entry's exports (the wrappers are separate entry points whose
+ *     same-named exports must not collide globally, e.g. `TrendChart`).
+ *   - Conventional fixtures (`candles`, `chart`, `container`, React/Vue
+ *     helpers like `useEffect` / `ref`) are declared with their real types —
+ *     see FIXTURE_TYPES below.
+ *   - The ellipsis placeholder convention is tolerated: `[1, 2, ...]` /
+ *     `{ a, ... }` become a spread of `any`, and a fully-elided call
+ *     `fn(...)` is checked as `(fn as any)()`.
+ *   - `import ... from "@trendcraft/chart[/sub]"` / `"trendcraft"` statements
+ *     are rewritten to in-repo source entries (same mapping as
+ *     docs-import-check; `trendcraft` resolves to core SOURCE so the test is
+ *     build-order-independent).
+ *   - `tsx` examples compile as .tsx with the package's `jsx: react-jsx`;
+ *     `vue` (SFC) examples check only their `<script>` block content — the
+ *     template needs the Vue compiler and is out of scope here.
+ *
+ * Suppressed diagnostics (documented noise, not stale-docs signal):
+ *   - TS6133/TS6196/TS6198/TS6205 — unused locals; examples assign results
+ *     without consuming them.
+ *   - TS2451/TS2393 — redeclarations; one example often shows several
+ *     alternative snippets reusing the same const name.
+ *   - TS7006/TS7031 — implicit-any callback params / binding elements in
+ *     illustrative fragments.
+ *   - TS2531/TS18047/TS18048 — strict-null elision; examples intentionally
+ *     skip null guards.
+ *
+ * Opt-out: an example whose first code line starts with `// notypecheck` is
+ * skipped (for intentionally partial pseudo-code that cannot type-check).
+ * The skip count is pinned below so opt-outs stay deliberate.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pkgRoot = path.resolve(here, "../..");
+const srcRoot = path.join(pkgRoot, "src");
+const INDEX = path.join(srcRoot, "index.ts");
+const CORE_INDEX = path.resolve(pkgRoot, "../core/src/index.ts");
+
+/** Number of examples deliberately opted out via `// notypecheck`. */
+const EXPECTED_SKIPS = 0;
+
+// Directories swept for @example blocks.
+const SWEEP_DIRS = [srcRoot, path.join(pkgRoot, "react"), path.join(pkgRoot, "vue")];
+
+// Entries whose exports become ambient globals (first entry wins on clashes).
+// react/vue wrapper entries are NOT global — they are injected per example
+// for files under react/ / vue/ (both export e.g. `TrendChart`).
+const AMBIENT_ENTRIES = [
+  INDEX,
+  path.join(srcRoot, "headless.ts"),
+  path.join(srcRoot, "presets.ts"),
+  path.join(srcRoot, "replay.ts"),
+  path.join(srcRoot, "sparkline/index.ts"),
+];
+
+// `import ... from "<pkg>"` → in-repo source entry (mirrors docs-import-check's
+// SOURCE_TO_ENTRY; `trendcraft` maps to core source for build independence).
+const IMPORT_REWRITES: Array<[RegExp, string]> = [
+  [/(["'])@trendcraft\/chart\/headless\1/g, JSON.stringify(path.join(srcRoot, "headless.ts"))],
+  [/(["'])@trendcraft\/chart\/presets\1/g, JSON.stringify(path.join(srcRoot, "presets.ts"))],
+  [/(["'])@trendcraft\/chart\/replay\1/g, JSON.stringify(path.join(srcRoot, "replay.ts"))],
+  [
+    /(["'])@trendcraft\/chart\/sparkline\1/g,
+    JSON.stringify(path.join(srcRoot, "sparkline/index.ts")),
+  ],
+  [
+    /(["'])@trendcraft\/chart\/react\/sparkline\1/g,
+    JSON.stringify(path.join(pkgRoot, "react/sparkline.ts")),
+  ],
+  [/(["'])@trendcraft\/chart\/react\1/g, JSON.stringify(path.join(pkgRoot, "react/index.ts"))],
+  [
+    /(["'])@trendcraft\/chart\/vue\/sparkline\1/g,
+    JSON.stringify(path.join(pkgRoot, "vue/sparkline.ts")),
+  ],
+  [/(["'])@trendcraft\/chart\/vue\1/g, JSON.stringify(path.join(pkgRoot, "vue/index.ts"))],
+  [/(["'])@trendcraft\/chart\1/g, JSON.stringify(INDEX)],
+  [/(["'])trendcraft\1/g, JSON.stringify(CORE_INDEX)],
+];
+
+// Conventional free variables JSDoc examples assume from context.
+const T = (t: string) => `import(${JSON.stringify(INDEX)}).${t}`;
+const FIXTURE_TYPES: Record<string, string> = {
+  // chart data / instances
+  candles: `${T("CandleData")}[]`,
+  chart: `ReturnType<typeof import(${JSON.stringify(INDEX)}).createChart>`,
+  container: "HTMLElement",
+  el: "HTMLElement",
+  listEl: "HTMLElement",
+  cv: "HTMLCanvasElement",
+  data: `${T("DataPoint")}[]`,
+  values: `${T("DataPoint")}[]`,
+  closes: "number[]",
+  tickers: "{ id: string; canvas: HTMLCanvasElement; closes: number[] }[]",
+  timeScale: `import(${JSON.stringify(path.join(srcRoot, "headless.ts"))}).TimeScale`,
+  priceScale: `import(${JSON.stringify(path.join(srcRoot, "headless.ts"))}).PriceScale`,
+  // live integration
+  source: T("LiveSource"),
+  // core-package objects used bare in integration examples
+  presets: `typeof import(${JSON.stringify(CORE_INDEX)}).indicatorPresets`,
+  indicatorPresets: `typeof import(${JSON.stringify(CORE_INDEX)}).indicatorPresets`,
+  entry: `import(${JSON.stringify(CORE_INDEX)}).Condition`,
+  exit: `import(${JSON.stringify(CORE_INDEX)}).Condition`,
+  // React helpers used bare in wrapper examples
+  useEffect: 'typeof import("react").useEffect',
+  useState: 'typeof import("react").useState',
+  useRef: 'typeof import("react").useRef',
+  // Vue helpers used bare in <script setup> examples
+  ref: 'typeof import("vue").ref',
+  computed: 'typeof import("vue").computed',
+  watch: 'typeof import("vue").watch',
+  watchEffect: 'typeof import("vue").watchEffect',
+};
+
+// Conventional fixture-name PATTERNS, injected per example for identifiers
+// the example uses but does not bind (data arrays only — called identifiers
+// are excluded).
+const FIXTURE_FAMILIES: Array<[RegExp, string]> = [
+  [
+    /^(?:[a-z_$][\w$]*)?Candles(?:[A-Z0-9][\w$]*)?$|^candles[A-Z0-9][\w$]*$/,
+    `${T("CandleData")}[]`,
+  ],
+  [/^series[A-Z0-9][\w$]*$|^[a-z_$][\w$]*Series$/, `${T("DataPoint")}[]`],
+  // multi-chart examples (chart1, chart2, …)
+  [/^chart[A-Z0-9][\w$]*$/, `ReturnType<typeof import(${JSON.stringify(INDEX)}).createChart>`],
+];
+
+// Names that would collide with DOM/ES globals from the default libs.
+const GLOBAL_NAME_SKIP = new Set([
+  "Event",
+  "Range",
+  "Node",
+  "Window",
+  "Position",
+  "History",
+  "Selection",
+  "Screen",
+]);
+
+// Diagnostic codes suppressed as documented noise (see file header).
+const SUPPRESSED_CODES = new Set([
+  6133,
+  6196,
+  6198,
+  6205, // unused locals/types
+  2451,
+  2393, // redeclared alternative-variant consts / functions
+  7006,
+  7031, // implicit-any example callback params / binding elements
+  2531,
+  18047,
+  18048, // strict-null elision
+]);
+
+// ---------------------------------------------------------------------------
+// 1. Sweep + extraction
+// ---------------------------------------------------------------------------
+
+type Example = { file: string; line: number; code: string; skip: boolean; jsx: boolean };
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (e.name === "__tests__" || e.name === "node_modules") continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, out);
+    else if (/\.tsx?$/.test(e.name) && !e.name.endsWith(".d.ts")) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Extract `@example` blocks (see the core package's harness for the format
+ * contract). Chart addition: fences carry a language — `vue` fences are SFCs,
+ * so only their `<script>` block content is kept; everything else (template,
+ * prose outside fences) is blanked, preserving line mapping.
+ */
+function extractExamples(file: string): Example[] {
+  const text = fs.readFileSync(file, "utf8");
+  const raw: Array<{ line: number; body: string[] }> = [];
+  const re = /\/\*\*[\s\S]*?\*\//g;
+  let m: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
+  while ((m = re.exec(text)) !== null) {
+    const startLine = text.slice(0, m.index).split("\n").length; // 1-based
+    const lines = m[0].split("\n");
+    let cur: { line: number; body: string[] } | null = null;
+    const flush = () => {
+      if (cur) raw.push(cur);
+      cur = null;
+    };
+    for (let i = 0; i < lines.length; i++) {
+      const stripped = lines[i].replace(/\s*\*\/\s*$/, "").replace(/^\s*\/?\*+ ?/, "");
+      if (/^@example\b/.test(stripped)) {
+        flush();
+        cur = { line: startLine + i + 1, body: [] };
+        continue;
+      }
+      if (cur && /^@[a-zA-Z]/.test(stripped)) {
+        flush();
+        continue;
+      }
+      if (cur) cur.body.push(stripped);
+    }
+    flush();
+  }
+  const out: Example[] = [];
+  for (const b of raw) {
+    let { line } = b;
+    let body = b.body;
+    while (body.length && body[0].trim() === "") {
+      body = body.slice(1);
+      line++;
+    }
+    while (body.length && body[body.length - 1].trim() === "") body = body.slice(0, -1);
+    let jsx = false;
+    if (body.some((l) => /^```/.test(l.trim()))) {
+      let lang = "";
+      let inScript = false;
+      body = body.map((l) => {
+        const fence = l.trim().match(/^```(\w*)/);
+        if (fence) {
+          lang = lang === "" ? fence[1] : "";
+          inScript = false;
+          return "";
+        }
+        if (lang === "") return ""; // outside any fence
+        if (lang === "vue") {
+          // keep only <script>…</script> inner lines of the SFC
+          if (/^<script[\s>]/.test(l.trim())) {
+            inScript = true;
+            return "";
+          }
+          if (/^<\/script>/.test(l.trim())) {
+            inScript = false;
+            return "";
+          }
+          return inScript ? l : "";
+        }
+        if (lang === "tsx") jsx = true;
+        return l;
+      });
+    }
+    const code = body.join("\n");
+    if (code.trim() === "") continue;
+    const firstLine = body.find((l) => l.trim() !== "")?.trim() ?? "";
+    out.push({ file, line, code, skip: firstLine.startsWith("// notypecheck"), jsx });
+  }
+  return out;
+}
+
+const allFiles = SWEEP_DIRS.flatMap((d) => walk(d));
+const examples = allFiles.flatMap(extractExamples);
+const checked = examples.filter((e) => !e.skip);
+const skipped = examples.filter((e) => e.skip);
+
+// ---------------------------------------------------------------------------
+// 2. Virtual compiler host (shared SourceFile cache across both programs)
+// ---------------------------------------------------------------------------
+
+const compilerOptions: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  lib: ["lib.es2022.d.ts", "lib.dom.d.ts"],
+  jsx: ts.JsxEmit.ReactJSX,
+  strict: true,
+  noEmit: true,
+  allowImportingTsExtensions: true,
+  skipLibCheck: true,
+  esModuleInterop: true,
+};
+
+const virtualFiles = new Map<string, string>();
+const sourceFileCache = new Map<string, ts.SourceFile>();
+const baseHost = ts.createCompilerHost(compilerOptions, true);
+const host: ts.CompilerHost = {
+  ...baseHost,
+  fileExists: (f) => virtualFiles.has(f) || baseHost.fileExists(f),
+  readFile: (f) => virtualFiles.get(f) ?? baseHost.readFile(f),
+  getSourceFile: (f, lang, onError, shouldCreate) => {
+    const v = virtualFiles.get(f);
+    if (v !== undefined) {
+      let sf = sourceFileCache.get(f);
+      if (!sf || sf.text !== v) {
+        sf = ts.createSourceFile(f, v, compilerOptions.target ?? ts.ScriptTarget.ES2022, true);
+        sourceFileCache.set(f, sf);
+      }
+      return sf;
+    }
+    let sf = sourceFileCache.get(f);
+    if (!sf) {
+      sf = baseHost.getSourceFile(f, lang, onError, shouldCreate);
+      if (sf) sourceFileCache.set(f, sf);
+    }
+    return sf;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 3. Export enumeration (phase-1 program) + ambient declaration generation
+// ---------------------------------------------------------------------------
+
+type ExportInfo = {
+  name: string;
+  isValue: boolean;
+  isType: boolean;
+  typeParams: { text: string; names: string } | null;
+};
+
+function buildAmbient(): {
+  ambientPath: string;
+  declared: Set<string>;
+  exportsOf: (f: string) => ExportInfo[];
+} {
+  const hostModules = [...new Set(checked.map((e) => e.file))];
+  const wrapperEntries = [
+    path.join(pkgRoot, "react/index.ts"),
+    path.join(pkgRoot, "react/sparkline.ts"),
+    path.join(pkgRoot, "vue/index.ts"),
+    path.join(pkgRoot, "vue/sparkline.ts"),
+  ];
+  const phase1 = ts.createProgram({
+    rootNames: [...AMBIENT_ENTRIES, ...wrapperEntries, ...hostModules],
+    options: compilerOptions,
+    host,
+  });
+  const checker = phase1.getTypeChecker();
+
+  const exportsCache = new Map<string, ExportInfo[]>();
+  function exportsOf(fileAbs: string): ExportInfo[] {
+    const cached = exportsCache.get(fileAbs);
+    if (cached) return cached;
+    const out: ExportInfo[] = [];
+    const sf = phase1.getSourceFile(fileAbs);
+    const sym = sf ? checker.getSymbolAtLocation(sf) : undefined;
+    if (sym) {
+      for (const ex of checker.getExportsOfModule(sym)) {
+        const name = ex.getName();
+        if (!/^[A-Za-z_$][\w$]*$/.test(name)) continue;
+        let resolved = ex;
+        try {
+          if (ex.flags & ts.SymbolFlags.Alias) resolved = checker.getAliasedSymbol(ex);
+        } catch {
+          // keep the alias symbol if resolution fails
+        }
+        const isValue = (resolved.flags & ts.SymbolFlags.Value) !== 0;
+        const isType =
+          (resolved.flags &
+            (ts.SymbolFlags.Interface |
+              ts.SymbolFlags.TypeAlias |
+              ts.SymbolFlags.Class |
+              ts.SymbolFlags.Enum)) !==
+          0;
+        // Generic types need their type-parameter list replicated on the alias.
+        let typeParams: ExportInfo["typeParams"] = null;
+        if (isType) {
+          const decl = (resolved.declarations ?? []).find(
+            (
+              d,
+            ): d is ts.DeclarationStatement & {
+              typeParameters: ts.NodeArray<ts.TypeParameterDeclaration>;
+            } =>
+              (d as { typeParameters?: ts.NodeArray<ts.TypeParameterDeclaration> })
+                .typeParameters !== undefined &&
+              ((d as { typeParameters?: ts.NodeArray<ts.TypeParameterDeclaration> }).typeParameters
+                ?.length ?? 0) > 0,
+          );
+          if (decl) {
+            typeParams = {
+              text: decl.typeParameters.map((p) => p.getText()).join(", "),
+              names: decl.typeParameters.map((p) => p.name.text).join(", "),
+            };
+          }
+        }
+        out.push({ name, isValue, isType, typeParams });
+      }
+    }
+    exportsCache.set(fileAbs, out);
+    return out;
+  }
+
+  const ambientLines: string[] = [];
+  const declared = new Set<string>();
+  for (const entry of AMBIENT_ENTRIES) {
+    const spec = JSON.stringify(entry);
+    for (const { name, isValue, isType, typeParams } of exportsOf(entry)) {
+      if (declared.has(name) || GLOBAL_NAME_SKIP.has(name)) continue;
+      declared.add(name);
+      if (isValue) ambientLines.push(`declare const ${name}: typeof import(${spec}).${name};`);
+      if (isType) {
+        ambientLines.push(
+          typeParams
+            ? `type ${name}<${typeParams.text}> = import(${spec}).${name}<${typeParams.names}>;`
+            : `type ${name} = import(${spec}).${name};`,
+        );
+      }
+    }
+  }
+  const fixtureLines = Object.entries(FIXTURE_TYPES)
+    .filter(([name]) => !declared.has(name))
+    .map(([name, type]) => `declare const ${name}: ${type};`);
+  const ambientPath = path.join(srcRoot, "__jsdoc_examples_ambient__.d.ts");
+  virtualFiles.set(ambientPath, [...ambientLines, ...fixtureLines].join("\n") + "\n");
+  return { ambientPath, declared, exportsOf };
+}
+
+// ---------------------------------------------------------------------------
+// 4. Virtual example files
+// ---------------------------------------------------------------------------
+
+function rewriteImports(code: string): string {
+  let out = code;
+  for (const [re, repl] of IMPORT_REWRITES) out = out.replace(re, repl);
+  return out;
+}
+
+/** Tolerate the ellipsis placeholder convention (see core harness). */
+function fillEllipsisHoles(code: string): string {
+  return code
+    .replace(/=>\s*\{\s*\.\.\.\s*\}/g, "=> {}") // elided function body
+    .replace(/([A-Za-z_$][\w$]*)\s*\(\s*\.\.\.\s*\)/g, "($1 as any)()")
+    .replace(/\.\.\.(?=\s*[,)\]}]|\s*$)/gm, "...(null as any)");
+}
+
+/** Names the example itself binds at top level (imports + declarations). */
+function boundNames(code: string): Set<string> {
+  const names = new Set<string>();
+  for (const m of code.matchAll(/import\s+([^;]*?)\s+from/g)) {
+    const clause = m[1];
+    const brace = clause.match(/\{([^}]*)\}/);
+    if (brace) {
+      for (const s of brace[1].split(",")) {
+        const p = s
+          .trim()
+          .replace(/^type\s+/, "")
+          .split(/\s+as\s+/);
+        const local = (p[1] ?? p[0]).trim();
+        if (local) names.add(local);
+      }
+    }
+    const star = clause.match(/\*\s+as\s+([A-Za-z_$][\w$]*)/);
+    if (star) names.add(star[1]);
+    const def = clause.match(/^([A-Za-z_$][\w$]*)\s*(,|$)/);
+    if (def) names.add(def[1]);
+  }
+  for (const m of code.matchAll(
+    /^\s*(?:const|let|var|function|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/gm,
+  )) {
+    names.add(m[1]);
+  }
+  for (const m of code.matchAll(/^\s*(?:const|let|var)\s*[{[]([^}\]]*)[}\]]/gm)) {
+    for (const part of m[1].split(",")) {
+      const p = part.trim();
+      if (!p) continue;
+      const alias = p.includes(":") ? p.split(":")[1] : p;
+      const name = alias.trim().split(/[=\s]/)[0];
+      if (/^[A-Za-z_$][\w$]*$/.test(name)) names.add(name);
+    }
+  }
+  return names;
+}
+
+// ---------------------------------------------------------------------------
+// 5. Diagnostics
+// ---------------------------------------------------------------------------
+
+function collectFindings(): { findings: string[] } {
+  const { ambientPath, declared, exportsOf } = buildAmbient();
+
+  type Meta = { file: string; line: number; headerLines: number };
+  const exampleMeta = new Map<string, Meta>();
+  let counter = 0;
+  for (const ex of checked) {
+    const bound = boundNames(ex.code);
+    const header: string[] = [];
+    const headerNames = new Set<string>();
+    // Own module first, then the wrapper entry for react/ and vue/ examples.
+    const contextModules = [ex.file];
+    if (ex.file.startsWith(path.join(pkgRoot, "react") + path.sep)) {
+      contextModules.push(
+        path.join(pkgRoot, "react/index.ts"),
+        path.join(pkgRoot, "react/sparkline.ts"),
+      );
+    } else if (ex.file.startsWith(path.join(pkgRoot, "vue") + path.sep)) {
+      contextModules.push(
+        path.join(pkgRoot, "vue/index.ts"),
+        path.join(pkgRoot, "vue/sparkline.ts"),
+      );
+    }
+    for (const mod of [...new Set(contextModules)]) {
+      const spec = JSON.stringify(mod);
+      for (const { name, isValue, isType, typeParams } of exportsOf(mod)) {
+        if (bound.has(name) || GLOBAL_NAME_SKIP.has(name) || headerNames.has(name)) continue;
+        headerNames.add(name);
+        if (isValue) header.push(`declare const ${name}: typeof import(${spec}).${name};`);
+        if (isType) {
+          header.push(
+            typeParams
+              ? `type ${name}<${typeParams.text}> = import(${spec}).${name}<${typeParams.names}>;`
+              : `type ${name} = import(${spec}).${name};`,
+          );
+        }
+      }
+    }
+    // family-pattern fixtures (data values only — called identifiers excluded)
+    const injected = new Set<string>();
+    for (const tok of ex.code.matchAll(/[A-Za-z_$][\w$]*/g)) {
+      const name = tok[0];
+      if (bound.has(name) || declared.has(name) || injected.has(name) || FIXTURE_TYPES[name])
+        continue;
+      if (new RegExp(`\\b${name}\\s*\\(`).test(ex.code)) continue;
+      const fam = FIXTURE_FAMILIES.find(([re]) => re.test(name));
+      if (fam) {
+        injected.add(name);
+        header.push(`declare const ${name}: ${fam[1]};`);
+      }
+    }
+    const headerText = header.length ? `${header.join("\n")}\n` : "";
+    const content = `${headerText}${fillEllipsisHoles(rewriteImports(ex.code))}\nexport {};\n`;
+    const ext = ex.jsx ? "tsx" : "ts";
+    const vpath = path.join(path.dirname(ex.file), `__jsdoc_example_${counter++}__.${ext}`);
+    virtualFiles.set(vpath, content);
+    exampleMeta.set(vpath, { file: ex.file, line: ex.line, headerLines: header.length });
+  }
+
+  const program = ts.createProgram({
+    rootNames: [ambientPath, ...exampleMeta.keys()],
+    options: compilerOptions,
+    host,
+  });
+
+  const findings: string[] = [];
+  for (const [vpath, meta] of exampleMeta) {
+    const sf = program.getSourceFile(vpath);
+    if (!sf) continue;
+    const diags = [...program.getSyntacticDiagnostics(sf), ...program.getSemanticDiagnostics(sf)];
+    for (const d of diags) {
+      if (SUPPRESSED_CODES.has(d.code)) continue;
+      const pos =
+        d.file && d.start !== undefined ? ts.getLineAndCharacterOfPosition(d.file, d.start) : null;
+      const origLine = pos ? meta.line + (pos.line - meta.headerLines) : meta.line;
+      const msg = ts.flattenDiagnosticMessageText(d.messageText, " ");
+      findings.push(`${path.relative(pkgRoot, meta.file)}:${origLine} TS${d.code}: ${msg}`);
+    }
+  }
+  return { findings };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("JSDoc @example blocks — type check", () => {
+  it("found @example blocks to check", () => {
+    expect(checked.length).toBeGreaterThan(0);
+  });
+
+  it("notypecheck opt-outs stay deliberate", () => {
+    const list = skipped.map((s) => `  ${path.relative(pkgRoot, s.file)}:${s.line}`).join("\n");
+    expect(
+      skipped.length,
+      `Expected exactly ${EXPECTED_SKIPS} '// notypecheck' example(s); found ${skipped.length}:\n${list}\n` +
+        "Update EXPECTED_SKIPS if the change is intentional.",
+    ).toBe(EXPECTED_SKIPS);
+  });
+
+  it("every @example type-checks against the current API", { timeout: 120_000 }, () => {
+    const { findings } = collectFindings();
+    expect(
+      findings.length,
+      `Stale JSDoc @example code (${findings.length} diagnostic(s)):\n${findings.map((f) => `  ${f}`).join("\n")}`,
+    ).toBe(0);
+  });
+});

--- a/packages/chart/src/headless.ts
+++ b/packages/chart/src/headless.ts
@@ -7,8 +7,14 @@
  */
 
 // Core
-export { DataLayer } from "./core/data-layer";
-export { decimateCandles, getDecimationTarget, lttb } from "./core/decimation";
+export { DataLayer, type InternalSeries } from "./core/data-layer";
+export {
+  type DecimatedCandles,
+  type DecimatedPoints,
+  decimateCandles,
+  getDecimationTarget,
+  lttb,
+} from "./core/decimation";
 // Drawing helper
 export { DrawHelper, type FillStyle, type StrokeStyle } from "./core/draw-helper";
 export {

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -6,7 +6,7 @@
  * import { createChart } from '@trendcraft/chart';
  * import { sma, rsi, bollingerBands } from 'trendcraft';
  *
- * const chart = createChart(document.getElementById('chart'), { theme: 'dark' });
+ * const chart = createChart(document.getElementById('chart')!, { theme: 'dark' });
  * chart.setCandles(candles);
  * chart.addIndicator(sma(candles, { period: 20 }));
  * chart.addIndicator(bollingerBands(candles));
@@ -28,7 +28,7 @@ import { CanvasChart } from "./renderer/canvas-chart";
  *
  * @example
  * ```typescript
- * const chart = createChart(document.getElementById('chart'), {
+ * const chart = createChart(document.getElementById('chart')!, {
  *   width: 800,
  *   height: 600,
  *   theme: 'dark',
@@ -47,11 +47,11 @@ export function createChart(container: HTMLElement, options?: ChartOptions): Cha
 
 // ---- Re-exports ----
 
+// Series model type used by plugin render contexts
+export type { InternalSeries } from "./core/data-layer";
 // Drawing helper
 export { DrawHelper, type FillStyle, type StrokeStyle } from "./core/draw-helper";
-
 export { DEFAULT_HOTKEYS, type HotkeyMap } from "./core/hotkeys";
-
 // i18n
 export type { ChartLocale } from "./core/i18n";
 export { DEFAULT_LOCALE, mergeLocale } from "./core/i18n";
@@ -72,6 +72,7 @@ export { type IntrospectionRule, SeriesRegistry } from "./core/series-registry";
 // Core types
 export type {
   ArrowDrawing,
+  BacktestResultData,
   BuiltinSeriesType,
   CandleData,
   ChannelDrawing,
@@ -80,6 +81,7 @@ export type {
   ChartEvent,
   ChartInstance,
   ChartOptions,
+  ChartPatternSignal,
   ChartType,
   CrosshairMode,
   CrosshairMoveData,

--- a/packages/chart/src/integration/connect-live-primitives.ts
+++ b/packages/chart/src/integration/connect-live-primitives.ts
@@ -16,10 +16,10 @@
  * import { srZones } from "trendcraft";
  *
  * const conn = connectIndicators(chart, { presets, candles, live: source });
- * const sr = connectSrConfluence(chart, srZones(source.completedCandles).zones);
+ * const sr = connectSrConfluence(chart, srZones([...source.completedCandles]).zones);
  *
  * const live = connectLivePrimitives(source, [
- *   { recompute: (candles) => srZones(candles).zones, handle: sr, name: "sr" },
+ *   { recompute: (candles) => srZones([...candles]).zones, handle: sr, name: "sr" },
  * ]);
  *
  * // later

--- a/packages/chart/src/presets.ts
+++ b/packages/chart/src/presets.ts
@@ -10,6 +10,7 @@
  * ```ts
  * import { createChart } from "@trendcraft/chart";
  * import { registerTrendCraftPresets } from "@trendcraft/chart/presets";
+ * import { klinger } from "trendcraft";
  *
  * const chart = createChart(el, { theme: "dark" });
  * registerTrendCraftPresets(chart);

--- a/packages/chart/src/replay.ts
+++ b/packages/chart/src/replay.ts
@@ -19,7 +19,7 @@
  * import { createLiveSimulator } from "@trendcraft/chart/replay";
  *
  * const sim = createLiveSimulator({ candles, seedRatio: 0.6, ticksPerCandle: 5 });
- * connectIndicators(chart, indicators, { live: sim.live });
+ * connectIndicators(chart, { presets: indicatorPresets, candles, live: sim.live });
  * sim.play();
  * sim.onChange((state, progress) => console.log(state, progress));
  * ```

--- a/packages/mcp/src/__tests__/jsdoc-examples-typecheck.test.ts
+++ b/packages/mcp/src/__tests__/jsdoc-examples-typecheck.test.ts
@@ -1,0 +1,439 @@
+// @vitest-environment node
+/**
+ * JSDoc @example type-check harness for @trendcraft/mcp.
+ *
+ * Sweeps every non-test `src/**` source file for JSDoc `@example` blocks and
+ * type-checks the extracted code in ONE virtual TypeScript program (compiler
+ * API, virtual host, skipLibCheck, noEmit) — same design as the core/chart
+ * harnesses; see packages/core/src/__tests__/jsdoc-examples-typecheck.test.ts
+ * for the full format contract and leniency model.
+ *
+ * The mcp source currently carries no @example blocks, so the harness also
+ * self-tests its extractor on an inline sample; the moment an @example is
+ * added to src/ it gets type-checked with no further wiring.
+ *
+ * Leniency: the package entry's exports and the module each example lives in
+ * are ambient-declared; `candles` is a conventional fixture; imports of
+ * "@trendcraft/mcp" / "trendcraft" are rewritten to in-repo sources (core
+ * resolves to SOURCE for build-order independence).
+ *
+ * Suppressed diagnostics (documented noise, not stale-docs signal):
+ * TS6133/TS6196/TS6198/TS6205 (unused), TS2451/TS2393 (alternative-variant
+ * redeclarations), TS7006/TS7031 (implicit-any example callback params),
+ * TS2531/TS18047/TS18048 (strict-null elision).
+ *
+ * Opt-out: first code line `// notypecheck`; count pinned via EXPECTED_SKIPS.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const srcRoot = path.resolve(here, "..");
+const INDEX = path.join(srcRoot, "index.ts");
+const CORE_INDEX = path.resolve(srcRoot, "../../core/src/index.ts");
+
+/** Number of examples deliberately opted out via `// notypecheck`. */
+const EXPECTED_SKIPS = 0;
+
+const AMBIENT_ENTRIES = [INDEX];
+
+const IMPORT_REWRITES: Array<[RegExp, string]> = [
+  [/(["'])@trendcraft\/mcp\1/g, JSON.stringify(INDEX)],
+  [/(["'])trendcraft\1/g, JSON.stringify(CORE_INDEX)],
+];
+
+const T = (t: string) => `import(${JSON.stringify(CORE_INDEX)}).${t}`;
+const FIXTURE_TYPES: Record<string, string> = {
+  candles: `${T("NormalizedCandle")}[]`,
+};
+
+const GLOBAL_NAME_SKIP = new Set([
+  "Event",
+  "Range",
+  "Node",
+  "Window",
+  "Position",
+  "History",
+  "Selection",
+  "Screen",
+]);
+
+const SUPPRESSED_CODES = new Set([
+  6133,
+  6196,
+  6198,
+  6205, // unused locals/types
+  2451,
+  2393, // redeclared alternative-variant consts / functions
+  7006,
+  7031, // implicit-any example callback params / binding elements
+  2531,
+  18047,
+  18048, // strict-null elision
+]);
+
+// ---------------------------------------------------------------------------
+// 1. Sweep + extraction
+// ---------------------------------------------------------------------------
+
+type Example = { file: string; line: number; code: string; skip: boolean };
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (e.name === "__tests__" || e.name === "node_modules") continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, out);
+    else if (e.name.endsWith(".ts") && !e.name.endsWith(".d.ts")) out.push(p);
+  }
+  return out;
+}
+
+/** Extract @example blocks from JSDoc text (see core harness for the contract). */
+function extractFromText(file: string, text: string): Example[] {
+  const raw: Array<{ line: number; body: string[] }> = [];
+  const re = /\/\*\*[\s\S]*?\*\//g;
+  let m: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
+  while ((m = re.exec(text)) !== null) {
+    const startLine = text.slice(0, m.index).split("\n").length; // 1-based
+    const lines = m[0].split("\n");
+    let cur: { line: number; body: string[] } | null = null;
+    const flush = () => {
+      if (cur) raw.push(cur);
+      cur = null;
+    };
+    for (let i = 0; i < lines.length; i++) {
+      const stripped = lines[i].replace(/\s*\*\/\s*$/, "").replace(/^\s*\/?\*+ ?/, "");
+      if (/^@example\b/.test(stripped)) {
+        flush();
+        cur = { line: startLine + i + 1, body: [] };
+        continue;
+      }
+      if (cur && /^@[a-zA-Z]/.test(stripped)) {
+        flush();
+        continue;
+      }
+      if (cur) cur.body.push(stripped);
+    }
+    flush();
+  }
+  const out: Example[] = [];
+  for (const b of raw) {
+    let { line } = b;
+    let body = b.body;
+    while (body.length && body[0].trim() === "") {
+      body = body.slice(1);
+      line++;
+    }
+    while (body.length && body[body.length - 1].trim() === "") body = body.slice(0, -1);
+    if (body.some((l) => /^```/.test(l.trim()))) {
+      let inside = false;
+      body = body.map((l) => {
+        if (/^```/.test(l.trim())) {
+          inside = !inside;
+          return "";
+        }
+        return inside ? l : "";
+      });
+    }
+    const code = body.join("\n");
+    if (code.trim() === "") continue;
+    const firstLine = body.find((l) => l.trim() !== "")?.trim() ?? "";
+    out.push({ file, line, code, skip: firstLine.startsWith("// notypecheck") });
+  }
+  return out;
+}
+
+function extractExamples(file: string): Example[] {
+  return extractFromText(file, fs.readFileSync(file, "utf8"));
+}
+
+const allFiles = walk(srcRoot);
+const examples = allFiles.flatMap(extractExamples);
+const checked = examples.filter((e) => !e.skip);
+const skipped = examples.filter((e) => e.skip);
+
+// ---------------------------------------------------------------------------
+// 2. Virtual compiler host
+// ---------------------------------------------------------------------------
+
+const compilerOptions: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  lib: ["lib.es2022.d.ts", "lib.dom.d.ts"],
+  strict: true,
+  noEmit: true,
+  allowImportingTsExtensions: true,
+  skipLibCheck: true,
+  esModuleInterop: true,
+};
+
+const virtualFiles = new Map<string, string>();
+const sourceFileCache = new Map<string, ts.SourceFile>();
+const baseHost = ts.createCompilerHost(compilerOptions, true);
+const host: ts.CompilerHost = {
+  ...baseHost,
+  fileExists: (f) => virtualFiles.has(f) || baseHost.fileExists(f),
+  readFile: (f) => virtualFiles.get(f) ?? baseHost.readFile(f),
+  getSourceFile: (f, lang, onError, shouldCreate) => {
+    const v = virtualFiles.get(f);
+    if (v !== undefined) {
+      let sf = sourceFileCache.get(f);
+      if (!sf || sf.text !== v) {
+        sf = ts.createSourceFile(f, v, compilerOptions.target ?? ts.ScriptTarget.ES2022, true);
+        sourceFileCache.set(f, sf);
+      }
+      return sf;
+    }
+    let sf = sourceFileCache.get(f);
+    if (!sf) {
+      sf = baseHost.getSourceFile(f, lang, onError, shouldCreate);
+      if (sf) sourceFileCache.set(f, sf);
+    }
+    return sf;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 3. Ambient generation + virtual example files + diagnostics
+// ---------------------------------------------------------------------------
+
+type ExportInfo = {
+  name: string;
+  isValue: boolean;
+  isType: boolean;
+  typeParams: { text: string; names: string } | null;
+};
+
+function rewriteImports(code: string): string {
+  let out = code;
+  for (const [re, repl] of IMPORT_REWRITES) out = out.replace(re, repl);
+  return out;
+}
+
+/** Tolerate the ellipsis placeholder convention (see core harness). */
+function fillEllipsisHoles(code: string): string {
+  return code
+    .replace(/=>\s*\{\s*\.\.\.\s*\}/g, "=> {}")
+    .replace(/([A-Za-z_$][\w$]*)\s*\(\s*\.\.\.\s*\)/g, "($1 as any)()")
+    .replace(/\.\.\.(?=\s*[,)\]}]|\s*$)/gm, "...(null as any)");
+}
+
+/** Names the example itself binds at top level (imports + declarations). */
+function boundNames(code: string): Set<string> {
+  const names = new Set<string>();
+  for (const m of code.matchAll(/import\s+([^;]*?)\s+from/g)) {
+    const clause = m[1];
+    const brace = clause.match(/\{([^}]*)\}/);
+    if (brace) {
+      for (const s of brace[1].split(",")) {
+        const p = s
+          .trim()
+          .replace(/^type\s+/, "")
+          .split(/\s+as\s+/);
+        const local = (p[1] ?? p[0]).trim();
+        if (local) names.add(local);
+      }
+    }
+    const star = clause.match(/\*\s+as\s+([A-Za-z_$][\w$]*)/);
+    if (star) names.add(star[1]);
+    const def = clause.match(/^([A-Za-z_$][\w$]*)\s*(,|$)/);
+    if (def) names.add(def[1]);
+  }
+  for (const m of code.matchAll(
+    /^\s*(?:const|let|var|function|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/gm,
+  )) {
+    names.add(m[1]);
+  }
+  for (const m of code.matchAll(/^\s*(?:const|let|var)\s*[{[]([^}\]]*)[}\]]/gm)) {
+    for (const part of m[1].split(",")) {
+      const p = part.trim();
+      if (!p) continue;
+      const alias = p.includes(":") ? p.split(":")[1] : p;
+      const name = alias.trim().split(/[=\s]/)[0];
+      if (/^[A-Za-z_$][\w$]*$/.test(name)) names.add(name);
+    }
+  }
+  return names;
+}
+
+function collectFindings(): { findings: string[] } {
+  if (checked.length === 0) return { findings: [] };
+
+  const hostModules = [...new Set(checked.map((e) => e.file))];
+  const phase1 = ts.createProgram({
+    rootNames: [...AMBIENT_ENTRIES, ...hostModules],
+    options: compilerOptions,
+    host,
+  });
+  const checker = phase1.getTypeChecker();
+
+  const exportsCache = new Map<string, ExportInfo[]>();
+  function exportsOf(fileAbs: string): ExportInfo[] {
+    const cached = exportsCache.get(fileAbs);
+    if (cached) return cached;
+    const out: ExportInfo[] = [];
+    const sf = phase1.getSourceFile(fileAbs);
+    const sym = sf ? checker.getSymbolAtLocation(sf) : undefined;
+    if (sym) {
+      for (const ex of checker.getExportsOfModule(sym)) {
+        const name = ex.getName();
+        if (!/^[A-Za-z_$][\w$]*$/.test(name)) continue;
+        let resolved = ex;
+        try {
+          if (ex.flags & ts.SymbolFlags.Alias) resolved = checker.getAliasedSymbol(ex);
+        } catch {
+          // keep the alias symbol if resolution fails
+        }
+        const isValue = (resolved.flags & ts.SymbolFlags.Value) !== 0;
+        const isType =
+          (resolved.flags &
+            (ts.SymbolFlags.Interface |
+              ts.SymbolFlags.TypeAlias |
+              ts.SymbolFlags.Class |
+              ts.SymbolFlags.Enum)) !==
+          0;
+        let typeParams: ExportInfo["typeParams"] = null;
+        if (isType) {
+          const decl = (resolved.declarations ?? []).find(
+            (
+              d,
+            ): d is ts.DeclarationStatement & {
+              typeParameters: ts.NodeArray<ts.TypeParameterDeclaration>;
+            } =>
+              (d as { typeParameters?: ts.NodeArray<ts.TypeParameterDeclaration> })
+                .typeParameters !== undefined &&
+              ((d as { typeParameters?: ts.NodeArray<ts.TypeParameterDeclaration> }).typeParameters
+                ?.length ?? 0) > 0,
+          );
+          if (decl) {
+            typeParams = {
+              text: decl.typeParameters.map((p) => p.getText()).join(", "),
+              names: decl.typeParameters.map((p) => p.name.text).join(", "),
+            };
+          }
+        }
+        out.push({ name, isValue, isType, typeParams });
+      }
+    }
+    exportsCache.set(fileAbs, out);
+    return out;
+  }
+
+  const ambientLines: string[] = [];
+  const declared = new Set<string>();
+  for (const entry of AMBIENT_ENTRIES) {
+    const spec = JSON.stringify(entry);
+    for (const { name, isValue, isType, typeParams } of exportsOf(entry)) {
+      if (declared.has(name) || GLOBAL_NAME_SKIP.has(name)) continue;
+      declared.add(name);
+      if (isValue) ambientLines.push(`declare const ${name}: typeof import(${spec}).${name};`);
+      if (isType) {
+        ambientLines.push(
+          typeParams
+            ? `type ${name}<${typeParams.text}> = import(${spec}).${name}<${typeParams.names}>;`
+            : `type ${name} = import(${spec}).${name};`,
+        );
+      }
+    }
+  }
+  const fixtureLines = Object.entries(FIXTURE_TYPES)
+    .filter(([name]) => !declared.has(name))
+    .map(([name, type]) => `declare const ${name}: ${type};`);
+  const ambientPath = path.join(srcRoot, "__jsdoc_examples_ambient__.d.ts");
+  virtualFiles.set(ambientPath, [...ambientLines, ...fixtureLines].join("\n") + "\n");
+
+  type Meta = { file: string; line: number; headerLines: number };
+  const exampleMeta = new Map<string, Meta>();
+  let counter = 0;
+  for (const ex of checked) {
+    const bound = boundNames(ex.code);
+    const spec = JSON.stringify(ex.file);
+    const header: string[] = [];
+    for (const { name, isValue, isType, typeParams } of exportsOf(ex.file)) {
+      if (bound.has(name) || GLOBAL_NAME_SKIP.has(name)) continue;
+      if (isValue) header.push(`declare const ${name}: typeof import(${spec}).${name};`);
+      if (isType) {
+        header.push(
+          typeParams
+            ? `type ${name}<${typeParams.text}> = import(${spec}).${name}<${typeParams.names}>;`
+            : `type ${name} = import(${spec}).${name};`,
+        );
+      }
+    }
+    const headerText = header.length ? `${header.join("\n")}\n` : "";
+    const content = `${headerText}${fillEllipsisHoles(rewriteImports(ex.code))}\nexport {};\n`;
+    const vpath = path.join(path.dirname(ex.file), `__jsdoc_example_${counter++}__.ts`);
+    virtualFiles.set(vpath, content);
+    exampleMeta.set(vpath, { file: ex.file, line: ex.line, headerLines: header.length });
+  }
+
+  const program = ts.createProgram({
+    rootNames: [ambientPath, ...exampleMeta.keys()],
+    options: compilerOptions,
+    host,
+  });
+
+  const findings: string[] = [];
+  for (const [vpath, meta] of exampleMeta) {
+    const sf = program.getSourceFile(vpath);
+    if (!sf) continue;
+    const diags = [...program.getSyntacticDiagnostics(sf), ...program.getSemanticDiagnostics(sf)];
+    for (const d of diags) {
+      if (SUPPRESSED_CODES.has(d.code)) continue;
+      const pos =
+        d.file && d.start !== undefined ? ts.getLineAndCharacterOfPosition(d.file, d.start) : null;
+      const origLine = pos ? meta.line + (pos.line - meta.headerLines) : meta.line;
+      const msg = ts.flattenDiagnosticMessageText(d.messageText, " ");
+      findings.push(`${path.relative(srcRoot, meta.file)}:${origLine} TS${d.code}: ${msg}`);
+    }
+  }
+  return { findings };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("JSDoc @example blocks — type check", () => {
+  it("extractor self-test (keeps the harness honest at zero examples)", () => {
+    const sample = [
+      "/**",
+      " * Docs.",
+      " *",
+      " * @example",
+      " * ```ts",
+      " * const x = 1;",
+      " * ```",
+      " * @returns nothing",
+      " */",
+      "export function f(): void {}",
+    ].join("\n");
+    const found = extractFromText("sample.ts", sample);
+    expect(found).toHaveLength(1);
+    expect(found[0].code.trim()).toBe("const x = 1;");
+    expect(found[0].line).toBe(5);
+    expect(found[0].skip).toBe(false);
+  });
+
+  it("notypecheck opt-outs stay deliberate", () => {
+    const list = skipped.map((s) => `  ${path.relative(srcRoot, s.file)}:${s.line}`).join("\n");
+    expect(
+      skipped.length,
+      `Expected exactly ${EXPECTED_SKIPS} '// notypecheck' example(s); found ${skipped.length}:\n${list}\n` +
+        "Update EXPECTED_SKIPS if the change is intentional.",
+    ).toBe(EXPECTED_SKIPS);
+  });
+
+  it("every @example type-checks against the current API", { timeout: 120_000 }, () => {
+    const { findings } = collectFindings();
+    expect(
+      findings.length,
+      `Stale JSDoc @example code (${findings.length} diagnostic(s)):\n${findings.map((f) => `  ${f}`).join("\n")}`,
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Companion to #311 — the chart and MCP portions of the Tier 1.5 prevention gates. Combined added wall-time: **~3s** inside `pnpm test`.

### New gates

1. **`docs-typecheck.test.ts`** (chart) — type-checks every `ts`/`tsx`/vue-script fence in the chart docs (96 checked + 4 type-mirror assertions) in one virtual TypeScript program; `trendcraft` resolves to core **source** for build-order independence (same pattern as the existing import-check). Opt-outs are reason-annotated `<!-- doctest-notypecheck: reason -->` markers with counts pinned by constants (6 today, all deliberate pseudo-syntax catalogs like the `draw.x(...)` helper listings).
2. **`jsdoc-examples-typecheck.test.ts`** (chart + mcp) — type-checks all 31 chart `@example` blocks (tsx examples compile with `react-jsx`; vue fences check their `<script>` content). The mcp harness ships with an extractor self-test so it activates untouched once mcp source gains `@example`s (0 today).
3. **`event-wiring.test.ts`** (chart) — every `ChartEvent` union member must have an emission site in `src/`, and every emitted event literal must be a declared union member (AST-based). This makes the "declared and documented but never emitted" class — `resize`/`paneResize`/`seriesRemoved`, fixed in #306 — structurally unrepresentable: deleting any one emitter fails the suite.

### What the first run caught (fixed here)

- **Type-mirror**: the docs' `CrosshairOptions` was missing `lockOnLongPress`; `SeriesHandle` was missing `config`
- **Non-compiling doc examples**: dynamic plugin-selection loops rewritten to a type-safe form, null-unsafe `getElementById` (2 sites), `readonly completedCandles` passed to mutable-array APIs, the React recipe typing candles with core's string-capable `time` where the chart needs numeric ms, a `crosshairMove` handler shown with a typed parameter that `on(…, (data: unknown) => void)` rejects
- **Stale JSDoc**: `replay.ts` still showed a removed 3-argument `connectIndicators` form; `presets.ts` example missing an import
- **Additive type re-exports** so types that appear in the documented public API are actually importable: `BacktestResultData`, `ChartPatternSignal`, `InternalSeries` from the main entry; `DecimatedPoints`, `DecimatedCandles`, `InternalSeries` from `headless`. Type-only — zero bundle impact.

## Test plan

- On this branch in isolation: chart `pnpm test` → **84 files / 934 tests pass**, `npx tsc --noEmit` → pass, `pnpm build` + `pnpm size-check` → all budgets unchanged (Main 40.95/41 kB, Headless 10.86/11 kB, Sparkline 3.79/5 kB, Replay 935 B/3 kB); mcp `pnpm test` → **9 files / 83 tests pass**, `npx tsc --noEmit` → pass
- On the full working tree (with #311): core 6307 / chart 934 / mcp 83 / strategy-studio 108 — all pass