### PR TITLE
fix(core): keep per-run state out of the shared IndicatorCache

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+### Fixed — per-run state no longer leaks through a shared `IndicatorCache`
+
+- `perfectOrderPullbackEntry` / `perfectOrderPullbackSellEntry` kept a mutable
+  breakdown-tracking state object on the indicators proxy under a shareable
+  key, so a later `runBacktest` on the same candles + shared cache (exactly
+  what grid search and walk-forward do) inherited the previous run's end
+  state — producing phantom trades that a fresh-cache run does not have. The
+  state now lives under a run-local key that never enters the shared cache,
+  and the key includes the full option set (previously two conditions
+  differing in `maType`/`collapseEps`/etc. shared one state object within a
+  run).
+- The engine-injected fundamentals scalars (`per`/`pbr` from the
+  `fundamentals` option) leaked the same way: a later run **without**
+  fundamentals on a shared cache read the previous run's last values on every
+  bar, making `perBelow`/`pbrAbove`-style conditions fire when they should
+  see no data. They are now run-local, like the relative-strength benchmark.
+- New internal convention: indicator keys prefixed with `__runLocal_` are
+  never read from or written to a shared `IndicatorCache` — use it for any
+  per-run mutable state a condition keeps on the indicators object.
+
 ### Fixed — condition caches no longer collide across parameter values
 
 Several backtest condition caches omitted parameters from their cache keys, so

--- a/packages/core/src/backtest/__tests__/run-local-cache-state.test.ts
+++ b/packages/core/src/backtest/__tests__/run-local-cache-state.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Run-local state must never leak through a shared IndicatorCache.
+ *
+ * The shared cache may only hold values that are a pure function of the
+ * candle array. Two things are not: per-run mutable condition state (the
+ * perfectOrderPullbackEntry breakdown tracker) and per-run inputs the engine
+ * injects (the `fundamentals` option's per/pbr scalars). If either reaches
+ * the shared cache, a later run on the same candles + cache inherits the
+ * previous run's end state — phantom trades with no way to see why.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  createCachedIndicators,
+  IndicatorCache,
+  RUN_LOCAL_KEY_PREFIX,
+} from "../../core/indicator-cache";
+import type { NormalizedCandle } from "../../types";
+import { perBelow } from "../conditions/fundamentals";
+import {
+  perfectOrderPullbackEntry,
+  perfectOrderPullbackSellEntry,
+} from "../conditions/po-pullback";
+import { runBacktest } from "../engine";
+
+/** Deterministic seeded PRNG (mulberry32). */
+function mulberry32(seed: number): () => number {
+  let s = seed | 0;
+  return () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function generateCandles(n: number, seed: number): NormalizedCandle[] {
+  const rng = mulberry32(seed);
+  const candles: NormalizedCandle[] = [];
+  let price = 100;
+  for (let i = 0; i < n; i++) {
+    // Uptrend with periodic pullbacks so perfect-order machinery engages
+    const change = 0.3 + Math.sin(i / 9) * 0.5 + (rng() - 0.5) * 1.5;
+    const open = price;
+    const close = Math.max(price + change, 1);
+    candles.push({
+      time: 1700000000000 + i * 86400000,
+      open,
+      high: Math.max(open, close) + rng(),
+      low: Math.max(Math.min(open, close) - rng(), 0.5),
+      close,
+      volume: 1000,
+    });
+    price = close;
+  }
+  return candles;
+}
+
+describe("run-local cache state", () => {
+  it("perfectOrderPullbackEntry keeps its mutable state out of the shared cache", () => {
+    const candles = generateCandles(200, 17);
+    const cache = new IndicatorCache();
+    const condition = perfectOrderPullbackEntry();
+
+    // Run 1 through a cache-backed proxy — evaluates every bar, builds state
+    const proxy1 = createCachedIndicators(candles, cache);
+    candles.forEach((c, i) => condition.evaluate(proxy1, c, i, candles));
+
+    // Only the derived poData series may be shared; the mutable state object
+    // must have stayed run-local.
+    expect(cache.size).toBe(1);
+
+    // Run 2 (fresh proxy, same cache) must behave exactly like a no-cache run
+    const truth = (() => {
+      const plain: Record<string, unknown> = {};
+      return candles.map((c, i) => condition.evaluate(plain, c, i, candles));
+    })();
+    const proxy2 = createCachedIndicators(candles, cache);
+    const run2 = candles.map((c, i) => condition.evaluate(proxy2, c, i, candles));
+    expect(run2).toEqual(truth);
+  });
+
+  it("buy/sell and different option sets get separate run-local state slots", () => {
+    const candles = generateCandles(120, 5);
+    const indicators: Record<string, unknown> = {};
+
+    // Same params: buy + sell share one poData series but must not share state
+    perfectOrderPullbackEntry().evaluate(indicators, candles[50], 50, candles);
+    perfectOrderPullbackSellEntry().evaluate(indicators, candles[50], 50, candles);
+    // Different collapseEps: previously the state key ignored every param
+    // except periods, so these silently shared one state object
+    perfectOrderPullbackEntry({ collapseEps: 0.05 }).evaluate(indicators, candles[50], 50, candles);
+
+    const stateKeys = Object.keys(indicators).filter((k) => k.startsWith(RUN_LOCAL_KEY_PREFIX));
+    expect(stateKeys.length).toBe(3);
+  });
+
+  it("fundamentals per/pbr do not leak into a later run that omits them (shared cache)", () => {
+    const candles = generateCandles(60, 29);
+    const fundamentals = candles.map((c) => ({ time: c.time, per: 10, pbr: 0.8 }));
+    const never = { type: "preset" as const, name: "never", evaluate: () => false };
+    const cache = new IndicatorCache();
+
+    // Run 1 WITH fundamentals: perBelow(15) fires (per=10 on every bar)
+    const run1 = runBacktest(
+      candles,
+      perBelow(15),
+      never,
+      { capital: 100000, fundamentals },
+      cache,
+    );
+    expect(run1.trades.length).toBeGreaterThan(0);
+
+    // Run 2 WITHOUT fundamentals on the SAME cache: per must be undefined,
+    // so perBelow never fires — identical to the fresh-cache control
+    const run2 = runBacktest(candles, perBelow(15), never, { capital: 100000 }, cache);
+    const control = runBacktest(candles, perBelow(15), never, { capital: 100000 });
+    expect(control.trades.length).toBe(0);
+    expect(run2.trades.length).toBe(0);
+  });
+});

--- a/packages/core/src/backtest/conditions/po-pullback.ts
+++ b/packages/core/src/backtest/conditions/po-pullback.ts
@@ -2,6 +2,7 @@
  * Perfect Order pullback and entry conditions
  */
 
+import { RUN_LOCAL_KEY_PREFIX } from "../../core/indicator-cache";
 import { type PerfectOrderValueEnhanced, perfectOrderEnhanced } from "../../signals/perfect-order";
 import type { PresetCondition } from "../../types";
 import type { PerfectOrderEnhancedConditionOptions } from "./po-enhanced";
@@ -42,7 +43,10 @@ export function perfectOrderPullbackEntry(
     lookbackBars = 5,
   } = options;
   const cacheKey = `poe_pullback_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}_${collapseEps}`;
-  const stateKey = `poe_pullback_state_${periods.join("_")}`;
+  // Mutable per-run state: the run-local prefix keeps it off the shared
+  // IndicatorCache (one run's end state must not seed the next run), and
+  // deriving from the full cacheKey keeps different option sets separate.
+  const stateKey = `${RUN_LOCAL_KEY_PREFIX}${cacheKey}_state`;
 
   return {
     type: "preset",
@@ -166,7 +170,9 @@ export function perfectOrderPullbackSellEntry(
     lookbackBars = 5,
   } = options;
   const cacheKey = `poe_pullback_${periods.join("_")}_${maType}_${slopeLookback}_${persistBars}_${collapseEps}`;
-  const stateKey = `poe_pullback_sell_state_${periods.join("_")}`;
+  // Run-local mutable state — see the buy variant for rationale. The `_sell`
+  // segment keeps buy/sell state separate (they share the same cacheKey).
+  const stateKey = `${RUN_LOCAL_KEY_PREFIX}${cacheKey}_sell_state`;
 
   return {
     type: "preset",

--- a/packages/core/src/backtest/engine.ts
+++ b/packages/core/src/backtest/engine.ts
@@ -56,6 +56,15 @@ import type { SlippageModel } from "./slippage-model";
 import { calculateDynamicSlippage, resolveSlippageModel } from "./slippage-model";
 
 /**
+ * Run-local indicator keys for engine runs: the RS benchmark plus the
+ * fundamentals scalars the engine itself injects per bar. `per`/`pbr` come
+ * from the run's `fundamentals` option, not from the candles, so they must
+ * never leak through a shared IndicatorCache into a later run that omits
+ * fundamentals (conditions like `perBelow` would fire on stale values).
+ */
+const ENGINE_RUN_LOCAL_KEYS: ReadonlySet<string> = new Set([...RUN_LOCAL_CACHE_KEYS, "per", "pbr"]);
+
+/**
  * Extended backtest options with MTF, ATR risk, and fundamentals support
  */
 export type MtfBacktestOptions = BacktestOptions & {
@@ -172,12 +181,12 @@ export function runBacktest(
   }
 
   const trades: Trade[] = [];
-  // The benchmark is a run-local input, so it is kept off the shared cache
-  // (see RUN_LOCAL_CACHE_KEYS) and must be re-supplied each run.
+  // Benchmark and fundamentals scalars are run-local inputs, so they are kept
+  // off the shared cache (see ENGINE_RUN_LOCAL_KEYS) and re-supplied each run.
   const indicators: Record<string, unknown> = createCachedIndicators(
     candles,
     cache,
-    RUN_LOCAL_CACHE_KEYS,
+    ENGINE_RUN_LOCAL_KEYS,
   );
 
   // Seed benchmark candles for Relative Strength conditions.

--- a/packages/core/src/core/indicator-cache.ts
+++ b/packages/core/src/core/indicator-cache.ts
@@ -67,19 +67,33 @@ export class IndicatorCache {
 }
 
 /**
+ * Keys with this prefix are run-local by convention: `createCachedIndicators`
+ * never reads them from or writes them to the shared {@link IndicatorCache},
+ * regardless of the `localOnlyKeys` set. Use it for mutable per-run state a
+ * condition keeps on the indicators object — such state is not a pure function
+ * of the candle array, so sharing it through the cache would leak one run's
+ * end state into the next run on the same candles.
+ */
+export const RUN_LOCAL_KEY_PREFIX = "__runLocal_";
+
+/**
  * Create a Proxy-based indicators object that integrates with IndicatorCache.
  *
  * When a condition reads `indicators[key]`, the Proxy first checks the local object,
  * then the shared cache. When a condition writes `indicators[key] = value`,
  * the value is stored both locally and in the shared cache.
  *
+ * Only values that are a pure function of the candle array may live in the
+ * shared cache. Two escape hatches keep everything else run-local:
+ * {@link RUN_LOCAL_KEY_PREFIX} (convention, for per-run mutable state) and
+ * `localOnlyKeys` (exact names, for per-run inputs like the RS benchmark).
+ *
  * @param candles - Candle array (used as cache identity key)
  * @param cache - Shared IndicatorCache instance (optional)
  * @param localOnlyKeys - Keys that are run-local inputs rather than candle-derived
- *   computations (e.g. the RS benchmark). The shared cache only stores values
- *   that are a pure function of the candle array, so these keys are kept on the
- *   local object and never read from or written to the shared cache — otherwise
- *   they would leak into later runs that reuse the same cache and candles.
+ *   computations (e.g. the RS benchmark). Kept on the local object and never
+ *   read from or written to the shared cache — otherwise they would leak into
+ *   later runs that reuse the same cache and candles.
  * @returns Proxied indicators object
  */
 export function createCachedIndicators(
@@ -91,13 +105,16 @@ export function createCachedIndicators(
 
   if (!cache) return local;
 
+  const isRunLocal = (prop: string) =>
+    prop.startsWith(RUN_LOCAL_KEY_PREFIX) || localOnlyKeys?.has(prop) === true;
+
   return new Proxy(local, {
     get(target, prop: string) {
       // Check local first
       if (prop in target) return target[prop];
 
-      // Run-local inputs are never shared via the cache
-      if (localOnlyKeys?.has(prop)) return undefined;
+      // Run-local inputs/state are never shared via the cache
+      if (isRunLocal(prop)) return undefined;
 
       // Then check shared cache
       const cached = cache.get(prop, candles);
@@ -110,7 +127,7 @@ export function createCachedIndicators(
     },
     set(target, prop: string, value) {
       target[prop] = value;
-      if (!localOnlyKeys?.has(prop)) {
+      if (!isRunLocal(prop)) {
         cache.set(prop, candles, value);
       }
       return true;


### PR DESCRIPTION
## Summary

The indicators proxy (`createCachedIndicators`) forwards writes to the shared `IndicatorCache` so that candle-derived series can be reused across backtests. Two things that are **not** pure functions of the candle array were being forwarded too, so a later run on the same candles + shared cache — exactly what `gridSearch` and walk-forward do — inherited the previous run's end state:

1. **`perfectOrderPullbackEntry` / `perfectOrderPullbackSellEntry` mutable state.** The conditions track `{hasConfirmedSinceBreakdown, lastProcessedIndex}` on the indicators object. Run 2 received run 1's end-of-run state: the rebuild loop was skipped (`lastProcessedIndex` already at the last bar) and the confirmation flag stayed frozen at its final value, producing phantom trades that a fresh-cache run does not have. Secondary: the state key only included `periods`, so two conditions differing in `maType`/`collapseEps`/etc. silently shared one state object even within a single run.
2. **Engine-injected fundamentals scalars.** `runBacktest` writes `indicators.per`/`indicators.pbr` per bar from the run's `fundamentals` option. A later run **without** fundamentals on the same cache read the previous run's last values on every bar, so `perBelow`-style conditions fired when they should see no data at all (a fresh-cache control run has 0 trades).

## Fix

Follows the existing run-local benchmark pattern:

- New internal convention in `createCachedIndicators`: keys prefixed with `__runLocal_` (`RUN_LOCAL_KEY_PREFIX`) never read from or write to the shared cache, in addition to the existing exact-name `localOnlyKeys` set. This gives conditions a sanctioned place for per-run mutable state.
- The po-pullback state keys use the prefix and derive from the full `cacheKey` parameter set (buy/sell suffixed separately, since they share a `cacheKey`).
- The engine declares `per`/`pbr` run-local via a new `ENGINE_RUN_LOCAL_KEYS` set — the engine owns those writes, so it owns the declaration.

## Test plan

- New `run-local-cache-state.test.ts` (3 tests):
  - After evaluating the pullback condition through a cache-backed proxy over 200 bars, `cache.size` is **1** (only the derived series is shared), and a second proxy run equals the no-cache ground truth.
  - Buy/sell variants and a different-`collapseEps` condition create **3** separate run-local state slots on one indicators object.
  - Fundamentals E2E: run with `fundamentals` (≥1 trade) → run without on the same cache → **0 trades**, identical to the fresh-cache control (parallel to the existing benchmark-leak test).
  - **All three fail on the previous implementation** (verified by stashing the fixes: 3/3 fail).
- Full verification: core **6329/6329** tests pass (357 files), `tsc --noEmit` clean, `pnpm build` OK, Biome clean.