### PR TITLE
fix(core): condition caches no longer collide across parameter values

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## [Unreleased]
 
+### Fixed — condition caches no longer collide across parameter values
+
+Several backtest condition caches omitted parameters from their cache keys, so
+two conditions differing only in that parameter shared one cached series —
+whichever evaluated first silently poisoned the other, both within a run
+(`and()`/`or()` combos) and across runs sharing an `IndicatorCache` (grid
+search sweeps over the omitted parameter returned identical results for every
+value). Fixed keys:
+
+- `bollingerBreakout` / Bollinger conditions — key now includes `stdDev`
+- `regimeIs` / `regimeNot` / `volatilityAbove`-family — the module-level cache
+  now differentiates the full `VolatilityRegimeOptions` (previously the first
+  options seen were pinned for the candles array, even across separate
+  `runBacktest` calls)
+- `atrPercentAbove` / `atrPercentBelow` — the module-level cache now
+  differentiates `atrPeriod`
+- `perfectOrderBullishConfirmed` and every other `perfectOrderEnhanced`-backed
+  condition (12 sites) — keys now include `collapseEps`
+- `volumeExtreme` — key now includes `threshold`
+- `candleFormerBullish` / `candleFormerBearish` — the predictions cache now
+  keys on the model weights identity, so mixing two trained models in one
+  backtest (or reusing a cache across runs with different models) no longer
+  serves the first model's predictions to the second
+
+Sweeps over `stdDev`, `atrPeriod`, `collapseEps`, volume thresholds, or regime
+options now produce genuinely distinct results per value; previously-poisoned
+runs may report different (correct) numbers.
+
 ### Added — 22 scoring exports that were unreachable are now on the main entry
 
 - The scoring module's signal-evaluator factories and pre-built signal

--- a/packages/core/src/backtest/__tests__/condition-cache-key-isolation.test.ts
+++ b/packages/core/src/backtest/__tests__/condition-cache-key-isolation.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Condition cache-key isolation.
+ *
+ * Every cached condition series must key on ALL parameters that influence its
+ * values. A key that omits a parameter lets two conditions that differ only in
+ * that parameter share one cached series — whichever evaluates first poisons
+ * the other, both within a run (shared `indicators` object / `and()` combos)
+ * and across runs sharing an `IndicatorCache` (gridSearch sweeps silently
+ * return identical results for every value of the omitted parameter).
+ *
+ * Each test evaluates two conditions differing only in one parameter, in
+ * poisoning order (the other condition first), and asserts the second matches
+ * its fresh-cache ground truth.
+ */
+import { describe, expect, it } from "vitest";
+import { atrPercentSeries } from "../../indicators/volatility/atr-filter";
+import { volatilityRegime } from "../../indicators/volatility/regime";
+import { candleFormerBullish } from "../../ml/conditions";
+import { trainCandleFormer } from "../../ml/train";
+import type { CandleFormerWeights } from "../../ml/types";
+import type { NormalizedCandle } from "../../types";
+import { bollingerBreakout } from "../conditions/bollinger";
+import { perfectOrderBullishConfirmed } from "../conditions/po-enhanced";
+import { atrPercentAbove, regimeIs } from "../conditions/volatility";
+import { volumeExtreme } from "../conditions/volume-anomaly-profile";
+
+/** Deterministic seeded PRNG (mulberry32). */
+function mulberry32(seed: number): () => number {
+  let s = seed | 0;
+  return () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function generateCandles(n: number, seed: number): NormalizedCandle[] {
+  const rng = mulberry32(seed);
+  const candles: NormalizedCandle[] = [];
+  let price = 100;
+  for (let i = 0; i < n; i++) {
+    const change = (rng() - 0.49) * 3;
+    const open = price;
+    const close = Math.max(price + change, 1);
+    candles.push({
+      time: 1700000000000 + i * 86400000,
+      open,
+      high: Math.max(open, close) + rng() * 2,
+      low: Math.max(Math.min(open, close) - rng() * 2, 0.5),
+      close,
+      volume: 1000 + Math.floor(rng() * 5000),
+    });
+    price = close;
+  }
+  return candles;
+}
+
+/** Evaluate a preset condition across all bars against a shared indicators object. */
+function evaluateAll(
+  condition: {
+    evaluate: (
+      i: Record<string, unknown>,
+      c: NormalizedCandle,
+      x: number,
+      a: NormalizedCandle[],
+    ) => boolean;
+  },
+  indicators: Record<string, unknown>,
+  candles: NormalizedCandle[],
+): boolean[] {
+  return candles.map((c, i) => condition.evaluate(indicators, c, i, candles));
+}
+
+describe("condition cache-key isolation", () => {
+  it("bollingerBreakout: stdDev participates in the cache key", () => {
+    const candles = generateCandles(120, 7);
+    // Ground truth with fresh caches
+    const fresh2 = evaluateAll(bollingerBreakout("upper", 20, 2), {}, candles);
+    const fresh3 = evaluateAll(bollingerBreakout("upper", 20, 3), {}, candles);
+    // 2σ breaks out more often than 3σ — the data must differentiate them
+    expect(fresh2).not.toEqual(fresh3);
+
+    // Poisoning order: 2σ first, then 3σ on the SAME indicators object
+    const shared: Record<string, unknown> = {};
+    evaluateAll(bollingerBreakout("upper", 20, 2), shared, candles);
+    const poisoned3 = evaluateAll(bollingerBreakout("upper", 20, 3), shared, candles);
+    expect(poisoned3).toEqual(fresh3);
+  });
+
+  it("regimeIs: options participate in the module-level cache key", () => {
+    const candles = generateCandles(200, 11);
+    const custom = { thresholds: { low: 99.9 } };
+    const isLow = (r: { value: { regime: string } | null }) =>
+      r.value !== null && r.value.regime === "low";
+    const truthDefault = volatilityRegime(candles).map(isLow);
+    const truthCustom = volatilityRegime(candles, custom).map(isLow);
+    // The data must differentiate the two option sets
+    expect(truthDefault).not.toEqual(truthCustom);
+
+    // Poisoning order: default options first pins the cache for this array
+    evaluateAll(regimeIs("low"), {}, candles);
+    const poisonedCustom = evaluateAll(regimeIs("low", custom), {}, candles);
+    expect(poisonedCustom).toEqual(truthCustom);
+  });
+
+  it("atrPercentAbove: atrPeriod participates in the module-level cache key", () => {
+    const candles = generateCandles(200, 13);
+    const s5 = atrPercentSeries(candles, 5);
+    const s50 = atrPercentSeries(candles, 50);
+    // Find a bar where a threshold separates the two periods' answers
+    const idx = candles.findIndex((_, i) => {
+      const a = s5[i]?.value;
+      const b = s50[i]?.value;
+      return (
+        a !== null && b !== null && a !== undefined && b !== undefined && Math.abs(a - b) > 0.05
+      );
+    });
+    expect(idx).toBeGreaterThan(-1);
+    const v5 = s5[idx].value as number;
+    const v50 = s50[idx].value as number;
+    const threshold = (v5 + v50) / 2;
+    const expected50 = v50 >= threshold;
+
+    // Poisoning order: period-5 condition first pins the cache for this array
+    atrPercentAbove(threshold, { atrPeriod: 5 }).evaluate({}, candles[idx], idx, candles);
+    const poisoned = atrPercentAbove(threshold, { atrPeriod: 50 }).evaluate(
+      {},
+      candles[idx],
+      idx,
+      candles,
+    );
+    expect(poisoned).toBe(expected50);
+  });
+
+  it("perfectOrderBullishConfirmed: collapseEps participates in the cache key", () => {
+    const candles = generateCandles(150, 17);
+    const tight = perfectOrderBullishConfirmed({ collapseEps: 0.003 });
+    const loose = perfectOrderBullishConfirmed({ collapseEps: 0.05 });
+
+    const freshLoose = evaluateAll(loose, {}, candles);
+    const shared: Record<string, unknown> = {};
+    evaluateAll(tight, shared, candles);
+    const poisonedLoose = evaluateAll(loose, shared, candles);
+
+    expect(poisonedLoose).toEqual(freshLoose);
+    // The two eps values must occupy two distinct cache slots
+    const poeKeys = Object.keys(shared).filter((k) => k.startsWith("poe_"));
+    expect(poeKeys.length).toBe(2);
+  });
+
+  it("volumeExtreme: threshold participates in the cache key", () => {
+    // Noisy baseline (alternating 500/1500) keeps the volume z-score below
+    // the promotion threshold so the level depends on the ratio alone.
+    // Spike bar ratio ≈ 1.95: extreme for threshold 1.5, not for 3.0.
+    const candles = generateCandles(31, 19).map((c, i) => ({
+      ...c,
+      volume: i === 30 ? 2000 : i % 2 === 0 ? 500 : 1500,
+    }));
+    const shared: Record<string, unknown> = {};
+    const hi = volumeExtreme(3.0, 20);
+    const lo = volumeExtreme(1.5, 20);
+
+    // Poisoning order: 3.0 first
+    const hiResult = hi.evaluate(shared, candles[30], 30, candles);
+    const loResult = lo.evaluate(shared, candles[30], 30, candles);
+    expect(hiResult).toBe(false);
+    expect(loResult).toBe(true);
+
+    // Reverse poisoning order on a fresh (cloned) setup
+    const shared2: Record<string, unknown> = {};
+    const candles2 = candles.map((c) => ({ ...c }));
+    const loFirst = volumeExtreme(1.5, 20).evaluate(shared2, candles2[30], 30, candles2);
+    const hiSecond = volumeExtreme(3.0, 20).evaluate(shared2, candles2[30], 30, candles2);
+    expect(loFirst).toBe(true);
+    expect(hiSecond).toBe(false);
+  });
+
+  it("candleFormer conditions: model weights participate in the cache key", () => {
+    const candles = generateCandles(60, 23);
+    const { weights } = trainCandleFormer(candles, { epochs: 2, seqLen: 8, seed: 42 });
+    // Second "model": same shape, output bias forced to always favor bullish
+    const weightsB = JSON.parse(JSON.stringify(weights)) as CandleFormerWeights;
+    (weightsB as unknown as { outB: number[] }).outB = (
+      weightsB as unknown as { outB: number[] }
+    ).outB.map((_, i) => (i === 0 ? 50 : -50));
+
+    const condA = candleFormerBullish(weights, 0);
+    const condB = candleFormerBullish(weightsB, 0);
+
+    const freshA = evaluateAll(condA, {}, candles);
+    const freshB = evaluateAll(condB, {}, candles);
+    // The forced-bias model must actually behave differently
+    expect(freshB).not.toEqual(freshA);
+
+    const shared: Record<string, unknown> = {};
+    evaluateAll(condA, shared, candles);
+    const poisonedB = evaluateAll(condB, shared, candles);
+
+    expect(poisonedB).toEqual(freshB);
+    const cfKeys = Object.keys(shared).filter((k) => k.startsWith("candleFormer_"));
+    expect(cfKeys.length).toBe(2);
+  });
+});

--- a/packages/core/src/backtest/conditions/bollinger.ts
+++ b/packages/core/src/backtest/conditions/bollinger.ts
@@ -19,7 +19,7 @@ function getBBData(
   period: number,
   stdDev: number,
 ): BBData {
-  const key = `bb${period}`;
+  const key = `bb${period}_${stdDev}`;
   let bbData = indicators[key] as BBData | undefined;
 
   if (!bbData) {

--- a/packages/core/src/backtest/conditions/po-enhanced.ts
+++ b/packages/core/src/backtest/conditions/po-enhanced.ts
@@ -49,7 +49,7 @@ export function perfectOrderBullishConfirmed(
     collapseEps = 0.003,
     minConfidence = 0,
   } = options;
-  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}`;
+  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}_${collapseEps}`;
 
   return {
     type: "preset",
@@ -100,7 +100,7 @@ export function perfectOrderBearishConfirmed(
     collapseEps = 0.003,
     minConfidence = 0,
   } = options;
-  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}`;
+  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}_${collapseEps}`;
 
   return {
     type: "preset",
@@ -151,7 +151,7 @@ export function perfectOrderConfirmationFormed(
     persistBars = 3,
     collapseEps = 0.003,
   } = options;
-  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}`;
+  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}_${collapseEps}`;
 
   return {
     type: "preset",
@@ -197,7 +197,7 @@ export function perfectOrderBreakdown(
     persistBars = 3,
     collapseEps = 0.003,
   } = options;
-  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}`;
+  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}_${collapseEps}`;
 
   return {
     type: "preset",
@@ -243,7 +243,7 @@ export function perfectOrderMaCollapsed(
     persistBars = 3,
     collapseEps = 0.003,
   } = options;
-  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}`;
+  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}_${collapseEps}`;
 
   return {
     type: "preset",
@@ -289,7 +289,7 @@ export function perfectOrderPreBullish(
     persistBars = 3,
     collapseEps = 0.003,
   } = options;
-  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}`;
+  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}_${collapseEps}`;
 
   return {
     type: "preset",
@@ -333,7 +333,7 @@ export function perfectOrderPreBearish(
     persistBars = 3,
     collapseEps = 0.003,
   } = options;
-  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}`;
+  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}_${collapseEps}`;
 
   return {
     type: "preset",

--- a/packages/core/src/backtest/conditions/po-pullback.ts
+++ b/packages/core/src/backtest/conditions/po-pullback.ts
@@ -41,7 +41,7 @@ export function perfectOrderPullbackEntry(
     minGapPercent = 0.5,
     lookbackBars = 5,
   } = options;
-  const cacheKey = `poe_pullback_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}`;
+  const cacheKey = `poe_pullback_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}_${collapseEps}`;
   const stateKey = `poe_pullback_state_${periods.join("_")}`;
 
   return {
@@ -165,7 +165,7 @@ export function perfectOrderPullbackSellEntry(
     minGapPercent = 0.5,
     lookbackBars = 5,
   } = options;
-  const cacheKey = `poe_pullback_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}`;
+  const cacheKey = `poe_pullback_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}_${collapseEps}`;
   const stateKey = `poe_pullback_sell_state_${periods.join("_")}`;
 
   return {
@@ -292,7 +292,7 @@ export function poPlusEntry(options: PerfectOrderEnhancedConditionOptions = {}):
     persistBars = 3,
     collapseEps = 0.003,
   } = options;
-  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}`;
+  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}_${collapseEps}`;
 
   return {
     type: "preset",
@@ -347,7 +347,7 @@ export function pbEntry(options: PerfectOrderEnhancedConditionOptions = {}): Pre
     persistBars = 3,
     collapseEps = 0.003,
   } = options;
-  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}`;
+  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}_${collapseEps}`;
 
   return {
     type: "preset",
@@ -396,7 +396,7 @@ export function poPlusPbEntry(options: PerfectOrderEnhancedConditionOptions = {}
     persistBars = 3,
     collapseEps = 0.003,
   } = options;
-  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}`;
+  const cacheKey = `poe_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}_${collapseEps}`;
 
   return {
     type: "preset",

--- a/packages/core/src/backtest/conditions/volatility.ts
+++ b/packages/core/src/backtest/conditions/volatility.ts
@@ -13,25 +13,51 @@ import {
 import { volatilityRegime } from "../../indicators/volatility/regime";
 import type { PresetCondition, VolatilityRegime, VolatilityRegimeOptions } from "../../types";
 
-// Cache for volatility regime series
-const regimeCache = new WeakMap<object, ReturnType<typeof volatilityRegime>>();
+// Cache for volatility regime series, keyed by candles array + options.
+// A single-level candles key would let the first condition's options poison
+// every other regime condition evaluated on the same array.
+const regimeCache = new WeakMap<object, Map<string, ReturnType<typeof volatilityRegime>>>();
 
 /**
- * Get or calculate volatility regime series (cached)
+ * Canonical cache key for the options that influence volatilityRegime output.
+ * Raw (pre-default) values are used positionally so no defaults are restated
+ * here; semantically-equal spellings (e.g. `{}` vs `{ atrPeriod: 14 }`) may
+ * compute twice, which is correct — only merging distinct options is a bug.
+ * The calendar contributes only its annualization identity (volatilityRegime
+ * does not consult `isTradingDay`).
+ */
+function regimeOptionsKey(options?: VolatilityRegimeOptions): string {
+  if (!options) return "default";
+  const t = options.thresholds;
+  const cal = options.calendar;
+  return [
+    options.atrPeriod,
+    options.bbPeriod,
+    options.lookbackPeriod,
+    t?.low,
+    t?.high,
+    t?.extreme,
+    cal ? `${cal.name}:${cal.tradingDaysPerYear}` : undefined,
+  ].join("|");
+}
+
+/**
+ * Get or calculate volatility regime series (cached per candles + options)
  */
 function getRegimeSeries(
   candles: Parameters<typeof volatilityRegime>[0],
   options?: VolatilityRegimeOptions,
 ) {
-  // Use candles array as cache key
-  const cacheKey = candles as object;
-
-  // For simplicity, we don't cache with options differentiation
-  // In production, you might want a more sophisticated cache key
-  let cached = regimeCache.get(cacheKey);
+  let byOptions = regimeCache.get(candles as object);
+  if (!byOptions) {
+    byOptions = new Map();
+    regimeCache.set(candles as object, byOptions);
+  }
+  const optionsKey = regimeOptionsKey(options);
+  let cached = byOptions.get(optionsKey);
   if (!cached) {
     cached = volatilityRegime(candles, options);
-    regimeCache.set(cacheKey, cached);
+    byOptions.set(optionsKey, cached);
   }
   return cached;
 }
@@ -340,18 +366,24 @@ export function volatilityContracting(
   };
 }
 
-// Cache for ATR% series
-const atrPercentCache = new WeakMap<object, ReturnType<typeof atrPercentSeries>>();
+// Cache for ATR% series, keyed by candles array + period. A single-level
+// candles key would serve the first period's series to every other period.
+const atrPercentCache = new WeakMap<object, Map<string, ReturnType<typeof atrPercentSeries>>>();
 
 /**
- * Get or calculate ATR% series (cached)
+ * Get or calculate ATR% series (cached per candles + period)
  */
 function getAtrPercentSeries(candles: Parameters<typeof atrPercentSeries>[0], atrPeriod?: number) {
-  const cacheKey = candles as object;
-  let cached = atrPercentCache.get(cacheKey);
+  let byPeriod = atrPercentCache.get(candles as object);
+  if (!byPeriod) {
+    byPeriod = new Map();
+    atrPercentCache.set(candles as object, byPeriod);
+  }
+  const periodKey = atrPeriod === undefined ? "default" : String(atrPeriod);
+  let cached = byPeriod.get(periodKey);
   if (!cached) {
     cached = atrPercentSeries(candles, atrPeriod);
-    atrPercentCache.set(cacheKey, cached);
+    byPeriod.set(periodKey, cached);
   }
   return cached;
 }

--- a/packages/core/src/backtest/conditions/volume-anomaly-profile.ts
+++ b/packages/core/src/backtest/conditions/volume-anomaly-profile.ts
@@ -55,7 +55,7 @@ export function volumeAnomalyCondition(threshold = 2.0, period = 20): PresetCond
  * @param period - Lookback period for average (default: 20)
  */
 export function volumeExtreme(threshold = 3.0, period = 20): PresetCondition {
-  const cacheKey = `volumeAnomaly_${period}_extreme`;
+  const cacheKey = `volumeAnomaly_${period}_${threshold}_extreme`;
 
   return {
     type: "preset",

--- a/packages/core/src/ml/__tests__/candle-former.test.ts
+++ b/packages/core/src/ml/__tests__/candle-former.test.ts
@@ -125,14 +125,15 @@ describe("candleFormerBullish / candleFormerBearish conditions", () => {
     const condition = candleFormerBullish(weights, 30);
     const indicators: Record<string, unknown> = {};
 
-    // First call populates cache
+    // First call populates cache (key carries a per-weights identity suffix)
     condition.evaluate(indicators, candles[10], 10, candles);
-    expect(indicators.candleFormer_predictions).toBeDefined();
+    const keys = Object.keys(indicators).filter((k) => k.startsWith("candleFormer_predictions"));
+    expect(keys.length).toBe(1);
 
-    // Second call should reuse cache
-    const cached = indicators.candleFormer_predictions;
+    // Second call with the same weights should reuse the same cached series
+    const cached = indicators[keys[0]];
     condition.evaluate(indicators, candles[11], 11, candles);
-    expect(indicators.candleFormer_predictions).toBe(cached);
+    expect(indicators[keys[0]]).toBe(cached);
   });
 
   it("bullish and bearish are mutually exclusive at same candle", () => {

--- a/packages/core/src/ml/conditions.ts
+++ b/packages/core/src/ml/conditions.ts
@@ -12,6 +12,23 @@ import type { CandleFormerValue, CandleFormerWeights } from "./types";
 const CACHE_PREFIX = "candleFormer_";
 
 /**
+ * Predictions are fully determined by the weights, so each distinct weights
+ * object gets a stable process-wide id that participates in the cache key.
+ * Without it, mixing two models in one backtest (or across runs sharing an
+ * IndicatorCache) would serve the first model's predictions to the second.
+ */
+const weightsIds = new WeakMap<CandleFormerWeights, number>();
+let nextWeightsId = 0;
+function weightsId(weights: CandleFormerWeights): number {
+  let id = weightsIds.get(weights);
+  if (id === undefined) {
+    id = nextWeightsId++;
+    weightsIds.set(weights, id);
+  }
+  return id;
+}
+
+/**
  * Get or compute cached CandleFormer predictions
  */
 function getCachedPredictions(
@@ -19,7 +36,7 @@ function getCachedPredictions(
   candles: NormalizedCandle[],
   weights: CandleFormerWeights,
 ): Series<CandleFormerValue> {
-  const cacheKey = `${CACHE_PREFIX}predictions`;
+  const cacheKey = `${CACHE_PREFIX}predictions_${weightsId(weights)}`;
   const cached = indicators[cacheKey] as Series<CandleFormerValue> | undefined;
   if (cached) return cached;
 


### PR DESCRIPTION
## Summary

Six backtest condition caches omitted parameters that fully determine their cached series. Two conditions differing only in that parameter therefore shared one cached series — whichever evaluated first silently poisoned the other. This corrupts results in two ways:

- **Within a run**: `and()`/`or()` combos mixing e.g. a 2σ and a 3σ Bollinger condition evaluate the second one against the first one's bands.
- **Across runs sharing an `IndicatorCache`** (exactly what `gridSearch`/walk-forward do): a sweep over the omitted parameter returns byte-identical results for every value — e.g. a `stdDev` sweep 1→4 reported the same return for all four values while isolated runs differ.

### Fixed sites

| Condition family | Omitted parameter | Fix |
|---|---|---|
| `bollingerBreakout` etc. | `stdDev` | key now `bb${period}_${stdDev}` |
| `regimeIs` / `regimeNot` / `volatilityAbove` family | entire `VolatilityRegimeOptions` | module-level cache is now two-level: candles array → canonical options key. Previously the first options seen were pinned for the array's lifetime, even across separate `runBacktest` calls |
| `atrPercentAbove` / `atrPercentBelow` | `atrPeriod` | two-level cache: candles array → period |
| `perfectOrderEnhanced`-backed conditions (12 sites in po-enhanced.ts / po-pullback.ts) | `collapseEps` | appended to every `poe_*` key |
| `volumeExtreme` | `threshold` | key now includes threshold (sibling `volumeAnomalyCondition` already did) |
| `candleFormerBullish` / `candleFormerBearish` | model `weights` | predictions keyed on a stable per-weights identity (`WeakMap` id — the same pattern the relative-strength benchmark cache uses), so mixing two trained models no longer serves model A's predictions to model B |

The regime options key uses raw (pre-default) option values positionally, so no defaults are restated in the key; semantically-equal spellings may compute twice, which only costs a recompute — merging distinct options is the bug.

## Test plan

- New `condition-cache-key-isolation.test.ts` (6 tests): each evaluates two conditions differing only in the previously-omitted parameter, in poisoning order against a shared cache, and asserts the second matches its fresh-cache ground truth. **All six fail against the previous implementation** (verified by stashing the fixes).
- One existing test updated: it asserted the old fixed `candleFormer_predictions` key name; it now checks the keyed form and same-weights reuse.
- Full verification: core **6326/6326** tests pass (356 files), `tsc --noEmit` clean, `pnpm build` OK, Biome clean.

## Behavior note

Sweeps over `stdDev` / `atrPeriod` / `collapseEps` / volume thresholds / regime options now produce genuinely distinct results per value. Previously-poisoned runs may report different (correct) numbers.