### PR TITLE
fix(core): divergence signals carry a causal confirmation bar

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## [Unreleased]
 
+### Breaking — `DivergenceSignal` gains a confirmation bar; trade-signal converters emit at causal timestamps
+
+`detectDivergence` (and `rsiDivergence` / `obvDivergence` / `macdDivergence` /
+`cvdDivergence`) anchors each signal at its second pivot. A pivot is only
+identifiable `swingLookback` bars after it occurs, so `time` and `secondIdx`
+point at a bar that was not knowable when it printed — and it is by
+construction a local price extreme. `fromDivergenceSignal` re-stamped that
+time onto an actionable BUY/SELL `TradeSignal`, and the documented usage
+passed `candles[s.secondIdx].close` as the entry price, so consumers were
+entering at the swing extreme five bars before the divergence could be seen.
+
+`DivergenceSignal` now carries `confirmedAt` (and `confirmedIdx`): the first
+bar at which the divergence is knowable, being the later of the price and
+indicator pivots plus `swingLookback`. Verified against a truncated re-run —
+each signal is detectable from the prefix ending at `confirmedAt` and not one
+bar earlier. `time`/`secondIdx` remain as pivot annotation (chart markers
+still want the pivot), and both new fields are required, so any code
+constructing a `DivergenceSignal` must supply them. A divergence whose
+confirmation bar falls outside the candle array is withheld rather than
+reported at the last bar — only reachable through `detectDivergence` when the
+price/indicator series passed are longer than `candles`.
+
+`fromDivergenceSignal` now stamps `time` and `id` from `confirmedAt`, keeping
+the pivot time in `metadata.pivotTime`. `fromPatternSignal` had the same
+problem and now stamps at the pattern's actionable bar (`confirmTime` when
+confirmed, otherwise `detectableTime`), keeping the pivot in
+`metadata.patternTime`. Emitted timestamps and ids therefore change for both
+converters; the streaming divergence detector was already causal, so batch
+and streaming now agree.
+
 ### Fixed — `runBacktestScaled` (tranches ≥ 2) now honors `fillMode` and `slTpMode`
 
 The multi-tranche path of `runBacktestScaled` accepted `fillMode`/`slTpMode`

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -2274,7 +2274,9 @@ const bearish = signals.filter(s => s.type === 'bearish');
 
 ```typescript
 interface DivergenceSignal {
-  time: number;
+  time: number;                  // 2番目のピボットの時刻（注記用。判断時刻ではない）
+  confirmedAt: number;           // ダイバージェンスが実時間で判明する最初のバーの時刻
+  confirmedIdx: number;          // confirmedAt のバーのインデックス
   type: 'bullish' | 'bearish';  // bullish: 強気, bearish: 弱気
   kind: 'regular' | 'hidden';   // regular: レギュラー（反転）/ hidden: ヒドゥン（継続）
   firstIdx: number;              // 最初のスイングポイントのインデックス
@@ -2283,6 +2285,12 @@ interface DivergenceSignal {
   indicator: { first: number; second: number };
 }
 ```
+
+ピボットは発生から `swingLookback` 本後にならないと特定できないため、`time`
+（2番目のピボット）はその時点では知り得ません。`confirmedAt` / `confirmedIdx`
+はダイバージェンスを実際に行動に移せる最初のバー（価格側とインジケーター側の
+ピボットの遅い方 + `swingLookback`）を指します。エントリー・アラート・他シグナル
+との時刻合わせなど、因果性が必要な用途ではこちらを使ってください。
 
 ---
 
@@ -5274,7 +5282,9 @@ const tradeSignals = signals.map(s => fromCrossSignal(s, candles.find(c => c.tim
 import { fromDivergenceSignal } from 'trendcraft';
 
 const divSignals = rsiDivergence(candles);
-const tradeSignals = divSignals.map(s => fromDivergenceSignal(s, candles[s.secondIdx].close));
+// `confirmedAt`（ダイバージェンスが判明するバー）の時刻でスタンプされるため、
+// エントリー価格もピボットではなくそのバーから取る
+const tradeSignals = divSignals.map(s => fromDivergenceSignal(s, candles[s.confirmedIdx].close));
 ```
 
 #### `fromSqueezeSignal(signal, direction?, entryPrice?)`
@@ -5288,7 +5298,10 @@ const tradeSignals = squeezes.map(s => fromSqueezeSignal(s, "LONG", candles.find
 
 #### `fromPatternSignal(signal, entryPrice?)`
 
-パターンの`target`と`stopLoss`を`TradeSignal.prices`にマッピング。
+パターンの`target`と`stopLoss`を`TradeSignal.prices`にマッピング。シグナルの時刻は
+パターンが行動可能になるバー（confirmed なら `confirmTime`、そうでなければ
+`detectableTime`）でスタンプされます。`PatternSignal.time` が指すピボットのバーでは
+ありません（ピボット時刻は `metadata.patternTime` に保持）。
 
 ```typescript
 import { fromPatternSignal } from 'trendcraft';

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -2298,7 +2298,9 @@ const bearish = signals.filter(s => s.type === 'bearish');
 
 ```typescript
 interface DivergenceSignal {
-  time: number;
+  time: number;                 // Second pivot bar — annotation only, not a decision time
+  confirmedAt: number;          // Bar where the divergence first becomes knowable
+  confirmedIdx: number;         // Index of the confirmedAt bar
   type: 'bullish' | 'bearish';
   kind: 'regular' | 'hidden';   // Regular (reversal) vs hidden (continuation) divergence
   firstIdx: number;
@@ -2307,6 +2309,12 @@ interface DivergenceSignal {
   indicator: { first: number; second: number };
 }
 ```
+
+A pivot is only identifiable `swingLookback` bars after it occurs, so `time`
+(the second pivot) is not knowable when it happens. `confirmedAt` /
+`confirmedIdx` give the first bar at which the divergence can be acted on — the
+later of the price and indicator pivots plus `swingLookback` — and are what
+causal consumers (entries, alerts, cross-signal alignment) should use.
 
 ---
 
@@ -5318,7 +5326,9 @@ const tradeSignals = signals.map(s => fromCrossSignal(s, candles.find(c => c.tim
 import { fromDivergenceSignal } from 'trendcraft';
 
 const divSignals = rsiDivergence(candles);
-const tradeSignals = divSignals.map(s => fromDivergenceSignal(s, candles[s.secondIdx].close));
+// Stamped at `confirmedAt` (the bar the divergence becomes knowable), so the
+// entry price comes from that bar rather than from the pivot.
+const tradeSignals = divSignals.map(s => fromDivergenceSignal(s, candles[s.confirmedIdx].close));
 ```
 
 #### `fromSqueezeSignal(signal, direction?, entryPrice?)`
@@ -5333,7 +5343,10 @@ const tradeSignals = squeezes.map(s => fromSqueezeSignal(s, "LONG", candles.find
 
 #### `fromPatternSignal(signal, entryPrice?)`
 
-Maps pattern `target` and `stopLoss` to `TradeSignal.prices`.
+Maps pattern `target` and `stopLoss` to `TradeSignal.prices`. The signal is
+stamped at the bar where the pattern becomes actionable (`confirmTime` when
+confirmed, otherwise `detectableTime`), not at the pivot bar `PatternSignal.time`
+anchors; the pivot time is kept in `metadata.patternTime`.
 
 ```typescript
 import { fromPatternSignal } from 'trendcraft';

--- a/packages/core/src/backtest/conditions/patterns.ts
+++ b/packages/core/src/backtest/conditions/patterns.ts
@@ -19,6 +19,7 @@ import {
   detectTriangle,
   detectWedge,
 } from "../../signals/patterns";
+import { patternActionableTime } from "../../signals/patterns/double-pattern-utils";
 import type { NormalizedCandle, PresetCondition } from "../../types";
 
 const PATTERN_CACHE_PREFIX = "pattern_";
@@ -132,22 +133,6 @@ function getPatternData(
 }
 
 /**
- * Get the earliest bar time at which the pattern is actionable.
- *
- * `PatternSignal.time` anchors the final structural pivot, which is only
- * identifiable `swingLookback` bars later (and confirmation requires a
- * breakout that can be weeks after the pivot). Matching conditions against
- * `time` would let a backtest act on future knowledge, so conditions match
- * against the causal timestamps instead.
- */
-function actionableTime(pattern: PatternSignal, confirmedOnly: boolean): number | undefined {
-  if (confirmedOnly) {
-    return pattern.confirmed ? pattern.confirmTime : undefined;
-  }
-  return pattern.detectableTime;
-}
-
-/**
  * Find a matching pattern actionable at the given candle time
  */
 function findPatternAtTime(
@@ -155,7 +140,7 @@ function findPatternAtTime(
   time: number | string,
   confirmedOnly: boolean,
 ): PatternSignal | undefined {
-  return patterns.find((p) => actionableTime(p, confirmedOnly) === time);
+  return patterns.find((p) => patternActionableTime(p, confirmedOnly) === time);
 }
 
 /**
@@ -292,8 +277,8 @@ export function anyBearishPattern(options: PatternConditionOptions = {}): Preset
  *
  * A confirmed pattern's confidence folds in breakout and breakout-bar volume
  * information, so it only becomes knowable at `confirmTime`; unconfirmed
- * patterns are gated on `detectableTime`. That is `actionableTime` with the
- * pattern's own `confirmed` flag as the requirement.
+ * patterns are gated on `detectableTime`. That is `patternActionableTime` with
+ * the pattern's own `confirmed` flag as the requirement.
  */
 function findHighConfidencePattern(
   patterns: PatternSignal[],
@@ -301,7 +286,7 @@ function findHighConfidencePattern(
   minConfidence: number,
 ): boolean {
   return patterns.some(
-    (p) => actionableTime(p, p.confirmed) === time && p.confidence >= minConfidence,
+    (p) => patternActionableTime(p, p.confirmed) === time && p.confidence >= minConfidence,
   );
 }
 
@@ -401,7 +386,7 @@ export function patternWithinBars(
 
       // Check if any pattern became actionable within the lookback window
       for (const pattern of patterns) {
-        const time = actionableTime(pattern, confirmedOnly);
+        const time = patternActionableTime(pattern, confirmedOnly);
         if (time !== undefined && lookbackTimes.has(time)) {
           return true;
         }

--- a/packages/core/src/signals/__tests__/divergence.test.ts
+++ b/packages/core/src/signals/__tests__/divergence.test.ts
@@ -366,3 +366,122 @@ describe("macdDivergence", () => {
     }
   });
 });
+
+describe("divergence causality", () => {
+  /** Deterministic PRNG so the walk below is stable across runs. */
+  function mulberry32(seed: number) {
+    let a = seed;
+    return () => {
+      a |= 0;
+      a = (a + 0x6d2b79f5) | 0;
+      let t = Math.imul(a ^ (a >>> 15), 1 | a);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+
+  function randomWalk(n: number, seed: number): NormalizedCandle[] {
+    const rnd = mulberry32(seed);
+    const out: NormalizedCandle[] = [];
+    let price = 100;
+    for (let i = 0; i < n; i++) {
+      price *= 1 + (rnd() - 0.5) * 0.04;
+      out.push({
+        time: 1_700_000_000 + i * 86_400,
+        open: price,
+        high: price * 1.01,
+        low: price * 0.99,
+        close: price,
+        volume: 1_000_000,
+      });
+    }
+    return out;
+  }
+
+  /** A flat series with troughs punched in at the given indices. */
+  function withTroughs(n: number, troughs: { idx: number; depth: number }[]): number[] {
+    const out = Array.from({ length: n }, (_, i) => 100 + (i % 3) * 0.001);
+    for (const t of troughs) out[t.idx] = 100 - t.depth;
+    return out;
+  }
+
+  const candles = randomWalk(300, 42);
+  const signals = rsiDivergence(candles);
+
+  const detectedIn = (
+    signal: { secondIdx: number; type: string; kind: string },
+    barCount: number,
+  ): boolean =>
+    rsiDivergence(candles.slice(0, barCount)).some(
+      (x) => x.secondIdx === signal.secondIdx && x.type === signal.type && x.kind === signal.kind,
+    );
+
+  it("produces signals on the fixture walk", () => {
+    expect(signals.length).toBeGreaterThan(0);
+  });
+
+  it("is not detectable at its own pivot bar", () => {
+    // The pivot needs swingLookback bars on its right to be identified, so a
+    // consumer acting at `time` would be acting on bars it cannot have seen.
+    for (const s of signals) {
+      expect(detectedIn(s, s.secondIdx + 1)).toBe(false);
+    }
+  });
+
+  it("confirmedIdx is exactly the first bar at which the divergence is detectable", () => {
+    for (const s of signals) {
+      expect(s.confirmedIdx).toBeGreaterThan(s.secondIdx);
+      expect(detectedIn(s, s.confirmedIdx + 1)).toBe(true);
+      expect(detectedIn(s, s.confirmedIdx)).toBe(false);
+      expect(s.confirmedAt).toBe(candles[s.confirmedIdx].time);
+    }
+  });
+
+  it("confirms on the later of the price and indicator pivots", () => {
+    // Price troughs at 20/60, indicator troughs 2 bars later at 22/62. The
+    // divergence is anchored at price pivot 60 but only knowable at 62 + 5.
+    const n = 100;
+    const prices = withTroughs(n, [
+      { idx: 20, depth: 5 },
+      { idx: 60, depth: 8 },
+    ]);
+    const indicator = withTroughs(n, [
+      { idx: 22, depth: 8 },
+      { idx: 62, depth: 5 },
+    ]);
+    const bars = randomWalk(n, 1);
+
+    const found = detectDivergence(bars, prices, indicator, { swingLookback: 5 });
+    expect(found).toHaveLength(1);
+    expect(found[0].secondIdx).toBe(60);
+    expect(found[0].confirmedIdx).toBe(67);
+    expect(found[0].confirmedAt).toBe(bars[67].time);
+  });
+
+  it("omits a divergence whose confirmation bar is beyond the candles", () => {
+    // Same pivots as above (confirmation at bar 67), but the caller passes
+    // series longer than the candle array. Reporting the divergence at the
+    // last available bar would claim knowledge before it exists, so it is
+    // withheld until the confirmation bar is in range.
+    const n = 100;
+    const prices = withTroughs(n, [
+      { idx: 20, depth: 5 },
+      { idx: 60, depth: 8 },
+    ]);
+    const indicator = withTroughs(n, [
+      { idx: 22, depth: 8 },
+      { idx: 62, depth: 5 },
+    ]);
+
+    expect(detectDivergence(randomWalk(67, 1), prices, indicator, { swingLookback: 5 })).toEqual(
+      [],
+    );
+
+    // One more bar and the confirmation bar exists, so the signal appears.
+    const atBoundary = detectDivergence(randomWalk(68, 1), prices, indicator, {
+      swingLookback: 5,
+    });
+    expect(atBoundary).toHaveLength(1);
+    expect(atBoundary[0].confirmedIdx).toBe(67);
+  });
+});

--- a/packages/core/src/signals/__tests__/trade-signal.test.ts
+++ b/packages/core/src/signals/__tests__/trade-signal.test.ts
@@ -68,6 +68,8 @@ describe("fromDivergenceSignal", () => {
   it("converts bullish divergence to BUY", () => {
     const signal: DivergenceSignal = {
       time: 2000,
+      confirmedAt: 2500,
+      confirmedIdx: 15,
       type: "bullish",
       kind: "regular",
       firstIdx: 5,
@@ -85,6 +87,8 @@ describe("fromDivergenceSignal", () => {
   it("converts bearish divergence to SELL", () => {
     const signal: DivergenceSignal = {
       time: 3000,
+      confirmedAt: 3500,
+      confirmedIdx: 15,
       type: "bearish",
       kind: "regular",
       firstIdx: 5,
@@ -95,6 +99,26 @@ describe("fromDivergenceSignal", () => {
     const result = fromDivergenceSignal(signal);
     expect(result.action).toBe("SELL");
     expect(result.direction).toBe("SHORT");
+  });
+
+  it("stamps the trade signal at confirmedAt, not at the pivot bar", () => {
+    const signal: DivergenceSignal = {
+      time: 2000,
+      confirmedAt: 2500,
+      confirmedIdx: 15,
+      type: "bullish",
+      kind: "regular",
+      firstIdx: 5,
+      secondIdx: 10,
+      price: { first: 100, second: 95 },
+      indicator: { first: 30, second: 35 },
+    };
+    const result = fromDivergenceSignal(signal, 95);
+    expect(result.time).toBe(2500);
+    expect(result.id).toBe("divergence-regular-bullish-2500");
+    // The pivot bar stays available as annotation metadata
+    expect(result.metadata?.pivotTime).toBe(2000);
+    expect(result.metadata?.secondIdx).toBe(10);
   });
 });
 
@@ -166,6 +190,36 @@ describe("fromPatternSignal", () => {
     expect(result.action).toBe("SELL");
     expect(result.direction).toBe("SHORT");
     expect(result.metadata?.confirmed).toBe(false);
+  });
+
+  it("stamps a confirmed pattern at confirmTime, not at the pivot bar", () => {
+    const signal: PatternSignal = {
+      time: 5000,
+      detectableTime: 5500,
+      confirmTime: 7000,
+      type: "double_bottom",
+      pattern: { startTime: 4000, endTime: 5000, keyPoints: [] },
+      confidence: 72,
+      confirmed: true,
+    };
+    const result = fromPatternSignal(signal);
+    expect(result.time).toBe(7000);
+    expect(result.id).toBe("pattern-double_bottom-7000");
+    expect(result.metadata?.patternTime).toBe(5000);
+  });
+
+  it("stamps an unconfirmed pattern at detectableTime", () => {
+    const signal: PatternSignal = {
+      time: 5000,
+      detectableTime: 5500,
+      type: "double_top",
+      pattern: { startTime: 4000, endTime: 5000, keyPoints: [] },
+      confidence: 65,
+      confirmed: false,
+    };
+    const result = fromPatternSignal(signal);
+    expect(result.time).toBe(5500);
+    expect(result.metadata?.patternTime).toBe(5000);
   });
 });
 

--- a/packages/core/src/signals/divergence.ts
+++ b/packages/core/src/signals/divergence.ts
@@ -27,8 +27,23 @@ export type DivergenceClass = "regular" | "hidden";
  * Divergence signal type
  */
 export type DivergenceSignal = {
-  /** Timestamp of the divergence point (second peak/trough) */
+  /**
+   * Timestamp of the divergence point (second peak/trough).
+   *
+   * This anchors the pivot itself and is annotation metadata, **not** a
+   * decision time: a pivot is only identifiable `swingLookback` bars after it
+   * occurs. Use {@link DivergenceSignal.confirmedAt} for anything actionable.
+   */
   time: number;
+  /**
+   * Earliest bar time at which the divergence is knowable in real time: the
+   * bar `swingLookback` bars after the later of the price and indicator
+   * pivots. Use this (not `time`) for causal entries and for aligning with
+   * other signals.
+   */
+  confirmedAt: number;
+  /** Index of the {@link DivergenceSignal.confirmedAt} bar */
+  confirmedIdx: number;
   /** Directional bias of the divergence (a buy lean vs. a sell lean) */
   type: "bullish" | "bearish";
   /** Regular (reversal) vs. hidden (continuation) divergence */
@@ -182,13 +197,24 @@ export function macdDivergence(
  * @param candles - Normalized candles (for timestamps)
  * @param prices - Price series (typically close prices)
  * @param indicator - Indicator series
+ * Each signal is anchored at its second pivot (`time`/`secondIdx`) but is only
+ * knowable `swingLookback` bars later; `confirmedAt`/`confirmedIdx` carry that
+ * decision time and are what causal consumers should act on. A divergence
+ * whose confirmation bar is not in `candles` is not returned — it is not yet
+ * confirmable from the data given.
+ *
  * @param options - Detection options
- * @returns Array of divergence signals, sorted by time
+ * @returns Array of divergence signals, sorted by pivot time
  *
  * @example
  * ```ts
  * // Reversal signals only (default)
  * const reversals = detectDivergence(candles, prices, rsiValues);
+ * // Act at the bar the divergence is knowable, not at the pivot
+ * const entries = reversals.map((s) => ({
+ *   time: s.confirmedAt,
+ *   price: candles[s.confirmedIdx].close,
+ * }));
  * // Both reversal and continuation signals
  * const all = detectDivergence(candles, prices, rsiValues, {
  *   kinds: ["regular", "hidden"],
@@ -258,8 +284,15 @@ export function detectDivergence(
         // Indicator must move strictly in the (opposing) required direction.
         if (indHigher ? currInd.value <= prevInd.value : currInd.value >= prevInd.value) continue;
 
+        // Not yet confirmable within the candles given — see causalDivergenceTime.
+        const confirmation = causalDivergenceTime(candles, curr.idx, currInd.idx, swingLookback);
+        if (!confirmation) continue;
+        const { confirmedAt, confirmedIdx } = confirmation;
+
         results.push({
           time: candles[curr.idx].time,
+          confirmedAt,
+          confirmedIdx,
           type,
           kind,
           firstIdx: prev.idx,
@@ -275,6 +308,34 @@ export function detectDivergence(
   results.sort((a, b) => a.time - b.time);
 
   return results;
+}
+
+/**
+ * Compute the bar at which a divergence first becomes knowable.
+ *
+ * Both pivots are found by scanning `swingLookback` bars on either side, so
+ * the later of the two pivots is only identifiable `swingLookback` bars after
+ * it occurs — that bar is the divergence's decision time. The indicator pivot
+ * can trail the price pivot (`findNearestSwing` matches within a
+ * `swingLookback` tolerance), which is why the maximum is taken rather than
+ * the price pivot alone. This is the single owner of that rule.
+ *
+ * Returns `null` when the confirmation bar lies beyond the candle array: such
+ * a divergence is not confirmable from the data given, and reporting it at the
+ * last available bar would claim knowledge earlier than it exists. With
+ * `prices`/`indicator` aligned to `candles` this cannot happen — a pivot needs
+ * `swingLookback` bars to its right to be found at all — so it only guards
+ * callers passing series longer than the candle array.
+ */
+function causalDivergenceTime(
+  candles: NormalizedCandle[],
+  pricePivotIdx: number,
+  indicatorPivotIdx: number,
+  swingLookback: number,
+): { confirmedAt: number; confirmedIdx: number } | null {
+  const confirmedIdx = Math.max(pricePivotIdx, indicatorPivotIdx) + swingLookback;
+  if (confirmedIdx >= candles.length) return null;
+  return { confirmedAt: candles[confirmedIdx].time, confirmedIdx };
 }
 
 /**

--- a/packages/core/src/signals/patterns/double-pattern-utils.ts
+++ b/packages/core/src/signals/patterns/double-pattern-utils.ts
@@ -3,6 +3,7 @@
  */
 
 import type { NormalizedCandle } from "../../types";
+import type { PatternSignal } from "./types";
 
 // Helper types
 export interface SwingPoint {
@@ -36,6 +37,25 @@ export function causalPatternTimes(
     confirmTime:
       breakoutIndex != null ? candles[Math.max(breakoutIndex, knowableIndex)].time : undefined,
   };
+}
+
+/**
+ * Earliest bar time at which a detected pattern can be acted on.
+ *
+ * `PatternSignal.time` anchors the final structural pivot, which is only
+ * identifiable `swingLookback` bars later (and confirmation requires a
+ * breakout that can come much later still), so consumers that act on `time`
+ * would be trading on future knowledge. Returns `undefined` when a confirmed
+ * pattern is required but the signal is unconfirmed.
+ */
+export function patternActionableTime(
+  pattern: PatternSignal,
+  confirmedOnly: boolean,
+): number | undefined {
+  if (confirmedOnly) {
+    return pattern.confirmed ? pattern.confirmTime : undefined;
+  }
+  return pattern.detectableTime;
 }
 
 /**

--- a/packages/core/src/signals/trade-signal/converters.ts
+++ b/packages/core/src/signals/trade-signal/converters.ts
@@ -10,6 +10,7 @@ import type { PriceLevels, TradeSignal } from "../../types/trade-signal";
 import type { SqueezeSignal } from "../bollinger-squeeze";
 import type { CrossSignalQuality } from "../cross";
 import type { DivergenceSignal } from "../divergence";
+import { patternActionableTime } from "../patterns/double-pattern-utils";
 import type { PatternSignal } from "../patterns/types";
 
 /**
@@ -53,21 +54,25 @@ export function fromCrossSignal(signal: CrossSignalQuality, entryPrice?: number)
 /**
  * Convert a DivergenceSignal to a TradeSignal
  *
+ * The trade signal is stamped at `confirmedAt` — the bar where the divergence
+ * first becomes knowable — not at the pivot bar it is anchored to. The pivot
+ * bar is carried in `metadata.pivotTime` for annotation.
+ *
  * @param signal - Divergence detection result
- * @param entryPrice - Current price at signal time
+ * @param entryPrice - Price at the confirmation bar
  * @returns Unified trade signal
  *
  * @example
  * ```ts
  * const divSignals = rsiDivergence(candles);
- * const tradeSignals = divSignals.map(s => fromDivergenceSignal(s, candles[s.secondIdx].close));
+ * const tradeSignals = divSignals.map(s => fromDivergenceSignal(s, candles[s.confirmedIdx].close));
  * ```
  */
 export function fromDivergenceSignal(signal: DivergenceSignal, entryPrice?: number): TradeSignal {
   const isBullish = signal.type === "bullish";
   return {
-    id: `divergence-${signal.kind}-${signal.type}-${signal.time}`,
-    time: signal.time,
+    id: `divergence-${signal.kind}-${signal.type}-${signal.confirmedAt}`,
+    time: signal.confirmedAt,
     action: isBullish ? "BUY" : "SELL",
     direction: isBullish ? "LONG" : "SHORT",
     confidence: 60,
@@ -82,6 +87,7 @@ export function fromDivergenceSignal(signal: DivergenceSignal, entryPrice?: numb
     metadata: {
       firstIdx: signal.firstIdx,
       secondIdx: signal.secondIdx,
+      pivotTime: signal.time,
     },
   };
 }
@@ -135,8 +141,13 @@ export function fromSqueezeSignal(
  *
  * Maps pattern target and stopLoss to TradeSignal price levels.
  *
+ * The trade signal is stamped at the bar where the pattern first becomes
+ * actionable — `confirmTime` for a confirmed pattern, `detectableTime`
+ * otherwise — not at the pivot bar `PatternSignal.time` anchors. The pivot bar
+ * is carried in `metadata.patternTime` for annotation.
+ *
  * @param signal - Pattern recognition signal
- * @param entryPrice - Current price at signal time
+ * @param entryPrice - Price at the actionable bar
  * @returns Unified trade signal
  *
  * @example
@@ -148,6 +159,9 @@ export function fromSqueezeSignal(
 export function fromPatternSignal(signal: PatternSignal, entryPrice?: number): TradeSignal {
   const bullishPatterns = ["double_bottom", "inverse_head_shoulders", "cup_handle"];
   const isBullish = bullishPatterns.includes(signal.type);
+  // A confirmed pattern's confidence folds in breakout information, so the
+  // whole signal is only knowable at confirmTime.
+  const actionableTime = patternActionableTime(signal, signal.confirmed) ?? signal.detectableTime;
 
   let prices: PriceLevels | undefined;
   if (entryPrice) {
@@ -161,8 +175,8 @@ export function fromPatternSignal(signal: PatternSignal, entryPrice?: number): T
   }
 
   return {
-    id: `pattern-${signal.type}-${signal.time}`,
-    time: signal.time,
+    id: `pattern-${signal.type}-${actionableTime}`,
+    time: actionableTime,
     action: isBullish ? "BUY" : "SELL",
     direction: isBullish ? "LONG" : "SHORT",
     confidence: signal.confidence,
@@ -177,6 +191,7 @@ export function fromPatternSignal(signal: PatternSignal, entryPrice?: number): T
     metadata: {
       confirmed: signal.confirmed,
       height: signal.pattern.height,
+      patternTime: signal.time,
     },
   };
 }


### PR DESCRIPTION
## Problem

`detectDivergence` — and the `rsiDivergence` / `obvDivergence` / `macdDivergence` / `cvdDivergence` wrappers built on it — anchors each signal at its second pivot. A pivot is only identifiable `swingLookback` bars after it occurs, so `time` and `secondIdx` point at a bar that was not knowable when it printed. By construction that bar is also a local price extreme.

`fromDivergenceSignal` re-stamped that timestamp onto an actionable BUY/SELL `TradeSignal`, and the documented usage passed `candles[s.secondIdx].close` as the entry price. Consumers were therefore entering at the swing extreme five bars before the divergence could have been seen.

Measured on a 500-bar seeded random walk (`swingLookback` default 5):

```
total signals on full series: 3
signal secondIdx=142: knowable at own time? false; first detectable at bar 147 (delay 5)
  entry candles[secondIdx].close=84.55 is local extreme of +-5 window: true
signal secondIdx=406: knowable at own time? false; first detectable at bar 411 (delay 5)
signal secondIdx=427: knowable at own time? false; first detectable at bar 432 (delay 5)

checked=3, undetectable-at-own-time=3, delays=[5,5,5]
fromDivergenceSignal -> action=BUY, time=1712268800 (== pivot time? true), entry=84.55
```

`fromPatternSignal` had the same defect: `PatternSignal` already carries causal timestamps (`detectableTime` / `confirmTime`), but the converter emitted at `signal.time`, the pivot bar.

## Change

`DivergenceSignal` gains `confirmedAt` / `confirmedIdx` — the later of the price and indicator pivots plus `swingLookback`. The maximum matters: the indicator pivot can trail the price pivot, since `findNearestSwing` matches within a `swingLookback` tolerance, so anchoring on the price pivot alone would still be early. `time` / `secondIdx` stay as pivot annotation, which is what chart markers want.

A divergence whose confirmation bar falls outside the candle array is now withheld instead of being reported at the last bar; reporting it there would claim knowledge earlier than it exists. With the price/indicator series aligned to `candles` this is unreachable, so it only guards `detectDivergence` callers passing longer series.

`fromDivergenceSignal` now stamps `time` and `id` from `confirmedAt`, keeping the pivot in `metadata.pivotTime`. `fromPatternSignal` stamps at the pattern's actionable bar — `confirmTime` when confirmed, `detectableTime` otherwise — keeping the pivot in `metadata.patternTime`. The actionable-time rule now lives in one helper shared with the pattern backtest conditions rather than being restated in the converter.

The streaming divergence detector was already causal, so batch and streaming now agree.

## Breaking

- `confirmedAt` and `confirmedIdx` are required, so code constructing a `DivergenceSignal` (test fixtures, adapters) must supply them.
- `fromDivergenceSignal` and `fromPatternSignal` emit different `time` and `id` values than before.

Documented in `packages/core/CHANGELOG.md` under `[Unreleased]`.

## Test plan

8 regression tests added (`divergence.test.ts`, `trade-signal.test.ts`):

- every signal on the fixture walk is undetectable at its own pivot bar
- `confirmedIdx` is exactly the first bar at which a truncated re-run surfaces the signal, and not one bar earlier; `confirmedAt` matches that bar's time
- confirmation falls on the later of the two pivots: price troughs at 20/60 with indicator troughs at 22/62 confirm at bar 67, not 65
- a divergence confirming at bar 67 is absent with 67 candles and present with 68
- `fromDivergenceSignal` / `fromPatternSignal` emit at the causal bar, with the pivot preserved in metadata

Negative check: 6 of the 8 fail against the unpatched sources (the other two pin pre-existing behavior). Cross-checked `confirmedIdx` against the empirical first-detectable bar over 3 seeds / 12 signals — exact match on all.

Verification: core 6370 tests, chart 934, mcp 83 all pass; `tsc --noEmit`, `pnpm build`, and `biome check` clean.