### PR TITLE
fix(core): correct Cornish-Fisher VaR, deflated Sharpe and MAR

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 ## [Unreleased]
 
+### Breaking — three financial formulas corrected: Cornish-Fisher VaR, deflated Sharpe, MAR
+
+**Cornish-Fisher VaR pointed risk the wrong way.** The expansion was evaluated
+at the positive quantile and the result negated. The kurtosis and squared-skew
+terms are odd in z and survive that, but the skew term `(z²−1)·S/6` is even,
+so it kept its sign: for the usual negatively skewed returns the fat-tail
+correction *reduced* VaR below the plain parametric figure instead of raising
+it, by `(z²−1)|S|σ/3` — 1.87 percentage points at 99% confidence on a skew of
+−1.25. The hybrid CVaR inherited the wrong cutoff, and `rollingVaR` inherited
+both. The expansion is now evaluated at the left-tail quantile. Existing tests
+only asserted that Cornish-Fisher differed from parametric, which held with
+either sign.
+
+**Deflated Sharpe silently stopped deflating.** `perReturnSharpe` returns
+±Infinity for a zero-variance trial by design, and a grid trial with a single
+trade always has zero variance. One such trial made the variance across trials
+`NaN`, which `expectedMaxSharpe` read as "no selection took place" and answered
+with the benchmark — so the deflated Sharpe collapsed to a plain probabilistic
+Sharpe against zero and reported a credible edge exactly when it was meant to
+be warning about overfitting (0.994 against a correctly deflated 0.444 in the
+module's own documented example). The three kinds of trial value are now told apart: `±Infinity` is
+excluded from the spread but still counts towards `trials`, since the search
+for it did happen; a `NaN` trial is broken input and propagates; and fewer
+than two finite trials among two or more searches leaves the spread
+unestimable, which is reported as `NaN` rather than as an absence of
+selection. `expectedMaxSharpe` propagates `NaN` rather than swallowing it.
+
+**MAR was a twelfth of the ratio its name denotes.** `calculateMAR` divided
+the arithmetic average *monthly* return by max drawdown; the canonical MAR is
+annualized return over max drawdown. Anything screening on the `"mar"`
+optimization metric — grid-search ranking, constraints, walk-forward
+aggregation — was comparing against industry thresholds an order of magnitude
+away. It is not a monotone rescaling either, so rankings could differ: over
+two years, 300% return against a 50% drawdown beat 200% against 36% on the
+monthly form (0.250 vs 0.231) and loses on the annualized one (2.00 vs 2.03).
+Note that this makes `"mar"` and `"calmar"` coincide for full-history results,
+which is what the two ratios are when computed over the same window.
+
 ### Breaking — Sharpe and Sortino are annualized from the equity curve, not from per-trade returns
 
 Five places annualized a series holding one return per **trade** by

--- a/packages/core/src/__tests__/financial-formulas.test.ts
+++ b/packages/core/src/__tests__/financial-formulas.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Three formula corrections whose common trait is that the wrong answer looked
+ * plausible: a risk measure that moved risk the wrong way, an overfitting
+ * defence that switched itself off, and a screening ratio an order of
+ * magnitude away from the number its name denotes.
+ */
+import { describe, expect, it } from "vitest";
+import { kurtosis, skewness } from "../core/statistics";
+import { calculateMAR } from "../optimization/metrics";
+import { calculateVaR } from "../risk/var";
+import {
+  deflatedSharpeFromReturns,
+  expectedMaxSharpe,
+  perReturnSharpe,
+  probabilisticSharpe,
+} from "../scoring/deflated-sharpe";
+
+/** Deterministic uniform generator. */
+function makeRng(seed: number): () => number {
+  let a = seed;
+  return () => {
+    a = (a * 1103515245 + 12345) & 0x7fffffff;
+    return a / 0x7fffffff;
+  };
+}
+
+/** Approximate standard normal by summing twelve uniforms. */
+function makeGauss(rnd: () => number): () => number {
+  return () => {
+    let s = 0;
+    for (let i = 0; i < 12; i++) s += rnd();
+    return s - 6;
+  };
+}
+
+/** Returns with a mild skew of the given sign — the regime CF is valid in. */
+function skewedReturns(sign: -1 | 1, n = 200_000): number[] {
+  const rnd = makeRng(12345);
+  const gauss = makeGauss(rnd);
+  return Array.from({ length: n }, () => {
+    const base = gauss() * 0.008 + 0.0005;
+    return rnd() < 0.05 ? base + sign * 0.012 : base;
+  });
+}
+
+describe("Cornish-Fisher VaR responds to skew in the right direction", () => {
+  it("raises VaR above the parametric figure for negatively skewed returns", () => {
+    const returns = skewedReturns(-1);
+    expect(skewness(returns)).toBeLessThan(0);
+
+    for (const confidence of [0.95, 0.99]) {
+      const parametric = calculateVaR(returns, { confidence, method: "parametric" });
+      const cornishFisher = calculateVaR(returns, { confidence, method: "cornishFisher" });
+
+      // A left tail fatter than the normal one means more risk, not less. The
+      // expansion used to be evaluated at the positive quantile, where the
+      // skew term — even in z — kept its sign and pulled VaR down instead.
+      expect(cornishFisher.var).toBeGreaterThan(parametric.var);
+    }
+  });
+
+  it("lowers VaR below the parametric figure for positively skewed returns", () => {
+    const returns = skewedReturns(1);
+    expect(skewness(returns)).toBeGreaterThan(0);
+
+    const parametric = calculateVaR(returns, { confidence: 0.95, method: "parametric" });
+    const cornishFisher = calculateVaR(returns, { confidence: 0.95, method: "cornishFisher" });
+
+    expect(cornishFisher.var).toBeLessThan(parametric.var);
+  });
+
+  it("keeps the hybrid CVaR at least as large as its own VaR", () => {
+    const returns = skewedReturns(-1);
+    const result = calculateVaR(returns, { confidence: 0.95, method: "cornishFisher" });
+
+    expect(kurtosis(returns)).toBeLessThan(1); // mild enough for the expansion
+    expect(result.cvar).toBeGreaterThanOrEqual(result.var);
+  });
+});
+
+describe("deflated Sharpe survives a non-finite trial", () => {
+  const rnd = makeRng(99);
+  const gauss = makeGauss(rnd);
+  const observed = Array.from({ length: 250 }, () => gauss() * 0.01 + 0.0008);
+  const finiteTrials = Array.from({ length: 50 }, (_, i) => 0.02 + (i % 7) * 0.01);
+
+  it("still deflates when one trial has zero variance", () => {
+    // A grid trial with a single trade has no variance, and perReturnSharpe
+    // reports Infinity for it by design.
+    expect(perReturnSharpe([0.05])).toBe(Number.POSITIVE_INFINITY);
+
+    const clean = deflatedSharpeFromReturns(observed, finiteTrials);
+    const withInfinity = deflatedSharpeFromReturns(observed, [
+      ...finiteTrials,
+      Number.POSITIVE_INFINITY,
+    ]);
+    // No trials means no selection to deflate against, so this is the same
+    // statistic with the deflation switched off — the honest reference, since
+    // it carries the same non-normality adjustment as the deflated figures.
+    const undeflated = deflatedSharpeFromReturns(observed, []);
+
+    // The deflation used to vanish: the variance went NaN, the benchmark fell
+    // back to 0, and the DSR became a plain PSR — reading as a credible edge
+    // precisely when it was meant to warn about overfitting.
+    expect(clean).toBeLessThan(undeflated);
+    expect(withInfinity).toBeLessThan(undeflated);
+    // Still deflated by the spread of the finite trials, and marginally more
+    // so than the 50-trial run: the extra trial was a search that happened,
+    // so it counts towards `trials` even though its Sharpe is not a number
+    // the spread can be measured from.
+    expect(withInfinity).toBeLessThan(clean);
+    expect(undeflated - withInfinity).toBeGreaterThan((undeflated - clean) * 0.9);
+  });
+
+  it("reports an undefined result when too few trials are finite to measure a spread", () => {
+    // Three searches happened; two of them cannot contribute a magnitude. That
+    // leaves the spread unknown, which is not the same as knowing there was no
+    // selection — answering 0 there would switch the deflation back off.
+    expect(
+      deflatedSharpeFromReturns(observed, [
+        Number.POSITIVE_INFINITY,
+        Number.POSITIVE_INFINITY,
+        0.1,
+      ]),
+    ).toBeNaN();
+  });
+
+  it("propagates a NaN trial rather than counting it as a search", () => {
+    // NaN is not something perReturnSharpe emits — it means the caller handed
+    // over a broken trial, and reporting a confident number from it would be
+    // worse than reporting nothing.
+    expect(deflatedSharpeFromReturns(observed, [0.1, 0.2, Number.NaN])).toBeNaN();
+  });
+
+  it("does not deflate when there was no selection", () => {
+    // With no trials, or one, nothing was chosen between: the result is the
+    // probabilistic Sharpe against a zero benchmark, up to the non-normality
+    // adjustment both share.
+    const undeflated = deflatedSharpeFromReturns(observed, []);
+    expect(deflatedSharpeFromReturns(observed, [0.1])).toBeCloseTo(undeflated, 10);
+    expect(undeflated).toBeCloseTo(
+      probabilisticSharpe(perReturnSharpe(observed), 0, observed.length),
+      2,
+    );
+  });
+
+  it("propagates a NaN variance instead of reporting no selection", () => {
+    expect(expectedMaxSharpe(50, Number.NaN)).toBeNaN();
+    // A genuine absence of spread still means "no selection".
+    expect(expectedMaxSharpe(50, 0)).toBe(0);
+    expect(expectedMaxSharpe(1, 0.5)).toBe(0);
+  });
+});
+
+describe("MAR ratio is annualized return over max drawdown", () => {
+  it("returns the canonical ratio, twelve times the old monthly form", () => {
+    // 10% over one year against a 5% drawdown is a MAR of 2, not 0.1667.
+    expect(calculateMAR(10, 252, 5)).toBeCloseTo(2, 6);
+  });
+
+  it("orders strategies the way the annualized ratio does", () => {
+    // Both over two years. Averaging is linear in total return while
+    // compounding is concave, so the two forms genuinely disagree here:
+    // by the old monthly form A led (300/24)/50 = 0.250 against B's
+    // (200/24)/36 = 0.231, while on compounded annual return B leads
+    // 73.2/36 = 2.03 against A's 100/50 = 2.00. This is not a rescaling —
+    // the ranking flips, and a grid search would pick the other strategy.
+    const a = calculateMAR(300, 504, 50);
+    const b = calculateMAR(200, 504, 36);
+
+    expect(a).toBeCloseTo(2.0, 2);
+    expect(b).toBeCloseTo(2.03, 2);
+    expect(b).toBeGreaterThan(a);
+  });
+});

--- a/packages/core/src/optimization/__tests__/metrics.test.ts
+++ b/packages/core/src/optimization/__tests__/metrics.test.ts
@@ -158,10 +158,16 @@ describe("Optimization Metrics", () => {
       expect(calculateMAR(10, -1, 5)).toBeNaN();
     });
 
-    it("computes monthly return / drawdown", () => {
-      // 10% return over 252 trading days ≈ 12 months → 0.833% / month / 5% DD = 0.1667
-      const v = calculateMAR(10, 252, 5);
-      expect(v).toBeCloseTo(0.1667, 3);
+    it("computes annualized return / drawdown", () => {
+      // 10% over exactly one year → 10% annualized / 5% DD = 2.
+      // Previously this divided the average *monthly* return instead, giving
+      // 0.1667 — a twelfth of the ratio the name denotes.
+      expect(calculateMAR(10, 252, 5)).toBeCloseTo(2, 6);
+    });
+
+    it("compounds over multi-year windows rather than averaging", () => {
+      // 21% over two years compounds to 10% a year, not 10.5%.
+      expect(calculateMAR(21, 504, 5)).toBeCloseTo(2, 3);
     });
   });
 

--- a/packages/core/src/optimization/metrics.ts
+++ b/packages/core/src/optimization/metrics.ts
@@ -83,8 +83,14 @@ export function calculateRecoveryFactor(netProfit: number, maxDrawdown: number):
 }
 
 /**
- * Calculate MAR Ratio (Monthly Average Return / Max Drawdown)
- * Similar to Calmar but uses monthly returns instead of annualized.
+ * Calculate MAR Ratio (annualized return / max drawdown).
+ *
+ * This used to divide the arithmetic average *monthly* return by max
+ * drawdown, which is roughly a twelfth of the ratio the name denotes — a
+ * strategy screened against the usual "MAR above 0.5" kind of threshold was
+ * being judged on a number an order of magnitude too small, and because the
+ * monthly form is not a monotone rescaling of the annualized one, it could
+ * also rank two strategies in the opposite order.
  *
  * Returns `NaN` when the ratio is undefined (no drawdown or no
  * trading days). See `calculateCalmarRatio` for rationale.
@@ -92,22 +98,22 @@ export function calculateRecoveryFactor(netProfit: number, maxDrawdown: number):
  * @param totalReturnPercent Total return in percent
  * @param tradingDays Number of trading days
  * @param maxDrawdownPercent Maximum drawdown in percent (positive number)
- * @param tradingDaysPerMonth Trading days per month (default: 21)
+ * @param tradingDaysPerYear Trading days per year (default: 252)
  * @returns MAR Ratio, or `NaN` when undefined
  */
 export function calculateMAR(
   totalReturnPercent: number,
   tradingDays: number,
   maxDrawdownPercent: number,
-  tradingDaysPerMonth = 21,
+  tradingDaysPerYear = 252,
 ): number {
   if (!(maxDrawdownPercent > 0)) return Number.NaN;
   if (tradingDays <= 0) return Number.NaN;
 
-  const months = tradingDays / tradingDaysPerMonth;
-  const monthlyAvgReturn = totalReturnPercent / months;
-
-  return monthlyAvgReturn / maxDrawdownPercent;
+  return calculateCalmarRatio(
+    annualizeReturn(totalReturnPercent, tradingDays, tradingDaysPerYear),
+    maxDrawdownPercent,
+  );
 }
 
 /**
@@ -284,7 +290,8 @@ export function calculateAllMetrics(
   // Calculate Calmar (annualized return / max DD)
   const calmar = calculateCalmarRatio(annualizedReturn, result.maxDrawdown);
 
-  // Calculate MAR (monthly avg return / max DD)
+  // Calculate MAR (annualized return / max DD — same ratio as calmar when,
+  // as here, both are taken over the full result window)
   const mar = calculateMAR(returns, tradingDays, result.maxDrawdown);
 
   // Calculate Recovery Factor (total return / max DD)

--- a/packages/core/src/risk/var.ts
+++ b/packages/core/src/risk/var.ts
@@ -255,18 +255,24 @@ export function calculateVaR(returns: number[], options?: VarOptions): VarResult
     }
 
     case "cornishFisher": {
-      const z = normalInverseCdf(confidence);
-      // Cornish-Fisher expansion to adjust z-score for non-normal distributions
+      // Evaluate the expansion at the LEFT-tail quantile. Taking the positive
+      // quantile and negating the result looks equivalent, but the skew term
+      // `(z²−1)·S/6` is even in z, so its sign does not flip with the rest:
+      // for the usual negatively skewed returns the fat-tail correction then
+      // *reduced* VaR below the plain parametric figure, moving risk the wrong
+      // way by `(z²−1)|S|σ/3` (1.87 percentage points at 99% on a skew of
+      // −1.25).
+      const zAlpha = normalInverseCdf(1 - confidence);
       const zCf =
-        z +
-        ((z * z - 1) * skew) / 6 +
-        ((z * z * z - 3 * z) * kurt) / 24 -
-        ((2 * z * z * z - 5 * z) * skew * skew) / 36;
+        zAlpha +
+        ((zAlpha * zAlpha - 1) * skew) / 6 +
+        ((zAlpha * zAlpha * zAlpha - 3 * zAlpha) * kurt) / 24 -
+        ((2 * zAlpha * zAlpha * zAlpha - 5 * zAlpha) * skew * skew) / 36;
 
-      varValue = -(mu - zCf * sigma);
+      varValue = -(mu + zCf * sigma);
 
       // Hybrid CVaR: use returns below VaR threshold
-      const threshold = mu - zCf * sigma;
+      const threshold = mu + zCf * sigma;
       let tailSum = 0;
       let tailCount = 0;
       for (let i = 0; i < returns.length; i++) {

--- a/packages/core/src/scoring/deflated-sharpe.ts
+++ b/packages/core/src/scoring/deflated-sharpe.ts
@@ -136,6 +136,9 @@ export function expectedMaxSharpe(
   trialSharpeVariance: number,
   trialSharpeMean = 0,
 ): number {
+  // A NaN variance is a broken input, not "no selection": returning the
+  // benchmark would silently switch the deflation off. Propagate it.
+  if (Number.isNaN(trialSharpeVariance)) return Number.NaN;
   if (trials <= 1 || !(trialSharpeVariance > 0)) return trialSharpeMean;
   const sd = Math.sqrt(trialSharpeVariance);
   const maxZ =
@@ -262,10 +265,39 @@ export function deflatedSharpeFromReturns(returns: number[], trialSharpes: numbe
     observedSharpe,
     sampleSize: returns.length,
     trials: trialSharpes.length,
-    trialSharpeVariance: trialSharpes.length > 0 ? variance(trialSharpes) : 0,
+    trialSharpeVariance: trialSpreadVariance(trialSharpes),
     skewness,
     kurtosis,
   });
+}
+
+/**
+ * Spread of the trial Sharpes that the deflation is measured against.
+ *
+ * The three kinds of input have to be told apart, because getting any of them
+ * wrong turns the deflation off silently — the one failure mode this statistic
+ * cannot afford, since it is what stands between an overfit grid search and a
+ * confident-looking number.
+ *
+ * - `NaN` is not something {@link perReturnSharpe} produces. It means the
+ *   caller handed over a broken trial, so it propagates rather than being
+ *   quietly dropped from a still-counted trial set.
+ * - `±Infinity` *is* deliberate: a zero-variance trial, which any trial with a
+ *   single trade is. It carries an ordering but no magnitude, so it cannot
+ *   enter a variance — yet the search for it did happen, so it still counts
+ *   towards `trials`.
+ * - Fewer than two finite trials leaves nothing to estimate a spread from.
+ *   That is an undefined statistic (`NaN`), not an absence of selection: a
+ *   grid of `[Infinity, Infinity, 0.1]` searched three times.
+ *
+ * With one trial or none there genuinely was no selection, and
+ * {@link expectedMaxSharpe} returns the benchmark regardless of this value.
+ */
+function trialSpreadVariance(trialSharpes: number[]): number {
+  if (trialSharpes.some((s) => Number.isNaN(s))) return Number.NaN;
+  if (trialSharpes.length <= 1) return 0;
+  const finite = trialSharpes.filter((s) => Number.isFinite(s));
+  return finite.length > 1 ? variance(finite) : Number.NaN;
 }
 
 /**


### PR DESCRIPTION
## Problem

Three formulas whose wrong answers all looked plausible — none of them produced an obviously broken number, and the existing tests passed either way.

### Cornish-Fisher VaR pointed risk the wrong way

The expansion was evaluated at the positive quantile `z = Φ⁻¹(confidence)` and the result negated. The kurtosis `(z³−3z)` and squared-skew `(2z³−5z)` terms are odd in z and survive that; the skew term `(z²−1)·S/6` is **even**, so it kept its sign. For the usual negatively skewed returns the fat-tail correction therefore *reduced* VaR below the plain parametric figure instead of raising it, by `(z²−1)|S|σ/3`:

```
n=200000  skew=-1.253  exKurt=4.301

confidence 0.95    parametric 1.701%    code 1.221%    correct 1.945%
confidence 0.99    parametric 2.394%    code 1.879%    correct 3.753%
```

The hybrid Cornish-Fisher CVaR inherited the wrong cutoff, and `rollingVaR` inherited both. The existing tests only asserted that Cornish-Fisher differed from parametric, which holds with either sign.

### Deflated Sharpe silently stopped deflating

`perReturnSharpe` returns `±Infinity` for a zero-variance series by design, and a grid trial with exactly one trade always has zero variance. One such trial made the variance across trials `NaN`, which `expectedMaxSharpe`'s `!(variance > 0)` guard read as "no selection took place" and answered with the benchmark. The deflated Sharpe then collapsed to a plain probabilistic Sharpe against zero — reporting a credible edge exactly when it was meant to warn about overfitting. The module's own documented example constructs the failing input:

```
DSR, 50 finite trials     = 0.4437   ← "likely overfit"
DSR, one Infinity trial   = 0.9938   ← reads as a credible edge
plain PSR vs benchmark 0  = 0.9938   ← deflation fully disabled
```

### MAR was a twelfth of the ratio its name denotes

`calculateMAR` divided the arithmetic average **monthly** return by max drawdown; the canonical MAR is annualized return over max drawdown. Anything screening on the `"mar"` optimization metric — grid-search ranking, constraints, walk-forward aggregation — was comparing against industry thresholds an order of magnitude away.

## Change

The Cornish-Fisher expansion is evaluated at the left-tail quantile `Φ⁻¹(1 − confidence)`, so every term carries the sign it should.

For the deflated Sharpe, the three kinds of trial value are now told apart, because getting any of them wrong turns the deflation off silently:

- `±Infinity` is deliberate — a zero-variance trial. It carries an ordering but no magnitude, so it is excluded from the spread while still counting towards `trials`: the search for it did happen.
- `NaN` is not something `perReturnSharpe` produces. It means a broken trial was handed over, so it propagates instead of being quietly dropped from a still-counted trial set.
- Fewer than two finite trials among two or more searches leaves nothing to estimate a spread from. That is an undefined statistic (`NaN`), not an absence of selection — `[Infinity, Infinity, 0.1]` searched three times.

`expectedMaxSharpe` propagates a `NaN` variance rather than answering with the benchmark.

`calculateMAR` now returns annualized return over max drawdown, reusing the existing `annualizeReturn` and `calculateCalmarRatio` owners.

## Breaking

- Cornish-Fisher VaR and its hybrid CVaR change, as does `rollingVaR` with that method. For negatively skewed returns the reported risk rises.
- Deflated Sharpe changes wherever a non-finite trial was present, and can now be `NaN` for trial sets it previously answered for.
- The `"mar"` optimization metric changes by roughly 12×, and rankings against it can differ from before.

Note that the MAR correction makes `"mar"` and `"calmar"` coincide for full-history results, which is what the two ratios are when computed over the same window. Whether to differentiate Calmar as a trailing-36-month figure, drop one of the keys, or leave both is an API question this PR deliberately does not decide.

## Test plan

10 regression tests in `src/__tests__/financial-formulas.test.ts`, built from the reproductions above.

- Cornish-Fisher VaR exceeds the parametric figure for negatively skewed returns at 95% and 99%, and falls below it for positively skewed returns; the hybrid CVaR stays at or above its own VaR. The fixtures use a mild skew (−0.17), the regime the expansion is valid in — at a skew near −3 it becomes non-monotone regardless of implementation
- Deflated Sharpe with one `Infinity` among 50 finite trials stays deflated and slightly below the 50-trial figure, since the extra trial counts as a search
- `[Infinity, Infinity, 0.1]` and `[0.1, 0.2, NaN]` both report `NaN`; no trials and one trial report the undeflated value
- `expectedMaxSharpe(50, NaN)` is `NaN`, while a genuine zero variance still means no selection
- MAR returns 2 for 10% over a year against a 5% drawdown, and ranks 200%/36% above 300%/50% over two years — the pair the monthly form ordered the other way

Negative check: 8 of the 10 fail against the unpatched sources.

Verification: core 6412 tests, chart 934, mcp 83 all pass; `tsc --noEmit`, `pnpm build` and `biome check` clean.