### PR TITLE
fix(core): keep snapshot sentinels alive through JSON persistence

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+### Breaking — snapshot sentinels survive persistence (`emv`, `garmanKlass` schema v2)
+
+Both indicators mark "this bar produced no usable value" inside their window
+buffer, and both used `NaN` as that marker. The state contract promises
+JSON-serializable snapshots, but `JSON.stringify` writes `NaN` as `null`: a
+snapshot that was persisted and read back had ordinary null slots where the
+resume path was looking for NaN, so the marker was gone. The resumed indicator
+then reported a number on bars where an uninterrupted run reported nothing,
+and considered itself warmed up while an unusable bar was still inside its
+window — no error, no gap, just a confident wrong value. It triggered on any
+snapshot taken within `period` bars of a doji or zero-volume bar
+(ease-of-movement) or a non-positive price (Garman-Klass).
+
+Both now hold `null` in the buffer, which survives the round trip unchanged.
+Their schema versions bump to 2, so earlier snapshots are rejected with the
+usual "re-warm required" error.
+
+The state-contract suite passed snapshots to the resumed indicator by
+reference, which is why none of this ever failed in CI. It now round-trips
+every snapshot through `JSON.parse(JSON.stringify(...))`, so the whole
+registry is held to what the contract actually promises.
+
 ### Breaking — second-stamped candles are converted again; multi-week resampling and long weekend gaps fixed
 
 `normalizeTime` documents a numeric time below 1e10 as Unix **seconds**, but

--- a/packages/core/src/indicators/incremental/__tests__/contract-helper.ts
+++ b/packages/core/src/indicators/incremental/__tests__/contract-helper.ts
@@ -181,6 +181,17 @@ export type ContractConfig<TValue, TState> = {
  * Each generated test is a `it(...)` inside the parent `describe`, so
  * standard vitest filtering (`--run name pattern`) works.
  */
+/**
+ * Persist a snapshot the way a caller would: serialize it and read it back.
+ *
+ * The state contract promises JSON-serializable snapshots, so anything that
+ * does not survive `JSON.stringify` is not state — it is a value the indicator
+ * only ever had in memory.
+ */
+function throughJson<T>(snapshot: T): T {
+  return JSON.parse(JSON.stringify(snapshot)) as T;
+}
+
 export function describeContract<TValue, TState>(config: ContractConfig<TValue, TState>): void {
   const streamLength = config.streamLength ?? 200;
   const tolerance = config.tolerance ?? 1e-10;
@@ -198,7 +209,11 @@ export function describeContract<TValue, TState>(config: ContractConfig<TValue, 
 
       const stage1 = config.create({ ...config.defaultParams });
       for (let i = 0; i < splitIdx; i++) stage1.next(candles[i]);
-      const snapshot = stage1.getState();
+      // Through the wire, not by reference. A snapshot exists to be persisted,
+      // and JSON.stringify turns NaN and +/-Infinity into null — so an
+      // indicator using either as an in-state sentinel resumes with the marker
+      // silently gone. Passing the object straight across hid that entirely.
+      const snapshot = throughJson(stage1.getState());
 
       const stage2 = config.create({ ...config.defaultParams }, { fromState: snapshot });
       const valuesResumed = valuesReference.slice(0, splitIdx);

--- a/packages/core/src/indicators/incremental/__tests__/snapshot-sentinels.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/snapshot-sentinels.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Snapshot sentinels have to survive being persisted.
+ *
+ * Both indicators here mark "this bar produced no usable value" inside their
+ * window buffer. The marker used to be `NaN`, which `JSON.stringify` writes as
+ * `null` — so a snapshot that went to disk and came back had ordinary null
+ * slots where the resume path was looking for NaN. The resumed indicator then
+ * reported a number on bars where an uninterrupted run reported nothing,
+ * which is the worst shape for this failure: no error, no gap, just a
+ * confident wrong value.
+ *
+ * The state-contract suite passed snapshots by reference, so it never saw any
+ * of this; it now round-trips every snapshot through JSON.
+ */
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../../types";
+import { createGarmanKlass } from "../volatility/garman-klass";
+import { createEmv } from "../volume/ease-of-movement";
+
+const DAY = 86_400_000;
+const START = 1_700_000_000_000;
+
+/** Persist a snapshot the way a caller would. */
+function throughJson<T>(snapshot: T): T {
+  return JSON.parse(JSON.stringify(snapshot)) as T;
+}
+
+function candle(i: number, close: number, opts: Partial<NormalizedCandle> = {}): NormalizedCandle {
+  return {
+    time: START + i * DAY,
+    open: close,
+    high: close + 1,
+    low: close - 1,
+    close,
+    volume: 1000,
+    ...opts,
+  };
+}
+
+/**
+ * A stream with one bar the given estimator cannot use. What makes a bar
+ * unusable differs by estimator — ease-of-movement needs a range and some
+ * volume, Garman-Klass needs strictly positive prices — so the fixture takes
+ * the marker-triggering shape rather than assuming one serves both.
+ */
+function streamWithUnusableBar(
+  length: number,
+  flatIndex: number,
+  unusable: (close: number) => Partial<NormalizedCandle>,
+): NormalizedCandle[] {
+  return Array.from({ length }, (_, i) => {
+    const close = 100 + Math.sin(i / 3) * 5;
+    return i === flatIndex ? candle(i, close, unusable(close)) : candle(i, close);
+  });
+}
+
+/** No range and no volume: ease-of-movement's box ratio is undefined. */
+const NO_RANGE_NO_VOLUME = (close: number) => ({ high: close, low: close, volume: 0 });
+
+/** A non-positive low: Garman-Klass's log terms are undefined. */
+const NON_POSITIVE_LOW = () => ({ low: 0 });
+
+/** Values from an uninterrupted run, and from one resumed at `splitIdx`. */
+function twinAndResumed<T>(
+  create: (fromState?: unknown) => { next(c: NormalizedCandle): { value: T }; getState(): unknown },
+  candles: NormalizedCandle[],
+  splitIdx: number,
+): { twin: T[]; resumed: T[] } {
+  const uninterrupted = create();
+  const twin = candles.map((c) => uninterrupted.next(c).value);
+
+  const first = create();
+  for (let i = 0; i < splitIdx; i++) first.next(candles[i]);
+  const second = create(throughJson(first.getState()));
+  const resumed = candles.slice(splitIdx).map((c) => second.next(c).value);
+
+  return { twin: twin.slice(splitIdx), resumed };
+}
+
+describe("easeOfMovement keeps its null-slot marker across a persisted snapshot", () => {
+  const candles = streamWithUnusableBar(40, 18, NO_RANGE_NO_VOLUME);
+  const period = 14;
+
+  it("emits null on the same bars as an uninterrupted run", () => {
+    const { twin, resumed } = twinAndResumed<number | null>(
+      (fromState) =>
+        createEmv({ period }, fromState ? { fromState: fromState as never } : undefined),
+      candles,
+      20,
+    );
+
+    // The unusable bar sits inside the resumed window, so both runs must
+    // withhold output until it leaves. Before, the resumed one produced
+    // numbers there.
+    expect(resumed.filter((v) => v === null).length).toBeGreaterThan(0);
+    expect(resumed).toEqual(twin);
+  });
+
+  it("does not report itself warmed up while an unusable bar is in the window", () => {
+    const first = createEmv({ period });
+    for (let i = 0; i < 20; i++) first.next(candles[i]);
+    const resumed = createEmv({}, { fromState: throughJson(first.getState()) });
+
+    expect(resumed.isWarmedUp).toBe(false);
+  });
+});
+
+describe("garmanKlass keeps its invalid-candle marker across a persisted snapshot", () => {
+  const candles = streamWithUnusableBar(40, 18, NON_POSITIVE_LOW);
+  const period = 10;
+
+  it("emits null on the same bars as an uninterrupted run", () => {
+    const { twin, resumed } = twinAndResumed<number | null>(
+      (fromState) =>
+        createGarmanKlass({ period }, fromState ? { fromState: fromState as never } : undefined),
+      candles,
+      20,
+    );
+
+    expect(resumed.filter((v) => v === null).length).toBeGreaterThan(0);
+    expect(resumed).toEqual(twin);
+  });
+});

--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -1635,7 +1635,7 @@ describeContract<number | null, GarmanKlassState>({
   create: (opts, warmUp) =>
     createGarmanKlass(opts as { period?: number; annualFactor?: number }, warmUp),
   category: "windowed",
-  version: 1,
+  version: 2,
   defaultParams: { period: 20, annualFactor: 252 },
   reconfigParams: [{ period: 10 }, { period: 30 }],
   resumeInvariantReconfig: [{ annualFactor: 365 }],
@@ -2132,7 +2132,7 @@ describeContract<number | null, EmvState>({
   name: "emv",
   create: (opts, warmUp) => createEmv(opts as { period?: number; volumeDivisor?: number }, warmUp),
   category: "mixed",
-  version: 1,
+  version: 2,
   defaultParams: { period: 14, volumeDivisor: 100_000_000 },
   reconfigParams: [{ period: 10 }, { volumeDivisor: 10_000 }],
   makeCandles,

--- a/packages/core/src/indicators/incremental/volatility/garman-klass.ts
+++ b/packages/core/src/indicators/incremental/volatility/garman-klass.ts
@@ -30,13 +30,20 @@ import type { IncrementalIndicator } from "../types";
  * live in `meta.params` on the wire.
  */
 export type GarmanKlassState = {
-  buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
+  /**
+   * Per-bar variance contributions. A candle the estimator cannot use is held
+   * as `null` rather than `NaN`: `JSON.stringify` turns `NaN` into `null`
+   * anyway, so a NaN marker came back from a persisted snapshot as a slot the
+   * resume path no longer recognised as invalid, and the resumed indicator
+   * reported volatility where its uninterrupted twin reported none.
+   */
+  buffer: ReturnType<CircularBuffer<number | null>["snapshot"]>;
   sum: number;
   count: number;
 };
 
 /** Per-indicator schema version. Bumped on any breaking state change. */
-export const GARMAN_KLASS_VERSION = 1;
+export const GARMAN_KLASS_VERSION = 2;
 
 type GarmanKlassParams = {
   period: number;
@@ -83,16 +90,16 @@ export function createGarmanKlass(
 
   const LN2_COEFF = 2 * Math.LN2 - 1;
 
-  let buffer: CircularBuffer<number>;
+  let buffer: CircularBuffer<number | null>;
   let sum: number;
   let count: number;
 
   if (state !== null) {
     if (reconfigured) {
       // Period changed — carry the component buffer forward and
-      // recompute the running sum (NaN markers are excluded).
+      // recompute the running sum (null markers are excluded).
       const old = CircularBuffer.fromSnapshot(state.buffer);
-      buffer = new CircularBuffer<number>(period);
+      buffer = new CircularBuffer<number | null>(period);
       const carry = Math.min(old.length, period);
       for (let i = old.length - carry; i < old.length; i++) {
         buffer.push(old.get(i));
@@ -100,7 +107,7 @@ export function createGarmanKlass(
       sum = 0;
       for (let i = 0; i < buffer.length; i++) {
         const v = buffer.get(i);
-        if (!Number.isNaN(v)) sum += v;
+        if (v !== null) sum += v;
       }
     } else {
       buffer = CircularBuffer.fromSnapshot(state.buffer);
@@ -108,7 +115,7 @@ export function createGarmanKlass(
     }
     count = state.count;
   } else {
-    buffer = new CircularBuffer<number>(period);
+    buffer = new CircularBuffer<number | null>(period);
     sum = 0;
     count = 0;
   }
@@ -131,19 +138,19 @@ export function createGarmanKlass(
 
       const component = computeComponent(candle);
       if (component === null) {
-        // Invalid candle — push NaN marker to track the invalid slot
+        // Invalid candle — push a null marker to track the unusable slot
         // so buffer.length still advances correctly
         if (buffer.isFull) {
           const oldest = buffer.oldest();
-          if (!Number.isNaN(oldest)) sum -= oldest;
+          if (oldest !== null) sum -= oldest;
         }
-        buffer.push(Number.NaN);
+        buffer.push(null);
         return { time: candle.time, value: null };
       }
 
       if (buffer.isFull) {
         const oldest = buffer.oldest();
-        if (!Number.isNaN(oldest)) {
+        if (oldest !== null) {
           sum = sum - oldest + component;
         } else {
           sum += component;
@@ -159,9 +166,9 @@ export function createGarmanKlass(
         return { time: candle.time, value: null };
       }
 
-      // Check for any NaN (invalid) entries in the window
+      // Check for any null (invalid) entries in the window
       for (let i = 0; i < buffer.length; i++) {
-        if (Number.isNaN(buffer.get(i))) {
+        if (buffer.get(i) === null) {
           return { time: candle.time, value: null };
         }
       }
@@ -178,7 +185,8 @@ export function createGarmanKlass(
       let peekSum = sum;
       if (buffer.isFull) {
         const oldest = buffer.oldest();
-        peekSum = peekSum - oldest + component;
+        // An unusable slot never entered `sum`, so there is nothing to remove.
+        peekSum = peekSum - (oldest ?? 0) + component;
       } else {
         peekSum += component;
       }
@@ -187,10 +195,10 @@ export function createGarmanKlass(
         return { time: candle.time, value: null };
       }
 
-      // A NaN marker anywhere in the simulated window invalidates output.
+      // A null marker anywhere in the simulated window invalidates output.
       const start = buffer.isFull ? 1 : 0;
       for (let i = start; i < buffer.length; i++) {
-        if (Number.isNaN(buffer.get(i))) {
+        if (buffer.get(i) === null) {
           return { time: candle.time, value: null };
         }
       }

--- a/packages/core/src/indicators/incremental/volume/ease-of-movement.ts
+++ b/packages/core/src/indicators/incremental/volume/ease-of-movement.ts
@@ -32,14 +32,21 @@ import type { IncrementalIndicator } from "../types";
 export type EmvState = {
   prevHigh: number | null;
   prevLow: number | null;
-  /** Circular buffer of raw EMV values; NaN marks null slots */
-  buffer: ReturnType<CircularBuffer<number>["snapshot"]>;
+  /**
+   * Circular buffer of raw EMV values. A bar with no defined raw value (a
+   * doji, or one with no volume) is held as `null` rather than `NaN`:
+   * `JSON.stringify` turns `NaN` into `null` anyway, so a NaN sentinel came
+   * back from a persisted snapshot as an ordinary null slot the resume path
+   * no longer recognised — the resumed indicator then emitted a number where
+   * its uninterrupted twin emitted nothing.
+   */
+  buffer: ReturnType<CircularBuffer<number | null>["snapshot"]>;
   sum: number;
   count: number;
 };
 
 /** Per-indicator schema version. Bumped on any breaking state change. */
-export const EMV_VERSION = 1;
+export const EMV_VERSION = 2;
 
 type EmvParams = {
   period: number;
@@ -93,7 +100,7 @@ export function createEmv(
 
   let prevHigh: number | null;
   let prevLow: number | null;
-  let buffer: CircularBuffer<number>;
+  let buffer: CircularBuffer<number | null>;
   let sum: number;
   let count: number;
 
@@ -106,7 +113,7 @@ export function createEmv(
   } else {
     prevHigh = null;
     prevLow = null;
-    buffer = new CircularBuffer<number>(period);
+    buffer = new CircularBuffer<number | null>(period);
     sum = 0;
     count = 0;
   }
@@ -122,16 +129,16 @@ export function createEmv(
     return distanceMoved / boxRatio;
   }
 
-  function hasNaN(buf: CircularBuffer<number>): boolean {
+  function hasUndefinedSlot(buf: CircularBuffer<number | null>): boolean {
     for (let i = 0; i < buf.length; i++) {
-      if (Number.isNaN(buf.get(i))) return true;
+      if (buf.get(i) === null) return true;
     }
     return false;
   }
 
   function computeOutput(): number | null {
     if (buffer.length < period) return null;
-    if (hasNaN(buffer)) return null;
+    if (hasUndefinedSlot(buffer)) return null;
     return sum / period;
   }
 
@@ -142,22 +149,18 @@ export function createEmv(
       prevHigh = candle.high;
       prevLow = candle.low;
 
-      // Use NaN as sentinel for null raw values
-      const val = raw ?? Number.NaN;
-
       if (buffer.isFull) {
         const oldest = buffer.oldest();
-        if (!Number.isNaN(oldest)) sum -= oldest;
+        if (oldest !== null) sum -= oldest;
       }
-      if (!Number.isNaN(val)) sum += val;
-      buffer.push(val);
+      if (raw !== null) sum += raw;
+      buffer.push(raw);
 
       return { time: candle.time, value: computeOutput() };
     },
 
     peek(candle: NormalizedCandle) {
       const raw = computeRawEmv(candle);
-      const val = raw ?? Number.NaN;
 
       if (buffer.length + 1 < period && !buffer.isFull) {
         return { time: candle.time, value: null };
@@ -165,31 +168,31 @@ export function createEmv(
 
       // Simulate buffer after push
       let peekSum = sum;
-      let peekHasNaN = false;
+      let peekHasUndefinedSlot = false;
 
       if (buffer.isFull) {
         const oldest = buffer.oldest();
-        if (!Number.isNaN(oldest)) peekSum -= oldest;
+        if (oldest !== null) peekSum -= oldest;
       }
-      if (!Number.isNaN(val)) {
-        peekSum += val;
+      if (raw !== null) {
+        peekSum += raw;
       } else {
-        peekHasNaN = true;
+        peekHasUndefinedSlot = true;
       }
 
       // Check existing buffer (skip oldest if full)
       const start = buffer.isFull ? 1 : 0;
-      if (!peekHasNaN) {
+      if (!peekHasUndefinedSlot) {
         for (let i = start; i < buffer.length; i++) {
-          if (Number.isNaN(buffer.get(i))) {
-            peekHasNaN = true;
+          if (buffer.get(i) === null) {
+            peekHasUndefinedSlot = true;
             break;
           }
         }
       }
 
       const peekLen = buffer.isFull ? buffer.length : buffer.length + 1;
-      if (peekLen < period || peekHasNaN) {
+      if (peekLen < period || peekHasUndefinedSlot) {
         return { time: candle.time, value: null };
       }
 
@@ -216,7 +219,7 @@ export function createEmv(
     },
 
     get isWarmedUp() {
-      return buffer.length >= period && !hasNaN(buffer);
+      return buffer.length >= period && !hasUndefinedSlot(buffer);
     },
   };
 


### PR DESCRIPTION
## Problem

`easeOfMovement` and `garmanKlass` both mark "this bar produced no usable value" inside their window buffer, and both used `NaN` as that marker. The state contract promises JSON-serializable snapshots — but `JSON.stringify` writes `NaN` as `null`. A snapshot that was persisted and read back therefore had ordinary null slots where the resume path was looking for NaN, and the marker was simply gone:

```
twin[119..128]:  null x10
snapshot buffer contains NaN:     true
after JSON round trip, null slots: 1
resumed isWarmedUp immediately:    true   (the twin is not warmed up here)

FIRST DIVERGENCE bar 120: resumed = -4403.96   twin = null
  bars 121-128 resumed = -6270.04, -7260.28, -8414.43, -8165.12, ... vs twin = null
control (no JSON round trip), divergent bars: 0
```

The resumed indicator reports a number on bars where an uninterrupted run reports nothing, and considers itself warmed up while an unusable bar is still inside its window. There is no error and no gap in the output — just a confident wrong value. It triggers on any snapshot taken within `period` bars of a doji or zero-volume bar (ease-of-movement) or a non-positive price (Garman-Klass).

The state-contract suite never caught it because it passed the snapshot to the resumed indicator **by reference**, so the values never went through the wire the contract describes.

## Change

Both indicators hold `null` in the buffer instead of `NaN`. Null survives the round trip unchanged, so the resume path sees exactly what `getState` wrote. Their schema versions bump to 2, and earlier snapshots are rejected with the existing "re-warm required" error.

The contract suite now round-trips every snapshot through `JSON.parse(JSON.stringify(...))` before resuming from it. The whole registry — 96 indicators — is held to what the contract actually promises rather than to what an in-process object reference happens to preserve.

## Breaking

`emv` and `garmanKlass` snapshots taken before this change are rejected and must be re-warmed.

## Test plan

3 regression tests in `src/indicators/incremental/__tests__/snapshot-sentinels.test.ts`, plus the hardened contract suite.

- With an unusable bar inside the resumed window, both indicators emit `null` on exactly the bars an uninterrupted run does — compared element-for-element, not just counted
- `easeOfMovement` does not report itself warmed up while that bar is still in the window
- What makes a bar unusable differs by estimator, so the fixture takes the marker-triggering shape as a parameter: no range and no volume for ease-of-movement, a non-positive low for Garman-Klass
- The contract suite's round-trip identity test now persists the snapshot; all 821 of its cases pass

Negative check: all 3 fail against the unpatched sources.

Verification: core 6422 tests, chart 934, mcp 83 all pass; `tsc --noEmit`, `pnpm build` and `biome check` clean.