### PR TITLE
fix(core): mid-bar fills no longer monetize pre-fill price action

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+### Fixed — mid-bar fills no longer monetize pre-fill price action
+
+When a pending limit/stop order filled mid-bar, the new position's
+peak/trough were seeded from the fill bar's full high/low, and same-bar
+stop/take-profit/trailing checks ran against the whole bar — including price
+action from before the order filled. A limit buy at 90 on a bar that spiked
+to 110 first could exit the same bar via "trailing" at 104.5 (a price the
+position never owned) and report an MFE of 22% instead of the real 5.6%.
+Now:
+
+- Peak/trough seed from the fill price.
+- On the fill bar, position management only uses post-fill knowledge (the
+  fill price and the close): profit-side triggers cap at
+  `max(fillPrice, close)`, stop-side at `min(fillPrice, close)`, and the
+  close is folded into peak/trough history only after the fill bar's checks
+  (the known path is fill → close, so the close is not a peak the entry
+  price then appears to dip below).
+- From the next bar on, management is unchanged. Next-bar-open entries are
+  unaffected (an open fill owns the whole bar). Exit-signal conditions still
+  evaluate against the real candle — market data is not altered, only the
+  position's price knowledge.
+
+Backtests entering via limit/stop orders on wide bars will report different
+(correct) same-bar exits and lower, honest MFE values.
+
 ### Fixed — limit/stop order fills no longer use future or pre-trigger prices
 
 - **Function-based order prices now resolve against the signal candle.**

--- a/packages/core/src/backtest/__tests__/exit-reason.test.ts
+++ b/packages/core/src/backtest/__tests__/exit-reason.test.ts
@@ -16,21 +16,7 @@
 import { describe, expect, it } from "vitest";
 import type { NormalizedCandle } from "../../types";
 import { runBacktest } from "../engine";
-
-// Helper to create candles
-const makeCandles = (
-  data: Array<{ o: number; h: number; l: number; c: number }>,
-  startTime = 1700000000000,
-  intervalMs = 86400000,
-): NormalizedCandle[] =>
-  data.map((d, i) => ({
-    time: startTime + i * intervalMs,
-    open: d.o,
-    high: d.h,
-    low: d.l,
-    close: d.c,
-    volume: 1000,
-  }));
+import { makeCandles } from "./step-candles";
 
 // Always true condition (for entry)
 const alwaysTrue = () => true;

--- a/packages/core/src/backtest/__tests__/fill-bar-management.test.ts
+++ b/packages/core/src/backtest/__tests__/fill-bar-management.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Fill-bar position management must not use pre-fill price action.
+ *
+ * When a pending limit/stop order fills mid-bar, the fill bar's high/low
+ * include price action from BEFORE the order filled — a position opened at
+ * 90 on a bar that spiked to 110 first never owned that spike. Peak/trough
+ * seeding and same-bar stop/TP/trailing checks must only use post-fill
+ * knowledge (the fill price and the close); otherwise a single wide fill
+ * bar manufactures profitable same-bar exits and inflated MFE.
+ *
+ * Scenario (all tests): signal at bar 1, limit buy at 90; bar 2
+ * {open 100, high 110, low 89, close 95} fills the order at 90.
+ * Post-fill price never exceeds 95, so no profit-side trigger above 95 may
+ * fire, and MFE is at most (95-90)/90 = 5.56%.
+ */
+import { describe, expect, it } from "vitest";
+import { runBacktest } from "../engine";
+import { at, makeCandles, never } from "./step-candles";
+
+const candles = makeCandles([
+  { o: 100, h: 100, l: 100, c: 100 },
+  { o: 100, h: 100, l: 100, c: 100 }, // signal bar
+  // Fill bar: the pre-fill spike to 110 is price action the position never
+  // owned; the low 89 fills the limit 90.
+  { o: 100, h: 110, l: 89, c: 95 },
+  { o: 95, h: 95, l: 95, c: 95 },
+  { o: 95, h: 95, l: 95, c: 95 },
+]);
+
+const base = {
+  capital: 100000,
+  orderType: { type: "limit" as const, price: 90 },
+};
+
+describe("fill-bar position management (mid-bar fills)", () => {
+  it("trailing stop (intraday) does not exit on the fill bar from the pre-fill peak", () => {
+    const result = runBacktest(candles, at(1), never, {
+      ...base,
+      trailingStop: 5,
+      slTpMode: "intraday",
+    });
+    expect(result.trades.length).toBe(1);
+    const trade = result.trades[0];
+    expect(trade.entryPrice).toBeCloseTo(90, 10);
+    // Pre-fix: same-bar 'trailing' exit at 104.5 (= 110 * 0.95, a price the
+    // position never saw). Post-fill path (90..95) never touches the trail.
+    expect(trade.exitReason).toBe("endOfData");
+    expect(trade.exitPrice).toBeCloseTo(95, 10);
+  });
+
+  it("take profit (intraday) does not trigger from the pre-fill high", () => {
+    const result = runBacktest(candles, at(1), never, {
+      ...base,
+      takeProfit: 10,
+      slTpMode: "intraday",
+    });
+    expect(result.trades.length).toBe(1);
+    // Pre-fix: TP 99 (= 90 * 1.10) 'triggered' by the pre-fill high 110.
+    // Post-fill prices (90..95) never reach 99.
+    expect(result.trades[0].exitReason).toBe("endOfData");
+  });
+
+  it("trailing stop (close-only) is not armed by the pre-fill peak either", () => {
+    const result = runBacktest(candles, at(1), never, {
+      ...base,
+      trailingStop: 5,
+      slTpMode: "close-only",
+    });
+    expect(result.trades.length).toBe(1);
+    // Pre-fix: peak seeded at 110 -> trail 104.5; every later close (95) is
+    // below it, so the position exits immediately on the next bar. Correct
+    // peak is 95 -> trail 90.25, never touched.
+    expect(result.trades[0].exitReason).toBe("endOfData");
+  });
+
+  it("MFE reflects only post-fill price action", () => {
+    const result = runBacktest(candles, at(1), never, { ...base });
+    expect(result.trades.length).toBe(1);
+    // Pre-fix: mfe 22.22% from the pre-fill high 110. Post-fill max profit
+    // is (95-90)/90 = 5.56%.
+    expect(result.trades[0].mfe ?? 0).toBeLessThanOrEqual(5.56);
+  });
+
+  it("next-bar-open entries still use the full bar (fill at open owns the whole bar)", () => {
+    // Same shape but entered via next-bar-open (no orderType): fill at bar-2
+    // open 100; the whole bar is post-fill, so intraday TP may legitimately
+    // trigger from the bar's high.
+    const result = runBacktest(candles, at(1), never, {
+      capital: 100000,
+      takeProfit: 5,
+      slTpMode: "intraday",
+    });
+    expect(result.trades.length).toBe(1);
+    expect(result.trades[0].exitReason).toBe("takeProfit");
+  });
+});

--- a/packages/core/src/backtest/__tests__/mfe-mae.test.ts
+++ b/packages/core/src/backtest/__tests__/mfe-mae.test.ts
@@ -10,21 +10,7 @@
 import { describe, expect, it } from "vitest";
 import type { NormalizedCandle } from "../../types";
 import { runBacktest } from "../engine";
-
-// Helper to create candles
-const makeCandles = (
-  data: Array<{ o: number; h: number; l: number; c: number }>,
-  startTime = 1700000000000,
-  intervalMs = 86400000,
-): NormalizedCandle[] =>
-  data.map((d, i) => ({
-    time: startTime + i * intervalMs,
-    open: d.o,
-    high: d.h,
-    low: d.l,
-    close: d.c,
-    volume: 1000,
-  }));
+import { makeCandles } from "./step-candles";
 
 // Always false condition (for exit)
 const alwaysFalse = () => false;

--- a/packages/core/src/backtest/__tests__/step-candles.ts
+++ b/packages/core/src/backtest/__tests__/step-candles.ts
@@ -39,3 +39,21 @@ export const at =
 
 /** Condition that never fires */
 export const never: ConditionFn = () => false;
+
+/**
+ * Precise-OHLC candle builder for tests that need exact bar shapes
+ * (stepCandles only produces flat open=close bars with a fixed ±1 band).
+ */
+export const makeCandles = (
+  data: Array<{ o: number; h: number; l: number; c: number }>,
+  startTime = 1700000000000,
+  intervalMs = 86400000,
+): NormalizedCandle[] =>
+  data.map((d, i) => ({
+    time: startTime + i * intervalMs,
+    open: d.o,
+    high: d.h,
+    low: d.l,
+    close: d.c,
+    volume: 1000,
+  }));

--- a/packages/core/src/backtest/engine-utils.ts
+++ b/packages/core/src/backtest/engine-utils.ts
@@ -180,6 +180,30 @@ export function checkProfitTrigger(
 }
 
 /**
+ * Clamp a fill bar to the position's post-fill price knowledge.
+ *
+ * When an order fills mid-bar, the bar's full high/low include price action
+ * from BEFORE the fill — a path the position never owned. The only knowable
+ * post-fill prices are the fill itself and the close, so same-bar position
+ * management (stop/TP/trailing checks, peak/trough, MFE/MAE) must run
+ * against this clamped view. The open is set to the fill price so the
+ * synthetic bar stays self-consistent (open within [low, high]).
+ *
+ * From the next bar on, the whole bar is post-fill and no clamp applies.
+ */
+export function clampCandleToPostFill(
+  fillPrice: number,
+  candle: NormalizedCandle,
+): NormalizedCandle {
+  return {
+    ...candle,
+    open: fillPrice,
+    high: Math.max(fillPrice, candle.close),
+    low: Math.min(fillPrice, candle.close),
+  };
+}
+
+/**
  * Check stop loss trigger with direction awareness
  * For long: price drops to stop level (same as checkStopTrigger)
  * For short: price rises to stop level

--- a/packages/core/src/backtest/engine.ts
+++ b/packages/core/src/backtest/engine.ts
@@ -36,6 +36,7 @@ import {
   calculateTradeClose,
   checkProfitTriggerDirectional,
   checkStopTriggerDirectional,
+  clampCandleToPostFill,
   emptyResult,
   MS_PER_DAY,
 } from "./engine-utils";
@@ -361,6 +362,22 @@ export function runBacktest(
   /**
    * Update MFE/MAE for direction
    */
+  /**
+   * Fold a bar's extremes into the position: peak/trough (the trailing-stop
+   * anchors) plus MFE/MAE. Single owner — the fill-bar path calls this after
+   * the exit checks instead of before, and the two call sites must apply the
+   * exact same update.
+   */
+  function foldBarIntoPosition(pos: Position, bar: NormalizedCandle): void {
+    if (bar.high > pos.peakPrice) {
+      pos.peakPrice = bar.high;
+    }
+    if (bar.low < pos.troughPrice) {
+      pos.troughPrice = bar.low;
+    }
+    updateMfeMae(pos, bar);
+  }
+
   function updateMfeMae(pos: Position, candle: NormalizedCandle): void {
     if (isShort) {
       // Short: profit when price drops, loss when price rises
@@ -553,6 +570,9 @@ export function runBacktest(
   }
 
   for (let i = 1; i < candles.length; i++) {
+    // True only on a bar where a pending order filled mid-bar; same-bar
+    // management then runs against a clamped view (see mgmtCandle below).
+    let filledMidBarThisBar = false;
     const candle = candles[i];
 
     // Update MTF indices for this candle
@@ -578,18 +598,21 @@ export function runBacktest(
         if (fillResult) {
           const currentSlip = getSlippage(candle, i);
           const fillPrice = applySlippage(fillResult.fillPrice, currentSlip, entrySide);
+          // Seed peak/trough from the fill price; same-bar management is
+          // clamped to post-fill knowledge (see clampCandleToPostFill).
           const opened = openPositionFromEntry(
             fillPrice,
             candle.time,
             pendingOrder.entryAtr,
-            candle.high,
-            candle.low,
+            fillPrice,
+            fillPrice,
             candle,
             i,
             pendingOrder.allowPartialFill,
           );
           if (opened) {
             position = opened;
+            filledMidBarThisBar = true;
           }
           pendingOrder = null;
         }
@@ -700,16 +723,22 @@ export function runBacktest(
     } else if (position !== null && pendingExit === null) {
       // === Position management ===
 
-      // Update peak/trough prices
-      if (candle.high > position.peakPrice) {
-        position.peakPrice = candle.high;
-      }
-      if (candle.low < position.troughPrice) {
-        position.troughPrice = candle.low;
-      }
+      // On a mid-bar fill bar, manage against post-fill knowledge only (see
+      // clampCandleToPostFill). Exit-signal condition evaluation below still
+      // sees the real candle — market data is not clamped, only the
+      // position's price knowledge is.
+      const mgmtCandle: NormalizedCandle = filledMidBarThisBar
+        ? clampCandleToPostFill(position.entryPrice, candle)
+        : candle;
 
-      // Track MFE/MAE
-      updateMfeMae(position, candle);
+      // Update peak/trough and MFE/MAE. On the fill bar this is DEFERRED
+      // until after the exit checks: the only known post-fill path is
+      // fill → close, so the close must not become a "peak" that the fill
+      // price then appears to dip below — that would fire trailing stops on
+      // the entry itself.
+      if (!filledMidBarThisBar) {
+        foldBarIntoPosition(position, mgmtCandle);
+      }
 
       let shouldExit = false;
       let exitPrice = candle.close;
@@ -784,7 +813,7 @@ export function runBacktest(
       // === Stop Loss Check ===
       if (stopLoss !== undefined) {
         const stopLossPrice = calcStopLossPrice(position.entryPrice, stopLoss);
-        const triggered = checkStopTriggerDirectional(candle, stopLossPrice, slTpMode, dir);
+        const triggered = checkStopTriggerDirectional(mgmtCandle, stopLossPrice, slTpMode, dir);
         if (triggered) {
           shouldExit = true;
           exitPrice = triggered.price;
@@ -799,7 +828,7 @@ export function runBacktest(
           currentAtr,
           atrRisk.atrStopMultiplier,
         );
-        const triggered = checkStopTriggerDirectional(candle, atrStopPrice, slTpMode, dir);
+        const triggered = checkStopTriggerDirectional(mgmtCandle, atrStopPrice, slTpMode, dir);
         if (triggered) {
           shouldExit = true;
           exitPrice = triggered.price;
@@ -810,7 +839,7 @@ export function runBacktest(
       // === Take Profit Check ===
       if (!shouldExit && takeProfit !== undefined) {
         const takeProfitPrice = calcTakeProfitPrice(position.entryPrice, takeProfit);
-        const triggered = checkProfitTriggerDirectional(candle, takeProfitPrice, slTpMode, dir);
+        const triggered = checkProfitTriggerDirectional(mgmtCandle, takeProfitPrice, slTpMode, dir);
         if (triggered) {
           shouldExit = true;
           exitPrice = triggered.price;
@@ -825,7 +854,7 @@ export function runBacktest(
           currentAtr,
           atrRisk.atrTakeProfitMultiplier,
         );
-        const triggered = checkProfitTriggerDirectional(candle, atrTpPrice, slTpMode, dir);
+        const triggered = checkProfitTriggerDirectional(mgmtCandle, atrTpPrice, slTpMode, dir);
         if (triggered) {
           shouldExit = true;
           exitPrice = triggered.price;
@@ -840,7 +869,7 @@ export function runBacktest(
           partialTakeProfit.threshold,
         );
         const partialTrigger = checkProfitTriggerDirectional(
-          candle,
+          mgmtCandle,
           partialThresholdPrice,
           slTpMode,
           dir,
@@ -884,7 +913,7 @@ export function runBacktest(
           const level = scaleOut.levels[levelIndex];
           const scaleOutThresholdPrice = calcTakeProfitPrice(position.entryPrice, level.threshold);
           const scaleOutTrigger = checkProfitTriggerDirectional(
-            candle,
+            mgmtCandle,
             scaleOutThresholdPrice,
             slTpMode,
             dir,
@@ -948,7 +977,7 @@ export function runBacktest(
         // Activate breakeven if threshold is reached
         if (!position.breakevenActivated) {
           const triggered = checkProfitTriggerDirectional(
-            candle,
+            mgmtCandle,
             breakevenThresholdPrice,
             slTpMode,
             dir,
@@ -960,7 +989,12 @@ export function runBacktest(
 
         // Check breakeven stop if activated
         if (position.breakevenActivated) {
-          const triggered = checkStopTriggerDirectional(candle, breakevenStopPrice, slTpMode, dir);
+          const triggered = checkStopTriggerDirectional(
+            mgmtCandle,
+            breakevenStopPrice,
+            slTpMode,
+            dir,
+          );
           if (triggered) {
             shouldExit = true;
             exitPrice = triggered.price;
@@ -972,7 +1006,7 @@ export function runBacktest(
       // Trailing stop check (fixed percentage)
       if (!shouldExit && trailingStop !== undefined) {
         const trailingStopPrice = calcTrailingStopPrice(position, trailingStop);
-        const triggered = checkStopTriggerDirectional(candle, trailingStopPrice, slTpMode, dir);
+        const triggered = checkStopTriggerDirectional(mgmtCandle, trailingStopPrice, slTpMode, dir);
         if (triggered) {
           shouldExit = true;
           exitPrice = triggered.price;
@@ -987,7 +1021,7 @@ export function runBacktest(
           currentAtr,
           atrRisk.atrTrailingMultiplier,
         );
-        const triggered = checkStopTriggerDirectional(candle, atrTrailPrice, slTpMode, dir);
+        const triggered = checkStopTriggerDirectional(mgmtCandle, atrTrailPrice, slTpMode, dir);
         if (triggered) {
           shouldExit = true;
           exitPrice = triggered.price;
@@ -1000,7 +1034,7 @@ export function runBacktest(
         const atrValue = atrSeries[i]?.value;
         if (atrValue !== null && atrValue !== undefined) {
           const atrTrailPrice = calcAtrTrailPrice(position, atrValue, atrTrailingStop.multiplier);
-          const triggered = checkStopTriggerDirectional(candle, atrTrailPrice, slTpMode, dir);
+          const triggered = checkStopTriggerDirectional(mgmtCandle, atrTrailPrice, slTpMode, dir);
           if (triggered) {
             shouldExit = true;
             exitPrice = triggered.price;
@@ -1079,6 +1113,13 @@ export function runBacktest(
             exitReason,
           };
         }
+      }
+
+      // Deferred fill-bar fold (see the comment at the top of this block):
+      // the clamped fill bar enters the position's history only after the
+      // fill bar's checks, so later bars also trail from its close.
+      if (filledMidBarThisBar && position !== null) {
+        foldBarIntoPosition(position, mgmtCandle);
       }
     }
     equityCurve[i] = markToMarketEquity(candle.close);


### PR DESCRIPTION
## Summary

When a pending limit/stop order fills mid-bar, the engine seeded the new position's peak/trough from the fill bar's **full high/low** and ran same-bar stop/take-profit/trailing checks against the whole bar — including price action from **before the order filled**.

Repro: limit buy at 90; the fill bar is `{open 100, high 110, low 89, close 95}` (the spike to 110 happens before the dip that fills the order). Previously:

- `trailingStop: 5` (intraday) exited the **same bar** at 104.5 — a trail level derived from the pre-fill peak 110, at a price the position never owned — reporting +16.1% on a trade whose post-fill path never exceeded 95.
- `takeProfit: 10` "triggered" at 99 off the pre-fill high.
- `trailingStop: 5` (close-only) armed the 104.5 trail from the phantom peak, so every subsequent close exited immediately.
- `Trade.mfe` reported 22.2% instead of the real maximum of 5.6%.

## Fix

Principle: **a position's management only ever sees the price path it owned since fill.**

- Peak/trough seed from the fill price (the engine's own same-bar-close entry path already did this).
- On the fill bar, management runs against a clamped view of the bar — the only post-fill knowledge is the fill price and the close (`clampCandleToPostFill` in engine-utils, single owner of that policy). Profit-side triggers cap at `max(fill, close)`, stop-side at `min(fill, close)`.
- The clamped bar folds into peak/trough/MFE history only **after** the fill bar's checks (`foldBarIntoPosition`, single owner of the update): the known path is fill → close, so the close must not become a "peak" that the fill price then appears to dip below — that would fire trailing stops on the entry itself.
- From the next bar on, management is unchanged. Next-bar-open entries are unaffected (an open fill owns the whole bar). Exit-signal conditions still evaluate the real candle — market data is never altered, only the position's price knowledge.

The three entry paths now share one coherent semantics: next-bar-open manages the full bar (owns [open..close]), same-bar-close gets no same-bar management (owns only the close), mid-bar fills manage the clamped [fill..close].

## Test plan

- 5 new tests in `fill-bar-management.test.ts` from the executed repros above; **4 of 5 fail on the previous implementation** (the 5th is a next-bar-open control pinning behavior that must not change).
- Shared test fixture: `makeCandles` promoted into `step-candles.ts` (was duplicated in two test files).
- Full verification: core **6345/6345** tests (358 files), `tsc --noEmit` clean, `pnpm build` OK, Biome clean.

## Behavior note

Backtests entering via limit/stop orders on wide bars will report different (correct) same-bar exits and lower, honest MFE values; previous results carried a same-bar look-ahead advantage.