### PR TITLE
fix(core): recognize second-stamped candles, multi-week buckets, long gaps

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## [Unreleased]
 
+### Breaking — second-stamped candles are converted again; multi-week resampling and long weekend gaps fixed
+
+`normalizeTime` documents a numeric time below 1e10 as Unix **seconds**, but
+every indicator gates conversion behind `isNormalized(candles) ? candles :
+normalizeCandles(candles)`, and `isNormalized` accepted any number. So
+second-stamped candles — the shape most exchange REST APIs return — were
+declared already normalized and never converted. Nothing errored; instead
+every `Math.floor(time / 86_400_000)` day bucket advanced once every 2.7
+years, so session VWAP and TWAP never reset, opening ranges and market
+profiles covered the whole history, `detectSessions` found no sessions at all,
+and resampling produced meaningless buckets. `isNormalized` is now
+magnitude-aware, matching the range `normalizeTime` leaves untouched, and the
+two private copies of it in the regime modules are gone.
+
+Callers passing epoch-second candles will see different (correct) output from
+every time-bucketed indicator. Callers already passing milliseconds are
+unaffected. Note that a numeric time below 1e10 is now treated as seconds
+everywhere, so toy timestamps like `time: 1` are scaled by 1000 rather than
+taken literally.
+
+`resample` ignored `value` for the `'week'` unit, so `{ value: 2, unit:
+'week' }` silently returned ordinary weekly candles. Multi-week periods now
+bucket against a fixed Monday reference the way multi-day and multi-month
+periods already bucketed against theirs.
+
+`detectGaps` classified any Friday-to-Monday hole as a weekend regardless of
+length, so a seventeen-day — or three-month — hole passed validation in
+silence whenever its endpoints happened to fall that way. A weekend gap now
+has to be short enough to be one.
+
 ### Breaking — three financial formulas corrected: Cornish-Fisher VaR, deflated Sharpe, MAR
 
 **Cornish-Fisher VaR pointed risk the wrong way.** The expansion was evaluated

--- a/packages/core/src/__tests__/time-handling.test.ts
+++ b/packages/core/src/__tests__/time-handling.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Three time-handling defects that shared a failure style: the wrong answer
+ * arrived without an error, a warning, or a visibly odd number.
+ */
+import { describe, expect, it } from "vitest";
+import { isNormalized, normalizeCandles } from "../core/normalize";
+import { resample } from "../core/resample";
+import { vwap } from "../indicators/volume/vwap";
+import type { Candle, NormalizedCandle } from "../types";
+import { detectGaps } from "../validation/gap-detection";
+
+const DAY_MS = 86_400_000;
+const DAY_S = 86_400;
+/** 2026-01-05T00:00Z — a Monday, so weekly buckets start cleanly. */
+const MONDAY_MS = 1_767_571_200_000;
+
+/** One bar per day at `close`, stamped in whichever unit is asked for. */
+function dailyCandles(closes: number[], unit: "s" | "ms"): NormalizedCandle[] {
+  const step = unit === "s" ? DAY_S : DAY_MS;
+  const start = unit === "s" ? MONDAY_MS / 1000 : MONDAY_MS;
+  return closes.map((close, i) => ({
+    time: start + i * step,
+    open: close,
+    high: close,
+    low: close,
+    close,
+    volume: 1000,
+  }));
+}
+
+describe("isNormalized recognises second-stamped candles", () => {
+  it("treats epoch seconds as not yet normalized", () => {
+    expect(isNormalized(dailyCandles([100], "s"))).toBe(false);
+    expect(isNormalized(dailyCandles([100], "ms"))).toBe(true);
+    // Empty input has nothing to judge and is left alone.
+    expect(isNormalized([])).toBe(true);
+  });
+
+  it("converts them, so day buckets advance once a day rather than once every 2.7 years", () => {
+    const seconds = dailyCandles([100, 101, 102], "s");
+    const converted = normalizeCandles(seconds as unknown as Candle[]);
+
+    expect(converted.map((c) => c.time)).toEqual(
+      dailyCandles([100, 101, 102], "ms").map((c) => c.time),
+    );
+    expect(new Set(converted.map((c) => Math.floor(c.time / DAY_MS))).size).toBe(3);
+    // Before the fix all three landed in one bucket, 1970-01-21.
+    expect(new Set(seconds.map((c) => Math.floor(c.time / DAY_MS))).size).toBe(1);
+  });
+
+  it("resets session VWAP per day for second-stamped input", () => {
+    // One bar per day at a flat price, so a session VWAP that resets daily
+    // reports that day's price and one that never resets drags the average.
+    const closes = [100, 101, 102];
+    const fromSeconds = vwap(dailyCandles(closes, "s") as unknown as Candle[], {
+      resetPeriod: "session",
+    });
+    const fromMs = vwap(dailyCandles(closes, "ms"), { resetPeriod: "session" });
+
+    expect(fromSeconds.map((p) => p.value)).toEqual(fromMs.map((p) => p.value));
+    expect(fromSeconds.map((p) => p.value.vwap)).toEqual(closes);
+  });
+
+  it("is idempotent: normalizing an already-normalized array changes nothing", () => {
+    const ms = dailyCandles([100, 101], "ms");
+    expect(normalizeCandles(ms as unknown as Candle[]).map((c) => c.time)).toEqual(
+      ms.map((c) => c.time),
+    );
+  });
+});
+
+describe("resample honours the value of a multi-week timeframe", () => {
+  it("puts adjacent weeks in one bucket for a 2-week timeframe", () => {
+    // Four calendar weeks of daily bars, weekdays only.
+    const closes: number[] = [];
+    const candles: NormalizedCandle[] = [];
+    for (let week = 0; week < 4; week++) {
+      for (let day = 0; day < 5; day++) {
+        const close = 100 + week * 4 + day;
+        closes.push(close);
+        candles.push({
+          time: MONDAY_MS + (week * 7 + day) * DAY_MS,
+          open: close,
+          high: close,
+          low: close,
+          close,
+          volume: 1000,
+        });
+      }
+    }
+
+    const weekly = resample(candles, { value: 1, unit: "week" });
+    const biweekly = resample(candles, { value: 2, unit: "week" });
+
+    expect(weekly).toHaveLength(4);
+    // Previously `value` was ignored here and this also returned four.
+    expect(biweekly).toHaveLength(2);
+    expect(biweekly[0].time).toBe(weekly[0].time);
+    expect(biweekly[1].time).toBe(weekly[2].time);
+    // Each two-week candle spans both of its weeks.
+    expect(biweekly[0].close).toBe(weekly[1].close);
+  });
+});
+
+describe("weekend gaps are bounded by their duration", () => {
+  function fridayToMondayGap(holeDays: number): NormalizedCandle[] {
+    // MONDAY_MS is a Monday; bar 4 is the Friday of that week.
+    const friday = MONDAY_MS + 4 * DAY_MS;
+    const times = [
+      MONDAY_MS,
+      MONDAY_MS + DAY_MS,
+      MONDAY_MS + 2 * DAY_MS,
+      MONDAY_MS + 3 * DAY_MS,
+      friday,
+      friday + holeDays * DAY_MS,
+    ];
+    return times.map((time) => ({
+      time,
+      open: 100,
+      high: 100,
+      low: 100,
+      close: 100,
+      volume: 1000,
+    }));
+  }
+
+  it("still ignores a genuine Friday-to-Monday weekend", () => {
+    expect(detectGaps(fridayToMondayGap(3), { skipWeekends: true })).toEqual([]);
+  });
+
+  it("reports a seventeen-day hole that happens to run Friday to Monday", () => {
+    const findings = detectGaps(fridayToMondayGap(17), { skipWeekends: true });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].category).toBe("gap");
+    expect(findings[0].message).toContain("17.0d");
+  });
+});

--- a/packages/core/src/__tests__/variance-stability.test.ts
+++ b/packages/core/src/__tests__/variance-stability.test.ts
@@ -33,7 +33,7 @@ function sineCandles(n: number, base: number, amp = 1, volume = 1_000_000): Norm
   return Array.from({ length: n }, (_, i) => {
     const close = base + amp * Math.sin(i * 0.7);
     return {
-      time: 1_700_000_000 + i * 86_400,
+      time: 1_700_000_000_000 + i * 86_400_000,
       open: close,
       high: close,
       low: close,
@@ -45,7 +45,7 @@ function sineCandles(n: number, base: number, amp = 1, volume = 1_000_000): Norm
 
 function candlesFromVolumes(volumes: number[]): NormalizedCandle[] {
   return volumes.map((volume, i) => ({
-    time: 1_700_000_000 + i * 86_400,
+    time: 1_700_000_000_000 + i * 86_400_000,
     open: 100,
     high: 100,
     low: 100,
@@ -215,7 +215,7 @@ describe("linearRegression slope accuracy at high price levels", () => {
     return Array.from({ length: n }, (_, i) => {
       const close = base + i * 0.5;
       return {
-        time: 1_700_000_000 + i * 86_400,
+        time: 1_700_000_000_000 + i * 86_400_000,
         open: close,
         high: close,
         low: close,
@@ -275,7 +275,7 @@ describe("incremental ↔ batch parity at high price levels", () => {
     const candles = Array.from({ length: 300 }, (_, i) => {
       const close = 1e8 + i * 0.5 + Math.sin(i * 0.7) * 2;
       return {
-        time: 1_700_000_000 + i * 86_400,
+        time: 1_700_000_000_000 + i * 86_400_000,
         open: close,
         high: close,
         low: close,
@@ -297,7 +297,7 @@ describe("incremental ↔ batch parity at high price levels", () => {
     const candles = Array.from({ length: 200 }, (_, i) => {
       const close = 100 * 2 ** i * (1 + Math.sin(i * 0.7) * 1e-9);
       return {
-        time: 1_700_000_000 + i * 86_400,
+        time: 1_700_000_000_000 + i * 86_400_000,
         open: close,
         high: close,
         low: close,

--- a/packages/core/src/analysis/market-regime.ts
+++ b/packages/core/src/analysis/market-regime.ts
@@ -18,7 +18,7 @@
  * ```
  */
 
-import { normalizeCandles } from "../core/normalize";
+import { isNormalized, normalizeCandles } from "../core/normalize";
 import { dmi } from "../indicators/momentum/dmi";
 import { ema } from "../indicators/moving-average/ema";
 import { atr } from "../indicators/volatility/atr";
@@ -201,9 +201,4 @@ function classifyTrend(
   }
 
   return { trend: "sideways", trendStrength };
-}
-
-function isNormalized(candles: Candle[] | NormalizedCandle[]): candles is NormalizedCandle[] {
-  if (candles.length === 0) return true;
-  return typeof candles[0].time === "number";
 }

--- a/packages/core/src/backtest/__tests__/scaled-entry-fill-modes.test.ts
+++ b/packages/core/src/backtest/__tests__/scaled-entry-fill-modes.test.ts
@@ -5,6 +5,8 @@ import { runBacktestScaled } from "../scaled-entry";
 import { at, makeCandles, never } from "./step-candles";
 
 const DAY = 86_400_000;
+/** Bar times must be epoch milliseconds, not a bare multiple of a day. */
+const BASE = 1_700_000_000_000;
 
 /**
  * Signal at i1; next-bar-open entry belongs at i2's open (105). The i3 wick
@@ -287,7 +289,7 @@ describe("runBacktestScaled matches runBacktest when only one tranche fills", ()
       const vol = price * (0.002 + rand() * 0.02);
       const high = Math.max(open, close) + rand() * vol;
       const low = Math.min(open, close) - rand() * vol;
-      out.push({ time: DAY * (i + 1), open, high, low, close, volume: 1000 });
+      out.push({ time: BASE + DAY * (i + 1), open, high, low, close, volume: 1000 });
       price = close;
     }
     return out;

--- a/packages/core/src/backtest/conditions/__tests__/pattern-lookahead.test.ts
+++ b/packages/core/src/backtest/conditions/__tests__/pattern-lookahead.test.ts
@@ -11,10 +11,12 @@ import {
 } from "../patterns";
 
 const DAY = 86_400_000;
+/** A realistic epoch: bar times must be milliseconds, not a small offset. */
+const BASE = 1_700_000_000_000;
 
 function candle(i: number, close: number, volume = 1000): NormalizedCandle {
   return {
-    time: DAY * (i + 1),
+    time: BASE + DAY * (i + 1),
     open: close,
     high: close + 0.5,
     low: close - 0.5,
@@ -24,7 +26,7 @@ function candle(i: number, close: number, volume = 1000): NormalizedCandle {
 }
 
 function timeAt(index: number): number {
-  return DAY * (index + 1);
+  return BASE + DAY * (index + 1);
 }
 
 /**

--- a/packages/core/src/core/normalize.ts
+++ b/packages/core/src/core/normalize.ts
@@ -95,8 +95,18 @@ export function getPriceSeries(candles: NormalizedCandle[], source: PriceSource)
  *
  * Use this to avoid redundant normalization when candles may have already been normalized.
  *
+ * "Numeric" is not enough on its own: {@link normalizeTime} treats a number
+ * below 1e10 as Unix *seconds* and one at or above 1e13 as microseconds, so
+ * accepting any number here declared second-stamped candles — the shape most
+ * exchange REST APIs return — already normalized and skipped the conversion.
+ * Every downstream `Math.floor(time / 86_400_000)` day bucket then advanced
+ * only once every 2.7 years, so session VWAP/TWAP/opening ranges never reset
+ * and `detectSessions` found nothing, with no error anywhere. The check is
+ * therefore magnitude-aware, matching the range `normalizeTime` leaves
+ * untouched; normalizing an already-normalized array is a no-op regardless.
+ *
  * @param candles - Array of candles to check
- * @returns true if candles are normalized (time is a number), false otherwise
+ * @returns true if candles already carry epoch-millisecond times
  *
  * @example
  * ```ts
@@ -107,7 +117,8 @@ export function isNormalized(
   candles: Candle[] | NormalizedCandle[],
 ): candles is NormalizedCandle[] {
   if (candles.length === 0) return true;
-  return typeof candles[0].time === "number";
+  const time = candles[0].time;
+  return typeof time === "number" && time >= 1e10 && time < 1e13;
 }
 
 /**

--- a/packages/core/src/core/resample.ts
+++ b/packages/core/src/core/resample.ts
@@ -5,6 +5,9 @@
 
 import type { NormalizedCandle, Timeframe, TimeframeShorthand } from "../types";
 
+/** 1970-01-05T00:00Z — the first Monday of the epoch, the reference for multi-week buckets. */
+const MONDAY_EPOCH = 345_600_000;
+
 /**
  * Parse shorthand timeframe string to Timeframe object
  */
@@ -75,6 +78,15 @@ export function getPeriodStart(time: number, timeframe: Timeframe): number {
       const diff = day === 0 ? 6 : day - 1; // Adjust so Monday = 0
       date.setUTCDate(date.getUTCDate() - diff);
       date.setUTCHours(0, 0, 0, 0);
+      if (timeframe.value > 1) {
+        // Multi-week periods count from a fixed Monday so that adjacent weeks
+        // land in the same bucket. Without this, `value` was ignored outright
+        // and a 2-week resample returned ordinary weekly candles.
+        const weekMs = 7 * 24 * 60 * 60 * 1000;
+        const weeksSinceRef = Math.floor((date.getTime() - MONDAY_EPOCH) / weekMs);
+        const periodStart = Math.floor(weeksSinceRef / timeframe.value) * timeframe.value;
+        return MONDAY_EPOCH + periodStart * weekMs;
+      }
       return date.getTime();
     }
     case "month": {

--- a/packages/core/src/indicators/__tests__/alma.test.ts
+++ b/packages/core/src/indicators/__tests__/alma.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { alma } from "../../indicators";
 
-function makeCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/awesome-oscillator.test.ts
+++ b/packages/core/src/indicators/__tests__/awesome-oscillator.test.ts
@@ -4,8 +4,8 @@ import type { NormalizedCandle } from "../../types";
 
 function _makeCandles(
   data: { high: number; low: number }[],
-  time0 = 1000,
-  step = 86400,
+  time0 = 1_700_000_000_000,
+  step = 86_400_000,
 ): NormalizedCandle[] {
   return data.map((d, i) => ({
     time: time0 + i * step,
@@ -17,7 +17,7 @@ function _makeCandles(
   }));
 }
 
-function makeSimpleCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeSimpleCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/balance-of-power.test.ts
+++ b/packages/core/src/indicators/__tests__/balance-of-power.test.ts
@@ -4,8 +4,8 @@ import type { NormalizedCandle } from "../../types";
 
 function makeCandles(
   data: { open: number; high: number; low: number; close: number }[],
-  time0 = 1000,
-  step = 86400,
+  time0 = 1_700_000_000_000,
+  step = 86_400_000,
 ): NormalizedCandle[] {
   return data.map((d, i) => ({
     time: time0 + i * step,
@@ -17,7 +17,7 @@ function makeCandles(
   }));
 }
 
-function makeSimpleCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeSimpleCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/cmo.test.ts
+++ b/packages/core/src/indicators/__tests__/cmo.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { cmo } from "../../indicators";
 
-function makeCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/coppock-curve.test.ts
+++ b/packages/core/src/indicators/__tests__/coppock-curve.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { coppockCurve } from "../../indicators";
 
-function makeCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/cvd.test.ts
+++ b/packages/core/src/indicators/__tests__/cvd.test.ts
@@ -68,12 +68,12 @@ describe("cvd", () => {
 
   it("should preserve time values", () => {
     const candles = [
-      makeCandle(1000, 100, 110, 90, 100, 500),
-      makeCandle(2000, 100, 110, 90, 100, 500),
+      makeCandle(1700000000000, 100, 110, 90, 100, 500),
+      makeCandle(1700086400000, 100, 110, 90, 100, 500),
     ];
     const result = cvd(candles);
-    expect(result[0].time).toBe(1000);
-    expect(result[1].time).toBe(2000);
+    expect(result[0].time).toBe(1700000000000);
+    expect(result[1].time).toBe(1700086400000);
   });
 });
 

--- a/packages/core/src/indicators/__tests__/dema.test.ts
+++ b/packages/core/src/indicators/__tests__/dema.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { dema } from "../../indicators";
 
-function makeCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/frama.test.ts
+++ b/packages/core/src/indicators/__tests__/frama.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { frama } from "../../indicators";
 
-function makeCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/garman-klass.test.ts
+++ b/packages/core/src/indicators/__tests__/garman-klass.test.ts
@@ -4,8 +4,8 @@ import type { NormalizedCandle } from "../../types";
 
 function makeOHLCCandles(
   data: { open: number; high: number; low: number; close: number }[],
-  time0 = 1000,
-  step = 86400,
+  time0 = 1_700_000_000_000,
+  step = 86_400_000,
 ): NormalizedCandle[] {
   return data.map((d, i) => ({
     time: time0 + i * step,
@@ -17,7 +17,7 @@ function makeOHLCCandles(
   }));
 }
 
-function makeSimpleCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeSimpleCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/historical-volatility.test.ts
+++ b/packages/core/src/indicators/__tests__/historical-volatility.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { historicalVolatility } from "../../indicators";
 
-function makeCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/kst.test.ts
+++ b/packages/core/src/indicators/__tests__/kst.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { kst } from "../../indicators";
 
-function makeCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/linear-regression.test.ts
+++ b/packages/core/src/indicators/__tests__/linear-regression.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { linearRegression } from "../../indicators";
 
-function makeCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/mass-index.test.ts
+++ b/packages/core/src/indicators/__tests__/mass-index.test.ts
@@ -4,8 +4,8 @@ import type { NormalizedCandle } from "../../types";
 
 function makeCandles(
   data: { high: number; low: number }[],
-  time0 = 1000,
-  step = 86400,
+  time0 = 1_700_000_000_000,
+  step = 86_400_000,
 ): NormalizedCandle[] {
   return data.map((d, i) => ({
     time: time0 + i * step,
@@ -17,7 +17,7 @@ function makeCandles(
   }));
 }
 
-function makeSimpleCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeSimpleCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/median-price.test.ts
+++ b/packages/core/src/indicators/__tests__/median-price.test.ts
@@ -4,8 +4,8 @@ import type { NormalizedCandle } from "../../types";
 
 function makeCandles(
   data: { open: number; high: number; low: number; close: number }[],
-  time0 = 1000,
-  step = 86400,
+  time0 = 1_700_000_000_000,
+  step = 86_400_000,
 ): NormalizedCandle[] {
   return data.map((d, i) => ({
     time: time0 + i * step,

--- a/packages/core/src/indicators/__tests__/nvi.test.ts
+++ b/packages/core/src/indicators/__tests__/nvi.test.ts
@@ -4,8 +4,8 @@ import type { NormalizedCandle } from "../../types";
 
 function makeCandles(
   data: { close: number; volume: number }[],
-  time0 = 1000,
-  step = 86400,
+  time0 = 1_700_000_000_000,
+  step = 86_400_000,
 ): NormalizedCandle[] {
   return data.map((d, i) => ({
     time: time0 + i * step,

--- a/packages/core/src/indicators/__tests__/ppo.test.ts
+++ b/packages/core/src/indicators/__tests__/ppo.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { ppo } from "../../indicators";
 
-function makeCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/pvt.test.ts
+++ b/packages/core/src/indicators/__tests__/pvt.test.ts
@@ -4,8 +4,8 @@ import type { NormalizedCandle } from "../../types";
 
 function makeCandles(
   data: { close: number; volume: number }[],
-  time0 = 1000,
-  step = 86400,
+  time0 = 1_700_000_000_000,
+  step = 86_400_000,
 ): NormalizedCandle[] {
   return data.map((d, i) => ({
     time: time0 + i * step,

--- a/packages/core/src/indicators/__tests__/qstick.test.ts
+++ b/packages/core/src/indicators/__tests__/qstick.test.ts
@@ -4,8 +4,8 @@ import type { NormalizedCandle } from "../../types";
 
 function makeCandles(
   data: { open: number; close: number }[],
-  time0 = 1000,
-  step = 86400,
+  time0 = 1_700_000_000_000,
+  step = 86_400_000,
 ): NormalizedCandle[] {
   return data.map((d, i) => ({
     time: time0 + i * step,
@@ -17,7 +17,7 @@ function makeCandles(
   }));
 }
 
-function makeSimpleCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeSimpleCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/schaff-trend-cycle.test.ts
+++ b/packages/core/src/indicators/__tests__/schaff-trend-cycle.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { schaffTrendCycle } from "../../indicators";
 
-function makeCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/standard-deviation.test.ts
+++ b/packages/core/src/indicators/__tests__/standard-deviation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { standardDeviation } from "../../indicators";
 
-function makeCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/tema.test.ts
+++ b/packages/core/src/indicators/__tests__/tema.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { tema } from "../../indicators";
 
-function makeCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/tsi.test.ts
+++ b/packages/core/src/indicators/__tests__/tsi.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { tsi } from "../../indicators";
 
-function makeCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/ulcer-index.test.ts
+++ b/packages/core/src/indicators/__tests__/ulcer-index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { ulcerIndex } from "../../indicators";
 
-function makeCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/ultimate-oscillator.test.ts
+++ b/packages/core/src/indicators/__tests__/ultimate-oscillator.test.ts
@@ -4,8 +4,8 @@ import type { NormalizedCandle } from "../../types";
 
 function makeCandles(
   data: { high: number; low: number; close: number }[],
-  time0 = 1000,
-  step = 86400,
+  time0 = 1_700_000_000_000,
+  step = 86_400_000,
 ): NormalizedCandle[] {
   return data.map((d, i) => ({
     time: time0 + i * step,
@@ -17,7 +17,7 @@ function makeCandles(
   }));
 }
 
-function makeSimpleCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeSimpleCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/__tests__/wyckoff-phases-coverage.test.ts
+++ b/packages/core/src/indicators/__tests__/wyckoff-phases-coverage.test.ts
@@ -176,7 +176,7 @@ describe("wyckoffPhases – edge cases", () => {
 
   it("raw (non-normalized) candles", () => {
     const c = Array.from({ length: 15 }, (_, i) => ({
-      time: 1000000 + i * 86400000,
+      time: 1_700_000_000_000 + i * 86_400_000,
       open: 100,
       high: 102,
       low: 98,

--- a/packages/core/src/indicators/__tests__/zlema.test.ts
+++ b/packages/core/src/indicators/__tests__/zlema.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { zlema } from "../../indicators";
 
-function makeCandles(closes: number[], time0 = 1000, step = 86400) {
+function makeCandles(closes: number[], time0 = 1_700_000_000_000, step = 86_400_000) {
   return closes.map((c, i) => ({
     time: time0 + i * step,
     open: c - 0.5,

--- a/packages/core/src/indicators/volatility/__tests__/keltner-channel.test.ts
+++ b/packages/core/src/indicators/volatility/__tests__/keltner-channel.test.ts
@@ -13,7 +13,7 @@ describe("keltnerChannel", () => {
       const low = price - 2 - Math.abs(volatility);
       const close = price + volatility * 0.5;
       candles.push({
-        time: i + 1,
+        time: 1_700_000_000_000 + i * 86_400_000,
         open: price,
         high,
         low,

--- a/packages/core/src/indicators/volatility/regime.ts
+++ b/packages/core/src/indicators/volatility/regime.ts
@@ -7,7 +7,7 @@
  */
 
 import { annualizationFactor } from "../../calendar";
-import { normalizeCandles } from "../../core/normalize";
+import { isNormalized, normalizeCandles } from "../../core/normalize";
 import type {
   Candle,
   NormalizedCandle,
@@ -325,12 +325,4 @@ function mergeOptions(options: VolatilityRegimeOptions): ResolvedOptions {
       extreme: options.thresholds?.extreme ?? DEFAULT_OPTIONS.thresholds.extreme,
     },
   };
-}
-
-/**
- * Check if candles are already normalized
- */
-function isNormalized(candles: Candle[] | NormalizedCandle[]): candles is NormalizedCandle[] {
-  if (candles.length === 0) return true;
-  return typeof candles[0].time === "number";
 }

--- a/packages/core/src/indicators/volume/__tests__/cmf.test.ts
+++ b/packages/core/src/indicators/volume/__tests__/cmf.test.ts
@@ -5,16 +5,16 @@ import { cmf } from "../cmf";
 describe("cmf", () => {
   // Sample data for testing
   const sampleCandles: NormalizedCandle[] = [
-    { time: 1, open: 100, high: 105, low: 95, close: 103, volume: 1000 },
-    { time: 2, open: 103, high: 108, low: 100, close: 106, volume: 1200 },
-    { time: 3, open: 106, high: 110, low: 104, close: 108, volume: 1100 },
-    { time: 4, open: 108, high: 112, low: 106, close: 110, volume: 1300 },
-    { time: 5, open: 110, high: 115, low: 108, close: 113, volume: 1400 },
-    { time: 6, open: 113, high: 118, low: 111, close: 116, volume: 1500 },
-    { time: 7, open: 116, high: 120, low: 114, close: 118, volume: 1600 },
-    { time: 8, open: 118, high: 122, low: 116, close: 120, volume: 1700 },
-    { time: 9, open: 120, high: 124, low: 118, close: 122, volume: 1800 },
-    { time: 10, open: 122, high: 126, low: 120, close: 124, volume: 1900 },
+    { time: 1700000000000, open: 100, high: 105, low: 95, close: 103, volume: 1000 },
+    { time: 1700086400000, open: 103, high: 108, low: 100, close: 106, volume: 1200 },
+    { time: 1700172800000, open: 106, high: 110, low: 104, close: 108, volume: 1100 },
+    { time: 1700259200000, open: 108, high: 112, low: 106, close: 110, volume: 1300 },
+    { time: 1700345600000, open: 110, high: 115, low: 108, close: 113, volume: 1400 },
+    { time: 1700432000000, open: 113, high: 118, low: 111, close: 116, volume: 1500 },
+    { time: 1700518400000, open: 116, high: 120, low: 114, close: 118, volume: 1600 },
+    { time: 1700604800000, open: 118, high: 122, low: 116, close: 120, volume: 1700 },
+    { time: 1700691200000, open: 120, high: 124, low: 118, close: 122, volume: 1800 },
+    { time: 1700777600000, open: 122, high: 126, low: 120, close: 124, volume: 1900 },
   ];
 
   it("should return empty array for empty input", () => {
@@ -123,9 +123,9 @@ describe("cmf", () => {
 
   it("should handle case where high equals low", () => {
     const flatCandles: NormalizedCandle[] = [
-      { time: 1, open: 100, high: 100, low: 100, close: 100, volume: 1000 },
-      { time: 2, open: 100, high: 100, low: 100, close: 100, volume: 1000 },
-      { time: 3, open: 100, high: 100, low: 100, close: 100, volume: 1000 },
+      { time: 1700000000000, open: 100, high: 100, low: 100, close: 100, volume: 1000 },
+      { time: 1700086400000, open: 100, high: 100, low: 100, close: 100, volume: 1000 },
+      { time: 1700172800000, open: 100, high: 100, low: 100, close: 100, volume: 1000 },
     ];
 
     const result = cmf(flatCandles, { period: 2 });

--- a/packages/core/src/indicators/volume/__tests__/volume-anomaly.test.ts
+++ b/packages/core/src/indicators/volume/__tests__/volume-anomaly.test.ts
@@ -9,7 +9,7 @@ import { volumeAnomaly } from "../volume-anomaly";
 // Helper to create test candles
 function createCandles(volumes: number[]): NormalizedCandle[] {
   return volumes.map((volume, i) => ({
-    time: 1000000 + i * 86400000,
+    time: 1_700_000_000_000 + i * 86_400_000,
     open: 100,
     high: 105,
     low: 95,

--- a/packages/core/src/indicators/volume/__tests__/volume-profile.test.ts
+++ b/packages/core/src/indicators/volume/__tests__/volume-profile.test.ts
@@ -11,7 +11,7 @@ function createCandles(
   data: Array<{ high: number; low: number; close: number; volume: number }>,
 ): NormalizedCandle[] {
   return data.map((d, i) => ({
-    time: 1000000 + i * 86400000,
+    time: 1_700_000_000_000 + i * 86_400_000,
     open: d.low + (d.high - d.low) * 0.3,
     high: d.high,
     low: d.low,
@@ -25,7 +25,7 @@ function createUniformCandles(count: number, volume = 100): NormalizedCandle[] {
   return Array(count)
     .fill(null)
     .map((_, i) => ({
-      time: 1000000 + i * 86400000,
+      time: 1_700_000_000_000 + i * 86_400_000,
       open: 100,
       high: 110,
       low: 90,

--- a/packages/core/src/indicators/volume/__tests__/volume-trend.test.ts
+++ b/packages/core/src/indicators/volume/__tests__/volume-trend.test.ts
@@ -9,7 +9,7 @@ import { volumeTrend } from "../volume-trend";
 // Helper to create test candles with specific price and volume patterns
 function createCandles(data: Array<{ close: number; volume: number }>): NormalizedCandle[] {
   return data.map((d, i) => ({
-    time: 1000000 + i * 86400000,
+    time: 1_700_000_000_000 + i * 86_400_000,
     open: d.close * 0.99,
     high: d.close * 1.02,
     low: d.close * 0.98,
@@ -29,7 +29,7 @@ function createTrendingCandles(
   return Array(count)
     .fill(null)
     .map((_, i) => ({
-      time: 1000000 + i * 86400000,
+      time: 1_700_000_000_000 + i * 86_400_000,
       open: startPrice + i * priceChange,
       high: startPrice + i * priceChange + 2,
       low: startPrice + i * priceChange - 2,

--- a/packages/core/src/indicators/wyckoff/__tests__/vsa.test.ts
+++ b/packages/core/src/indicators/wyckoff/__tests__/vsa.test.ts
@@ -11,7 +11,7 @@ function makeCandle(
   volume: number,
 ): NormalizedCandle {
   return {
-    time: 1000000 + i * 86400000,
+    time: 1_700_000_000_000 + i * 86_400_000,
     open,
     high,
     low,

--- a/packages/core/src/indicators/wyckoff/__tests__/wyckoff-phases.test.ts
+++ b/packages/core/src/indicators/wyckoff/__tests__/wyckoff-phases.test.ts
@@ -10,7 +10,7 @@ function mc(
   close: number,
   volume: number,
 ): NormalizedCandle {
-  return { time: 1000000 + i * 86400000, open, high, low, close, volume };
+  return { time: 1_700_000_000_000 + i * 86_400_000, open, high, low, close, volume };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/meta-strategy/__tests__/equity-curve.test.ts
+++ b/packages/core/src/meta-strategy/__tests__/equity-curve.test.ts
@@ -7,7 +7,7 @@ function makeTrade(i: number, returnAmt: number, holdingDays = 1): Trade {
   const entryPrice = 100;
   const exitPrice = entryPrice + returnAmt / 100;
   return {
-    entryTime: 1000000 + i * 86400000 * 2,
+    entryTime: 1_700_000_000_000 + i * 86_400_000 * 2,
     entryPrice,
     exitTime: 1000000 + (i * 2 + 1) * 86400000,
     exitPrice,

--- a/packages/core/src/meta-strategy/__tests__/strategy-rotation.test.ts
+++ b/packages/core/src/meta-strategy/__tests__/strategy-rotation.test.ts
@@ -5,7 +5,7 @@ import { rotateStrategies } from "../strategy-rotation";
 
 function makeTrade(i: number, returnAmt: number): Trade {
   return {
-    entryTime: 1000000 + i * 86400000 * 2,
+    entryTime: 1_700_000_000_000 + i * 86_400_000 * 2,
     entryPrice: 100,
     exitTime: 1000000 + (i * 2 + 1) * 86400000,
     exitPrice: 100 + returnAmt / 100,

--- a/packages/core/src/optimization/__tests__/walkforward-json.test.ts
+++ b/packages/core/src/optimization/__tests__/walkforward-json.test.ts
@@ -19,7 +19,7 @@ function makeCandles(count: number): NormalizedCandle[] {
     const high = Math.max(open, close) + 1;
     const low = Math.min(open, close) - 1;
     candles.push({
-      time: 1_700_000_000 + i * 86_400,
+      time: 1_700_000_000_000 + i * 86_400_000,
       open,
       high,
       low,

--- a/packages/core/src/signals/__tests__/divergence.test.ts
+++ b/packages/core/src/signals/__tests__/divergence.test.ts
@@ -387,7 +387,7 @@ describe("divergence causality", () => {
     for (let i = 0; i < n; i++) {
       price *= 1 + (rnd() - 0.5) * 0.04;
       out.push({
-        time: 1_700_000_000 + i * 86_400,
+        time: 1_700_000_000_000 + i * 86_400_000,
         open: price,
         high: price * 1.01,
         low: price * 0.99,

--- a/packages/core/src/signals/patterns/__tests__/pattern-filter.test.ts
+++ b/packages/core/src/signals/patterns/__tests__/pattern-filter.test.ts
@@ -5,7 +5,7 @@ import type { PatternSignal } from "../types";
 
 function makeCandles(count: number): NormalizedCandle[] {
   return Array.from({ length: count }, (_, i) => ({
-    time: 1000 + i,
+    time: 1_700_000_000_000 + i * 86_400_000,
     open: 100 + i * 0.1,
     high: 101 + i * 0.1,
     low: 99 + i * 0.1,
@@ -16,7 +16,7 @@ function makeCandles(count: number): NormalizedCandle[] {
 
 function makePattern(overrides: Partial<PatternSignal> = {}): PatternSignal {
   return {
-    time: 1050,
+    time: 1704320000000,
     detectableTime: 1055,
     confirmTime: 1055,
     type: "double_top",

--- a/packages/core/src/validation/__tests__/validation.test.ts
+++ b/packages/core/src/validation/__tests__/validation.test.ts
@@ -24,6 +24,8 @@ function makeCandle(
 }
 
 const DAY = 86400000;
+/** Bar times must be epoch milliseconds, not a bare multiple of a day. */
+const T0 = 1_700_000_000_000;
 
 describe("gap-detection", () => {
   it("detects time gaps", () => {
@@ -265,14 +267,14 @@ describe("validateCandles", () => {
 
   it("autoClean removes duplicates and sorts", () => {
     const candles = [
-      makeCandle(DAY * 2, 102),
-      makeCandle(DAY, 100),
-      makeCandle(DAY, 101), // duplicate
+      makeCandle(T0 + DAY * 2, 102),
+      makeCandle(T0 + DAY, 100),
+      makeCandle(T0 + DAY, 101), // duplicate
     ];
     const result = validateCandles(candles, { autoClean: true });
     expect(result.cleanedCandles).toBeDefined();
     expect(result.cleanedCandles?.length).toBe(2);
-    expect(result.cleanedCandles?.[0].time).toBe(DAY);
+    expect(result.cleanedCandles?.[0].time).toBe(T0 + DAY);
   });
 
   it("accepts raw Candle[] with string time", () => {

--- a/packages/core/src/validation/gap-detection.ts
+++ b/packages/core/src/validation/gap-detection.ts
@@ -70,11 +70,21 @@ export function detectGaps(
   return findings;
 }
 
+/** The longest a genuine weekend hole can be: Friday open to Monday close. */
+const MAX_WEEKEND_MS = 4 * 24 * 60 * 60 * 1000;
+
 /**
  * Check if a gap spans only weekend days (Friday close to Monday open).
  * Returns true if the gap starts on Friday/Saturday and ends on Sunday/Monday.
+ *
+ * The duration bound is what makes that "only": weekday endpoints alone
+ * classified a three-month hole as a weekend as long as it happened to run
+ * Friday to Monday, so months of missing data passed the quality check in
+ * silence.
  */
 function isWeekendGap(startTime: number, endTime: number): boolean {
+  if (endTime - startTime > MAX_WEEKEND_MS) return false;
+
   const startDay = new Date(startTime).getUTCDay(); // 0=Sun, 5=Fri, 6=Sat
   const endDay = new Date(endTime).getUTCDay();
 


### PR DESCRIPTION
## Problem

Three time-handling defects that shared a failure style: the wrong answer arrived without an error, a warning, or a visibly odd number.

### Second-stamped candles were never converted

`normalizeTime` documents a numeric time below 1e10 as Unix **seconds** and converts it, but every indicator gates that behind `isNormalized(candles) ? candles : normalizeCandles(candles)` — and `isNormalized` returned true for *any* number. Candles stamped in epoch seconds, the shape most exchange REST APIs return, were therefore declared already normalized and skipped the conversion entirely:

```
normalizeTime(1767571200)   = 1767571200000
isNormalized(secondCandles) = true          ← so the conversion never runs

day buckets (seconds): [20, 20, 20]         ← every bar lands on 1970-01-21
day buckets (ms):      [20458, 20459, 20460]

session vwap, second-stamped: ['100.000', '100.500', '101.000']   ← never resets
session vwap, ms-stamped:     ['100.000', '101.000', '102.000']   ← correct
detectSessions(second-stamped): session=null, inSession=false on every bar
```

`Math.floor(time / 86_400_000)` on a seconds value advances once every 2.7 years, so session VWAP and TWAP never reset, opening ranges and market profiles covered the whole history, `detectSessions` found nothing, and resample buckets were meaningless — silently, in all cases. `isNormalized` was also duplicated privately in two regime modules.

### `resample` ignored `value` for weeks

`'minute'`, `'hour'`, `'day'` and `'month'` all honour `value > 1`; the `'week'` case never read it, so `{ value: 2, unit: 'week' }` returned ordinary weekly candles with no error and no doc caveat:

```
20 daily bars, 2026-01-05 .. 2026-01-30
1-week candles: 4   ['2026-01-05', '2026-01-12', '2026-01-19', '2026-01-26']
2-week candles: 4   ← identical; expected 2
```

### Any Friday-to-Monday hole counted as a weekend

`isWeekendGap` classified a gap purely by its endpoint weekdays, with no duration bound, so a seventeen-day — or three-month — hole passed validation whenever its ends happened to fall Friday and Monday. The function's own documentation says "spans only weekend days".

```
endpoints Fri -> Mon, hole 17 days
skipWeekends: true  => []          ← nothing reported
skipWeekends: false => [{severity: "warning", message: "Time gap of 17.0d ..."}]
```

## Change

`isNormalized` is magnitude-aware, accepting the range `normalizeTime` leaves untouched (`>= 1e10 && < 1e13`). Normalizing an already-normalized array is a no-op, so the gate stays cheap and the two private copies are deleted in favour of the shared one.

Multi-week periods bucket against a fixed Monday reference (1970-01-05), the way multi-day and multi-month periods already bucket against theirs.

A weekend gap now has to be short enough to be one: at most four days, Friday open to Monday close.

## Breaking

Callers passing epoch-second candles get different — correct — output from every time-bucketed indicator. Callers already passing milliseconds are unaffected. Note that a numeric time below 1e10 is now read as seconds everywhere, so a toy timestamp like `time: 1` is scaled by 1000 rather than taken literally.

## Reviewing this diff

Three source files carry the change: `src/core/normalize.ts`, `src/core/resample.ts`, `src/validation/gap-detection.ts` (plus the two deleted copies in `src/analysis/market-regime.ts` and `src/indicators/volatility/regime.ts`).

Everything else is test fixtures. They used placeholder timestamps like `time0 = 1000, step = 86400` — which is itself second-stamped data — so they now take the conversion path and assert scaled times. They carry realistic epoch-millisecond values instead. 43 tests across 35 files were affected; all pass.

## Test plan

7 regression tests in `src/__tests__/time-handling.test.ts`, built from the reproductions above.

- `isNormalized` reports false for epoch seconds and true for milliseconds; empty input is left alone
- Converting second-stamped daily bars yields three distinct day buckets where the unconverted array yields one, and the converted times match the millisecond fixture exactly
- Session VWAP over second-stamped daily bars resets per day and equals the millisecond result
- Normalizing an already-normalized array changes nothing
- Four weeks of daily bars resample to 4 weekly and 2 biweekly candles, with the biweekly opens landing on weeks 1 and 3
- A three-day Friday-to-Monday gap stays unreported; a seventeen-day one is reported with its duration

Negative check: 4 of the 7 fail against the unpatched sources.

Verification: core 6419 tests, chart 934, mcp 83 all pass; `tsc --noEmit`, `pnpm build` and `biome check` clean.