### PR TITLE
fix(core): pattern backtest conditions no longer enter at the pattern pivot bar

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## [Unreleased]
 
+### Breaking — `PatternSignal` gains causal timestamps; pattern backtest conditions no longer enter at the pivot bar
+
+Chart-pattern detectors anchor `PatternSignal.time` at the pattern's final
+structural pivot (e.g. a double bottom's second trough), but that pivot is
+only identifiable `swingLookback` bars later, and breakout confirmation can
+come weeks after that. The pattern backtest conditions (`patternDetected`,
+`patternConfirmed`, `patternWithinBars`, `patternConfidenceAbove`,
+`anyBullishPattern`, `anyBearishPattern`, and friends) matched entries
+against `time`, so a backtest bought the exact double-bottom low with
+knowledge of a breakout that had not happened yet — a measured ~10% per-trade
+look-ahead edge on synthetic data.
+
+- `PatternSignal` now carries `detectableTime` (required — the bar where the
+  formation becomes knowable in real time: final pivot + `swingLookback`
+  bars) and `confirmTime` (optional — where the breakout confirmation
+  becomes knowable: the later of the breakout bar and `detectableTime`; only
+  set when `confirmed` is true). All detectors (double top/bottom, head &
+  shoulders, cup & handle, triangle, wedge, channel, flag/pennant, harmonics)
+  populate them. Code constructing `PatternSignal` values by hand must now
+  provide `detectableTime`.
+- Pattern backtest conditions match against these causal timestamps instead
+  of `time`: `patternDetected` fires when the formation is knowable,
+  `patternConfirmed` when the breakout is knowable, and
+  `patternConfidenceAbove` gates a confirmed pattern's confidence (which
+  folds in breakout-bar information) on the confirmation bar.
+  `patternWithinBars` looks back over actionable bars.
+
+Backtests entering on pattern conditions will show later (honest) entries
+and typically lower returns; previous results carried systematic look-ahead
+bias. `PatternSignal.time` itself is unchanged, so chart rendering and
+pattern-marker placement are unaffected.
+
 ### Fixed — mid-bar fills no longer monetize pre-fill price action
 
 When a pending limit/stop order filled mid-bar, the new position's

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -2765,7 +2765,11 @@ const filtered = filterPatterns(raw, candles, {
 
 ```typescript
 interface PatternSignal {
-  time: number;              // パターン完成時刻
+  time: number;              // パターン完成時刻（最終構造ピボット）
+  detectableTime: number;    // リアルタイムで形成が判明する最初のバー
+                             // （最終ピボット + swingLookback 確定バー）
+  confirmTime?: number;      // ブレイクアウト確認が判明する最初のバー
+                             // （confirmed が true の場合のみ設定）
   type: PatternType;         // 'double_top' | 'double_bottom' | 'head_shoulders' など
   pattern: {
     startTime: number;       // パターン開始

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -2787,7 +2787,11 @@ All pattern detection functions return `PatternSignal[]`:
 
 ```typescript
 interface PatternSignal {
-  time: number;              // Pattern completion time
+  time: number;              // Pattern completion time (final structural pivot)
+  detectableTime: number;    // First bar where the formation is knowable in real time
+                             // (final pivot + swingLookback confirmation bars)
+  confirmTime?: number;      // First bar where the breakout confirmation is knowable
+                             // (only set when confirmed is true)
   type: PatternType;         // 'double_top' | 'double_bottom' | 'head_shoulders' | etc.
   pattern: {
     startTime: number;       // Pattern start

--- a/packages/core/docs/GUIDE.ja.md
+++ b/packages/core/docs/GUIDE.ja.md
@@ -1147,6 +1147,14 @@ const entry = and(
 const cupEntry = cupHandleDetected({ confirmedOnly: true });
 ```
 
+パターン条件はパターンのピボットバーではなく、リアルタイムで判明する
+バーで発火します。スイングピボットは形成の `swingLookback` バー後に
+初めて確定し、確認（confirmed）にはブレイクアウトバーが必要です。
+`patternDetected` は形成が判明した時点で、`confirmedOnly: true`（または
+`patternConfirmed`）はブレイクアウトが判明したバーで発火します。これに
+よりバックテストは因果的になり、エントリーがパターンの未来情報を使う
+ことはありません。
+
 ---
 
 ## マルチタイムフレーム（MTF）分析

--- a/packages/core/docs/GUIDE.md
+++ b/packages/core/docs/GUIDE.md
@@ -1146,6 +1146,14 @@ const entry = and(
 const cupEntry = cupHandleDetected({ confirmedOnly: true });
 ```
 
+Pattern conditions fire when the pattern is knowable in real time, not at the
+pattern's pivot bar: a swing pivot is only identifiable `swingLookback` bars
+after it forms, and confirmation requires the breakout bar. `patternDetected`
+fires once the formation is knowable; with `confirmedOnly: true` (or
+`patternConfirmed`) it fires on the bar where the breakout becomes knowable.
+This keeps backtests causal — entries never use future knowledge of the
+pattern.
+
 ---
 
 ## Multi-Timeframe (MTF) Analysis

--- a/packages/core/src/analysis/__tests__/pattern-projection.test.ts
+++ b/packages/core/src/analysis/__tests__/pattern-projection.test.ts
@@ -192,6 +192,8 @@ describe("projectFromPatterns", () => {
 
     const signal: PatternSignal = {
       time: candles[0].time,
+      detectableTime: candles[0].time,
+      confirmTime: candles[0].time,
       type: "double_top",
       pattern: {
         startTime: candles[0].time,
@@ -214,6 +216,8 @@ describe("projectFromPatterns", () => {
 
     const signal: PatternSignal = {
       time: candles[0].time,
+      detectableTime: candles[0].time,
+      confirmTime: candles[0].time,
       type: "double_bottom",
       pattern: {
         startTime: candles[0].time,

--- a/packages/core/src/backtest/conditions/__tests__/pattern-lookahead.test.ts
+++ b/packages/core/src/backtest/conditions/__tests__/pattern-lookahead.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import { doubleBottom } from "../../../signals/patterns/double-top-bottom";
+import type { NormalizedCandle } from "../../../types";
+import { alwaysFalse } from "../../conditions";
+import { runBacktest } from "../../engine";
+import {
+  patternConfidenceAbove,
+  patternConfirmed,
+  patternDetected,
+  patternWithinBars,
+} from "../patterns";
+
+const DAY = 86_400_000;
+
+function candle(i: number, close: number, volume = 1000): NormalizedCandle {
+  return {
+    time: DAY * (i + 1),
+    open: close,
+    high: close + 0.5,
+    low: close - 0.5,
+    close,
+    volume,
+  };
+}
+
+function timeAt(index: number): number {
+  return DAY * (index + 1);
+}
+
+/**
+ * Deterministic double bottom (swingLookback = 5):
+ * - first trough at i10 (90), middle peak at i16 (101, the neckline)
+ * - second trough at i22 (90.2) — a swing low only identifiable at i27
+ * - neckline breakout at i28 (close 103 > 101)
+ *
+ * So the formation is knowable at i27 and the confirmation at i28. A causal
+ * backtest with next-bar-open fills must not enter before i28 (detected) /
+ * i29 (confirmed).
+ */
+function doubleBottomCandles(): NormalizedCandle[] {
+  const closes: number[] = [];
+  for (let i = 0; i < 10; i++) closes.push(110 - i * 2); // i0..i9 decline
+  closes.push(90); // i10 first trough
+  for (let i = 1; i <= 5; i++) closes.push(90 + i * 2); // i11..i15 rally
+  closes.push(101); // i16 middle peak (neckline)
+  closes.push(99, 97, 95, 93, 91); // i17..i21 decline
+  closes.push(90.2); // i22 second trough
+  closes.push(92, 93.5, 95, 96.5, 98); // i23..i27 rally below neckline
+  closes.push(103); // i28 breakout
+  closes.push(104, 105, 106, 107, 108, 109); // i29..i34 continuation
+  return closes.map((c, i) => candle(i, c, i === 28 ? 3000 : 1000));
+}
+
+function evaluateAt(
+  condition: ReturnType<typeof patternDetected>,
+  candles: NormalizedCandle[],
+  index: number,
+  indicators: Record<string, unknown> = {},
+): boolean {
+  return condition.evaluate(indicators, candles[index], index, candles);
+}
+
+describe("pattern signal causal timestamps", () => {
+  const candles = doubleBottomCandles();
+
+  it("anchors time at the pivot but exposes when the pattern is actually knowable", () => {
+    const patterns = doubleBottom(candles);
+    expect(patterns).toHaveLength(1);
+    const p = patterns[0];
+    expect(p.confirmed).toBe(true);
+    expect(p.time).toBe(timeAt(22)); // second trough pivot
+    expect(p.detectableTime).toBe(timeAt(27)); // pivot + swingLookback
+    expect(p.confirmTime).toBe(timeAt(28)); // neckline breakout bar
+  });
+
+  it("matches what a bar-by-bar (causal) rerun of the detector can see", () => {
+    // One bar before detectableTime: the second trough is not yet a swing low
+    expect(doubleBottom(candles.slice(0, 27))).toHaveLength(0);
+    // At detectableTime: formation knowable, breakout not yet
+    const atDetectable = doubleBottom(candles.slice(0, 28));
+    expect(atDetectable).toHaveLength(1);
+    expect(atDetectable[0].confirmed).toBe(false);
+    expect(atDetectable[0].confirmTime).toBeUndefined();
+    // At confirmTime: breakout knowable
+    const atConfirm = doubleBottom(candles.slice(0, 29));
+    expect(atConfirm).toHaveLength(1);
+    expect(atConfirm[0].confirmed).toBe(true);
+  });
+
+  it("leaves confirmTime unset for unconfirmed patterns", () => {
+    // Cut the data before the breakout: pattern forms but never confirms
+    const unconfirmed = doubleBottom(candles.slice(0, 28));
+    expect(unconfirmed[0].confirmTime).toBeUndefined();
+  });
+});
+
+describe("pattern conditions fire at the causal bar, not the pivot bar", () => {
+  const candles = doubleBottomCandles();
+
+  it("patternDetected fires only when the formation becomes knowable", () => {
+    const condition = patternDetected("double_bottom");
+    const indicators: Record<string, unknown> = {};
+    const firingBars: number[] = [];
+    for (let i = 0; i < candles.length; i++) {
+      if (evaluateAt(condition, candles, i, indicators)) firingBars.push(i);
+    }
+    expect(firingBars).toEqual([27]);
+  });
+
+  it("patternConfirmed fires only when the breakout becomes knowable", () => {
+    const condition = patternConfirmed("double_bottom");
+    const indicators: Record<string, unknown> = {};
+    const firingBars: number[] = [];
+    for (let i = 0; i < candles.length; i++) {
+      if (evaluateAt(condition, candles, i, indicators)) firingBars.push(i);
+    }
+    expect(firingBars).toEqual([28]);
+  });
+
+  it("patternConfidenceAbove gates confirmed-pattern confidence on the breakout bar", () => {
+    // The pattern's confidence folds in breakout + breakout-volume information,
+    // so it must not be visible at the pivot bar.
+    const condition = patternConfidenceAbove("double_bottom", 50);
+    const indicators: Record<string, unknown> = {};
+    const firingBars: number[] = [];
+    for (let i = 0; i < candles.length; i++) {
+      if (evaluateAt(condition, candles, i, indicators)) firingBars.push(i);
+    }
+    expect(firingBars).toEqual([28]);
+  });
+
+  it("patternWithinBars looks back over actionable bars", () => {
+    const condition = patternWithinBars("double_bottom", 3, { confirmedOnly: true });
+    const indicators: Record<string, unknown> = {};
+    // Window [i-3, i] must contain the confirm bar i28
+    expect(evaluateAt(condition, candles, 27, indicators)).toBe(false);
+    expect(evaluateAt(condition, candles, 28, indicators)).toBe(true);
+    expect(evaluateAt(condition, candles, 31, indicators)).toBe(true);
+    expect(evaluateAt(condition, candles, 32, indicators)).toBe(false);
+  });
+});
+
+describe("backtest entries carry no pattern look-ahead", () => {
+  const candles = doubleBottomCandles();
+
+  it("patternConfirmed entry fills after the breakout is knowable", () => {
+    const result = runBacktest(candles, patternConfirmed("double_bottom"), alwaysFalse(), {
+      capital: 1_000_000,
+    });
+    expect(result.trades).toHaveLength(1);
+    // Condition fires at i28 (breakout bar); next-bar-open fill = i29.
+    // Before the fix the condition fired at the second-trough pivot (i22)
+    // and the backtest bought the exact bottom with future knowledge.
+    expect(result.trades[0].entryTime).toBe(timeAt(29));
+    expect(result.trades[0].entryPrice).toBe(104);
+  });
+
+  it("patternDetected entry fills after the formation is knowable", () => {
+    const result = runBacktest(candles, patternDetected("double_bottom"), alwaysFalse(), {
+      capital: 1_000_000,
+    });
+    expect(result.trades).toHaveLength(1);
+    expect(result.trades[0].entryTime).toBe(timeAt(28));
+  });
+});

--- a/packages/core/src/backtest/conditions/patterns.ts
+++ b/packages/core/src/backtest/conditions/patterns.ts
@@ -132,14 +132,30 @@ function getPatternData(
 }
 
 /**
- * Find a matching pattern at the given candle time
+ * Get the earliest bar time at which the pattern is actionable.
+ *
+ * `PatternSignal.time` anchors the final structural pivot, which is only
+ * identifiable `swingLookback` bars later (and confirmation requires a
+ * breakout that can be weeks after the pivot). Matching conditions against
+ * `time` would let a backtest act on future knowledge, so conditions match
+ * against the causal timestamps instead.
+ */
+function actionableTime(pattern: PatternSignal, confirmedOnly: boolean): number | undefined {
+  if (confirmedOnly) {
+    return pattern.confirmed ? pattern.confirmTime : undefined;
+  }
+  return pattern.detectableTime;
+}
+
+/**
+ * Find a matching pattern actionable at the given candle time
  */
 function findPatternAtTime(
   patterns: PatternSignal[],
   time: number | string,
   confirmedOnly: boolean,
 ): PatternSignal | undefined {
-  return patterns.find((p) => p.time === time && (!confirmedOnly || p.confirmed));
+  return patterns.find((p) => actionableTime(p, confirmedOnly) === time);
 }
 
 /**
@@ -171,6 +187,11 @@ function hasMatchingPattern(
 /**
  * Pattern of specific type detected at current bar
  *
+ * Fires at the first bar where the pattern formation is knowable in real
+ * time (the final structural pivot plus `swingLookback` confirmation bars),
+ * not at the pivot bar itself. With `confirmedOnly: true` it fires at the
+ * bar where the breakout confirmation becomes knowable.
+ *
  * @param type - Pattern type to detect
  * @param options - Pattern detection options
  *
@@ -197,6 +218,10 @@ export function patternDetected(
 
 /**
  * Pattern of specific type is confirmed (breakout occurred)
+ *
+ * Fires at the bar where the breakout confirmation becomes knowable in real
+ * time (the later of the breakout bar and the bar where the final pivot is
+ * identifiable).
  *
  * @param type - Pattern type to check
  * @param options - Pattern detection options
@@ -263,14 +288,21 @@ export function anyBearishPattern(options: PatternConditionOptions = {}): Preset
 // ============================================
 
 /**
- * Find a pattern at the given time with confidence above threshold
+ * Find a pattern actionable at the given time with confidence above threshold
+ *
+ * A confirmed pattern's confidence folds in breakout and breakout-bar volume
+ * information, so it only becomes knowable at `confirmTime`; unconfirmed
+ * patterns are gated on `detectableTime`. That is `actionableTime` with the
+ * pattern's own `confirmed` flag as the requirement.
  */
 function findHighConfidencePattern(
   patterns: PatternSignal[],
   time: number | string,
   minConfidence: number,
 ): boolean {
-  return patterns.some((p) => p.time === time && p.confidence >= minConfidence);
+  return patterns.some(
+    (p) => actionableTime(p, p.confirmed) === time && p.confidence >= minConfidence,
+  );
 }
 
 /**
@@ -333,7 +365,9 @@ export function anyPatternConfidenceAbove(
 /**
  * Pattern detected within last N bars
  *
- * Useful for detecting patterns that were recently formed but not exactly at current bar.
+ * Useful for detecting patterns that recently became actionable but not exactly at
+ * the current bar. The lookback window is matched against the bar where the pattern
+ * became knowable in real time (see `patternDetected`), not the pivot bar.
  *
  * @param type - Pattern type to detect
  * @param lookback - Number of bars to look back (default: 5)
@@ -365,12 +399,11 @@ export function patternWithinBars(
         lookbackTimes.add(candles[i].time);
       }
 
-      // Check if any pattern falls within the lookback window
+      // Check if any pattern became actionable within the lookback window
       for (const pattern of patterns) {
-        if (lookbackTimes.has(pattern.time)) {
-          if (!confirmedOnly || pattern.confirmed) {
-            return true;
-          }
+        const time = actionableTime(pattern, confirmedOnly);
+        if (time !== undefined && lookbackTimes.has(time)) {
+          return true;
         }
       }
 

--- a/packages/core/src/signals/__tests__/trade-signal.test.ts
+++ b/packages/core/src/signals/__tests__/trade-signal.test.ts
@@ -130,6 +130,8 @@ describe("fromPatternSignal", () => {
   it("converts double_bottom to BUY with price levels", () => {
     const signal: PatternSignal = {
       time: 5000,
+      detectableTime: 5000,
+      confirmTime: 5000,
       type: "double_bottom",
       pattern: {
         startTime: 4000,
@@ -154,6 +156,7 @@ describe("fromPatternSignal", () => {
   it("converts double_top to SELL", () => {
     const signal: PatternSignal = {
       time: 6000,
+      detectableTime: 6000,
       type: "double_top",
       pattern: { startTime: 5000, endTime: 6000, keyPoints: [] },
       confidence: 65,

--- a/packages/core/src/signals/patterns/__tests__/pattern-filter.test.ts
+++ b/packages/core/src/signals/patterns/__tests__/pattern-filter.test.ts
@@ -17,6 +17,8 @@ function makeCandles(count: number): NormalizedCandle[] {
 function makePattern(overrides: Partial<PatternSignal> = {}): PatternSignal {
   return {
     time: 1050,
+    detectableTime: 1055,
+    confirmTime: 1055,
     type: "double_top",
     pattern: {
       startTime: 1020,

--- a/packages/core/src/signals/patterns/channel.ts
+++ b/packages/core/src/signals/patterns/channel.ts
@@ -13,6 +13,7 @@ import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { getSwingHighs, getSwingLows } from "../../indicators/price/swing-points";
 import { atr as calcAtr } from "../../indicators/volatility/atr";
 import type { Candle, NormalizedCandle } from "../../types";
+import { causalPatternTimes } from "./double-pattern-utils";
 import {
   avgClosePrice,
   buildTouchKeyPoints,
@@ -219,6 +220,7 @@ export function detectChannel(
 
         results.push({
           time: normalized[detectionIndex].time,
+          ...causalPatternTimes(normalized, endIndex + scale, breakout?.index),
           type: subtype,
           pattern: {
             startTime: normalized[startIndex].time,

--- a/packages/core/src/signals/patterns/cup-handle.ts
+++ b/packages/core/src/signals/patterns/cup-handle.ts
@@ -8,7 +8,7 @@
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { getSwingHighs, getSwingLows } from "../../indicators/price/swing-points";
 import type { Candle, NormalizedCandle } from "../../types";
-import { validateBreakoutVolume } from "./double-pattern-utils";
+import { causalPatternTimes, validateBreakoutVolume } from "./double-pattern-utils";
 import type { CupHandleOptions, PatternKeyPoint, PatternSignal } from "./types";
 
 /**
@@ -167,8 +167,17 @@ export function cupWithHandle(
         },
       ];
 
+      // The handle low is typically a swing low (identifiable swingLookback
+      // bars later); the handle end itself is knowable at that bar. The
+      // fallback handle-low path is not a swing pivot, so the index may run
+      // past the end of data (causalPatternTimes clamps it).
       patterns.push({
         time: normalized[handle.endIndex].time,
+        ...causalPatternTimes(
+          normalized,
+          Math.max(handle.endIndex, handle.lowIndex + swingLookback),
+          breakoutIndex,
+        ),
         type: "cup_handle",
         pattern: {
           startTime: normalized[leftRim.index].time,

--- a/packages/core/src/signals/patterns/double-pattern-utils.ts
+++ b/packages/core/src/signals/patterns/double-pattern-utils.ts
@@ -11,6 +11,34 @@ export interface SwingPoint {
 }
 
 /**
+ * Compute the causal timestamps for a detected pattern.
+ *
+ * A swing pivot is only identifiable once its right-hand confirmation bars
+ * exist, so a pattern's formation becomes knowable at `detectableIndex`
+ * (final structural pivot + swing lookback), and its breakout confirmation
+ * at the later of the breakout bar and `detectableIndex` — a breakout can
+ * occur before the pivot itself is identifiable. This is the single owner
+ * of that rule; detectors only derive `detectableIndex` (which pivot is
+ * final varies per pattern) and pass the raw breakout index.
+ *
+ * `detectableIndex` is clamped to the last bar for detectors whose final
+ * anchor is not a swing pivot (e.g. cup-with-handle's fallback handle low)
+ * and may point past the end of data; for swing pivots the clamp is a no-op.
+ */
+export function causalPatternTimes(
+  candles: NormalizedCandle[],
+  detectableIndex: number,
+  breakoutIndex: number | null | undefined,
+): { detectableTime: number; confirmTime: number | undefined } {
+  const knowableIndex = Math.min(detectableIndex, candles.length - 1);
+  return {
+    detectableTime: candles[knowableIndex].time,
+    confirmTime:
+      breakoutIndex != null ? candles[Math.max(breakoutIndex, knowableIndex)].time : undefined,
+  };
+}
+
+/**
  * Interpolate time between two points to find where price crosses a target level
  * Used in strict mode to find neckline intersection points
  */

--- a/packages/core/src/signals/patterns/double-top-bottom.ts
+++ b/packages/core/src/signals/patterns/double-top-bottom.ts
@@ -11,6 +11,7 @@ import type { Candle, NormalizedCandle } from "../../types";
 import {
   calculateDoublePatternConfidence,
   calculateProminence,
+  causalPatternTimes,
   countNecklineCrosses,
   findMiddlePeak,
   findMiddleTrough,
@@ -351,6 +352,7 @@ export function doubleTop(
 
       patterns.push({
         time: normalized[secondPeak.index].time,
+        ...causalPatternTimes(normalized, secondPeak.index + swingLookback, breakdownPoint?.index),
         type: "double_top",
         pattern: {
           startTime: patternStartTime,
@@ -708,6 +710,7 @@ export function doubleBottom(
 
       patterns.push({
         time: normalized[secondTrough.index].time,
+        ...causalPatternTimes(normalized, secondTrough.index + swingLookback, breakoutPoint?.index),
         type: "double_bottom",
         pattern: {
           startTime: patternStartTime,

--- a/packages/core/src/signals/patterns/flag.ts
+++ b/packages/core/src/signals/patterns/flag.ts
@@ -14,6 +14,7 @@ import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { getSwingHighs, getSwingLows } from "../../indicators/price/swing-points";
 import { atr as calcAtr } from "../../indicators/volatility/atr";
 import type { Candle, NormalizedCandle } from "../../types";
+import { causalPatternTimes } from "./double-pattern-utils";
 import {
   avgClosePrice,
   calculateBreakoutLevels,
@@ -358,8 +359,19 @@ export function detectFlag(
     }
     keyPoints.sort((a, b) => a.index - b.index);
 
+    // Consolidation swing points are only identifiable swingLookback bars
+    // later; the pattern also consumes data through consEnd.
+    const lastSwingIndex = Math.max(
+      ...consHighs.map((p) => p.index),
+      ...consLows.map((p) => p.index),
+    );
     results.push({
       time: normalized[detectionIndex].time,
+      ...causalPatternTimes(
+        normalized,
+        Math.max(consEnd, lastSwingIndex + swingLookback),
+        breakout?.index,
+      ),
       type: subtype,
       pattern: {
         startTime: normalized[pole.startIndex].time,

--- a/packages/core/src/signals/patterns/harmonic-patterns.ts
+++ b/packages/core/src/signals/patterns/harmonic-patterns.ts
@@ -8,6 +8,7 @@
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { getAlternatingSwingPoints } from "../../indicators/price/swing-points";
 import type { Candle, NormalizedCandle } from "../../types";
+import { causalPatternTimes } from "./double-pattern-utils";
 import type {
   HarmonicPatternOptions,
   HarmonicPatternType,
@@ -248,8 +249,11 @@ export function detectHarmonicPatterns(
           label: XABCD_LABELS[idx],
         }));
 
+        // The pattern is confirmed at the D pivot itself, so confirmation
+        // becomes knowable together with the formation.
         const signal: PatternSignal = {
           time: D.time,
+          ...causalPatternTimes(normalized, D.index + swingLookback, D.index),
           type: patternType,
           pattern: {
             startTime: X.time,

--- a/packages/core/src/signals/patterns/head-shoulders.ts
+++ b/packages/core/src/signals/patterns/head-shoulders.ts
@@ -8,7 +8,7 @@
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { getSwingHighs, getSwingLows } from "../../indicators/price/swing-points";
 import type { Candle, NormalizedCandle } from "../../types";
-import { validateBreakoutVolume } from "./double-pattern-utils";
+import { causalPatternTimes, validateBreakoutVolume } from "./double-pattern-utils";
 import type {
   HeadShouldersOptions,
   PatternKeyPoint,
@@ -171,6 +171,7 @@ export function headAndShoulders(
 
     patterns.push({
       time: normalized[rightShoulder.index].time,
+      ...causalPatternTimes(normalized, rightShoulder.index + swingLookback, breakoutIndex),
       type: "head_shoulders",
       pattern: {
         startTime: normalized[leftShoulder.index].time,
@@ -332,6 +333,7 @@ export function inverseHeadAndShoulders(
 
     patterns.push({
       time: normalized[rightShoulder.index].time,
+      ...causalPatternTimes(normalized, rightShoulder.index + swingLookback, breakoutIndex),
       type: "inverse_head_shoulders",
       pattern: {
         startTime: normalized[leftShoulder.index].time,

--- a/packages/core/src/signals/patterns/triangle.ts
+++ b/packages/core/src/signals/patterns/triangle.ts
@@ -13,6 +13,7 @@ import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { getSwingHighs, getSwingLows } from "../../indicators/price/swing-points";
 import { atr as calcAtr } from "../../indicators/volatility/atr";
 import type { Candle, NormalizedCandle } from "../../types";
+import { causalPatternTimes } from "./double-pattern-utils";
 import {
   avgClosePrice,
   buildTouchKeyPoints,
@@ -233,6 +234,7 @@ export function detectTriangle(
 
         results.push({
           time: normalized[detectionIndex].time,
+          ...causalPatternTimes(normalized, endIndex + scale, breakout?.index),
           type: subtype,
           pattern: {
             startTime: normalized[startIndex].time,

--- a/packages/core/src/signals/patterns/types.ts
+++ b/packages/core/src/signals/patterns/types.ts
@@ -87,6 +87,20 @@ export interface PatternNeckline {
 export interface PatternSignal {
   /** Timestamp when pattern was detected (usually at completion) */
   time: number;
+  /**
+   * Earliest bar time at which the pattern formation is knowable in real time.
+   * Swing pivots are only identifiable `swingLookback` bars after they occur,
+   * so this is the time of the bar `swingLookback` bars after the final
+   * structural pivot. Use this (not `time`) for causal/backtest entries.
+   */
+  detectableTime: number;
+  /**
+   * Earliest bar time at which the breakout confirmation is knowable in real
+   * time: the later of the breakout bar and `detectableTime` (a breakout can
+   * occur before the final pivot itself is identifiable). Only set when
+   * `confirmed` is true.
+   */
+  confirmTime?: number;
   /** Pattern type */
   type: PatternType;
   /** Pattern details */

--- a/packages/core/src/signals/patterns/wedge.ts
+++ b/packages/core/src/signals/patterns/wedge.ts
@@ -11,6 +11,7 @@ import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { getSwingHighs, getSwingLows } from "../../indicators/price/swing-points";
 import { atr as calcAtr } from "../../indicators/volatility/atr";
 import type { Candle, NormalizedCandle } from "../../types";
+import { causalPatternTimes } from "./double-pattern-utils";
 import {
   buildTouchKeyPoints,
   calculateBaseConfidence,
@@ -224,6 +225,7 @@ export function detectWedge(
 
         results.push({
           time: normalized[detectionIndex].time,
+          ...causalPatternTimes(normalized, endIndex + scale, breakout?.index),
           type: subtype,
           pattern: {
             startTime: normalized[startIndex].time,


### PR DESCRIPTION
## Problem

Chart-pattern detectors anchor `PatternSignal.time` at the pattern's final structural pivot — a double bottom's second trough, an H&S right shoulder, a harmonic D point. That pivot is only identifiable `swingLookback` bars (default 5) after it forms, and breakout confirmation can come up to `maxBreakoutDistance` bars (default 20) after that. The pattern backtest conditions (`patternDetected`, `patternConfirmed`, `patternWithinBars`, `patternConfidenceAbove`, `anyBullishPattern`, `anyBearishPattern`, and the convenience wrappers) matched `candle.time` against that pivot-anchored `time`, so backtests acted on future knowledge.

Concrete repro (35-bar synthetic double bottom, in the new test file): the second trough sits at bar 22, becomes identifiable as a swing low at bar 27, and the neckline breakout happens at bar 28. `patternConfirmed("double_bottom")` fired at bar 22 and the backtest bought at bar 23's open (92) — the exact bottom, with knowledge of a breakout 6 bars in the future. A causal entry is bar 29's open (104). On longer synthetic data the per-trade look-ahead edge measured ~10%.

`patternConfidenceAbove` had the same leak twice over: a confirmed pattern's confidence score folds in breakout and breakout-bar volume information, yet it was visible at the pivot bar.

## Fix

- `PatternSignal` gains two causal timestamps:
  - `detectableTime` (required): the bar where the formation becomes knowable in real time — final pivot + `swingLookback` confirmation bars.
  - `confirmTime` (optional): the bar where breakout confirmation becomes knowable — the later of the breakout bar and `detectableTime` (a breakout can land before the pivot itself is identifiable); only set when `confirmed` is true.
- All eight detectors (double top/bottom, head & shoulders + inverse, cup & handle, triangle, wedge, channel, flag/pennant, harmonics) populate them through a new single-owner helper `causalPatternTimes()` in `double-pattern-utils.ts`, so the `max(breakout, detectable)` rule and the end-of-data clamp live in exactly one place.
- Backtest conditions match against the causal timestamps: `patternDetected` fires at `detectableTime`, `patternConfirmed` at `confirmTime`, `patternConfidenceAbove` gates a confirmed pattern's confidence on the confirmation bar, and `patternWithinBars` looks back over actionable bars.
- Docs updated: `PatternSignal` structure in API.md/API.ja.md, firing semantics in GUIDE.md/GUIDE.ja.md and the condition JSDoc; CHANGELOG entry under Unreleased → Breaking.

**Breaking**: `detectableTime` is a required field, so code constructing `PatternSignal` values by hand must now provide it. `PatternSignal.time` itself is unchanged — chart rendering and pattern-marker placement are unaffected. Backtests entering on pattern conditions will show later (honest) entries and typically lower returns; previous results carried systematic look-ahead bias.

## Test plan

- New `src/backtest/conditions/__tests__/pattern-lookahead.test.ts` (9 tests):
  - detector emits `time`=bar 22, `detectableTime`=bar 27, `confirmTime`=bar 28 on the fixture, matching a bar-by-bar truncated rerun of the detector (nothing at ≤26 bars, unconfirmed at 27, confirmed at 28);
  - each condition fires exactly at its causal bar (detected: [27], confirmed: [28], confidence-gated: [28]); `patternWithinBars` windows over actionable bars;
  - end-to-end `runBacktest` entries: confirmed → bar 29 @ 104, detected → bar 28.
  - Verified the regression tests fail without the fix: 7/9 fail on the pre-fix source.
- Behavior-preservation check for the shared-helper consolidation: 300 seeded random OHLCV series × 14 detector configurations → 7,274 emitted patterns, output identical with the per-detector inline computation and the shared helper.
- Full suites green: core 6,354 tests / 359 files, chart 934 tests, mcp 83 tests; `npx tsc --noEmit --ignoreDeprecations 6.0` clean; `pnpm build` clean; biome clean on touched files.