### PR TITLE
fix(core): wire or remove 5 latent option keys flagged by the options-key-usage harness

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## [Unreleased]
 
+### Fixed — `highestLowest` now honors the `source` option
+
+- `highestLowest(candles, { period, source })` previously ignored `source` and
+  always computed the highest from candle highs and the lowest from candle
+  lows. Passing `source: "close"` now computes both extremes from that field,
+  e.g. close-based ranges for breakout logic. Omitting `source` keeps the
+  previous high/low behavior. The option also widened from
+  `"high" | "low" | "close"` to the full `PriceSource` union (adding `open`,
+  `hl2`, `hlc3`, `ohlc4`, `volume`), matching other source-accepting
+  indicators.
+
+### Changed — robustness parameter sensitivity uses random perturbation samples
+
+- `calculateRobustnessScore` now honors `RobustnessOptions.perturbationSamples`
+  (default: 10), which was previously declared and documented but never read.
+  The Parameter Sensitivity dimension draws that many random parameter sets
+  within the perturbation neighborhood (seeded via `options.seed`) and
+  backtests each, instead of grid-searching the narrowed ranges with the
+  original step sizes. Sensitivity scores may differ from previous releases;
+  the sample count is now independent of the ranges' steps, which removes the
+  degenerate "Insufficient parameter combinations" case that occurred when the
+  narrowed ranges contained fewer than 3 grid points.
+
+### Breaking — removed option keys that were never read
+
+- **`ScreeningOptions.concurrency`** — `runScreening` is fully synchronous;
+  the documented "max concurrent file processing" never existed.
+- **`CandleFormerTrainOptions.temperature`** — softmax temperature is an
+  inference-time parameter; setting it at training time never had any effect.
+  Use `CandleFormerOptions.temperature` (the `candleFormer` indicator option),
+  which is wired.
+- **`ParseFundamentalsOptions.encoding`** — `parseFundamentals` takes an
+  already-decoded string, so the option could never influence decoding. Decode
+  the CSV content before calling.
+
+  None of these keys ever changed behavior, so removing them cannot change
+  results — but code that sets them will now fail to type-check; delete the
+  key at the call site.
+
 ### Fixed — documentation: streaming imports and a stale helper reference
 
 - The API docs imported streaming exports from a `trendcraft/streaming` subpath

--- a/packages/core/src/__tests__/docs-import-check.test.ts
+++ b/packages/core/src/__tests__/docs-import-check.test.ts
@@ -182,7 +182,9 @@ describe("doc snippets — import check (Tier 1)", () => {
     expect(bad.length, `Unpublished subpath(s) in docs:\n${report}`).toBe(0);
   });
 
-  it("every named value import resolves to a real export", async () => {
+  // Importing the full source entry can exceed the default 5s timeout when
+  // the machine is loaded (the rest of the suite runs in parallel workers).
+  it("every named value import resolves to a real export", { timeout: 30_000 }, async () => {
     const exportsBySubpath = new Map<string, Set<string>>();
     for (const subpath of new Set(allRefs.map((r) => r.subpath))) {
       const source = SUBPATH_TO_SOURCE[subpath];
@@ -202,7 +204,9 @@ describe("doc snippets — import check (Tier 1)", () => {
     expect(missing.length, `Unknown named import(s) in docs:\n${missing.join("\n")}`).toBe(0);
   });
 
-  it("every destructured namespace member resolves to a real member", async () => {
+  it("every destructured namespace member resolves to a real member", {
+    timeout: 30_000,
+  }, async () => {
     // Cache loaded source modules so each entry is imported once.
     const modBySubpath = new Map<string, Record<string, unknown>>();
     async function loadModule(subpath: string): Promise<Record<string, unknown> | null> {

--- a/packages/core/src/__tests__/docs-snippets.test.ts
+++ b/packages/core/src/__tests__/docs-snippets.test.ts
@@ -106,7 +106,9 @@ describe("doc snippets — execute (Tier 2)", () => {
   });
 
   for (const s of runnable) {
-    it(`${s.file} #${s.index} runs without throwing`, async () => {
+    // The first snippet pays the full transform/import cost of the source
+    // entry, which can exceed the default 5s timeout on a loaded machine.
+    it(`${s.file} #${s.index} runs without throwing`, { timeout: 30_000 }, async () => {
       mkdirSync(tmpDir, { recursive: true });
       const moduleSrc = `${FIXTURE_PREAMBLE}\n${rewriteImports(s.code)}\n`;
       const file = path.join(tmpDir, `${s.file.replace(/\W/g, "_")}_${s.index}.ts`);

--- a/packages/core/src/__tests__/options-key-usage.test.ts
+++ b/packages/core/src/__tests__/options-key-usage.test.ts
@@ -54,26 +54,6 @@ const SRC_ROOT = path.resolve(here, ".."); // packages/core/src
 // removed from here, not parked forever.
 // ---------------------------------------------------------------------------
 const ALLOWLIST: Record<string, string[]> = {
-  // LATENT BUG (flagged 2026-07): parseFundamentals() takes an already-decoded
-  // string, so `encoding` ("default: utf-8") is never read. Wire it up (accept
-  // a Buffer) or remove the key.
-  ParseFundamentalsOptions: ["encoding"],
-  // LATENT BUG (flagged 2026-07): documented as "softmax temperature for
-  // inference (default: 1.0)" but trainCandleFormer() never reads it and does
-  // not propagate it into the trained model/config; inference uses predict()'s
-  // own parameter. Setting it in train options silently does nothing.
-  CandleFormerTrainOptions: ["temperature"],
-  // LATENT BUG (flagged 2026-07): documented "(default: 10)" but runScreening
-  // is fully synchronous and never reads `concurrency`. Remove or implement.
-  ScreeningOptions: ["concurrency"],
-  // LATENT BUG (flagged 2026-07): highestLowest() always reads candle
-  // high/low; `source?: "high" | "low" | "close"` is never consulted, so
-  // callers asking for close-based extremes silently get high/low behavior.
-  HighestLowestOptions: ["source"],
-  // LATENT BUG (flagged 2026-07): documented "(default: 10)" but
-  // robustness/full.ts never reads `perturbationSamples` (unlike its sibling
-  // perturbationPercent, which is wired). Remove or implement.
-  RobustnessOptions: ["perturbationSamples"],
   // Known-dead, documented in source: "Unused — reserved for future use;
   // riskParityAllocation does not read this option". Kept for API compat.
   RiskParityOptions: ["riskFreeRate"],

--- a/packages/core/src/core/fundamentals.ts
+++ b/packages/core/src/core/fundamentals.ts
@@ -10,8 +10,6 @@ import type { FundamentalMetrics } from "../types";
  * Parse options for fundamentals CSV
  */
 export type ParseFundamentalsOptions = {
-  /** Encoding for CSV content (default: 'utf-8') */
-  encoding?: "utf-8" | "shift-jis";
   /** Column index for PER (0-based, default: 7) */
   perColumn?: number;
   /** Column index for PBR (0-based, default: 8) */

--- a/packages/core/src/indicators/__tests__/highest-lowest.test.ts
+++ b/packages/core/src/indicators/__tests__/highest-lowest.test.ts
@@ -53,6 +53,48 @@ describe("highestLowest", () => {
     expect(result[3].value.highest).toBe(125);
     expect(result[3].value.lowest).toBe(95);
   });
+
+  it("should compute both extremes from close when source is 'close'", () => {
+    // close = (high + low) / 2 per makeCandles
+    const candles = makeCandles([
+      [110, 90], // close 100
+      [120, 100], // close 110
+      [115, 95], // close 105
+      [125, 105], // close 115
+      [118, 98], // close 108
+    ]);
+    const result = highestLowest(candles, { period: 3, source: "close" });
+
+    expect(result[1].value.highest).toBeNull();
+
+    // Third value: highest/lowest of closes [100, 110, 105]
+    expect(result[2].value.highest).toBe(110);
+    expect(result[2].value.lowest).toBe(100);
+
+    // Fifth value: highest/lowest of closes [105, 115, 108]
+    expect(result[4].value.highest).toBe(115);
+    expect(result[4].value.lowest).toBe(105);
+  });
+
+  it("should match default behavior when source is 'high'/'low' respectively", () => {
+    const candles = makeCandles([
+      [110, 90],
+      [120, 100],
+      [115, 95],
+      [125, 105],
+      [118, 98],
+    ]);
+    const defaultResult = highestLowest(candles, { period: 3 });
+    const highResult = highestLowest(candles, { period: 3, source: "high" });
+    const lowResult = highestLowest(candles, { period: 3, source: "low" });
+
+    // With source "high", the highest matches default; with "low", the lowest matches default
+    expect(highResult[4].value.highest).toBe(defaultResult[4].value.highest);
+    expect(lowResult[4].value.lowest).toBe(defaultResult[4].value.lowest);
+    // And the opposite extreme comes from the same field, not the default one
+    expect(highResult[4].value.lowest).toBe(115); // min of highs [115, 125, 118]
+    expect(lowResult[4].value.highest).toBe(105); // max of lows [95, 105, 98]
+  });
 });
 
 describe("highest", () => {

--- a/packages/core/src/indicators/price/highest-lowest.ts
+++ b/packages/core/src/indicators/price/highest-lowest.ts
@@ -2,7 +2,7 @@
  * Highest/Lowest price indicators
  */
 
-import { isNormalized, normalizeCandles } from "../../core/normalize";
+import { getPriceSeries, isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries } from "../../core/tag-series";
 import type { Candle, HighestLowestOptions, NormalizedCandle, Series } from "../../types";
 
@@ -17,8 +17,12 @@ export type HighestLowestValue = {
 /**
  * Calculate Highest and Lowest values over n periods
  *
+ * By default the highest is taken from candle highs and the lowest from
+ * candle lows. Pass `source` to compute both extremes from a single price
+ * series (e.g. `source: "close"` for close-based ranges).
+ *
  * @param candles - Array of candles (raw or normalized)
- * @param options - Options (period)
+ * @param options - Options (period, source)
  * @returns Series of highest/lowest values
  *
  * @example
@@ -26,13 +30,16 @@ export type HighestLowestValue = {
  * const hl20 = highestLowest(candles, { period: 20 });
  * console.log(hl20[i].value.highest); // 20-period high
  * console.log(hl20[i].value.lowest);  // 20-period low
+ *
+ * const closeRange = highestLowest(candles, { period: 20, source: "close" });
+ * console.log(closeRange[i].value.highest); // 20-period highest close
  * ```
  */
 export function highestLowest(
   candles: Candle[] | NormalizedCandle[],
   options: HighestLowestOptions,
 ): Series<HighestLowestValue> {
-  const { period } = options;
+  const { period, source } = options;
 
   if (period < 1) {
     throw new Error("Period must be at least 1");
@@ -40,6 +47,12 @@ export function highestLowest(
 
   // Normalize if needed
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
+
+  // Default: highest from highs, lowest from lows. With `source`, both
+  // extremes come from that single price series.
+  const sourceValues = source ? getPriceSeries(normalized, source) : null;
+  const maxValues = sourceValues ?? normalized.map((c) => c.high);
+  const minValues = sourceValues ?? normalized.map((c) => c.low);
 
   const result: Series<HighestLowestValue> = [];
 
@@ -52,8 +65,8 @@ export function highestLowest(
   const minDeque: number[] = [];
 
   for (let i = 0; i < normalized.length; i++) {
-    const high = normalized[i].high;
-    const low = normalized[i].low;
+    const high = maxValues[i];
+    const low = minValues[i];
 
     // Remove elements outside the window from front
     while (maxDeque.length > 0 && maxDeque[0] <= i - period) {
@@ -64,13 +77,13 @@ export function highestLowest(
     }
 
     // For max deque: remove smaller elements from back (they can't be max)
-    while (maxDeque.length > 0 && normalized[maxDeque[maxDeque.length - 1]].high <= high) {
+    while (maxDeque.length > 0 && maxValues[maxDeque[maxDeque.length - 1]] <= high) {
       maxDeque.pop();
     }
     maxDeque.push(i);
 
     // For min deque: remove larger elements from back (they can't be min)
-    while (minDeque.length > 0 && normalized[minDeque[minDeque.length - 1]].low >= low) {
+    while (minDeque.length > 0 && minValues[minDeque[minDeque.length - 1]] >= low) {
       minDeque.pop();
     }
     minDeque.push(i);
@@ -85,8 +98,8 @@ export function highestLowest(
       result.push({
         time: normalized[i].time,
         value: {
-          highest: normalized[maxDeque[0]].high,
-          lowest: normalized[minDeque[0]].low,
+          highest: maxValues[maxDeque[0]],
+          lowest: minValues[minDeque[0]],
         },
       });
     }

--- a/packages/core/src/ml/types.ts
+++ b/packages/core/src/ml/types.ts
@@ -159,8 +159,6 @@ export type CandleFormerTrainOptions = {
   seed?: number;
   /** Neutral threshold for target classification (default: 0.001) */
   neutralThreshold?: number;
-  /** Softmax temperature for inference (default: 1.0) */
-  temperature?: number;
   /** Early stopping patience (default: 10, 0 = disabled) */
   patience?: number;
   /** Dropout rate during training (default: 0.1) */

--- a/packages/core/src/optimization/constants.ts
+++ b/packages/core/src/optimization/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared constants for optimization-layer helpers.
+ */
+
+/**
+ * Default capital applied when a strategy factory's options omit `capital`
+ * (`BacktestOptions` requires it). Single owner — grid search, walk-forward,
+ * Pareto, and robustness sensitivity must all backtest against the same
+ * default so their scores stay comparable.
+ */
+export const DEFAULT_BACKTEST_CAPITAL = 100000;

--- a/packages/core/src/optimization/grid-search.ts
+++ b/packages/core/src/optimization/grid-search.ts
@@ -16,6 +16,7 @@ import type {
   ParameterRange,
 } from "../types/optimization";
 import { err, ok, type Result, tcError } from "../types/result";
+import { DEFAULT_BACKTEST_CAPITAL } from "./constants";
 import { calculateAllMetrics, checkConstraint, getMetricValue } from "./metrics";
 
 /**
@@ -182,7 +183,7 @@ export function gridSearch(
       // Create strategy with current parameters
       const strategy = createStrategy(params);
       const backtestOptions: BacktestOptions = {
-        capital: 100000,
+        capital: DEFAULT_BACKTEST_CAPITAL,
         ...strategy.options,
       };
 

--- a/packages/core/src/optimization/pareto.ts
+++ b/packages/core/src/optimization/pareto.ts
@@ -18,6 +18,7 @@ import type {
   ParetoResultEntry,
 } from "../types/optimization";
 import { err, ok, type Result, tcError } from "../types/result";
+import { DEFAULT_BACKTEST_CAPITAL } from "./constants";
 import { generateParameterCombinations, type StrategyFactory } from "./grid-search";
 import { calculateAllMetrics, checkConstraint, getMetricValue } from "./metrics";
 
@@ -251,7 +252,7 @@ export function paretoOptimization(
     try {
       const { entry, exit, options: btOptions } = createStrategy(params);
       const backtestOptions: BacktestOptions = {
-        capital: 100000,
+        capital: DEFAULT_BACKTEST_CAPITAL,
         ...btOptions,
       };
       const result = runBacktest(candles, entry, exit, backtestOptions, cache);

--- a/packages/core/src/optimization/walkforward.ts
+++ b/packages/core/src/optimization/walkforward.ts
@@ -16,6 +16,7 @@ import type {
   WalkForwardResult,
 } from "../types/optimization";
 import { err, ok, type Result, tcError } from "../types/result";
+import { DEFAULT_BACKTEST_CAPITAL } from "./constants";
 import { generateParameterCombinations, gridSearch, type StrategyFactory } from "./grid-search";
 import { calculateAllMetrics } from "./metrics";
 
@@ -235,7 +236,7 @@ export function walkForwardAnalysis(
     // Run backtest on training data with best params
     const trainStrategy = createStrategy(bestParams);
     const trainBacktest = runBacktest(trainCandles, trainStrategy.entry, trainStrategy.exit, {
-      capital: 100000,
+      capital: DEFAULT_BACKTEST_CAPITAL,
       ...trainStrategy.options,
     });
     const inSampleMetrics = calculateAllMetrics(trainBacktest, trainCandles);
@@ -243,7 +244,7 @@ export function walkForwardAnalysis(
     // Run backtest on test data with same params
     const testStrategy = createStrategy(bestParams);
     const testBacktest = runBacktest(testCandles, testStrategy.entry, testStrategy.exit, {
-      capital: 100000,
+      capital: DEFAULT_BACKTEST_CAPITAL,
       ...testStrategy.options,
     });
     const outOfSampleMetrics = calculateAllMetrics(testBacktest, testCandles);

--- a/packages/core/src/robustness/__tests__/full.test.ts
+++ b/packages/core/src/robustness/__tests__/full.test.ts
@@ -377,6 +377,82 @@ describe("calculateRobustnessScore", () => {
     expect(result.compositeScore).toBeLessThanOrEqual(100);
   });
 
+  /** Shared fixture for the perturbation-sampling tests below. */
+  const makeSensitivityFixture = () => {
+    const candles = generateCandles(200, 42);
+
+    const createStrategy = (params: Record<string, number>) => ({
+      entry: and(goldenCross(params.shortMA, params.longMA)),
+      exit: and(deadCross(params.shortMA, params.longMA)),
+      options: { capital: 100000 as const },
+    });
+
+    const paramRanges = [
+      { name: "shortMA", min: 3, max: 7, step: 2 },
+      { name: "longMA", min: 15, max: 25, step: 5 },
+    ];
+
+    const original = runBacktest(candles, and(goldenCross(5, 20)), and(deadCross(5, 20)), {
+      capital: 100000,
+    });
+
+    const baseOptions = {
+      monteCarloSimulations: 10,
+      walkForwardWindowSize: 80,
+      walkForwardStepSize: 40,
+      walkForwardTestSize: 30,
+      seed: 42,
+    };
+
+    return { candles, createStrategy, paramRanges, original, baseOptions };
+  };
+
+  it("draws perturbationSamples random samples for sensitivity analysis", () => {
+    const { candles, createStrategy, paramRanges, original, baseOptions } =
+      makeSensitivityFixture();
+
+    // Default sample count is 10
+    const defaultResult = calculateRobustnessScore(
+      candles,
+      original,
+      createStrategy,
+      paramRanges,
+      baseOptions,
+    );
+    expect(defaultResult.dimensions.parameterSensitivity.detail).toContain("(10 samples)");
+
+    // Explicit sample count is honored
+    const explicit = calculateRobustnessScore(candles, original, createStrategy, paramRanges, {
+      ...baseOptions,
+      perturbationSamples: 5,
+    });
+    expect(explicit.dimensions.parameterSensitivity.detail).toContain("(5 samples)");
+
+    // Same seed → identical sensitivity score (sampling is seeded)
+    const repeat = calculateRobustnessScore(candles, original, createStrategy, paramRanges, {
+      ...baseOptions,
+      perturbationSamples: 5,
+    });
+    expect(repeat.dimensions.parameterSensitivity.score).toBe(
+      explicit.dimensions.parameterSensitivity.score,
+    );
+  });
+
+  it("returns neutral sensitivity score when perturbationSamples is below 3", () => {
+    const { candles, createStrategy, paramRanges, original, baseOptions } =
+      makeSensitivityFixture();
+
+    const result = calculateRobustnessScore(candles, original, createStrategy, paramRanges, {
+      ...baseOptions,
+      perturbationSamples: 2,
+    });
+
+    expect(result.dimensions.parameterSensitivity.score).toBe(50);
+    expect(result.dimensions.parameterSensitivity.detail).toContain(
+      "Insufficient perturbation samples",
+    );
+  });
+
   it("does not skip integer parameter neighborhoods during sensitivity analysis", () => {
     const candles = generateCandles(200, 42);
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/core/src/robustness/full.ts
+++ b/packages/core/src/robustness/full.ts
@@ -6,7 +6,10 @@
  * Requires candles, strategy definition, and parameter ranges.
  */
 
-import { gridSearch } from "../optimization/grid-search";
+import { runBacktest } from "../backtest";
+import { IndicatorCache } from "../core/indicator-cache";
+import { mulberry32 } from "../core/random";
+import { DEFAULT_BACKTEST_CAPITAL } from "../optimization/constants";
 import { runMonteCarloSimulation } from "../optimization/monte-carlo";
 import { walkForwardAnalysis } from "../optimization/walkforward";
 import type { BacktestOptions, BacktestResult, NormalizedCandle } from "../types";
@@ -17,10 +20,6 @@ import { scoreToGrade } from "./grade";
 
 function isIntegerRange(range: ParameterRange): boolean {
   return Number.isInteger(range.min) && Number.isInteger(range.max) && Number.isInteger(range.step);
-}
-
-function clampToRange(value: number, range: ParameterRange): number {
-  return Math.min(range.max, Math.max(range.min, value));
 }
 
 /**
@@ -200,45 +199,81 @@ function scoreParameterSensitivity(
   try {
     // Create narrow ranges around the midpoint for perturbation analysis
     const perturbPct = (options.perturbationPercent ?? 20) / 100;
+    const sampleCount = options.perturbationSamples ?? 10;
+    const random = options.seed !== undefined ? mulberry32(options.seed) : Math.random;
 
     const narrowRanges = ranges.map((r) => {
       const mid = (r.min + r.max) / 2;
       const range = (r.max - r.min) * perturbPct;
-      const min = Math.max(r.min, mid - range / 2);
-      const max = Math.min(r.max, mid + range / 2);
-
-      if (isIntegerRange(r)) {
-        return {
-          name: r.name,
-          min: clampToRange(Math.round(min), r),
-          max: clampToRange(Math.round(max), r),
-          step: r.step,
-        };
-      }
-
       return {
         name: r.name,
-        min,
-        max,
-        step: r.step,
+        isInt: isIntegerRange(r),
+        min: Math.max(r.min, mid - range / 2),
+        max: Math.min(r.max, mid + range / 2),
       };
     });
 
-    const gs = gridSearch(candles, createStrategy, narrowRanges, {
-      metric: "sharpe",
-    });
+    // Randomly sample parameter sets within the perturbation neighborhood
+    // and backtest each. Random sampling (vs. a grid) keeps the sample
+    // count independent of the ranges' step sizes. Integer rounding can
+    // collapse nearby draws to the same params, so identical sets reuse
+    // their result instead of rerunning the backtest.
+    const cache = new IndicatorCache();
+    const evaluated = new Map<string, { sharpe: number; profitable: boolean } | null>();
+    const sharpes: number[] = [];
+    let profitableCount = 0;
 
-    if (gs.results.length < 3) {
+    for (let i = 0; i < sampleCount; i++) {
+      const params: Record<string, number> = {};
+      for (const nr of narrowRanges) {
+        const raw = nr.min + random() * (nr.max - nr.min);
+        params[nr.name] = nr.isInt ? Math.round(raw) : raw;
+      }
+
+      const key = narrowRanges.map((nr) => params[nr.name]).join(",");
+      let sample = evaluated.get(key);
+      if (sample === undefined) {
+        try {
+          const strategy = createStrategy(params);
+          const backtest = runBacktest(
+            candles,
+            strategy.entry,
+            strategy.exit,
+            {
+              capital: DEFAULT_BACKTEST_CAPITAL,
+              ...strategy.options,
+            },
+            cache,
+          );
+          sample = {
+            sharpe: backtest.sharpeRatio,
+            profitable: backtest.totalReturnPercent > 0,
+          };
+        } catch {
+          // Skip samples whose strategy or backtest fails
+          sample = null;
+        }
+        evaluated.set(key, sample);
+      }
+
+      if (sample !== null) {
+        sharpes.push(sample.sharpe);
+        if (sample.profitable) {
+          profitableCount++;
+        }
+      }
+    }
+
+    if (sharpes.length < 3) {
       return {
         name: "Parameter Sensitivity",
         score: 50,
         weight: 0.25,
-        detail: "Insufficient parameter combinations",
+        detail: "Insufficient perturbation samples",
       };
     }
 
     // Calculate coefficient of variation of Sharpe ratios
-    const sharpes = gs.results.map((r) => r.backtest.sharpeRatio);
     const mean = sharpes.reduce((a, b) => a + b, 0) / sharpes.length;
     const stdDev = Math.sqrt(sharpes.reduce((a, v) => a + (v - mean) ** 2, 0) / sharpes.length);
     const cv = mean !== 0 ? stdDev / Math.abs(mean) : 10;
@@ -247,9 +282,8 @@ function scoreParameterSensitivity(
     // CV < 0.2 = very stable (100), CV > 1.0 = very sensitive (0)
     const cvScore = Math.max(0, Math.min(100, ((1.0 - cv) / 0.8) * 100));
 
-    // Also check what fraction of parameter combos are profitable
-    const profitableCount = gs.results.filter((r) => r.backtest.totalReturnPercent > 0).length;
-    const profitableRate = profitableCount / gs.results.length;
+    // Also check what fraction of parameter samples are profitable
+    const profitableRate = profitableCount / sharpes.length;
     const profitableScore = profitableRate * 100;
 
     const finalScore = cvScore * 0.6 + profitableScore * 0.4;
@@ -258,7 +292,7 @@ function scoreParameterSensitivity(
       name: "Parameter Sensitivity",
       score: Math.round(Math.max(0, Math.min(100, finalScore)) * 10) / 10,
       weight: 0.25,
-      detail: `CV: ${cv.toFixed(3)}, ${(profitableRate * 100).toFixed(0)}% profitable in neighborhood`,
+      detail: `CV: ${cv.toFixed(3)}, ${(profitableRate * 100).toFixed(0)}% profitable in neighborhood (${sharpes.length} samples)`,
     };
   } catch {
     return {

--- a/packages/core/src/screening/types.ts
+++ b/packages/core/src/screening/types.ts
@@ -104,8 +104,6 @@ export type ScreeningOptions = {
   minDataPoints?: number;
   /** Filter by ATR% threshold (default: no filter) */
   minAtrPercent?: number;
-  /** Maximum concurrent file processing (default: 10) */
-  concurrency?: number;
   /** Include full candle data in results (default: false) */
   includeCandles?: boolean;
   /** Higher timeframes to make available to MTF conditions (e.g. `["1w"]`) */

--- a/packages/core/src/types/candle.ts
+++ b/packages/core/src/types/candle.ts
@@ -227,8 +227,13 @@ export type AtrOptions = {
  * Options for Highest/Lowest calculation
  */
 export type HighestLowestOptions = {
+  /** Lookback period (required) */
   period: number;
-  source?: "high" | "low" | "close";
+  /**
+   * Price source both extremes are computed from. When omitted, highest uses
+   * candle highs and lowest uses candle lows (default behavior).
+   */
+  source?: PriceSource;
 };
 
 /**

--- a/packages/core/src/types/robustness.ts
+++ b/packages/core/src/types/robustness.ts
@@ -42,7 +42,10 @@ export type RobustnessOptions = {
   monteCarloSimulations?: number;
   /** Parameter perturbation range in percent (default: 20) */
   perturbationPercent?: number;
-  /** Number of perturbation samples (default: 10) */
+  /**
+   * Number of random parameter samples drawn within the perturbation
+   * neighborhood for the sensitivity dimension (default: 10)
+   */
   perturbationSamples?: number;
   /** Walk-Forward window size in candles (default: 252) */
   walkForwardWindowSize?: number;
@@ -57,7 +60,7 @@ export type RobustnessOptions = {
     walkForward?: number;
     regimeConsistency?: number;
   };
-  /** Random seed for reproducibility */
+  /** Random seed for Monte Carlo and perturbation sampling reproducibility */
   seed?: number;
   /** Progress callback */
   progressCallback?: (phase: string, progress: number) => void;


### PR DESCRIPTION
## Summary

The `options-key-usage` contract test (added in #311) flagged five exported `*Options` keys that were declared and documented but never read by any runtime code. This PR fixes all five — wiring the two that should work, and removing the three that can never work — and empties their allowlist entries.

### Wired

| Option | Fix |
|---|---|
| `HighestLowestOptions.source` | `highestLowest` now computes both extremes from the requested price series (values resolved once via `getPriceSeries`, same pattern as RSI/SMA). Omitting `source` keeps the previous highs/lows behavior. The option also widened from `"high" \| "low" \| "close"` to the full `PriceSource` union, matching every other source-accepting indicator. |
| `RobustnessOptions.perturbationSamples` | The Parameter Sensitivity dimension of `calculateRobustnessScore` now draws N (default 10) random parameter sets within the perturbation neighborhood — seeded via `options.seed`, duplicates memoized — instead of grid-searching the narrowed ranges with the original step sizes. This makes the sample count independent of range steps and removes the degenerate "Insufficient parameter combinations" case when narrowed ranges held fewer than 3 grid points. **Behavior change**: sensitivity scores may differ from previous releases (documented in CHANGELOG). |

### Removed (Breaking — never functional, so removal cannot change results)

- `ScreeningOptions.concurrency` — `runScreening` is fully synchronous; the documented "max concurrent file processing" never existed.
- `CandleFormerTrainOptions.temperature` — softmax temperature is inference-time; the wired option is `CandleFormerOptions.temperature`.
- `ParseFundamentalsOptions.encoding` — `parseFundamentals` takes an already-decoded string.

Code that sets these keys will now fail to type-check; delete the key at the call site.

### Also in this PR

- New single-owner `DEFAULT_BACKTEST_CAPITAL` constant (`src/optimization/constants.ts`) replaces four independently restated `capital: 100000` literals in grid-search, walk-forward, Pareto, and the new robustness sampling loop — same value everywhere, so no behavior change, but the default can no longer drift between optimizers.
- Explicit 30s timeouts on the two core doc-harness tests that dynamically import the full source entry (`docs-import-check`, `docs-snippets`); they can exceed vitest's 5s default when the rest of the suite loads the machine. The chart package's twin harness already uses 30s.

## Test plan

- 2 new tests for `highestLowest` source selection (close-based extremes; high/low source parity with the default).
- 2 new tests for perturbation sampling (default 10 / explicit 5 sample counts surfaced in the dimension detail; same-seed reproducibility; `< 3` samples → neutral score).
- Full verification: core **6311/6311** tests pass (2 consecutive runs), chart **934/934**, mcp **83/83**; `tsc --noEmit` clean for core and chart; core `pnpm build` OK; Biome clean on all touched files.