### PR TITLE
fix(core): limit/stop order fills no longer use future or pre-trigger prices

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+### Fixed — limit/stop order fills no longer use future or pre-trigger prices
+
+- **Function-based order prices now resolve against the signal candle.**
+  `LimitPriceFunc`/`StopPriceFunc` are documented as deriving a level from the
+  entry-signal bar (e.g. `stopAboveHigh()` = break of the signal bar's high),
+  but the engine re-resolved them against every later fill-check bar. The
+  level drifted bar by bar and self-referenced the bar being tested —
+  `stopAboveHigh(0)` degenerated to `high >= high` and filled unconditionally,
+  even in a falling market; `limitBelowClose(1)` filled in rallies that never
+  touched the intended level. Prices are now frozen once at order creation
+  (new `freezeOrderPrices` helper, exported for direct `tryFillOrder` users).
+  All 10 price presets were affected; fixed numeric prices were always
+  correct.
+- **stopLimit orders no longer fill at the pre-trigger open on the bar that
+  activates them.** The order goes live intra-bar at the stop trigger, so on
+  the trigger bar it now fills at `max(stopPrice, open)` (long; mirrored for
+  short) when within the limit, or at the limit when the bar also trades
+  through it. Previously it fell straight into the resting-limit formula and
+  filled at the bar's open — a price from before the order existed. Fills on
+  later bars (already-activated orders) are unchanged.
+
+Backtests using function-based prices or same-bar stopLimit activations will
+report different (correct) entries; results previously carried a look-ahead
+advantage.
+
 ### Fixed — per-run state no longer leaks through a shared `IndicatorCache`
 
 - `perfectOrderPullbackEntry` / `perfectOrderPullbackSellEntry` kept a mutable

--- a/packages/core/src/backtest/__tests__/order-types.test.ts
+++ b/packages/core/src/backtest/__tests__/order-types.test.ts
@@ -18,6 +18,7 @@ import {
   stopBelowLow,
   tryFillOrder,
 } from "../order-types";
+import { at, never } from "./step-candles";
 
 const candle: NormalizedCandle = {
   time: 1000,
@@ -586,12 +587,6 @@ describe("runBacktest with function-based order prices", () => {
       close: c,
       volume: 1000,
     }) as NormalizedCandle;
-  const entryAt = (idx: number) => ({
-    type: "preset" as const,
-    name: `entryAt(${idx})`,
-    evaluate: (_i: Record<string, unknown>, _c: NormalizedCandle, index: number) => index === idx,
-  });
-  const never = { type: "preset" as const, name: "never", evaluate: () => false };
 
   it("stopAboveHigh(0) never fills in a falling market", () => {
     // Signal at bar 1 (high 100.4); every later high is lower, so a breakout
@@ -604,7 +599,7 @@ describe("runBacktest with function-based order prices", () => {
         return mk(2 + k, h - 1, h, h - 2, h - 1.5);
       }),
     ];
-    const result = runBacktest(candles, entryAt(1), never, {
+    const result = runBacktest(candles, at(1), never, {
       capital: 100000,
       orderType: { type: "stop", price: stopAboveHigh(0) },
     });
@@ -621,7 +616,7 @@ describe("runBacktest with function-based order prices", () => {
         return mk(2 + k, l + 1, l + 2, l, l + 1.5);
       }),
     ];
-    const result = runBacktest(candles, entryAt(1), never, {
+    const result = runBacktest(candles, at(1), never, {
       capital: 100000,
       orderType: { type: "limit", price: limitBelowClose(1) },
     });
@@ -637,7 +632,7 @@ describe("runBacktest with function-based order prices", () => {
       mk(3, 100, 101.5, 99.9, 101),
       mk(4, 101, 102, 100.5, 101.5),
     ];
-    const result = runBacktest(candles, entryAt(1), never, {
+    const result = runBacktest(candles, at(1), never, {
       capital: 100000,
       orderType: { type: "stop", price: stopAboveHigh(0) },
     });

--- a/packages/core/src/backtest/__tests__/order-types.test.ts
+++ b/packages/core/src/backtest/__tests__/order-types.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { NormalizedCandle } from "../../types";
+import { runBacktest } from "../engine";
 import type { PendingOrder } from "../order-types";
 import {
+  freezeOrderPrices,
   limitAboveClose,
   limitAtHigh,
   limitAtLow,
@@ -440,5 +442,206 @@ describe("tryFillOrder — TIF fillPriceOverride", () => {
     });
     const result = tryFillOrder(order, candle);
     expect(result).toEqual({ filled: true, fillPrice: 105 }); // candle.close
+  });
+});
+
+// ---------------------------------------------------------------------------
+// freezeOrderPrices — function prices resolve against the SIGNAL candle
+// ---------------------------------------------------------------------------
+
+describe("freezeOrderPrices", () => {
+  const signalCandle: NormalizedCandle = {
+    time: 500,
+    open: 99,
+    high: 100.4,
+    low: 98,
+    close: 100,
+    volume: 5000,
+  } as NormalizedCandle;
+
+  it("resolves stop/limit/stopLimit function prices to signal-candle numbers", () => {
+    const stop = freezeOrderPrices({ type: "stop", price: stopAboveHigh(0) }, signalCandle, 2);
+    expect(stop).toEqual({ type: "stop", price: 100.4 });
+
+    const limit = freezeOrderPrices({ type: "limit", price: limitBelowClose(1) }, signalCandle, 2);
+    expect(limit).toEqual({ type: "limit", price: 99 });
+
+    const stopLimit = freezeOrderPrices(
+      { type: "stopLimit", stopPrice: stopAboveHigh(0), limitPrice: (c) => c.high + 1 },
+      signalCandle,
+      2,
+    );
+    expect(stopLimit).toEqual({ type: "stopLimit", stopPrice: 100.4, limitPrice: 101.4 });
+  });
+
+  it("a frozen stopAboveHigh(0) order does NOT fill in a falling market", () => {
+    const frozen = freezeOrderPrices({ type: "stop", price: stopAboveHigh(0) }, signalCandle, 0);
+    const order = makePending({ orderType: frozen, direction: "long" });
+    // Every later bar stays below the signal high 100.4; an unfrozen function
+    // would degenerate to `high >= high` and fill on the first bar.
+    for (const high of [99.4, 98.4, 97.4]) {
+      const bar = { time: 2000, open: high - 1, high, low: high - 2, close: high - 1.5 };
+      expect(tryFillOrder(order, bar as NormalizedCandle)).toBeNull();
+    }
+    // A genuine later break of the frozen level fills at that level
+    const breakout = { time: 3000, open: 100, high: 101, low: 99.5, close: 100.8 };
+    expect(tryFillOrder(order, breakout as NormalizedCandle)).toEqual({
+      filled: true,
+      fillPrice: 100.4,
+    });
+  });
+
+  it("a frozen limitBelowClose(1) order does NOT fill in a rallying market", () => {
+    const frozen = freezeOrderPrices({ type: "limit", price: limitBelowClose(1) }, signalCandle, 0);
+    const order = makePending({ orderType: frozen, direction: "long" });
+    // Intended limit = signal close 100 * 0.99 = 99; price never dips there.
+    // An unfrozen function re-derived from each bar's close would fill.
+    for (const low of [100.1, 100.5, 101.2]) {
+      const bar = { time: 2000, open: low + 1, high: low + 2, low, close: low + 1.5 };
+      expect(tryFillOrder(order, bar as NormalizedCandle)).toBeNull();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tryFillOrder — stopLimit same-bar activation fill price
+// ---------------------------------------------------------------------------
+
+describe("tryFillOrder — stopLimit same-bar activation", () => {
+  const bar = (o: number, h: number, l: number, c: number): NormalizedCandle =>
+    ({ time: 1000, open: o, high: h, low: l, close: c, volume: 1000 }) as NormalizedCandle;
+
+  it("long: fills at the stop trigger, not the pre-trigger open", () => {
+    const order = makePending({
+      orderType: { type: "stopLimit", stopPrice: 105, limitPrice: 106 },
+      direction: "long",
+    });
+    // open 100 is pre-trigger price action; the order goes live at 105
+    const result = tryFillOrder(order, bar(100, 107, 99, 106));
+    expect(result).toEqual({ filled: true, fillPrice: 105 });
+  });
+
+  it("short: fills at the stop trigger, not the pre-trigger open", () => {
+    const order = makePending({
+      orderType: { type: "stopLimit", stopPrice: 95, limitPrice: 94 },
+      direction: "short",
+    });
+    const result = tryFillOrder(order, bar(100, 101, 93, 94));
+    expect(result).toEqual({ filled: true, fillPrice: 95 });
+  });
+
+  it("long gap through the stop: fills at the open (order live from the open)", () => {
+    const order = makePending({
+      orderType: { type: "stopLimit", stopPrice: 100, limitPrice: 106 },
+      direction: "long",
+    });
+    const result = tryFillOrder(order, bar(104, 107, 103, 105));
+    expect(result).toEqual({ filled: true, fillPrice: 104 });
+  });
+
+  it("long triggered above the limit: fills at the limit only if the bar trades down to it", () => {
+    const fills = makePending({
+      orderType: { type: "stopLimit", stopPrice: 101, limitPrice: 102 },
+      direction: "long",
+    });
+    // open 103 > limit 102 => not marketable at trigger; low 100 <= 102 => limit fill
+    expect(tryFillOrder(fills, bar(103, 104, 100, 101))).toEqual({
+      filled: true,
+      fillPrice: 102,
+    });
+
+    const stays = makePending({
+      orderType: { type: "stopLimit", stopPrice: 101, limitPrice: 102 },
+      direction: "long",
+    });
+    // low 102.5 never reaches the limit => activated but unfilled this bar
+    expect(tryFillOrder(stays, bar(103, 104, 102.5, 103.5))).toBeNull();
+    expect(stays.stopActivated).toBe(true);
+  });
+
+  it("later bars (already activated) still fill like a resting limit at the open", () => {
+    const order = makePending({
+      orderType: { type: "stopLimit", stopPrice: 105, limitPrice: 106 },
+      direction: "long",
+      stopActivated: true,
+    });
+    // Already live before this bar opened: open fill is legitimate
+    const result = tryFillOrder(order, bar(104, 106, 103, 105));
+    expect(result).toEqual({ filled: true, fillPrice: 104 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Engine integration — function prices resolve at signal time
+// ---------------------------------------------------------------------------
+
+describe("runBacktest with function-based order prices", () => {
+  const day = 86400000;
+  const mk = (i: number, o: number, h: number, l: number, c: number): NormalizedCandle =>
+    ({
+      time: 1700000000000 + i * day,
+      open: o,
+      high: h,
+      low: l,
+      close: c,
+      volume: 1000,
+    }) as NormalizedCandle;
+  const entryAt = (idx: number) => ({
+    type: "preset" as const,
+    name: `entryAt(${idx})`,
+    evaluate: (_i: Record<string, unknown>, _c: NormalizedCandle, index: number) => index === idx,
+  });
+  const never = { type: "preset" as const, name: "never", evaluate: () => false };
+
+  it("stopAboveHigh(0) never fills in a falling market", () => {
+    // Signal at bar 1 (high 100.4); every later high is lower, so a breakout
+    // stop above the signal high must never trigger.
+    const candles = [
+      mk(0, 100, 100.9, 99, 100.2),
+      mk(1, 100, 100.4, 99, 100),
+      ...Array.from({ length: 8 }, (_, k) => {
+        const h = 99.4 - k;
+        return mk(2 + k, h - 1, h, h - 2, h - 1.5);
+      }),
+    ];
+    const result = runBacktest(candles, entryAt(1), never, {
+      capital: 100000,
+      orderType: { type: "stop", price: stopAboveHigh(0) },
+    });
+    expect(result.trades.length).toBe(0);
+  });
+
+  it("limitBelowClose(1) never fills in a rallying market", () => {
+    // Signal close 100 => intended limit 99; later lows never dip below 100.
+    const candles = [
+      mk(0, 100, 101, 99.5, 100.2),
+      mk(1, 100, 101, 99.8, 100),
+      ...Array.from({ length: 8 }, (_, k) => {
+        const l = 100.1 + k;
+        return mk(2 + k, l + 1, l + 2, l, l + 1.5);
+      }),
+    ];
+    const result = runBacktest(candles, entryAt(1), never, {
+      capital: 100000,
+      orderType: { type: "limit", price: limitBelowClose(1) },
+    });
+    expect(result.trades.length).toBe(0);
+  });
+
+  it("a genuine later break of the signal-derived level fills at that level", () => {
+    // Signal high 100.4 at bar 1; bar 3 breaks above it.
+    const candles = [
+      mk(0, 100, 100.9, 99, 100.2),
+      mk(1, 100, 100.4, 99, 100),
+      mk(2, 99.5, 100.0, 99, 99.8),
+      mk(3, 100, 101.5, 99.9, 101),
+      mk(4, 101, 102, 100.5, 101.5),
+    ];
+    const result = runBacktest(candles, entryAt(1), never, {
+      capital: 100000,
+      orderType: { type: "stop", price: stopAboveHigh(0) },
+    });
+    expect(result.trades.length).toBe(1);
+    expect(result.trades[0].entryPrice).toBeCloseTo(100.4, 10);
   });
 });

--- a/packages/core/src/backtest/engine.ts
+++ b/packages/core/src/backtest/engine.ts
@@ -662,11 +662,9 @@ export function runBacktest(
           const tif = tifOpt ?? "gtc";
           const tifResolved = resolveTimeInForce(tif, orderTTL);
           pendingOrder = {
-            // Function-based prices describe a level derived from the signal
-            // bar, so they are resolved exactly once here; re-resolving on
-            // each fill-check bar would let the level drift and self-reference
-            // the bar being tested.
-            orderType: freezeOrderPrices(orderTypeOpt, candle, entryAtr ?? 0),
+            // Resolve function prices once against the signal bar — see
+            // freezeOrderPrices for why.
+            orderType: freezeOrderPrices(orderTypeOpt, candle, entryAtr),
             direction: dir,
             signalTime: candle.time,
             signalIndex: i,

--- a/packages/core/src/backtest/engine.ts
+++ b/packages/core/src/backtest/engine.ts
@@ -50,7 +50,7 @@ import {
   updateMarginState,
 } from "./margin";
 import type { PendingOrder } from "./order-types";
-import { resolveTimeInForce, tryFillOrder } from "./order-types";
+import { freezeOrderPrices, resolveTimeInForce, tryFillOrder } from "./order-types";
 import { calculateSizedShares } from "./sizing";
 import type { SlippageModel } from "./slippage-model";
 import { calculateDynamicSlippage, resolveSlippageModel } from "./slippage-model";
@@ -662,7 +662,11 @@ export function runBacktest(
           const tif = tifOpt ?? "gtc";
           const tifResolved = resolveTimeInForce(tif, orderTTL);
           pendingOrder = {
-            orderType: orderTypeOpt,
+            // Function-based prices describe a level derived from the signal
+            // bar, so they are resolved exactly once here; re-resolving on
+            // each fill-check bar would let the level drift and self-reference
+            // the bar being tested.
+            orderType: freezeOrderPrices(orderTypeOpt, candle, entryAtr ?? 0),
             direction: dir,
             signalTime: candle.time,
             signalIndex: i,

--- a/packages/core/src/backtest/index.ts
+++ b/packages/core/src/backtest/index.ts
@@ -225,6 +225,7 @@ export type {
 
 // Order Types (Limit/Stop)
 export {
+  freezeOrderPrices,
   limitAboveClose,
   limitAtHigh,
   limitAtLow,

--- a/packages/core/src/backtest/order-types.ts
+++ b/packages/core/src/backtest/order-types.ts
@@ -388,6 +388,48 @@ export function resolvePrice(
 }
 
 // ---------------------------------------------------------------------------
+// freezeOrderPrices
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve any function-based prices of an order against the signal candle,
+ * returning an order whose prices are concrete numbers.
+ *
+ * Price functions are documented as `(entryCandle, atr)` — they describe a
+ * level derived from the SIGNAL bar (e.g. `stopAboveHigh()` = break of the
+ * signal bar's high). They must therefore be resolved exactly once, when the
+ * pending order is created. Re-resolving against each later fill-check bar
+ * would let the level drift bar by bar and self-reference the very bar being
+ * tested — `stopAboveHigh(0)` would degenerate to `high >= high`, filling
+ * unconditionally even in a falling market.
+ *
+ * @param orderType - The order whose prices may be functions.
+ * @param signalCandle - The candle that generated the entry signal.
+ * @param atr - ATR value at signal time (passed to price functions).
+ * @returns An equivalent order with all prices resolved to numbers.
+ */
+export function freezeOrderPrices(
+  orderType: OrderType,
+  signalCandle: NormalizedCandle,
+  atr: number,
+): OrderType {
+  switch (orderType.type) {
+    case "market":
+      return orderType;
+    case "limit":
+      return { type: "limit", price: resolvePrice(orderType.price, signalCandle, atr) };
+    case "stop":
+      return { type: "stop", price: resolvePrice(orderType.price, signalCandle, atr) };
+    case "stopLimit":
+      return {
+        type: "stopLimit",
+        stopPrice: resolvePrice(orderType.stopPrice, signalCandle, atr),
+        limitPrice: resolvePrice(orderType.limitPrice, signalCandle, atr),
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
 // tryFillOrder
 // ---------------------------------------------------------------------------
 
@@ -404,9 +446,15 @@ export function resolvePrice(
  * - **stop (long)** — fills when `candle.high >= stopPrice` at `max(stopPrice, candle.open)`.
  * - **stop (short)** — fills when `candle.low <= stopPrice` at `min(stopPrice, candle.open)`.
  * - **stopLimit** — first the stop must trigger (same logic as a stop order), then the limit
- *   condition is checked. If both conditions are met on the same candle the order fills
- *   immediately. The `stopActivated` flag on the order is mutated to `true` when the stop
- *   triggers.
+ *   condition is checked. On the trigger bar itself the order goes live intra-bar, so it
+ *   fills at `max(stopPrice, open)` (long; mirror for short) when that is within the limit,
+ *   or at the limit price when the bar also trades through it — never at the pre-trigger
+ *   open. On later bars it fills like a resting limit order. The `stopActivated` flag on
+ *   the order is mutated to `true` when the stop triggers.
+ *
+ * Function-based prices must be resolved against the SIGNAL candle before the order starts
+ * being tested (see {@link freezeOrderPrices} — the engine does this at order creation).
+ * Passing an unresolved function here would re-derive the level from every fill-check bar.
  *
  * @param order - The pending order to evaluate.
  * @param candle - The current candle to test against.
@@ -477,6 +525,7 @@ export function tryFillOrder(order: PendingOrder, candle: NormalizedCandle): Fil
       const limitPrice = resolvePrice(orderType.limitPrice, candle, atr);
 
       // Phase 1: check if stop is triggered (or was already activated)
+      let activatedThisBar = false;
       if (!order.stopActivated) {
         let stopTriggered = false;
         if (direction === "long") {
@@ -491,14 +540,43 @@ export function tryFillOrder(order: PendingOrder, candle: NormalizedCandle): Fil
 
         // Mutate the order to mark stop as activated
         order.stopActivated = true;
+        activatedThisBar = true;
       }
 
-      // Phase 2: check limit condition
+      // Phase 2: check limit condition.
+      //
+      // On the trigger bar the order goes live intra-bar at the stop price
+      // (or at the open when the bar gapped through the stop) — NOT at the
+      // open, which is pre-trigger price action. The earliest tradable price
+      // is therefore the trigger itself; fill-at-open is only legitimate on
+      // later bars where the order was already resting as a live limit.
       if (direction === "long") {
+        if (activatedThisBar) {
+          const trigger = Math.max(stopPrice, candle.open);
+          if (trigger <= limitPrice) {
+            return { filled: true, fillPrice: trigger };
+          }
+          // Triggered above the limit: the order rests as a limit; fill only
+          // if the bar also trades down to it (modeled via the bar low).
+          if (candle.low <= limitPrice) {
+            return { filled: true, fillPrice: limitPrice };
+          }
+          return null;
+        }
         if (candle.low <= limitPrice) {
           return { filled: true, fillPrice: Math.min(limitPrice, candle.open) };
         }
       } else {
+        if (activatedThisBar) {
+          const trigger = Math.min(stopPrice, candle.open);
+          if (trigger >= limitPrice) {
+            return { filled: true, fillPrice: trigger };
+          }
+          if (candle.high >= limitPrice) {
+            return { filled: true, fillPrice: limitPrice };
+          }
+          return null;
+        }
         if (candle.high >= limitPrice) {
           return { filled: true, fillPrice: Math.max(limitPrice, candle.open) };
         }

--- a/packages/core/src/backtest/order-types.ts
+++ b/packages/core/src/backtest/order-types.ts
@@ -339,7 +339,11 @@ export type PendingOrder = {
   signalTime: number;
   /** Index of the signal candle in the data array. */
   signalIndex: number;
-  /** ATR value at signal time (used to resolve price functions). `null` if ATR is unavailable. */
+  /**
+   * ATR value at signal time. Passed to price functions when the order is
+   * created (see {@link freezeOrderPrices}) and used for ATR-based stop
+   * sizing after the fill. `null` if ATR is unavailable.
+   */
   entryAtr: number | null;
   /** Number of bars the order remains active before expiring. Decremented each bar. */
   barsRemaining: number;
@@ -369,7 +373,8 @@ export type FillResult = {
  * Resolve a static or function-based price to a concrete number.
  *
  * @param price - A fixed number or a function `(candle, atr) => number`.
- * @param candle - The current candle used when `price` is a function.
+ * @param candle - The candle the price function derives its level from — for
+ *   order prices this must be the SIGNAL candle (see {@link freezeOrderPrices}).
  * @param atr - The ATR value passed to the price function.
  * @returns The resolved numeric price.
  *
@@ -405,26 +410,28 @@ export function resolvePrice(
  *
  * @param orderType - The order whose prices may be functions.
  * @param signalCandle - The candle that generated the entry signal.
- * @param atr - ATR value at signal time (passed to price functions).
+ * @param atr - ATR value at signal time, or `null` when unavailable (price
+ *   functions then receive `0` — this fallback is owned here).
  * @returns An equivalent order with all prices resolved to numbers.
  */
 export function freezeOrderPrices(
   orderType: OrderType,
   signalCandle: NormalizedCandle,
-  atr: number,
+  atr: number | null,
 ): OrderType {
+  const resolvedAtr = atr ?? 0;
   switch (orderType.type) {
     case "market":
       return orderType;
     case "limit":
-      return { type: "limit", price: resolvePrice(orderType.price, signalCandle, atr) };
+      return { type: "limit", price: resolvePrice(orderType.price, signalCandle, resolvedAtr) };
     case "stop":
-      return { type: "stop", price: resolvePrice(orderType.price, signalCandle, atr) };
+      return { type: "stop", price: resolvePrice(orderType.price, signalCandle, resolvedAtr) };
     case "stopLimit":
       return {
         type: "stopLimit",
-        stopPrice: resolvePrice(orderType.stopPrice, signalCandle, atr),
-        limitPrice: resolvePrice(orderType.limitPrice, signalCandle, atr),
+        stopPrice: resolvePrice(orderType.stopPrice, signalCandle, resolvedAtr),
+        limitPrice: resolvePrice(orderType.limitPrice, signalCandle, resolvedAtr),
       };
   }
 }
@@ -452,9 +459,8 @@ export function freezeOrderPrices(
  *   open. On later bars it fills like a resting limit order. The `stopActivated` flag on
  *   the order is mutated to `true` when the stop triggers.
  *
- * Function-based prices must be resolved against the SIGNAL candle before the order starts
- * being tested (see {@link freezeOrderPrices} — the engine does this at order creation).
- * Passing an unresolved function here would re-derive the level from every fill-check bar.
+ * Function-based prices must be resolved against the signal candle before the order starts
+ * being tested — see {@link freezeOrderPrices} (the engine does this at order creation).
  *
  * @param order - The pending order to evaluate.
  * @param candle - The current candle to test against.
@@ -468,6 +474,16 @@ export function freezeOrderPrices(
  * }
  * ```
  */
+/**
+ * Earliest tradable price on the bar that triggers a stop: the stop price
+ * itself, or the open when the bar gapped through the stop (the order is
+ * live from the open in that case). Shared by the `stop` fill and the
+ * `stopLimit` trigger-bar fill so the policy has a single owner.
+ */
+function stopTriggerPrice(direction: PositionDirection, stopPrice: number, open: number): number {
+  return direction === "long" ? Math.max(stopPrice, open) : Math.min(stopPrice, open);
+}
+
 export function tryFillOrder(order: PendingOrder, candle: NormalizedCandle): FillResult | null {
   // Handle fill-price overrides from TIF (opg/cls)
   if (order.fillPriceOverride === "open") {
@@ -508,12 +524,12 @@ export function tryFillOrder(order: PendingOrder, candle: NormalizedCandle): Fil
       if (direction === "long") {
         // Breakout buy above stopPrice
         if (candle.high >= stopPrice) {
-          return { filled: true, fillPrice: Math.max(stopPrice, candle.open) };
+          return { filled: true, fillPrice: stopTriggerPrice("long", stopPrice, candle.open) };
         }
       } else {
         // Breakdown sell below stopPrice
         if (candle.low <= stopPrice) {
-          return { filled: true, fillPrice: Math.min(stopPrice, candle.open) };
+          return { filled: true, fillPrice: stopTriggerPrice("short", stopPrice, candle.open) };
         }
       }
       return null;
@@ -543,42 +559,22 @@ export function tryFillOrder(order: PendingOrder, candle: NormalizedCandle): Fil
         activatedThisBar = true;
       }
 
-      // Phase 2: check limit condition.
-      //
-      // On the trigger bar the order goes live intra-bar at the stop price
-      // (or at the open when the bar gapped through the stop) — NOT at the
-      // open, which is pre-trigger price action. The earliest tradable price
-      // is therefore the trigger itself; fill-at-open is only legitimate on
-      // later bars where the order was already resting as a live limit.
+      // Phase 2: fill like a resting limit, except that on the trigger bar
+      // the earliest tradable price is the stop trigger, not the open (which
+      // is pre-trigger price action).
       if (direction === "long") {
-        if (activatedThisBar) {
-          const trigger = Math.max(stopPrice, candle.open);
-          if (trigger <= limitPrice) {
-            return { filled: true, fillPrice: trigger };
-          }
-          // Triggered above the limit: the order rests as a limit; fill only
-          // if the bar also trades down to it (modeled via the bar low).
-          if (candle.low <= limitPrice) {
-            return { filled: true, fillPrice: limitPrice };
-          }
-          return null;
-        }
+        const ref = activatedThisBar
+          ? stopTriggerPrice("long", stopPrice, candle.open)
+          : candle.open;
         if (candle.low <= limitPrice) {
-          return { filled: true, fillPrice: Math.min(limitPrice, candle.open) };
+          return { filled: true, fillPrice: Math.min(limitPrice, ref) };
         }
       } else {
-        if (activatedThisBar) {
-          const trigger = Math.min(stopPrice, candle.open);
-          if (trigger >= limitPrice) {
-            return { filled: true, fillPrice: trigger };
-          }
-          if (candle.high >= limitPrice) {
-            return { filled: true, fillPrice: limitPrice };
-          }
-          return null;
-        }
+        const ref = activatedThisBar
+          ? stopTriggerPrice("short", stopPrice, candle.open)
+          : candle.open;
         if (candle.high >= limitPrice) {
-          return { filled: true, fillPrice: Math.max(limitPrice, candle.open) };
+          return { filled: true, fillPrice: Math.max(limitPrice, ref) };
         }
       }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1180,6 +1180,7 @@ export {
   calculateDynamicSlippage,
   checkMarginCall,
   createMarginState,
+  freezeOrderPrices,
   limitAboveClose,
   limitAtHigh,
   limitAtLow,


### PR DESCRIPTION
## Summary

Two information leaks in the pending-order fill path gave backtests entry prices that were not obtainable at fill time.

### 1. Function-based order prices resolved against the wrong candle

`LimitPriceFunc` / `StopPriceFunc` are documented as `(entryCandle, atr)` — a level derived from the **signal** bar (e.g. `stopAboveHigh()` = break of the signal bar's high). But `tryFillOrder` re-resolved them against every later fill-check bar, so the level drifted bar by bar and self-referenced the very bar being tested:

- `stopAboveHigh(0)` degenerated to `candle.high >= candle.high` — a "breakout confirmation" order filled unconditionally on the next bar, **even in a strictly falling market** (repro: signal high 100.4, every later high lower → 1 phantom trade at that bar's own high; expected 0).
- `limitBelowClose(1)` (intended limit: signal close −1%) filled in rallies whose lows never came near the intended level, at a price re-derived from the current bar's close.

All 10 exported price presets were affected; fixed numeric prices were always correct (`PendingOrder` freezing `entryAtr` but not the signal candle shows signal-time resolution was the intent). Prices are now resolved **once at pending-order creation** via a new exported `freezeOrderPrices(orderType, signalCandle, atr)` helper; `tryFillOrder` only ever sees concrete numbers from the engine.

### 2. stopLimit same-bar activation filled at the pre-trigger open

When the stop triggered and the limit was satisfiable on the same candle, the code fell straight into the resting-limit formula `min(limitPrice, open)` — but the order was not live at the open. Long `stop=105/limit=106` against `{open:100, high:107, low:99}` filled at **100**; the legitimate range is `[105, 106]`. The trigger bar now fills at `max(stopPrice, open)` (long; mirrored for short) when within the limit, at the limit when the bar also trades through it, or stays activated and unfilled. Later-bar fills (already-activated orders) are unchanged.

## Test plan

- 11 new tests: freeze semantics for all order shapes; falling-market stop and rallying-market limit at both `tryFillOrder` and `runBacktest` level (0 trades, plus a genuine-breakout control filling exactly at the frozen level); same-bar trigger fills long/short; gap-through-stop; triggered-above-limit (limit fill and stay-activated cases); already-activated later-bar control.
- **8 of the 11 fail on the previous implementation** (verified by stashing the fix); the other 3 pin behavior that must not change.
- Existing stopLimit tests pass unchanged — their configurations converge to the same fill prices under the corrected semantics.
- Full verification: core **6340/6340** tests (357 files), chart **934/934**, mcp **83/83**, `tsc --noEmit` clean, `pnpm build` OK, Biome clean.

## Behavior note

Backtests using function-based order prices or same-bar stopLimit activations will report different (correct) entries — previous results carried a look-ahead advantage.