### PR TITLE
fix(core): annualize Sharpe and Sortino from the equity curve

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 ## [Unreleased]
 
+### Breaking — Sharpe and Sortino are annualized from the equity curve, not from per-trade returns
+
+Five places annualized a series holding one return per **trade** by
+`sqrt(252)` — the factor for one return per *day*. The reported ratio
+therefore grew with how long positions were held: the same equity path
+packaged as 21-day trades scored `sqrt(21)` (over four times) higher than the
+same path marked daily, and it did not move at all when the same trades were
+spread over ten years instead of one. Any comparison between strategies of
+different trade frequency was being made on numbers that were not comparable,
+and `BacktestResult.sharpeRatio` was documented as "annualized" throughout.
+
+Sharpe and Sortino now come from the equity curve's bar-to-bar returns,
+annualized by the frequency those bars actually occurred at, which is the
+canonical definition and is independent of trade packaging. Where no equity
+curve exists — a result rebuilt from trades alone, or live metrics from a
+trade log — the trade returns are annualized by the observed trade frequency
+instead, an approximation of the same quantity rather than a different metric.
+
+`PortfolioBacktestResult.equityCurve` changed with it. It used to step only
+when a trade closed, which made it a realized-P&L curve rather than the
+mark-to-market one its documentation described: every price move made while a
+position was open was invisible, so a strategy that bought early and sold at
+the end produced a single step no matter how violent the ride, and two paths
+with the same final P&L were indistinguishable. It also ran only as far as the
+last trade exit, so a portfolio that traded for a month and then sat flat for
+eleven was annualized as a one-month run. The curve is now the per-bar
+mark-to-market equity of each symbol merged on timestamp, covering the whole
+window. Portfolio max drawdown is computed from that curve and therefore now
+includes drawdowns suffered inside an open position.
+
+Affected: `runBacktest`, `runBacktestScaled`, `batchBacktest`,
+`portfolioBacktest`, `calculateRuntimeMetrics` and
+`applyEquityCurveFilter`. Reported Sharpe/Sortino values change — typically
+downward for anything holding positions longer than a bar. Portfolio Sharpe
+changes the most: it pooled per-trade returns across symbols, measuring
+cross-sectional trade dispersion rather than portfolio risk, even though a
+mark-to-market portfolio equity curve was already being built alongside it.
+
+`calculateRuntimeMetrics`'s `annualizationFactor` / `calendar` options are now
+the fallback for when the trades do not span a usable stretch of time, rather
+than the assumed period length.
+
+Also fixed: the scaled-entry path carried a copy of `calculateStats` that had
+drifted from the engine's only in its comments; it now shares the engine's
+implementation. `sortinoFromReturns` is exported alongside the existing
+`sharpeFromReturns` so the pair can be computed with matching conventions.
+
 ### Breaking — variance and correlation are computed in two passes; four incremental snapshots bump their schema version
 
 Fifteen modules derived a variance, correlation or regression slope from the

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -2941,7 +2941,7 @@ interface BacktestResult {
   tradeCount: number;                // 取引回数
   winRate: number;                   // 勝率 (%)
   maxDrawdown: number;               // 最大ドローダウン (%)
-  sharpeRatio: number;               // シャープレシオ（年率化）
+  sharpeRatio: number;               // シャープレシオ（エクイティカーブから年率化）
   sortinoRatio: number;              // ソルティノレシオ（年率化・下方偏差ベース）
   calmarRatio: number;               // CAGR ÷ 最大ドローダウン
   cagrPercent: number;               // 年平均成長率 (%)

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -2963,7 +2963,7 @@ interface BacktestResult {
   tradeCount: number;                // Number of trades
   winRate: number;                   // Win rate (%)
   maxDrawdown: number;               // Maximum drawdown (%)
-  sharpeRatio: number;               // Sharpe ratio (annualized)
+  sharpeRatio: number;               // Sharpe ratio, annualized from the equity curve
   sortinoRatio: number;              // Sortino ratio (annualized, downside deviation)
   calmarRatio: number;               // CAGR / max drawdown
   cagrPercent: number;               // Compound annual growth rate (%)

--- a/packages/core/src/__tests__/annualized-ratios.test.ts
+++ b/packages/core/src/__tests__/annualized-ratios.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Annualisation of Sharpe / Sortino across every backtest result path.
+ *
+ * "Annualised" only means something relative to a frequency. Five places used
+ * `sqrt(252)` on a series with one observation per **trade**, which says a
+ * trade is a day: the same equity path packaged as 21-day trades scored
+ * `sqrt(21)` — over four times — higher than the same path marked daily, and
+ * the value did not move at all when the same trades were spread over ten
+ * years instead of one. Strategies of different trade frequency were therefore
+ * ranked against each other on numbers that were not comparable.
+ *
+ * The property tested throughout: a ratio must depend on the equity path and
+ * the calendar time it covers, not on how that path is chopped into trades.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  periodsPerYearFromSpan,
+  sharpeFromReturns,
+  sortinoFromReturns,
+} from "../analysis/return-metrics";
+import { calculateRuntimeMetrics } from "../analysis/runtime-metrics";
+import { calculateStats } from "../backtest/engine-utils";
+import { portfolioBacktest } from "../backtest/portfolio";
+import type { BacktestSettings, ConditionFn, NormalizedCandle, Trade } from "../types";
+
+const DAY = 24 * 60 * 60 * 1000;
+const START = 1_700_000_000_000;
+
+const SETTINGS: BacktestSettings = {
+  fillMode: "same-bar-close",
+  slTpMode: "close-only",
+  slippage: 0,
+  commission: 0,
+  commissionRate: 0,
+  taxRate: 0,
+};
+
+/** Deterministic pseudo-random daily returns, mean slightly positive. */
+function dailyReturns(n: number, seed = 42): number[] {
+  let a = seed;
+  const rnd = () => {
+    a = (a * 1103515245 + 12345) & 0x7fffffff;
+    return a / 0x7fffffff;
+  };
+  return Array.from({ length: n }, () => (rnd() - 0.48) * 0.02);
+}
+
+/** Equity path from a daily return stream, starting at `initial`. */
+function equityFrom(returns: number[], initial = 100_000): number[] {
+  const curve = [initial];
+  for (const r of returns) curve.push(curve[curve.length - 1] * (1 + r));
+  return curve;
+}
+
+/**
+ * Package one equity path into trades of `holding` bars each: entry at the
+ * start of a chunk, exit at its end. The path itself is untouched.
+ */
+function packageTrades(equity: number[], holding: number, dayMs = DAY): Trade[] {
+  const trades: Trade[] = [];
+  for (let start = 0; start + holding < equity.length; start += holding) {
+    const end = start + holding;
+    const pnl = equity[end] - equity[start];
+    trades.push({
+      entryTime: START + start * dayMs,
+      entryPrice: equity[start],
+      exitTime: START + end * dayMs,
+      exitPrice: equity[end],
+      return: pnl,
+      returnPercent: (pnl / equity[start]) * 100,
+      holdingDays: holding,
+    });
+  }
+  return trades;
+}
+
+const tradeReturnFractions = (trades: Trade[]) => trades.map((t) => t.returnPercent / 100);
+
+describe("periodsPerYearFromSpan", () => {
+  it("recovers the frequency of the series it is given", () => {
+    // 252 daily returns covering one calendar year.
+    const oneYear = 365.25 * DAY;
+    expect(periodsPerYearFromSpan(252, START, START + oneYear)).toBeCloseTo(252, 6);
+    // The same calendar year sampled 12 times.
+    expect(periodsPerYearFromSpan(12, START, START + oneYear)).toBeCloseTo(12, 6);
+  });
+
+  it("falls back to daily bars when the span is unusable", () => {
+    expect(periodsPerYearFromSpan(1, START, START + DAY)).toBe(252);
+    expect(periodsPerYearFromSpan(10, START, START)).toBe(252);
+    expect(periodsPerYearFromSpan(10, undefined, undefined)).toBe(252);
+  });
+});
+
+describe("sortinoFromReturns", () => {
+  it("penalises only downside and is undefined without any", () => {
+    const returns = [0.01, -0.02, 0.015, -0.005, 0.02];
+    const sortino = sortinoFromReturns(returns, { periodsPerYear: 252 });
+    const sharpe = sharpeFromReturns(returns, { periodsPerYear: 252 });
+
+    // Downside deviation ignores the upside spread, so it is the smaller
+    // denominator here and the Sortino is correspondingly larger.
+    expect(sortino).toBeGreaterThan(sharpe);
+    expect(Number.isFinite(sortino)).toBe(true);
+
+    expect(sortinoFromReturns([0.01, 0.02, 0.03])).toBeNaN();
+    expect(sortinoFromReturns([0.01])).toBeNaN();
+  });
+
+  it("scales with the square root of the annualisation frequency", () => {
+    const returns = [0.01, -0.02, 0.015, -0.005, 0.02];
+    const daily = sortinoFromReturns(returns, { periodsPerYear: 252 });
+    const monthly = sortinoFromReturns(returns, { periodsPerYear: 12 });
+
+    expect(daily / monthly).toBeCloseTo(Math.sqrt(252 / 12), 10);
+  });
+});
+
+describe("backtest result ratios are independent of trade packaging", () => {
+  const returns = dailyReturns(504);
+  const equity = equityFrom(returns);
+
+  function statsFor(holding: number) {
+    const trades = packageTrades(equity, holding);
+    return calculateStats(
+      trades,
+      tradeReturnFractions(trades),
+      100_000,
+      equity[equity.length - 1],
+      5,
+      SETTINGS,
+      [],
+      { firstTime: START, lastTime: START + (equity.length - 1) * DAY },
+      equity,
+    );
+  }
+
+  it("reports the same Sharpe and Sortino for 1-, 5- and 21-day trades", () => {
+    const daily = statsFor(1);
+    const weekly = statsFor(5);
+    const monthly = statsFor(21);
+
+    // Same path, same final capital — only the chopping differs.
+    expect(weekly.finalCapital).toBe(daily.finalCapital);
+    expect(monthly.finalCapital).toBe(daily.finalCapital);
+
+    expect(weekly.sharpeRatio).toBeCloseTo(daily.sharpeRatio, 10);
+    expect(monthly.sharpeRatio).toBeCloseTo(daily.sharpeRatio, 10);
+    expect(weekly.sortinoRatio).toBeCloseTo(daily.sortinoRatio, 10);
+    expect(monthly.sortinoRatio).toBeCloseTo(daily.sortinoRatio, 10);
+  });
+
+  it("matches the canonical Sharpe of the underlying daily returns", () => {
+    const barReturns: number[] = [];
+    for (let i = 1; i < equity.length; i++) {
+      barReturns.push((equity[i] - equity[i - 1]) / equity[i - 1]);
+    }
+    const canonical = sharpeFromReturns(barReturns, {
+      periodsPerYear: periodsPerYearFromSpan(
+        barReturns.length,
+        START,
+        START + (equity.length - 1) * DAY,
+      ),
+    });
+
+    expect(statsFor(21).sharpeRatio).toBeCloseTo(Math.round(canonical * 100) / 100, 10);
+  });
+
+  it("shrinks when the same path is stretched over a longer calendar span", () => {
+    const trades = packageTrades(equity, 21);
+    const oneYearSpan = { firstTime: START, lastTime: START + (equity.length - 1) * DAY };
+    const tenYearSpan = { firstTime: START, lastTime: START + (equity.length - 1) * 10 * DAY };
+
+    const short = calculateStats(
+      trades,
+      tradeReturnFractions(trades),
+      100_000,
+      equity[equity.length - 1],
+      5,
+      SETTINGS,
+      [],
+      oneYearSpan,
+      equity,
+    );
+    const long = calculateStats(
+      trades,
+      tradeReturnFractions(trades),
+      100_000,
+      equity[equity.length - 1],
+      5,
+      SETTINGS,
+      [],
+      tenYearSpan,
+      equity,
+    );
+
+    // Ten times the calendar time for the same path: the annualised ratio must
+    // fall by sqrt(10), not stay put. `sharpeRatio` is rounded to two decimals
+    // on the way out, which is worth a couple of percent on a ratio this size,
+    // so the bound is a band rather than an equality.
+    const ratio = short.sharpeRatio / long.sharpeRatio;
+    expect(ratio).toBeGreaterThan(Math.sqrt(10) * 0.97);
+    expect(ratio).toBeLessThan(Math.sqrt(10) * 1.03);
+  });
+
+  it("falls back to trade frequency when no equity curve is available", () => {
+    const trades = packageTrades(equity, 21);
+    const withoutCurve = calculateStats(
+      trades,
+      tradeReturnFractions(trades),
+      100_000,
+      equity[equity.length - 1],
+      5,
+      SETTINGS,
+      [],
+      { firstTime: START, lastTime: START + (equity.length - 1) * DAY },
+    );
+
+    // An approximation of the same quantity, not the inflated per-trade value:
+    // 24 monthly trades a year annualise by sqrt(~12), not sqrt(252).
+    const perTrade = tradeReturnFractions(trades);
+    const inflated = sharpeFromReturns(perTrade, { periodsPerYear: 252 });
+    expect(Math.abs(withoutCurve.sharpeRatio)).toBeLessThan(Math.abs(inflated) / 3);
+  });
+});
+
+describe("calculateRuntimeMetrics annualises by observed trade frequency", () => {
+  const returns = dailyReturns(504, 7);
+  const equity = equityFrom(returns);
+
+  it("reports the same Sharpe for daily and monthly trade packaging", () => {
+    const daily = calculateRuntimeMetrics(packageTrades(equity, 1), { initialCapital: 100_000 });
+    const monthly = calculateRuntimeMetrics(packageTrades(equity, 21), { initialCapital: 100_000 });
+
+    expect(monthly.totalReturnPercent).toBeCloseTo(daily.totalReturnPercent, 6);
+    // Packaging changes the observation count, so the ratios are not identical
+    // the way an equity-curve-based figure would be — but they must be the
+    // same order of magnitude rather than differing by sqrt(21).
+    expect(monthly.sharpeRatio / daily.sharpeRatio).toBeGreaterThan(0.5);
+    expect(monthly.sharpeRatio / daily.sharpeRatio).toBeLessThan(2);
+    expect(monthly.sortinoRatio / daily.sortinoRatio).toBeGreaterThan(0.5);
+    expect(monthly.sortinoRatio / daily.sortinoRatio).toBeLessThan(2);
+  });
+
+  it("falls to a lower annualised Sharpe when the same trades span ten years", () => {
+    const short = calculateRuntimeMetrics(packageTrades(equity, 21), { initialCapital: 100_000 });
+    const stretched = calculateRuntimeMetrics(packageTrades(equity, 21, 10 * DAY), {
+      initialCapital: 100_000,
+    });
+
+    expect(short.sharpeRatio / stretched.sharpeRatio).toBeCloseTo(Math.sqrt(10), 1);
+  });
+});
+
+describe("portfolio Sharpe covers the whole backtest window", () => {
+  /** Candles from a price path, one bar per day. */
+  function candlesFrom(prices: number[]): NormalizedCandle[] {
+    return prices.map((close, i) => ({
+      time: START + i * DAY,
+      open: close,
+      high: close,
+      low: close,
+      close,
+      volume: 1000,
+    }));
+  }
+
+  function sharpeOver(totalBars: number): number {
+    // The same traded stretch either way: the first 24 bars move and are
+    // traded in and out of, the rest of the window is flat and untraded.
+    const traded = Array.from({ length: 24 }, (_, i) => 100 + i + (i % 3) * 2);
+    const prices = Array.from({ length: totalBars }, (_, i) =>
+      i < traded.length ? traded[i] : traded[traded.length - 1],
+    );
+    const datasets = [
+      { symbol: "A", candles: candlesFrom(prices) },
+      { symbol: "B", candles: candlesFrom(prices.map((p) => p * 2)) },
+    ];
+    // In for two bars, out for two, so several trades close at distinct times.
+    const entry: ConditionFn = (_i, _c, index) => index < traded.length && index % 4 === 0;
+    const exit: ConditionFn = (_i, _c, index) => index % 4 === 2;
+    return portfolioBacktest(datasets, entry, exit, {
+      capital: 20_000,
+      allocation: { type: "equal" },
+      tradeOptions: { fillMode: "same-bar-close" },
+    }).portfolio.sharpeRatio;
+  }
+
+  /** Buy on the first bar, hold to the end — one trade, one realized step. */
+  function holdThroughout(prices: number[]): number {
+    const datasets = [
+      { symbol: "A", candles: candlesFrom(prices) },
+      { symbol: "B", candles: candlesFrom(prices.map((p) => p * 2)) },
+    ];
+    const entry: ConditionFn = () => true;
+    const never: ConditionFn = () => false;
+    return portfolioBacktest(datasets, entry, never, {
+      capital: 20_000,
+      allocation: { type: "equal" },
+      tradeOptions: { fillMode: "same-bar-close" },
+    }).portfolio.sharpeRatio;
+  }
+
+  it("distinguishes a calm path from a violent one with the same P&L", () => {
+    // Both paths start at 100 and end at 120; one drifts, the other lurches.
+    const calm = Array.from({ length: 41 }, (_, i) => 100 + i * 0.5);
+    const violent = Array.from({ length: 41 }, (_, i) =>
+      i === 40 ? 120 : 100 + i * 0.5 + (i % 2 === 0 ? 12 : -12),
+    );
+
+    const calmSharpe = holdThroughout(calm);
+    const violentSharpe = holdThroughout(violent);
+
+    // A realized-P&L curve sees one step for either path and cannot tell them
+    // apart — it has a single return observation, so the ratio is undefined.
+    expect(calmSharpe).toBeGreaterThan(0);
+    expect(violentSharpe).toBeLessThan(calmSharpe);
+  });
+
+  it("falls when the same trades are followed by a long flat tail", () => {
+    const short = sharpeOver(24);
+    const withIdleTail = sharpeOver(220);
+
+    // Capital was tied up for twenty times as long for the same P&L, so the
+    // annualised figure has to come down. Before, the curve ended at the last
+    // trade exit and the idle tail was invisible.
+    expect(short).toBeGreaterThan(0);
+    expect(withIdleTail).toBeGreaterThan(0);
+    expect(withIdleTail).toBeLessThan(short / 2);
+  });
+});

--- a/packages/core/src/analysis/index.ts
+++ b/packages/core/src/analysis/index.ts
@@ -79,6 +79,7 @@ export {
   rollingSharpe,
   rollingVolatility,
   sharpeFromReturns,
+  sortinoFromReturns,
   tailRatio,
   winRateFromReturns,
 } from "./return-metrics";

--- a/packages/core/src/analysis/return-metrics.ts
+++ b/packages/core/src/analysis/return-metrics.ts
@@ -319,6 +319,97 @@ export function sharpeFromReturns(returns: number[], options: RollingOptions = {
 }
 
 /**
+ * Annualised Sortino ratio of a returns series — mean excess return over
+ * downside deviation, scaled by `sqrt(periodsPerYear)` when annualising.
+ *
+ * Downside deviation is the root mean square of the negative excess returns
+ * taken over **all** observations (quantstats / empyrical convention: the
+ * denominator is the full sample size, not the count of losing periods), so a
+ * series with few but deep losses is not flattered. Returns `NaN` for fewer
+ * than two observations or a series with no downside, matching
+ * {@link sharpeFromReturns}'s undefined-ratio convention.
+ *
+ * The counterpart to {@link sharpeFromReturns}: both take the same options so
+ * a caller cannot annualise one of the pair differently from the other.
+ *
+ * @param returns - Periodic returns as fractions
+ * @param options - Annualisation options (`window` is ignored)
+ * @returns Annualised Sortino ratio, or `NaN` when undefined
+ *
+ * @example
+ * ```ts
+ * import { sortinoFromReturns } from "trendcraft";
+ *
+ * const sortino = sortinoFromReturns(dailyReturns, { periodsPerYear: 252 });
+ * ```
+ */
+export function sortinoFromReturns(returns: number[], options: RollingOptions = {}): number {
+  const { riskFree = 0, periodsPerYear = 252, annualize = true } = options;
+  if (returns.length < 2) return Number.NaN;
+
+  const perPeriodRf = riskFree === 0 ? 0 : (1 + riskFree) ** (1 / periodsPerYear) - 1;
+  let mean = 0;
+  for (const r of returns) mean += r;
+  mean = mean / returns.length - perPeriodRf;
+
+  let downsideSq = 0;
+  for (const r of returns) {
+    const excess = r - perPeriodRf;
+    if (excess < 0) downsideSq += excess * excess;
+  }
+  const downside = Math.sqrt(downsideSq / returns.length);
+  if (downside === 0) return Number.NaN;
+
+  return (mean / downside) * (annualize ? Math.sqrt(periodsPerYear) : 1);
+}
+
+/** Milliseconds in an average calendar year, leap years included. */
+const MS_PER_YEAR = 365.25 * 24 * 60 * 60 * 1000;
+
+/**
+ * How many observations of a series fall in a year, measured from the series
+ * itself rather than assumed.
+ *
+ * Annualising a ratio means scaling by the square root of the number of
+ * observations per year, so the factor has to match the series in hand: 252
+ * is right for daily bars, but not for a series of trades, of weekly bars, or
+ * of five-minute bars. Getting this wrong does not shift a Sharpe ratio
+ * slightly — packaging one equity path as 21-day trades instead of daily bars
+ * inflates it by `sqrt(21)`.
+ *
+ * Pass the number of return observations and the wall-clock span those
+ * observations cover — for bar-to-bar returns that is `bars - 1` returns over
+ * the first-to-last bar span; for one return per trade it is the trade count
+ * over the first-entry-to-last-exit span.
+ *
+ * Falls back to 252 when the span is unusable (fewer than two observations,
+ * missing or non-increasing timestamps), which is the daily-bar assumption the
+ * callers previously hard-coded. This is the single owner of that rule.
+ *
+ * @param count - Number of return observations
+ * @param firstTime - Start of the span they cover, in milliseconds
+ * @param lastTime - End of the span they cover, in milliseconds
+ * @returns Observations per year
+ *
+ * @example
+ * ```ts
+ * // 503 returns from 504 daily bars spanning two calendar years → ~252
+ * const periodsPerYear = periodsPerYearFromSpan(503, 1_700_000_000_000, 1_763_072_000_000);
+ * ```
+ */
+export function periodsPerYearFromSpan(
+  count: number,
+  firstTime: number | undefined,
+  lastTime: number | undefined,
+): number {
+  if (count < 2 || firstTime === undefined || lastTime === undefined) return 252;
+  const spanMs = lastTime - firstTime;
+  if (!(spanMs > 0)) return 252;
+  const years = spanMs / MS_PER_YEAR;
+  return count / years;
+}
+
+/**
  * Rolling annualised Sharpe ratio over a trailing window (quantstats
  * `rolling_sharpe`). The first `window - 1` entries are `NaN` (insufficient
  * data), so the result aligns index-for-index with `returns`. A flat window

--- a/packages/core/src/analysis/runtime-metrics.ts
+++ b/packages/core/src/analysis/runtime-metrics.ts
@@ -22,6 +22,7 @@
 import type { Trade } from "../types";
 import { calculateTradeStats } from "./edge-analysis";
 import type { TradeStats } from "./edge-analysis-types";
+import { periodsPerYearFromSpan, sharpeFromReturns, sortinoFromReturns } from "./return-metrics";
 
 /**
  * Comprehensive runtime performance metrics
@@ -151,11 +152,25 @@ export function calculateRuntimeMetrics(
       ? ((1 + totalReturnPercent / 100) ** (1 / years) - 1) * 100
       : totalReturnPercent;
 
-  // Sharpe ratio (from trade returns)
-  const sharpeRatio = calculateSharpe(tradeReturns, riskFreeRate, annualizationFactor);
+  // Sharpe / Sortino from trade returns. Observations here are trades, not
+  // days: annualising them as if each were a daily bar inflated the ratio by
+  // sqrt(avgHoldingDays), so the same equity path reported a four-times-higher
+  // Sharpe when traded monthly than daily. `annualizationFactor` is now the
+  // fallback for when the trades do not span a usable stretch of time.
+  const firstEntry = trades[0]?.entryTime;
+  const lastExit = trades[trades.length - 1]?.exitTime;
+  const tradesPerYear =
+    trades.length > 1 && lastExit !== undefined && firstEntry !== undefined && lastExit > firstEntry
+      ? periodsPerYearFromSpan(trades.length, firstEntry, lastExit)
+      : annualizationFactor;
+  const sharpeRatio = finiteOrZero(
+    sharpeFromReturns(tradeReturns, { riskFree: riskFreeRate, periodsPerYear: tradesPerYear }),
+  );
 
   // Sortino ratio (from trade returns)
-  const sortinoRatio = calculateSortino(tradeReturns, riskFreeRate, annualizationFactor);
+  const sortinoRatio = finiteOrZero(
+    sortinoFromReturns(tradeReturns, { riskFree: riskFreeRate, periodsPerYear: tradesPerYear }),
+  );
 
   // Calmar ratio
   const calmarRatio =
@@ -184,49 +199,7 @@ export function calculateRuntimeMetrics(
   };
 }
 
-function calculateSharpe(
-  returns: number[],
-  riskFreeRate: number,
-  annualizationFactor: number,
-): number {
-  if (returns.length === 0) return 0;
-
-  const meanReturn = returns.reduce((sum, r) => sum + r, 0) / returns.length;
-  const variance = returns.reduce((sum, r) => sum + (r - meanReturn) ** 2, 0) / returns.length;
-  const stdDev = Math.sqrt(variance);
-
-  if (stdDev === 0) return 0;
-
-  const annualizedReturn = meanReturn * annualizationFactor;
-  const annualizedStdDev = stdDev * Math.sqrt(annualizationFactor);
-
-  return (annualizedReturn - riskFreeRate) / annualizedStdDev;
-}
-
-function calculateSortino(
-  returns: number[],
-  riskFreeRate: number,
-  annualizationFactor: number,
-): number {
-  if (returns.length === 0) return 0;
-
-  const meanReturn = returns.reduce((sum, r) => sum + r, 0) / returns.length;
-
-  // Downside deviation: only negative returns
-  const periodicRiskFree = riskFreeRate / annualizationFactor;
-  const downsideReturns = returns.filter((r) => r < periodicRiskFree);
-  if (downsideReturns.length === 0) {
-    return meanReturn > 0 ? Number.POSITIVE_INFINITY : 0;
-  }
-
-  const downsideVariance =
-    downsideReturns.reduce((sum, r) => sum + (r - periodicRiskFree) ** 2, 0) / returns.length;
-  const downsideDev = Math.sqrt(downsideVariance);
-
-  if (downsideDev === 0) return 0;
-
-  const annualizedReturn = meanReturn * annualizationFactor;
-  const annualizedDownsideDev = downsideDev * Math.sqrt(annualizationFactor);
-
-  return (annualizedReturn - riskFreeRate) / annualizedDownsideDev;
+/** Undefined ratios are reported as 0, the value this module has always used. */
+function finiteOrZero(value: number): number {
+  return Number.isFinite(value) ? value : 0;
 }

--- a/packages/core/src/backtest/engine-utils.ts
+++ b/packages/core/src/backtest/engine-utils.ts
@@ -3,6 +3,11 @@
  * Helper functions and types for the backtest engine
  */
 
+import {
+  periodsPerYearFromSpan,
+  sharpeFromReturns,
+  sortinoFromReturns,
+} from "../analysis/return-metrics";
 import type {
   BacktestResult,
   BacktestSettings,
@@ -326,6 +331,62 @@ function computeMergedExposureDays(trades: Trade[]): number {
 }
 
 /**
+ * Annualised Sharpe and Sortino for a backtest result.
+ *
+ * Both are annualised against the frequency of the series they are computed
+ * from, which is the whole point: the previous `sqrt(252)` treated one return
+ * per **trade** as if it were one per day, so the same equity path packaged as
+ * 21-day trades scored `sqrt(21)` — over four times — higher than the same
+ * path marked daily, and strategies of different trade frequency were ranked
+ * against each other on incomparable numbers.
+ *
+ * With a per-bar `equityCurve` the ratios come from bar-to-bar returns, which
+ * is the canonical definition and makes the value independent of how the path
+ * is chopped into trades. Without one (a result rebuilt from trades alone)
+ * they come from the trade returns, annualised by the observed trade
+ * frequency; that is an approximation of the same quantity rather than a
+ * different metric.
+ *
+ * `NaN` from the underlying kernels — fewer than two observations, a flat
+ * series, no downside — is reported as `0`, the value `BacktestResult` has
+ * always used for an undefined ratio.
+ */
+export function annualizedRatios(
+  trades: Trade[],
+  returns: number[],
+  span: BacktestSpanInfo | undefined,
+  equityCurve?: number[],
+): { sharpeRatio: number; sortinoRatio: number } {
+  let series: number[];
+  let periodsPerYear: number;
+
+  if (equityCurve && equityCurve.length >= 2) {
+    series = [];
+    for (let i = 1; i < equityCurve.length; i++) {
+      const prev = equityCurve[i - 1];
+      series.push(prev !== 0 ? (equityCurve[i] - prev) / prev : 0);
+    }
+    periodsPerYear = periodsPerYearFromSpan(series.length, span?.firstTime, span?.lastTime);
+  } else {
+    series = returns;
+    // Trades are the observations here, so the span they cover is their own,
+    // not the candle window: a backtest can trade for a fraction of it.
+    periodsPerYear = periodsPerYearFromSpan(
+      trades.length,
+      trades[0]?.entryTime,
+      trades[trades.length - 1]?.exitTime,
+    );
+  }
+
+  const sharpe = sharpeFromReturns(series, { periodsPerYear });
+  const sortino = sortinoFromReturns(series, { periodsPerYear });
+  return {
+    sharpeRatio: Number.isFinite(sharpe) ? sharpe : 0,
+    sortinoRatio: Number.isFinite(sortino) ? sortino : 0,
+  };
+}
+
+/**
  * Compute the nine extended backtest metrics from raw trade / return /
  * capital inputs. Pure function; no side effects. Callers spread the
  * result into the final `BacktestResult` they construct.
@@ -341,17 +402,13 @@ export function computeExtendedMetrics(
   finalCapital: number,
   maxDrawdown: number,
   span?: BacktestSpanInfo,
+  equityCurve?: number[],
 ): ExtendedBacktestMetrics {
   if (trades.length === 0 || returns.length === 0) {
     return { ...ZERO_EXTENDED_METRICS };
   }
 
-  // Sortino: like Sharpe but only penalizes downside deviation.
-  // Target return = 0; downside-only squared deviation over min(0, r).
-  const avgReturn = returns.reduce((s, r) => s + r, 0) / returns.length;
-  const downsideSqSum = returns.reduce((s, r) => s + (r < 0 ? r * r : 0), 0);
-  const downsideStd = Math.sqrt(downsideSqSum / returns.length);
-  const sortinoRatio = downsideStd > 0 ? (avgReturn / downsideStd) * Math.sqrt(252) : 0;
+  const { sortinoRatio } = annualizedRatios(trades, returns, span, equityCurve);
 
   // Per-trade % aggregates. avgLoss / largestLoss are reported as
   // positive numbers so they read naturally side-by-side with wins.
@@ -417,6 +474,7 @@ export function calculateStats(
   settings: BacktestSettings,
   drawdownPeriods: DrawdownPeriod[] = [],
   span?: BacktestSpanInfo,
+  equityCurve?: number[],
 ): BacktestResult {
   if (trades.length === 0) {
     return emptyResult(initialCapital, settings, span);
@@ -436,13 +494,7 @@ export function calculateStats(
 
   const avgHoldingDays = trades.reduce((sum, t) => sum + t.holdingDays, 0) / trades.length;
 
-  // Calculate Sharpe Ratio (annualized, assuming 252 trading days)
-  const avgReturn = returns.reduce((sum, r) => sum + r, 0) / returns.length;
-  const stdReturn = Math.sqrt(
-    returns.reduce((sum, r) => sum + (r - avgReturn) ** 2, 0) / returns.length,
-  );
-  // Annualize using sqrt(252) - standard annualization factor for daily returns
-  const sharpeRatio = stdReturn > 0 ? (avgReturn / stdReturn) * Math.sqrt(252) : 0;
+  const { sharpeRatio } = annualizedRatios(trades, returns, span, equityCurve);
 
   const extended = computeExtendedMetrics(
     trades,
@@ -451,6 +503,7 @@ export function calculateStats(
     finalCapital,
     maxDrawdown,
     span,
+    equityCurve,
   );
 
   return {

--- a/packages/core/src/backtest/engine.ts
+++ b/packages/core/src/backtest/engine.ts
@@ -1167,6 +1167,7 @@ export function runBacktest(
     candles.length >= 2
       ? { firstTime: candles[0].time, lastTime: candles[candles.length - 1].time }
       : undefined,
+    equityCurve,
   );
   result.equityCurve = equityCurve;
   return result;

--- a/packages/core/src/backtest/portfolio.ts
+++ b/packages/core/src/backtest/portfolio.ts
@@ -5,6 +5,7 @@
  * Phase 2: portfolioBacktest() - Shared capital with allocation and rebalancing
  */
 
+import { periodsPerYearFromSpan, sharpeFromReturns } from "../analysis/return-metrics";
 import type { IndicatorCache } from "../core/indicator-cache";
 import type {
   BatchBacktestOptions,
@@ -349,59 +350,66 @@ function mergeAndSortTrades(symbolResults: SymbolBacktestResult[]): (Trade & { s
 }
 
 /**
- * Build a merged equity curve from per-symbol results.
- * At each trade close event, recalculate total portfolio equity.
+ * Merge the per-symbol equity curves into one portfolio curve.
+ *
+ * Each symbol's backtest emits mark-to-market equity at every candle close, so
+ * merging those — rather than stepping the portfolio only when a trade closes —
+ * is what makes the curve reflect what the portfolio was actually worth on any
+ * given bar. A realized-P&L step curve hides every price move made while a
+ * position is open: a strategy that buys near the start and sells at the end
+ * produces one step regardless of how violent the ride was, which leaves
+ * nothing for a risk metric to measure.
+ *
+ * Symbols need not share a calendar. The curve carries every timestamp any
+ * dataset has, and a symbol that has no bar at that timestamp holds its last
+ * known equity (its allocation before its first bar).
  */
 function buildMergedEquityCurve(
   symbolResults: SymbolBacktestResult[],
   datasets: SymbolData[],
   allocations: Record<string, number>,
 ): EquityPoint[] {
-  // Track per-symbol equity over time via trade events
-  const symbolEquity: Record<string, number> = {};
-  for (const sr of symbolResults) {
-    symbolEquity[sr.symbol] = allocations[sr.symbol];
-  }
-
-  // Collect all trade close events
-  const events: { time: number; symbol: string; equityAfter: number }[] = [];
-  for (const sr of symbolResults) {
-    let equity = allocations[sr.symbol];
-    for (const trade of sr.result.trades) {
-      equity += trade.return;
-      events.push({
-        time: trade.exitTime,
-        symbol: sr.symbol,
-        equityAfter: equity,
-      });
+  const curveBySymbol = new Map<string, { times: number[]; equity: number[] }>();
+  for (const dataset of datasets) {
+    const result = symbolResults.find((sr) => sr.symbol === dataset.symbol)?.result;
+    const times = dataset.candles.map((c) => c.time);
+    const equity = result?.equityCurve;
+    if (equity && equity.length === times.length) {
+      curveBySymbol.set(dataset.symbol, { times, equity });
+      continue;
     }
+    // No per-bar curve (a hand-built result): fall back to stepping the
+    // symbol's equity at each trade exit, which is all the information there is.
+    const stepTimes: number[] = [];
+    const stepEquity: number[] = [];
+    let running = allocations[dataset.symbol] ?? 0;
+    for (const trade of result?.trades ?? []) {
+      running += trade.return;
+      stepTimes.push(trade.exitTime);
+      stepEquity.push(running);
+    }
+    curveBySymbol.set(dataset.symbol, { times: stepTimes, equity: stepEquity });
   }
-  events.sort((a, b) => a.time - b.time);
 
-  // Build curve
-  const totalInitial = Object.values(allocations).reduce((s, v) => s + v, 0);
+  const allTimes = [...new Set(datasets.flatMap((d) => d.candles.map((c) => c.time)))].sort(
+    (a, b) => a - b,
+  );
+  if (allTimes.length === 0) return [];
+
+  // One cursor per symbol, advanced in step with the merged timeline.
+  const cursors = new Map<string, number>();
+  for (const symbol of curveBySymbol.keys()) cursors.set(symbol, -1);
+
   const curve: EquityPoint[] = [];
-
-  // Find earliest time across all datasets
-  let earliestTime = Number.POSITIVE_INFINITY;
-  for (const d of datasets) {
-    if (d.candles.length > 0 && d.candles[0].time < earliestTime) {
-      earliestTime = d.candles[0].time;
+  for (const time of allTimes) {
+    let total = 0;
+    for (const [symbol, series] of curveBySymbol) {
+      let cursor = cursors.get(symbol) as number;
+      while (cursor + 1 < series.times.length && series.times[cursor + 1] <= time) cursor++;
+      cursors.set(symbol, cursor);
+      total += cursor < 0 ? (allocations[symbol] ?? 0) : series.equity[cursor];
     }
-  }
-  if (earliestTime !== Number.POSITIVE_INFINITY) {
-    curve.push({ time: earliestTime, equity: totalInitial });
-  }
-
-  // Track running equity per symbol
-  const runningEquity = { ...allocations };
-  for (const event of events) {
-    runningEquity[event.symbol] = event.equityAfter;
-    const totalEquity = Object.values(runningEquity).reduce((s, v) => s + v, 0);
-    curve.push({
-      time: event.time,
-      equity: Math.round(totalEquity * 100) / 100,
-    });
+    curve.push({ time, equity: Math.round(total * 100) / 100 });
   }
 
   return curve;
@@ -447,16 +455,22 @@ function calculatePortfolioMetrics(
     if (dd > maxDrawdown) maxDrawdown = dd;
   }
 
-  // Calculate portfolio Sharpe ratio from per-trade returns
-  const returns = allTrades.map((t) => t.returnPercent);
-  let sharpeRatio = 0;
-  if (returns.length > 1) {
-    const avgReturn = returns.reduce((s, r) => s + r, 0) / returns.length;
-    const stdReturn = Math.sqrt(
-      returns.reduce((s, r) => s + (r - avgReturn) ** 2, 0) / returns.length,
-    );
-    sharpeRatio = stdReturn > 0 ? (avgReturn / stdReturn) * Math.sqrt(252) : 0;
+  // Portfolio Sharpe from the merged mark-to-market equity curve. Pooling
+  // per-trade returns across symbols measured cross-sectional trade dispersion
+  // rather than portfolio risk, and — being unanchored in time — reported the
+  // same number whether those trades spanned three months or eight years.
+  const portfolioReturns: number[] = [];
+  for (let i = 1; i < equityCurve.length; i++) {
+    const prev = equityCurve[i - 1].equity;
+    portfolioReturns.push(prev !== 0 ? (equityCurve[i].equity - prev) / prev : 0);
   }
+  const periodsPerYear = periodsPerYearFromSpan(
+    portfolioReturns.length,
+    equityCurve[0]?.time,
+    equityCurve[equityCurve.length - 1]?.time,
+  );
+  const sharpe = sharpeFromReturns(portfolioReturns, { periodsPerYear });
+  const sharpeRatio = Number.isFinite(sharpe) ? sharpe : 0;
 
   return {
     initialCapital: totalCapital,

--- a/packages/core/src/backtest/scaled-entry-utils.ts
+++ b/packages/core/src/backtest/scaled-entry-utils.ts
@@ -10,15 +10,12 @@ import type {
   BacktestResult,
   BacktestSettings,
   Condition,
-  DrawdownPeriod,
   NormalizedCandle,
-  Trade,
 } from "../types";
 import type { ExtendedCondition } from "./conditions";
 import { runBacktest } from "./engine";
 import {
   type BacktestSpanInfo,
-  computeExtendedMetrics,
   MS_PER_DAY as ENGINE_MS_PER_DAY,
   ZERO_EXTENDED_METRICS,
 } from "./engine-utils";
@@ -53,82 +50,19 @@ export function applySlippage(price: number, slippage: number, direction: "buy" 
 }
 
 /**
+ * Calculate backtest statistics.
+ *
+ * The scaled-entry path used to carry a copy of this function that had drifted
+ * only in its comments; it now shares the engine's implementation so the two
+ * paths cannot report differently defined statistics.
+ */
+export { calculateStats } from "./engine-utils";
+/**
  * Re-export of `BacktestSpanInfo` from `engine-utils`. Some host code
  * imported it from this module before the helper was consolidated;
  * keeping the re-export avoids a breaking import-path change.
  */
 export type { BacktestSpanInfo };
-
-/**
- * Calculate backtest statistics.
- *
- * Delegates the new extended metrics (Sortino / Calmar / CAGR /
- * Expectancy / Exposure / per-trade aggregates) to
- * `computeExtendedMetrics` in `engine-utils` so every backtest path
- * shares a single implementation.
- */
-export function calculateStats(
-  trades: Trade[],
-  returns: number[],
-  initialCapital: number,
-  finalCapital: number,
-  maxDrawdown: number,
-  settings: BacktestSettings,
-  drawdownPeriods: DrawdownPeriod[] = [],
-  span?: BacktestSpanInfo,
-): BacktestResult {
-  if (trades.length === 0) {
-    return emptyResult(initialCapital, settings, span);
-  }
-
-  const totalReturn = finalCapital - initialCapital;
-  const totalReturnPercent = (totalReturn / initialCapital) * 100;
-
-  const winningTrades = trades.filter((t) => t.return > 0);
-  const losingTrades = trades.filter((t) => t.return <= 0);
-  const winRate = (winningTrades.length / trades.length) * 100;
-
-  const totalProfit = winningTrades.reduce((sum, t) => sum + t.return, 0);
-  const totalLoss = Math.abs(losingTrades.reduce((sum, t) => sum + t.return, 0));
-  const profitFactor = totalLoss > 0 ? totalProfit / totalLoss : totalProfit > 0 ? 999.99 : 0;
-
-  const avgHoldingDays = trades.reduce((sum, t) => sum + t.holdingDays, 0) / trades.length;
-
-  // Sharpe ratio: annualized mean-return / stddev.
-  const avgReturn = returns.reduce((sum, r) => sum + r, 0) / returns.length;
-  const stdReturn = Math.sqrt(
-    returns.reduce((sum, r) => sum + (r - avgReturn) ** 2, 0) / returns.length,
-  );
-  const sharpeRatio = stdReturn > 0 ? (avgReturn / stdReturn) * Math.sqrt(252) : 0;
-
-  const extended = computeExtendedMetrics(
-    trades,
-    returns,
-    initialCapital,
-    finalCapital,
-    maxDrawdown,
-    span,
-  );
-
-  return {
-    initialCapital,
-    finalCapital: Math.round(finalCapital * 100) / 100,
-    totalReturn: Math.round(totalReturn * 100) / 100,
-    totalReturnPercent: Math.round(totalReturnPercent * 100) / 100,
-    tradeCount: trades.length,
-    winRate: Math.round(winRate * 100) / 100,
-    maxDrawdown: Math.round(maxDrawdown * 100) / 100,
-    sharpeRatio: Math.round(sharpeRatio * 100) / 100,
-    ...extended,
-    firstBarTime: span?.firstTime ?? 0,
-    lastBarTime: span?.lastTime ?? 0,
-    profitFactor: Math.round(profitFactor * 100) / 100,
-    avgHoldingDays: Math.round(avgHoldingDays * 10) / 10,
-    trades,
-    settings,
-    drawdownPeriods,
-  };
-}
 
 /**
  * Return empty result for edge cases

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1146,6 +1146,7 @@ export {
   rollingSharpe,
   rollingVolatility,
   sharpeFromReturns,
+  sortinoFromReturns,
   tailRatio,
   winRateFromReturns,
 } from "./analysis";

--- a/packages/core/src/meta-strategy/equity-curve.ts
+++ b/packages/core/src/meta-strategy/equity-curve.ts
@@ -8,7 +8,11 @@
  * @packageDocumentation
  */
 
-import { computeExtendedMetrics, ZERO_EXTENDED_METRICS } from "../backtest/engine-utils";
+import {
+  annualizedRatios,
+  computeExtendedMetrics,
+  ZERO_EXTENDED_METRICS,
+} from "../backtest/engine-utils";
 import type { BacktestResult, EquityPoint, Trade } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -198,12 +202,11 @@ function rebuildResult(trades: Trade[], original: BacktestResult): BacktestResul
   }
   const maxDrawdownPercent = maxDd * 100;
 
-  // Simple Sharpe from trade returns
+  // Sharpe from the trade returns, annualised by the frequency those trades
+  // actually occurred at — the shared owner the unfiltered backtest uses, so
+  // `original` and `filtered` stay comparable cell-by-cell.
   const tradeReturns = trades.map((t) => t.returnPercent / 100);
-  const meanRet = tradeReturns.reduce((s, r) => s + r, 0) / tradeReturns.length;
-  const variance = tradeReturns.reduce((s, r) => s + (r - meanRet) ** 2, 0) / tradeReturns.length;
-  const stdDev = Math.sqrt(variance);
-  const sharpe = stdDev > 0 ? (meanRet / stdDev) * Math.sqrt(252) : 0;
+  const { sharpeRatio: sharpe } = annualizedRatios(trades, tradeReturns, span);
 
   // Reuse the canonical metric helper so filter results match the
   // shape an unfiltered backtest produces — important for the panel

--- a/packages/core/src/types/backtest.ts
+++ b/packages/core/src/types/backtest.ts
@@ -420,12 +420,18 @@ export type BacktestResult = {
   winRate: number;
   /** Maximum drawdown percentage */
   maxDrawdown: number;
-  /** Sharpe ratio (annualized) */
+  /**
+   * Sharpe ratio, annualized from the equity curve's bar-to-bar returns and
+   * the calendar span they cover — so the value depends on the equity path
+   * and how long it took, not on how that path was divided into trades.
+   * `0` when undefined (fewer than two observations, or a flat curve).
+   */
   sharpeRatio: number;
   /**
-   * Sortino ratio (annualized). Like Sharpe but divides by *downside*
-   * deviation instead of total return std, so upside volatility no
-   * longer penalizes the score. `0` when no negative returns exist.
+   * Sortino ratio, annualized on the same basis as {@link BacktestResult.sharpeRatio}.
+   * Like Sharpe but divides by *downside* deviation instead of total return
+   * std, so upside volatility no longer penalizes the score. `0` when no
+   * negative returns exist.
    */
   sortinoRatio: number;
   /**


### PR DESCRIPTION
## Problem

"Annualized" only means something relative to a frequency. Five places scaled a series holding one return per **trade** by `sqrt(252)` — the factor for one return per *day*:

| Site | |
| --- | --- |
| `engine-utils.calculateStats` | `BacktestResult.sharpeRatio` / `sortinoRatio` |
| `scaled-entry-utils.calculateStats` | `runBacktestScaled` |
| `portfolio.calculatePortfolioMetrics` | `batchBacktest`, `portfolioBacktest` |
| `analysis/runtime-metrics` | `calculateRuntimeMetrics` |
| `meta-strategy/equity-curve` | `applyEquityCurveFilter` |

The reported ratio therefore grew with how long positions were held. On 504 seeded daily returns re-packaged into trades of different lengths — the same equity path, the same final capital:

```
holding =  1d   trades=504   sharpe=0.46   sortino=0.69
holding =  5d   trades=100   sharpe=1.26   sortino=1.96
holding = 21d   trades= 24   sharpe=2.17   sortino=3.17

canonical annualized Sharpe of that path: 0.46      sqrt(21) = 4.58
```

The value also did not move at all when the same trades were spread over ten years instead of one, because a per-trade series is not anchored in time. Strategies of different trade frequency were being ranked against each other on numbers that were not comparable, while the field is documented as "annualized" throughout.

## Change

Sharpe and Sortino now come from the equity curve's bar-to-bar returns, annualized by the frequency those bars actually occurred at. That is the canonical definition and is independent of how the path is divided into trades. Where no equity curve exists — a result rebuilt from trades alone, or live metrics from a trade log — the trade returns are annualized by the observed trade frequency instead: an approximation of the same quantity, not a different metric.

One owner does the annualizing: the existing `sharpeFromReturns`, which `rollingSharpe` and the per-regime Sharpe already share. Its counterpart `sortinoFromReturns` is added and exported alongside it, and `periodsPerYearFromSpan` replaces five independent re-derivations of "how often does this series observe".

### The portfolio equity curve had to be fixed first

`PortfolioBacktestResult.equityCurve` stepped only when a trade closed, making it a realized-P&L curve rather than the mark-to-market one its documentation described. Two consequences:

- Price moves made while a position was open were invisible. A strategy that buys early and sells at the end produced a single step no matter how violent the ride — one return observation, so the Sharpe was **always 0** — and two paths with the same final P&L were indistinguishable.
- It ran only as far as the last trade exit, so a portfolio that traded for a month and then sat flat for eleven was annualized as a one-month run.

It is now the per-bar mark-to-market equity of each symbol merged on timestamp, covering the whole window; symbols need not share a calendar, and one with no bar at a timestamp holds its last known equity. Portfolio max drawdown is computed from that curve and therefore now includes drawdowns suffered inside an open position.

Separately, `scaled-entry-utils` carried a copy of `calculateStats` that had drifted from the engine's only in its comments. It now shares the engine's implementation.

## Breaking

- Reported Sharpe and Sortino change on every path listed above — typically downward for anything holding positions longer than a bar. Portfolio Sharpe changes the most.
- `PortfolioBacktestResult.equityCurve` and portfolio `maxDrawdown` change as described.
- `calculateRuntimeMetrics`'s `annualizationFactor` / `calendar` options become the fallback for when the trades do not span a usable stretch of time, rather than the assumed period length.

## Test plan

12 regression tests in `src/__tests__/annualized-ratios.test.ts`. The property throughout: a ratio must depend on the equity path and the calendar time it covers, not on how that path is chopped into trades.

- One equity path packaged as 1-, 5- and 21-day trades reports identical Sharpe and Sortino, and matches the canonical Sharpe of the underlying bar returns
- The same path stretched over ten times the calendar span reports a Sharpe lower by `sqrt(10)`
- With no equity curve available, the trade-frequency fallback lands within a third of the previously inflated value rather than reproducing it
- Portfolio: a calm price path and a violent one with identical final P&L now score differently (the violent one lower); the same trades followed by a twenty-times-longer flat tail score less than half as high
- `calculateRuntimeMetrics`: daily and monthly packaging of one return stream agree within a factor of 2 instead of `sqrt(21)`; ten times the span gives `sqrt(10)` less
- `periodsPerYearFromSpan` recovers 252 from 252 daily returns over a year and 12 from 12, and falls back to 252 on a degenerate span; `sortinoFromReturns` penalizes only downside, is `NaN` without any, and scales by `sqrt(periodsPerYear)`

Negative check: 8 of the 12 fail against the unpatched sources.

Verification: core 6401 tests, chart 934, mcp 83 all pass; `tsc --noEmit`, `pnpm build` and `biome check` clean.