### PR TITLE
fix(core): runBacktestScaled multi-tranche path honors fillMode and slTpMode

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -34,6 +34,14 @@ from before the fill can no longer trigger take-profits computed off the
 updated average. Exit checks also run before tranche additions, so a bar
 that exits does not add a tranche at the same close.
 
+A partial take profit followed by a later tranche addition also computed the
+average entry price wrong: the sold shares were left inside the per-tranche
+records at full weight, so the recomputed average over-weighted the old cost
+basis (e.g. buy 500 @100, sell 250, add ~511 @97.9 → average reported as
+~98.94 instead of the correct ~98.59), skewing subsequent SL/TP levels and
+the final P&L. Tranche shares are now scaled down by the sold fraction, so
+later additions average against the remaining position only.
+
 Multi-tranche backtest results will change (honestly): entries shift to the
 next bar's open under the default mode, and wick-based stop-outs disappear
 under the default `close-only` mode; previous results carried same-bar

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## [Unreleased]
 
+### Fixed — `runBacktestScaled` (tranches ≥ 2) now honors `fillMode` and `slTpMode`
+
+The multi-tranche path of `runBacktestScaled` accepted `fillMode`/`slTpMode`
+and recorded them in `result.settings`, but never used them:
+
+- Entries (first and additional tranches) always filled at the signal bar's
+  own close — a same-bar fill even under the default `next-bar-open`, giving
+  the backtest the signal bar's close before it could have acted on it.
+- Stop loss, take profit, partial take profit, and trailing stops always
+  triggered on intrabar wicks and exited at the trigger price, ignoring the
+  default `close-only` mode. A bar that dipped through the stop but closed
+  above it stopped the position out anyway.
+- The single-tranche fallback honored both modes, so semantics silently
+  flipped when `tranches` went from 1 to 2, and `result.settings` misreported
+  what actually ran.
+
+The multi-tranche path now mirrors the single-entry engine: `next-bar-open`
+queues entries/exits and fills them at the next bar's open, `same-bar-close`
+fills at the signal bar's close; SL/TP/partial/trailing route through the
+same trigger helpers as `runBacktest`, honoring `slTpMode`. With identical
+options and only one tranche filling, `runBacktestScaled` now produces
+trade-for-trade identical results to `runBacktest`. Scaled trades also carry
+`exitReason` now (previously undefined).
+
+Additionally, tranche additions no longer look ahead: the bar that triggers
+an additional tranche evaluates its exit checks against the pre-tranche
+average entry price (a `same-bar-close` tranche fill only exists from the
+close, a `next-bar-open` fill from the next bar's open), so price action
+from before the fill can no longer trigger take-profits computed off the
+updated average. Exit checks also run before tranche additions, so a bar
+that exits does not add a tranche at the same close.
+
+Multi-tranche backtest results will change (honestly): entries shift to the
+next bar's open under the default mode, and wick-based stop-outs disappear
+under the default `close-only` mode; previous results carried same-bar
+look-ahead.
+
 ### Breaking — `PatternSignal` gains causal timestamps; pattern backtest conditions no longer enter at the pivot bar
 
 Chart-pattern detectors anchor `PatternSignal.time` at the pattern's final

--- a/packages/core/src/backtest/__tests__/scaled-entry-fill-modes.test.ts
+++ b/packages/core/src/backtest/__tests__/scaled-entry-fill-modes.test.ts
@@ -180,6 +180,67 @@ describe("additional tranches carry no look-ahead", () => {
   });
 });
 
+describe("partial take profit keeps the tranche cost basis in sync", () => {
+  /**
+   * 2 tranches fill -> partial TP sells 50% -> 3rd tranche fills.
+   *
+   * capital 90,000, 3 equal tranches (30,000 each), no commission,
+   * same-bar-close fills for exact close-price entries:
+   * - t1 @100 (300 sh), t2 @98 (~306.12 sh) -> avg 98.9899
+   * - partial TP (threshold 3% -> 101.9596) fires at close 102, sells 50%
+   *   (selling does not change the remaining shares' average)
+   * - t3 @96 (312.5 sh): correct remaining-basis average is
+   *   (150*100 + 153.06*98 + 312.5*96) / 615.56 = 97.4720
+   *
+   * Without scaling the sold shares out of the tranches, the recomputed
+   * average counted them at full weight: 90,000 / 918.62 = 97.9728.
+   */
+  const candles = makeCandles(
+    [
+      { o: 100, h: 100.5, l: 99.5, c: 100 }, // i0
+      { o: 100, h: 100.5, l: 99.5, c: 100 }, // i1 <- signal, tranche 1 @100
+      { o: 98, h: 98.5, l: 97.5, c: 98 }, // i2 add trigger (98 <= 98): tranche 2 @98
+      { o: 102, h: 102.5, l: 101.5, c: 102 }, // i3 partial TP (close 102 >= 101.9596)
+      { o: 96, h: 96.5, l: 95.5, c: 96 }, // i4 add trigger (96 <= 96): tranche 3 @96
+      { o: 96, h: 96.5, l: 95.5, c: 96 }, // i5
+      { o: 96, h: 96.5, l: 95.5, c: 96 }, // i6 endOfData @96
+    ],
+    DAY,
+    DAY,
+  );
+
+  it("a tranche added after a partial exit averages against the remaining shares", () => {
+    const result = runBacktestScaled(candles, at(1), never, {
+      capital: 90_000,
+      fillMode: "same-bar-close",
+      partialTakeProfit: { threshold: 3, sellPercent: 50 },
+      scaledEntry: {
+        tranches: 3,
+        strategy: "equal",
+        intervalType: "price",
+        priceInterval: -2,
+      },
+    });
+
+    expect(result.trades).toHaveLength(2);
+
+    const partial = result.trades[0];
+    expect(partial.isPartial).toBe(true);
+    expect(partial.exitPercent).toBe(50);
+    expect(partial.exitReason).toBe("partialTakeProfit");
+    expect(partial.entryPrice).toBeCloseTo(98.9899, 3);
+    expect(partial.exitPrice).toBe(102);
+
+    const final = result.trades[1];
+    expect(final.exitReason).toBe("endOfData");
+    expect(final.exitPrice).toBe(96);
+    // Remaining-cost-basis average; with the sold shares still weighted in
+    // the tranches this came out as 97.9728 instead.
+    expect(final.entryPrice).toBeCloseTo(97.472, 3);
+    expect(final.returnPercent).toBeCloseTo(((96 - 97.472) / 97.472) * 100, 2);
+  });
+});
+
 describe("runBacktestScaled matches runBacktest when only one tranche fills", () => {
   const optionGrid: Record<string, unknown>[] = [];
   // No-modes entry: both engines must resolve their DEFAULTS identically

--- a/packages/core/src/backtest/__tests__/scaled-entry-fill-modes.test.ts
+++ b/packages/core/src/backtest/__tests__/scaled-entry-fill-modes.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle, PresetCondition, Trade } from "../../types";
+import { runBacktest } from "../engine";
+import { runBacktestScaled } from "../scaled-entry";
+import { at, makeCandles, never } from "./step-candles";
+
+const DAY = 86_400_000;
+
+/**
+ * Signal at i1; next-bar-open entry belongs at i2's open (105). The i3 wick
+ * dips to 95 (through a 5% stop from 105 = 99.75) but closes at 101, so
+ * close-only mode must NOT stop out. End of data exits at 101.
+ */
+function stopWickCandles(): NormalizedCandle[] {
+  return makeCandles(
+    [
+      { o: 100, h: 100.5, l: 99.5, c: 100 }, // i0
+      { o: 100, h: 100.5, l: 99.5, c: 100 }, // i1 <- entry signal
+      { o: 105, h: 106, l: 104, c: 104 }, // i2 entry bar under next-bar-open
+      { o: 104, h: 105, l: 95, c: 101 }, // i3 wick through the stop, closes above it
+      { o: 101, h: 102, l: 100, c: 101 }, // i4 endOfData
+    ],
+    DAY,
+    DAY,
+  );
+}
+
+const periodicEnter: PresetCondition = {
+  type: "preset",
+  name: "periodicEnter",
+  evaluate: (_indicators, _candle, index) => index % 17 === 3,
+};
+
+const periodicExit: PresetCondition = {
+  type: "preset",
+  name: "periodicExit",
+  evaluate: (_indicators, _candle, index) => index % 13 === 7,
+};
+
+/** Trade fields that must match between the two engines (shares/notional differ) */
+function comparable(t: Trade) {
+  return {
+    entryTime: t.entryTime,
+    entryPrice: t.entryPrice,
+    exitTime: t.exitTime,
+    exitPrice: t.exitPrice,
+    returnPercent: Number(t.returnPercent.toFixed(8)),
+    exitReason: t.exitReason,
+    isPartial: t.isPartial,
+    exitPercent: t.exitPercent,
+    holdingDays: t.holdingDays,
+  };
+}
+
+const SCALED_TWO_TRANCHES = {
+  tranches: 2,
+  strategy: "equal",
+  intervalType: "signal",
+} as const;
+
+describe("runBacktestScaled honors fillMode", () => {
+  it("fills the first tranche at the next bar's open under next-bar-open (default)", () => {
+    const result = runBacktestScaled(stopWickCandles(), at(1), never, {
+      capital: 100_000,
+      stopLoss: 5,
+      scaledEntry: SCALED_TWO_TRANCHES,
+    });
+
+    expect(result.trades).toHaveLength(1);
+    // Before the fix the tranche filled at the signal bar's own close (100).
+    expect(result.trades[0].entryTime).toBe(DAY * 3);
+    expect(result.trades[0].entryPrice).toBe(105);
+  });
+
+  it("fills the first tranche at the signal bar's close under same-bar-close", () => {
+    const result = runBacktestScaled(stopWickCandles(), at(1), never, {
+      capital: 100_000,
+      fillMode: "same-bar-close",
+      scaledEntry: SCALED_TWO_TRANCHES,
+    });
+
+    expect(result.trades).toHaveLength(1);
+    expect(result.trades[0].entryTime).toBe(DAY * 2);
+    expect(result.trades[0].entryPrice).toBe(100);
+  });
+});
+
+describe("runBacktestScaled honors slTpMode", () => {
+  it("close-only (default): a wick through the stop does not exit", () => {
+    const result = runBacktestScaled(stopWickCandles(), at(1), never, {
+      capital: 100_000,
+      stopLoss: 5,
+      scaledEntry: SCALED_TWO_TRANCHES,
+    });
+
+    // Before the fix the i3 wick (low 95) always triggered the stop
+    // intraday and exited at the stop price on a bar that closed at 101.
+    expect(result.trades).toHaveLength(1);
+    expect(result.trades[0].exitReason).toBe("endOfData");
+    expect(result.trades[0].exitPrice).toBe(101);
+  });
+
+  it("intraday: the wick triggers the stop; the exit fills at the next bar's open", () => {
+    const result = runBacktestScaled(stopWickCandles(), at(1), never, {
+      capital: 100_000,
+      stopLoss: 5,
+      slTpMode: "intraday",
+      scaledEntry: SCALED_TWO_TRANCHES,
+    });
+
+    expect(result.trades).toHaveLength(1);
+    expect(result.trades[0].exitReason).toBe("stopLoss");
+    // Stop triggers at i3; next-bar-open closes at i4's open.
+    expect(result.trades[0].exitTime).toBe(DAY * 5);
+    expect(result.trades[0].exitPrice).toBe(101);
+  });
+});
+
+describe("additional tranches carry no look-ahead", () => {
+  /**
+   * The i3 bar spikes to 109 before closing at 97.9, which triggers the
+   * price-based second tranche (-2% from 100). With take profit 10%:
+   * - vs the OLD average (100) the TP level is 110 — the 109 high must not exit;
+   * - vs the NEW average (~98.94) the TP level is ~108.8 — the fix must not
+   *   let the pre-tranche 109 high trigger it either (the tranche only
+   *   exists from the close / next open).
+   */
+  const addTrancheCandles = makeCandles(
+    [
+      { o: 100, h: 100.5, l: 99.5, c: 100 }, // i0
+      { o: 100, h: 100.5, l: 99.5, c: 100 }, // i1 <- entry signal
+      { o: 100, h: 100.5, l: 99.5, c: 100 }, // i2
+      { o: 100, h: 109, l: 97, c: 97.9 }, // i3 pre-tranche spike + add trigger (97.9 <= 98)
+      { o: 98, h: 98.5, l: 97.5, c: 98 }, // i4
+      { o: 98, h: 98.5, l: 97.5, c: 98 }, // i5 endOfData
+    ],
+    DAY,
+    DAY,
+  );
+
+  const priceScaled = {
+    tranches: 2,
+    strategy: "equal",
+    intervalType: "price",
+    priceInterval: -2,
+  } as const;
+
+  it("same-bar-close: the add bar's pre-fill high does not fire TP off the new average", () => {
+    const result = runBacktestScaled(addTrancheCandles, at(1), never, {
+      capital: 100_000,
+      takeProfit: 10,
+      fillMode: "same-bar-close",
+      slTpMode: "intraday",
+      scaledEntry: priceScaled,
+    });
+
+    // Before the fix: tranche added at i3's close, average updated to ~98.94,
+    // then the TP check consumed the whole bar's high (109 >= ~108.8) and
+    // exited with a profit on a bar that closed at 97.9.
+    expect(result.trades).toHaveLength(1);
+    expect(result.trades[0].exitReason).toBe("endOfData");
+    expect(result.trades[0].exitPrice).toBe(98);
+    // Both tranches filled: average sits between the two fills
+    expect(result.trades[0].entryPrice).toBeLessThan(100);
+    expect(result.trades[0].entryPrice).toBeCloseTo(98.94, 1);
+  });
+
+  it("next-bar-open: the tranche fills at the next open and TP never fires", () => {
+    const result = runBacktestScaled(addTrancheCandles, at(1), never, {
+      capital: 100_000,
+      takeProfit: 10,
+      slTpMode: "intraday",
+      scaledEntry: priceScaled,
+    });
+
+    expect(result.trades).toHaveLength(1);
+    expect(result.trades[0].exitReason).toBe("endOfData");
+    // First tranche i2 open (100), second tranche i4 open (98)
+    expect(result.trades[0].entryPrice).toBeLessThan(100);
+  });
+});
+
+describe("runBacktestScaled matches runBacktest when only one tranche fills", () => {
+  const optionGrid: Record<string, unknown>[] = [];
+  // No-modes entry: both engines must resolve their DEFAULTS identically
+  // (they currently restate the default literals independently)
+  optionGrid.push({ stopLoss: 3, takeProfit: 4 });
+  for (const fillMode of ["next-bar-open", "same-bar-close"] as const) {
+    for (const slTpMode of ["close-only", "intraday"] as const) {
+      optionGrid.push({ fillMode, slTpMode, stopLoss: 3 });
+      optionGrid.push({ fillMode, slTpMode, takeProfit: 4 });
+      optionGrid.push({ fillMode, slTpMode, trailingStop: 5 });
+      optionGrid.push({
+        fillMode,
+        slTpMode,
+        partialTakeProfit: { threshold: 2, sellPercent: 50 },
+        takeProfit: 6,
+      });
+      optionGrid.push({
+        fillMode,
+        slTpMode,
+        stopLoss: 4,
+        takeProfit: 5,
+        trailingStop: 6,
+        slippage: 0.1,
+        commissionRate: 0.1,
+        taxRate: 20,
+      });
+    }
+  }
+
+  // Deterministic LCG so failures are reproducible
+  let seed = 424242;
+  function rand(): number {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+    return seed / 0x7fffffff;
+  }
+
+  function makeRandomSeries(len: number): NormalizedCandle[] {
+    let price = 80 + rand() * 40;
+    const out: NormalizedCandle[] = [];
+    for (let i = 0; i < len; i++) {
+      const open = price;
+      const drift = (rand() - 0.49) * 0.02 * price;
+      const close = Math.max(1, price + drift);
+      const vol = price * (0.002 + rand() * 0.02);
+      const high = Math.max(open, close) + rand() * vol;
+      const low = Math.min(open, close) - rand() * vol;
+      out.push({ time: DAY * (i + 1), open, high, low, close, volume: 1000 });
+      price = close;
+    }
+    return out;
+  }
+
+  it("trade-for-trade parity across fillMode x slTpMode x exit-option grid", () => {
+    let comparisons = 0;
+    for (let s = 0; s < 15; s++) {
+      const candles = makeRandomSeries(60 + Math.floor(rand() * 120));
+      for (const opts of optionGrid) {
+        // (a) one-shot entry; the second signal tranche never fires
+        {
+          const ref = runBacktest(candles, at(3), periodicExit, {
+            capital: 100_000,
+            ...opts,
+          });
+          const scaled = runBacktestScaled(candles, at(3), periodicExit, {
+            capital: 100_000,
+            ...opts,
+            scaledEntry: SCALED_TWO_TRANCHES,
+          });
+          expect(scaled.trades.map(comparable)).toEqual(ref.trades.map(comparable));
+          comparisons++;
+        }
+        // (b) repeated entries; the price-based second tranche never triggers
+        {
+          const ref = runBacktest(candles, periodicEnter, periodicExit, {
+            capital: 100_000,
+            ...opts,
+          });
+          const scaled = runBacktestScaled(candles, periodicEnter, periodicExit, {
+            capital: 100_000,
+            ...opts,
+            scaledEntry: {
+              tranches: 3,
+              strategy: "equal",
+              intervalType: "price",
+              priceInterval: -90,
+            },
+          });
+          expect(scaled.trades.map(comparable)).toEqual(ref.trades.map(comparable));
+          comparisons++;
+        }
+      }
+    }
+    expect(comparisons).toBe(15 * optionGrid.length * 2);
+  });
+});

--- a/packages/core/src/backtest/scaled-entry.ts
+++ b/packages/core/src/backtest/scaled-entry.ts
@@ -466,7 +466,8 @@ export function runBacktestScaled(
           position.avgEntryPrice * (1 + partialTakeProfit.threshold / 100);
         const partialTrigger = checkProfitTrigger(candle, partialThresholdPrice, slTpMode);
         if (partialTrigger) {
-          const sharesToSell = position.totalShares * (partialTakeProfit.sellPercent / 100);
+          const sellFraction = partialTakeProfit.sellPercent / 100;
+          const sharesToSell = position.totalShares * sellFraction;
           closeShares(
             position,
             partialTrigger.price,
@@ -480,6 +481,14 @@ export function runBacktestScaled(
             },
           );
 
+          // Scale every tranche by the sold fraction so per-tranche shares
+          // stay in sync with totalShares. Selling at market does not change
+          // the remaining shares' average cost, and a later addTranche()
+          // recomputes the average from tranches — leaving the sold shares
+          // in place would weight the old cost basis as if nothing was sold.
+          for (const tranche of position.tranches) {
+            tranche.shares *= 1 - sellFraction;
+          }
           position.totalShares -= sharesToSell;
           position.partialTaken = true;
         }

--- a/packages/core/src/backtest/scaled-entry.ts
+++ b/packages/core/src/backtest/scaled-entry.ts
@@ -14,6 +14,7 @@ import type {
   BacktestResult,
   BacktestSettings,
   Condition,
+  ExitReason,
   FillMode,
   NormalizedCandle,
   ScaledEntryConfig,
@@ -23,6 +24,7 @@ import type {
 } from "../types";
 import type { ExtendedCondition } from "./conditions";
 import { evaluateCondition, seedBenchmark } from "./conditions";
+import { checkProfitTrigger, checkStopTrigger } from "./engine-utils";
 import {
   applySlippage,
   calculateStats,
@@ -212,12 +214,156 @@ export function runBacktestScaled(
   let maxDrawdown = 0;
   const returns: number[] = [];
 
+  // Fills queued by next-bar-open mode; they execute at the next bar's open,
+  // mirroring the single-entry engine's pendingEntry/pendingExit handling.
+  let pendingTranche: { entryAtr: number | null } | null = null;
+  let pendingExit: { exitReason: ExitReason } | null = null;
+
+  function openFirstTranche(
+    entryPrice: number,
+    time: number,
+    entryAtr: number | null,
+  ): ScaledPosition {
+    const trancheCapital = currentCapital * trancheWeights[0];
+    const entryCommission = commission + trancheCapital * (commissionRate / 100);
+    const shares = (trancheCapital - entryCommission) / entryPrice;
+
+    const opened: ScaledPosition = {
+      tranches: [
+        {
+          time,
+          price: entryPrice,
+          shares,
+          capitalUsed: trancheCapital,
+        },
+      ],
+      targetTranches: tranches,
+      firstEntryPrice: entryPrice,
+      avgEntryPrice: entryPrice,
+      totalShares: shares,
+      peakPrice: entryPrice,
+      partialTaken: false,
+      entryAtr,
+      reservedCapital: currentCapital - trancheCapital,
+    };
+
+    currentCapital = 0; // All capital (including reserved) is committed
+    return opened;
+  }
+
+  function addTranche(pos: ScaledPosition, entryPrice: number, time: number): void {
+    const trancheIndex = pos.tranches.length;
+    const trancheWeight = trancheWeights[trancheIndex];
+    const trancheCapital = capital * trancheWeight;
+    const entryCommission = commission + trancheCapital * (commissionRate / 100);
+    const shares = (trancheCapital - entryCommission) / entryPrice;
+
+    pos.tranches.push({
+      time,
+      price: entryPrice,
+      shares,
+      capitalUsed: trancheCapital,
+    });
+
+    pos.totalShares += shares;
+    pos.avgEntryPrice = calculateAvgEntryPrice(pos.tranches);
+    pos.reservedCapital -= trancheCapital;
+  }
+
+  function trackDrawdown(): void {
+    if (currentCapital > peakCapital) {
+      peakCapital = currentCapital;
+    }
+    const drawdown = ((peakCapital - currentCapital) / peakCapital) * 100;
+    if (drawdown > maxDrawdown) {
+      maxDrawdown = drawdown;
+    }
+  }
+
+  function closeShares(
+    pos: ScaledPosition,
+    rawExitPrice: number,
+    time: number,
+    exitReason: ExitReason,
+    sharesToClose: number,
+    opts: { withSlippage: boolean; releaseReserved: boolean; partial?: { exitPercent: number } },
+  ): void {
+    const exitPrice = opts.withSlippage
+      ? applySlippage(rawExitPrice, slippage, "sell")
+      : rawExitPrice;
+
+    const grossReturn = (exitPrice - pos.avgEntryPrice) * sharesToClose;
+    const exitValue = exitPrice * sharesToClose;
+    const exitCommission = commission + exitValue * (commissionRate / 100);
+
+    let tax = 0;
+    if (grossReturn > 0 && taxRate > 0) {
+      tax = grossReturn * (taxRate / 100);
+    }
+
+    const netReturn = grossReturn - exitCommission - tax;
+    const returnPercent = (netReturn / (pos.avgEntryPrice * sharesToClose)) * 100;
+    const holdingDays = Math.round((time - pos.tranches[0].time) / MS_PER_DAY);
+
+    trades.push({
+      entryTime: pos.tranches[0].time,
+      entryPrice: pos.avgEntryPrice,
+      exitTime: time,
+      exitPrice,
+      return: netReturn,
+      returnPercent,
+      holdingDays,
+      ...(opts.partial ? { isPartial: true, exitPercent: opts.partial.exitPercent } : {}),
+      exitReason,
+    });
+
+    // Add back any reserved capital that wasn't used (full closes only)
+    currentCapital +=
+      exitValue - exitCommission - tax + (opts.releaseReserved ? pos.reservedCapital : 0);
+    returns.push(returnPercent / 100);
+    trackDrawdown();
+  }
+
+  function closeFullPosition(
+    pos: ScaledPosition,
+    rawExitPrice: number,
+    time: number,
+    exitReason: ExitReason,
+    withSlippage: boolean,
+  ): void {
+    closeShares(pos, rawExitPrice, time, exitReason, pos.totalShares, {
+      withSlippage,
+      releaseReserved: true,
+    });
+  }
+
   for (let i = 1; i < candles.length; i++) {
     const candle = candles[i];
 
     // Update MTF indices for this candle
     if (mtfContext && mtfIndexMap) {
       updateMtfIndices(mtfContext, mtfIndexMap, i, candle.time);
+    }
+
+    // === Fill pending exit (next-bar-open mode) at this bar's open ===
+    if (pendingExit !== null) {
+      if (position !== null) {
+        closeFullPosition(position, candle.open, candle.time, pendingExit.exitReason, true);
+        position = null;
+      }
+      pendingExit = null;
+    }
+
+    // === Fill pending tranche (next-bar-open mode) at this bar's open ===
+    // An open fill owns the whole bar, so management below runs normally.
+    if (pendingTranche !== null) {
+      const fillPrice = applySlippage(candle.open, slippage, "buy");
+      if (position === null) {
+        position = openFirstTranche(fillPrice, candle.time, pendingTranche.entryAtr);
+      } else {
+        addTranche(position, fillPrice, candle.time);
+      }
+      pendingTranche = null;
     }
 
     if (position === null) {
@@ -232,49 +378,171 @@ export function runBacktestScaled(
           mtfContext,
         )
       ) {
-        const entryPrice = applySlippage(candle.close, slippage, "buy");
-
-        // Calculate capital allocation for first tranche
-        const trancheCapital = currentCapital * trancheWeights[0];
-        const entryCommission = commission + trancheCapital * (commissionRate / 100);
-        const shares = (trancheCapital - entryCommission) / entryPrice;
-
         const entryAtr = atrSeries ? atrSeries[i].value : null;
 
-        position = {
-          tranches: [
-            {
-              time: candle.time,
-              price: entryPrice,
-              shares,
-              capitalUsed: trancheCapital,
-            },
-          ],
-          targetTranches: tranches,
-          firstEntryPrice: entryPrice,
-          avgEntryPrice: entryPrice,
-          totalShares: shares,
-          peakPrice: entryPrice,
-          partialTaken: false,
-          entryAtr,
-          reservedCapital: currentCapital - trancheCapital,
-        };
-
-        currentCapital = 0; // All capital (including reserved) is committed
+        if (fillMode === "same-bar-close") {
+          // Close fill: position management starts on the next bar
+          position = openFirstTranche(
+            applySlippage(candle.close, slippage, "buy"),
+            candle.time,
+            entryAtr,
+          );
+        } else {
+          // next-bar-open mode: queue the first tranche for the next bar
+          pendingTranche = { entryAtr };
+        }
       }
     } else {
-      // Position exists - check for additional entries or exit
+      // === Position management ===
 
-      // Update peak price for trailing stop
+      // Fold this bar into the peak before trigger checks (mirrors the
+      // single-entry engine's ordering)
       if (candle.high > position.peakPrice) {
         position.peakPrice = candle.high;
       }
 
       let shouldExit = false;
       let exitPrice = candle.close;
+      let exitReason: ExitReason = "signal";
 
-      // Check for additional entry tranches
-      if (position.tranches.length < position.targetTranches && position.reservedCapital > 0) {
+      // Get current ATR value for ATR-based risk management
+      let currentAtr: number | null = null;
+      if (atrRisk && atrSeries) {
+        if (atrRisk.useEntryAtr && position.entryAtr !== null) {
+          currentAtr = position.entryAtr;
+        } else {
+          currentAtr = atrSeries[i].value;
+        }
+      }
+
+      // Stop loss check (using average entry price)
+      if (stopLoss !== undefined) {
+        const stopLossPrice = position.avgEntryPrice * (1 - stopLoss / 100);
+        const triggered = checkStopTrigger(candle, stopLossPrice, slTpMode);
+        if (triggered) {
+          shouldExit = true;
+          exitPrice = triggered.price;
+          exitReason = "stopLoss";
+        }
+      }
+
+      // ATR-based stop loss
+      if (!shouldExit && currentAtr !== null && atrRisk?.atrStopMultiplier !== undefined) {
+        const atrStopPrice = position.avgEntryPrice - currentAtr * atrRisk.atrStopMultiplier;
+        const triggered = checkStopTrigger(candle, atrStopPrice, slTpMode);
+        if (triggered) {
+          shouldExit = true;
+          exitPrice = triggered.price;
+          exitReason = "stopLoss";
+        }
+      }
+
+      // Take profit check
+      if (!shouldExit && takeProfit !== undefined) {
+        const takeProfitPrice = position.avgEntryPrice * (1 + takeProfit / 100);
+        const triggered = checkProfitTrigger(candle, takeProfitPrice, slTpMode);
+        if (triggered) {
+          shouldExit = true;
+          exitPrice = triggered.price;
+          exitReason = "takeProfit";
+        }
+      }
+
+      // ATR-based take profit
+      if (!shouldExit && currentAtr !== null && atrRisk?.atrTakeProfitMultiplier !== undefined) {
+        const atrTpPrice = position.avgEntryPrice + currentAtr * atrRisk.atrTakeProfitMultiplier;
+        const triggered = checkProfitTrigger(candle, atrTpPrice, slTpMode);
+        if (triggered) {
+          shouldExit = true;
+          exitPrice = triggered.price;
+          exitReason = "takeProfit";
+        }
+      }
+
+      // Partial take profit (on entire scaled position; executes immediately
+      // at the trigger price, mirroring the single-entry engine)
+      if (!shouldExit && partialTakeProfit && !position.partialTaken) {
+        const partialThresholdPrice =
+          position.avgEntryPrice * (1 + partialTakeProfit.threshold / 100);
+        const partialTrigger = checkProfitTrigger(candle, partialThresholdPrice, slTpMode);
+        if (partialTrigger) {
+          const sharesToSell = position.totalShares * (partialTakeProfit.sellPercent / 100);
+          closeShares(
+            position,
+            partialTrigger.price,
+            candle.time,
+            "partialTakeProfit",
+            sharesToSell,
+            {
+              withSlippage: true,
+              releaseReserved: false,
+              partial: { exitPercent: partialTakeProfit.sellPercent },
+            },
+          );
+
+          position.totalShares -= sharesToSell;
+          position.partialTaken = true;
+        }
+      }
+
+      // Trailing stop check
+      if (!shouldExit && trailingStop !== undefined) {
+        const trailingStopPrice = position.peakPrice * (1 - trailingStop / 100);
+        const triggered = checkStopTrigger(candle, trailingStopPrice, slTpMode);
+        if (triggered) {
+          shouldExit = true;
+          exitPrice = triggered.price;
+          exitReason = "trailing";
+        }
+      }
+
+      // ATR-based trailing stop
+      if (!shouldExit && currentAtr !== null && atrRisk?.atrTrailingMultiplier !== undefined) {
+        const atrTrailPrice = position.peakPrice - currentAtr * atrRisk.atrTrailingMultiplier;
+        const triggered = checkStopTrigger(candle, atrTrailPrice, slTpMode);
+        if (triggered) {
+          shouldExit = true;
+          exitPrice = triggered.price;
+          exitReason = "trailing";
+        }
+      }
+
+      // Signal-based exit condition
+      if (
+        !shouldExit &&
+        evaluateCondition(
+          exitCondition as ExtendedCondition,
+          indicators,
+          candle,
+          i,
+          candles,
+          mtfContext,
+        )
+      ) {
+        shouldExit = true;
+        exitPrice = candle.close;
+        exitReason = "signal";
+      }
+
+      if (shouldExit) {
+        if (fillMode === "same-bar-close") {
+          closeFullPosition(position, exitPrice, candle.time, exitReason, true);
+          position = null;
+        } else {
+          // next-bar-open mode: queue exit; it fills at the next bar's open
+          pendingExit = { exitReason };
+        }
+      } else if (
+        pendingTranche === null &&
+        position.tranches.length < position.targetTranches &&
+        position.reservedCapital > 0
+      ) {
+        // === Additional tranche check ===
+        // Runs after the exit checks: this bar's SL/TP/trailing ran against
+        // the pre-tranche position, so a same-bar-close tranche fill cannot
+        // be exited by price action from before the fill (the new average
+        // entry applies from the next bar). A bar that exits does not also
+        // add a tranche.
         let shouldAddTranche = false;
 
         if (intervalType === "signal") {
@@ -296,232 +564,23 @@ export function runBacktestScaled(
         }
 
         if (shouldAddTranche) {
-          const trancheIndex = position.tranches.length;
-          const trancheWeight = trancheWeights[trancheIndex];
-          const trancheCapital = capital * trancheWeight;
-          const entryPrice = applySlippage(candle.close, slippage, "buy");
-          const entryCommission = commission + trancheCapital * (commissionRate / 100);
-          const shares = (trancheCapital - entryCommission) / entryPrice;
-
-          position.tranches.push({
-            time: candle.time,
-            price: entryPrice,
-            shares,
-            capitalUsed: trancheCapital,
-          });
-
-          position.totalShares += shares;
-          position.avgEntryPrice = calculateAvgEntryPrice(position.tranches);
-          position.reservedCapital -= trancheCapital;
-        }
-      }
-
-      // Get current ATR value for ATR-based risk management
-      let currentAtr: number | null = null;
-      if (atrRisk && atrSeries) {
-        if (atrRisk.useEntryAtr && position.entryAtr !== null) {
-          currentAtr = position.entryAtr;
-        } else {
-          currentAtr = atrSeries[i].value;
-        }
-      }
-
-      // Stop loss check (using average entry price)
-      if (stopLoss !== undefined) {
-        const stopLossPrice = position.avgEntryPrice * (1 - stopLoss / 100);
-        if (candle.low <= stopLossPrice) {
-          shouldExit = true;
-          exitPrice = stopLossPrice;
-        }
-      }
-
-      // ATR-based stop loss
-      if (!shouldExit && currentAtr !== null && atrRisk?.atrStopMultiplier !== undefined) {
-        const atrStopDistance = currentAtr * atrRisk.atrStopMultiplier;
-        const atrStopPrice = position.avgEntryPrice - atrStopDistance;
-        if (candle.low <= atrStopPrice) {
-          shouldExit = true;
-          exitPrice = atrStopPrice;
-        }
-      }
-
-      // Take profit check
-      if (!shouldExit && takeProfit !== undefined) {
-        const takeProfitPrice = position.avgEntryPrice * (1 + takeProfit / 100);
-        if (candle.high >= takeProfitPrice) {
-          shouldExit = true;
-          exitPrice = takeProfitPrice;
-        }
-      }
-
-      // ATR-based take profit
-      if (!shouldExit && currentAtr !== null && atrRisk?.atrTakeProfitMultiplier !== undefined) {
-        const atrTpDistance = currentAtr * atrRisk.atrTakeProfitMultiplier;
-        const atrTpPrice = position.avgEntryPrice + atrTpDistance;
-        if (candle.high >= atrTpPrice) {
-          shouldExit = true;
-          exitPrice = atrTpPrice;
-        }
-      }
-
-      // Partial take profit (on entire scaled position)
-      if (!shouldExit && partialTakeProfit && !position.partialTaken) {
-        const partialThresholdPrice =
-          position.avgEntryPrice * (1 + partialTakeProfit.threshold / 100);
-        if (candle.high >= partialThresholdPrice) {
-          const partialExitPrice = applySlippage(partialThresholdPrice, slippage, "sell");
-          const sharesToSell = position.totalShares * (partialTakeProfit.sellPercent / 100);
-          const sharesRemaining = position.totalShares - sharesToSell;
-
-          const grossReturn = (partialExitPrice - position.avgEntryPrice) * sharesToSell;
-          const exitValue = partialExitPrice * sharesToSell;
-          const exitCommission = commission + exitValue * (commissionRate / 100);
-
-          let tax = 0;
-          if (grossReturn > 0 && taxRate > 0) {
-            tax = grossReturn * (taxRate / 100);
+          if (fillMode === "same-bar-close") {
+            addTranche(position, applySlippage(candle.close, slippage, "buy"), candle.time);
+          } else {
+            // next-bar-open mode: queue the tranche for the next bar's open
+            pendingTranche = { entryAtr: null };
           }
-
-          const netReturn = grossReturn - exitCommission - tax;
-          const returnPercent = (netReturn / (position.avgEntryPrice * sharesToSell)) * 100;
-          const holdingDays = Math.round((candle.time - position.tranches[0].time) / MS_PER_DAY);
-
-          trades.push({
-            entryTime: position.tranches[0].time,
-            entryPrice: position.avgEntryPrice,
-            exitTime: candle.time,
-            exitPrice: partialExitPrice,
-            return: netReturn,
-            returnPercent,
-            holdingDays,
-            isPartial: true,
-            exitPercent: partialTakeProfit.sellPercent,
-          });
-
-          currentCapital += exitValue - exitCommission - tax;
-          returns.push(returnPercent / 100);
-
-          if (currentCapital > peakCapital) {
-            peakCapital = currentCapital;
-          }
-          const drawdown = ((peakCapital - currentCapital) / peakCapital) * 100;
-          if (drawdown > maxDrawdown) {
-            maxDrawdown = drawdown;
-          }
-
-          position.totalShares = sharesRemaining;
-          position.partialTaken = true;
         }
-      }
-
-      // Trailing stop check
-      if (!shouldExit && trailingStop !== undefined) {
-        const trailingStopPrice = position.peakPrice * (1 - trailingStop / 100);
-        if (candle.low <= trailingStopPrice) {
-          shouldExit = true;
-          exitPrice = trailingStopPrice;
-        }
-      }
-
-      // ATR-based trailing stop
-      if (!shouldExit && currentAtr !== null && atrRisk?.atrTrailingMultiplier !== undefined) {
-        const atrTrailDistance = currentAtr * atrRisk.atrTrailingMultiplier;
-        const atrTrailPrice = position.peakPrice - atrTrailDistance;
-        if (candle.low <= atrTrailPrice) {
-          shouldExit = true;
-          exitPrice = atrTrailPrice;
-        }
-      }
-
-      // Signal-based exit condition
-      if (
-        !shouldExit &&
-        evaluateCondition(
-          exitCondition as ExtendedCondition,
-          indicators,
-          candle,
-          i,
-          candles,
-          mtfContext,
-        )
-      ) {
-        shouldExit = true;
-        exitPrice = candle.close;
-      }
-
-      if (shouldExit) {
-        exitPrice = applySlippage(exitPrice, slippage, "sell");
-
-        const grossReturn = (exitPrice - position.avgEntryPrice) * position.totalShares;
-        const exitValue = exitPrice * position.totalShares;
-        const exitCommission = commission + exitValue * (commissionRate / 100);
-
-        let tax = 0;
-        if (grossReturn > 0 && taxRate > 0) {
-          tax = grossReturn * (taxRate / 100);
-        }
-
-        const netReturn = grossReturn - exitCommission - tax;
-        const returnPercent = (netReturn / (position.avgEntryPrice * position.totalShares)) * 100;
-        const holdingDays = Math.round((candle.time - position.tranches[0].time) / MS_PER_DAY);
-
-        trades.push({
-          entryTime: position.tranches[0].time,
-          entryPrice: position.avgEntryPrice,
-          exitTime: candle.time,
-          exitPrice,
-          return: netReturn,
-          returnPercent,
-          holdingDays,
-        });
-
-        // Add back any reserved capital that wasn't used
-        currentCapital += exitValue - exitCommission - tax + position.reservedCapital;
-        returns.push(returnPercent / 100);
-
-        if (currentCapital > peakCapital) {
-          peakCapital = currentCapital;
-        }
-        const drawdown = ((peakCapital - currentCapital) / peakCapital) * 100;
-        if (drawdown > maxDrawdown) {
-          maxDrawdown = drawdown;
-        }
-
-        position = null;
       }
     }
   }
 
-  // Close any open position at the end
+  // Close any open position at the end (no slippage, matching the
+  // single-entry engine's end-of-data close). A queued next-bar-open exit
+  // that never got its fill bar also ends here as endOfData.
   if (position !== null) {
     const lastCandle = candles[candles.length - 1];
-    const exitPrice = lastCandle.close;
-
-    const grossReturn = (exitPrice - position.avgEntryPrice) * position.totalShares;
-    const exitValue = exitPrice * position.totalShares;
-    const exitCommission = commission + exitValue * (commissionRate / 100);
-
-    let tax = 0;
-    if (grossReturn > 0 && taxRate > 0) {
-      tax = grossReturn * (taxRate / 100);
-    }
-
-    const netReturn = grossReturn - exitCommission - tax;
-    const returnPercent = (netReturn / (position.avgEntryPrice * position.totalShares)) * 100;
-    const holdingDays = Math.round((lastCandle.time - position.tranches[0].time) / MS_PER_DAY);
-
-    trades.push({
-      entryTime: position.tranches[0].time,
-      entryPrice: position.avgEntryPrice,
-      exitTime: lastCandle.time,
-      exitPrice,
-      return: netReturn,
-      returnPercent,
-      holdingDays,
-    });
-
-    currentCapital += exitValue - exitCommission - tax + position.reservedCapital;
-    returns.push(returnPercent / 100);
+    closeFullPosition(position, lastCandle.close, lastCandle.time, "endOfData", false);
   }
 
   return calculateStats(


### PR DESCRIPTION
## Problem

The multi-tranche path of `runBacktestScaled` (`scaledEntry.tranches >= 2`) accepted `fillMode` and `slTpMode`, recorded them in `result.settings`, and then never used either:

- **Entries always filled at the signal bar's own close** — a same-bar fill even under the default `next-bar-open`, letting the backtest buy the very close that generated the signal. This applied to the first tranche and every additional tranche.
- **Stop loss, take profit, partial take profit, and trailing stops always triggered on intrabar wicks** and exited at the trigger price, ignoring the default `close-only` mode. A bar whose low pierced the stop but which closed back above it stopped the position out anyway.
- The single-tranche fallback delegates to `runBacktest` and honors both modes, so semantics silently flipped when `tranches` went from 1 to 2, and `result.settings` misreported what actually ran.

Concrete repro (5-bar fixture in the new test file, signal at bar 1, `stopLoss: 5`, default modes): `runBacktest` enters at bar 2's open (105), ignores bar 3's wick to 95 because it closes at 101 (above the 99.75 stop), and exits end-of-data at 101. The scaled path with `tranches: 2` instead entered at bar 1's own close (100) and stop-exited into bar 3's wick at 95 — on a bar that closed at 101.

A related look-ahead sat in the tranche-add path: on the bar that triggered an additional tranche, the average entry price was updated first and SL/TP were then evaluated against the whole bar's high/low — so price action from *before* the tranche existed could fire a take-profit computed off the updated average (e.g. a bar spiking to 109 before closing at 97.9 "profitably" exited a position whose second tranche only came into existence at that 97.9 close).

## Fix

The multi-tranche loop now mirrors the single-entry engine:

- `next-bar-open` queues entries (`pendingTranche`, first and additional) and exits (`pendingExit`) and fills them at the next bar's open; `same-bar-close` fills at the signal bar's close. An open fill owns its whole bar; a close fill starts management on the next bar.
- All stop/profit triggers route through the same `checkStopTrigger` / `checkProfitTrigger` helpers `runBacktest` uses, honoring `slTpMode`.
- Exit checks run before the add-tranche evaluation, against the pre-tranche average entry — a bar that exits does not also add a tranche, and a same-bar-close tranche fill cannot be exited by price action from before the fill.
- Scaled trades now carry `exitReason` (previously `undefined`); end-of-data closes match the engine (last close, no slippage, `"endOfData"`).
- Exit/partial-exit accounting is consolidated into a single shares-parameterized close helper, so full, partial, and end-of-data closes share one money path.

`runBacktestScaled` with identical options and only one filling tranche is now trade-for-trade identical to `runBacktest`.

## Test plan

- New `src/backtest/__tests__/scaled-entry-fill-modes.test.ts` (7 tests):
  - fill timing per mode (next-bar-open → bar 2 open @105; same-bar-close → bar 1 close @100);
  - `close-only` ignores the stop-piercing wick (exit `endOfData` @101); `intraday` stops on the wick and fills the exit at the next open;
  - tranche-add causality in both fill modes (the pre-fill 109 spike must not fire TP off the ~98.94 post-add average);
  - trade-for-trade parity vs `runBacktest`: 15 seeded random series × 21-entry option grid (`fillMode` × `slTpMode` × stop/TP/trailing/partial/slippage/commission/tax, plus a defaults-only entry) × 2 scaled configs = 630 trade-list comparisons on entry/exit time, price, returnPercent, exitReason, partial fields.
  - Verified the tests fail without the fix: 7 of 7 → 6 fail on the pre-fix source (the parity suite alone fails on 100+ of its comparisons).
- Independent parity sweep during development: 1,600 randomized `runBacktest` vs `runBacktestScaled` comparisons across the option grid — 0 mismatches.
- Behavior-preservation check for the close-helper consolidation: 1,920 randomized multi-tranche runs (80 series × 12 option sets × 2 scaled configs, partial-TP paths included) — outputs byte-identical before/after the consolidation.
- Full suites green: core 6,361 tests / 360 files, chart 934, mcp 83; `npx tsc --noEmit --ignoreDeprecations 6.0` clean; `pnpm build` clean; biome clean on touched files.