### PR TITLE
release: core 0.5.0, chart 0.4.0, mcp 0.3.0

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `@trendcraft/chart` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-07-25
 
 ### Fixed — `resize`, `paneResize`, and `seriesRemoved` events now fire
 
@@ -25,7 +25,7 @@ but the chart never emitted them. They now fire with the documented payloads:
   `remove()` calls on the same handle are silent, and `chart.destroy()`
   emits nothing (matching `seriesAdded`, which is also silent on teardown).
 
-### Fixed — `CrosshairMoveData` type now matches the emitted payload
+### Breaking — `CrosshairMoveData` type now matches the emitted payload
 
 The exported `CrosshairMoveData` type declared `{ time, price, x, y, paneId }`,
 but the chart has always emitted `{ time, index, ohlcv, paneId }` from
@@ -42,6 +42,33 @@ behavior is otherwise unchanged — this is a type/docs correction. TypeScript
 consumers who typed handlers against the old (never-delivered) `price`/`x`/`y`
 fields will get compile errors pointing at the fields that never existed at
 runtime.
+
+### Added — unknown preset ids suggest the closest match
+
+`connectIndicators(...).add()` used to fail an unrecognised preset id with a
+bare "unknown preset" error, leaving a typo to be found by eye against a list
+of over a hundred ids. It now names the closest id it knows, so
+`add("bolinger")` points at `bollingerBands`.
+
+### Fixed — two-row time axis labels no longer overflow the plot
+
+Edge labels on the two-row time axis were positioned from their anchor without
+regard to the plot bounds, so the first and last of them could hang past the
+left or right edge and be clipped by the canvas. They are now clamped to stay
+inside the plot area.
+
+### Fixed — daily axis no longer shows a time on its first label
+
+On a daily series the first label carried a time component that came from the
+timezone offset of the underlying timestamp rather than from the data — a
+daily chart could open with a label reading "1 Jan 09:00". Daily and coarser
+timeframes now label the date alone.
+
+### Changed — React peer dependency relaxed to `>=18`
+
+The React wrapper declared a peer of `>=19.0.0`, which forced React 18
+projects to either upgrade or install with an override even though nothing in
+the wrapper needs 19. The peer is now `>=18.0.0`.
 
 ## [0.3.0] - 2026-06-09
 

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trendcraft/chart",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Zero-dependency Canvas charting for TypeScript — candlestick & financial charts that work on plain OHLC data, with React/Vue wrappers and a headless API. Auto-places TrendCraft indicators when paired.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Changelog
 
-## [Unreleased]
+## [0.5.0] - 2026-07-25
+
+### Read this first — your numbers will change
+
+This release is mostly correctness work, so the same code over the same data
+will report different figures than 0.4.0 did. That is the fix, not a
+regression. The changes you are most likely to notice:
+
+| What | Was | Now |
+| --- | --- | --- |
+| `sharpeRatio` / `sortinoRatio` | Annualized as if one trade were one day, so the value grew with holding period — the same equity path packaged as 21-day trades scored over four times higher | Annualized from the equity curve at the frequency its bars actually occurred |
+| Backtest entries and fills | Pattern and limit/stop entries could use prices from bars the strategy could not have seen | Fills use only price action the position already owned |
+| Cornish-Fisher VaR | Skew term carried the wrong sign, so fat left tails *lowered* reported risk | Risk rises with negative skew, as it should |
+| `"mar"` optimization metric | Average monthly return over max drawdown — about a twelfth of the ratio the name denotes | Annualized return over max drawdown |
+| Bollinger Bands, correlation, regression slopes | Lost all precision once prices were large relative to their spread (yen, won, rupiah levels); bands could collapse to zero width | Computed in two passes, accurate at any price level |
+| Candles stamped in epoch **seconds** | Silently treated as milliseconds, so every day bucket advanced once every 2.7 years: session VWAP never reset, `detectSessions` found nothing | Converted as documented |
+| Portfolio `sharpeRatio` / `equityCurve` / `maxDrawdown` | Built from realized trade P&L only, blind to price moves inside open positions, and ending at the last trade | Per-bar mark-to-market across the whole window |
+
+Snapshots of the incremental `standardDeviation`, `bollingerBands`,
+`linearRegression`, `historicalVolatility`, `emv` and `garmanKlass` taken with
+0.4.0 are rejected and must be re-warmed.
+
+Required-field additions to `PatternSignal` and `DivergenceSignal`, and the
+removal of `setBenchmark` and of option keys that were never read, are the
+source-level breaks — each is described in its own section below.
 
 ### Breaking — snapshot sentinels survive persistence (`emv`, `garmanKlass` schema v2)
 
@@ -9,10 +33,11 @@ buffer, and both used `NaN` as that marker. The state contract promises
 JSON-serializable snapshots, but `JSON.stringify` writes `NaN` as `null`: a
 snapshot that was persisted and read back had ordinary null slots where the
 resume path was looking for NaN, so the marker was gone. The resumed indicator
-then reported a number on bars where an uninterrupted run reported nothing,
-and considered itself warmed up while an unusable bar was still inside its
-window — no error, no gap, just a confident wrong value. It triggered on any
-snapshot taken within `period` bars of a doji or zero-volume bar
+then reported a number on bars where an uninterrupted run reported nothing —
+no error, no gap, just a confident wrong value. Ease-of-movement, whose
+`isWarmedUp` also consults the marker, additionally declared itself warmed up
+while an unusable bar was still inside its window. It triggered on any
+snapshot taken within `period` bars of a zero-range or zero-volume bar
 (ease-of-movement) or a non-positive price (Garman-Klass).
 
 Both now hold `null` in the buffer, which survives the round trip unchanged.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trendcraft",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Technical analysis library for TypeScript — 130+ indicators, backtesting, optimization, streaming, and zero dependencies",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.3.0 (2026-07-25)
+
+### Fixed — tool descriptions and examples now match runtime behavior
+
+A tool description is not internal documentation here: it is handed to the
+model on the other side of the protocol and shapes the calls it makes. Several
+had drifted from what the server actually does, so a client was being told the
+wrong parameter names and the wrong response shape.
+
+- Corrected the documented parameters for `rsiDivergence` and the detection
+  semantics of `volumeBreakout`.
+- Documented candlestick-pattern support in `detect_signal`, along with the
+  `processedBars` and `symbol` fields it returns.
+- Documented the `storeSize` and `capacity` fields returned by `load_candles`.
+- Corrected the MACD parameters and the RSI-divergence output shape in
+  `EXAMPLES.md`.
+
+### Changed — requires `trendcraft` 0.5.0 or later
+
+The dependency range is raised so that installs pick up the correctness fixes
+in core 0.5.0. No tool signature changes, but the **values the tools return
+change** wherever those fixes apply — most visibly annualized Sharpe and
+Sortino, Cornish-Fisher VaR, the MAR optimization metric, variance-derived
+indicators at high price levels, and every time-bucketed indicator when
+candles are stamped in epoch seconds. See the `trendcraft` 0.5.0 changelog.
+
 ## 0.2.0 (2026-06-09)
 
 ### Fixed — reject non-finite candle OHLCV at the input boundary

--- a/packages/mcp/EXAMPLES.md
+++ b/packages/mcp/EXAMPLES.md
@@ -167,13 +167,23 @@ The two shapes carry different output structure.
 { "time": 1768259200000, "bandwidth": 0.034, "percentile": 3.2, /* ... */ }
 
 // rsiDivergence output element
-{ "time": 1768259200000, "type": "bullish", "kind": "regular",
+{ "time": 1768259200000, "confirmedAt": 1768691200000, "confirmedIdx": 39,
+  "type": "bullish", "kind": "regular",
   "firstIdx": 12, "secondIdx": 34,
   "price": { "first": 250.0, "second": 245.5 },
   "indicator": { "first": 28.0, "second": 32.1 } }
 ```
 
-`firedAt` for `events` shape is just the `time` of every event — equivalent to `output.map(e => e.time)`.
+**Divergences carry two timestamps, and the difference matters.** `time` (and
+`secondIdx`) anchor the second pivot — a bar that is only identifiable several
+bars after it prints, because a pivot needs bars on both sides to be one. Act
+on `confirmedAt` / `confirmedIdx` instead: that is the first bar at which the
+divergence could actually have been seen. Using `time` to place an entry or
+fire an alert means acting on a bar the market had not yet produced, and it
+lands on a local price extreme by construction, which flatters any backtest
+built from it.
+
+`firedAt` for `events` shape is just the `time` of every event — equivalent to `output.map(e => e.time)`. For the divergence signals that is therefore the **pivot** time, not the confirmation time; read `confirmedAt` off the `output` elements when you need the actionable bar.
 
 ---
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trendcraft/mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Model Context Protocol server for TrendCraft — exposes 96+ indicator manifests (whenToUse / pitfalls / synergy / regime) plus calc and signal dispatchers to LLM clients like Claude Desktop and Cursor",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Version bumps and changelog finalization for all three packages. No source changes beyond one documentation correction.

| Package | From | To |
| --- | --- | --- |
| `trendcraft` | 0.4.0 | **0.5.0** |
| `@trendcraft/chart` | 0.3.0 | **0.4.0** |
| `@trendcraft/mcp` | 0.2.0 | **0.3.0** |

## `trendcraft` 0.5.0

Seven weeks of correctness work — 34 changelog sections, 10 of them breaking. The bulk of it makes previously wrong numbers right, so the same code over the same data reports different figures than 0.4.0 did. The changelog opens with a table of what users will notice: Sharpe/Sortino annualization, backtest fill look-ahead, the Cornish-Fisher VaR sign, the MAR ratio, precision at high price levels, epoch-second timestamps, and portfolio equity curves.

Incremental snapshots for `standardDeviation`, `bollingerBands`, `linearRegression`, `historicalVolatility`, `emv` and `garmanKlass` bump their schema version, so snapshots taken with 0.4.0 are rejected and must be re-warmed.

## `@trendcraft/chart` 0.4.0

Minor rather than patch because `CrosshairMoveData` loses `price`/`x`/`y` and gains `index`/`ohlcv`: handlers typed against the old fields stop compiling. Those fields were never delivered at runtime, so this is a type correction, but it is a source break and is now classified as one.

Also carries the previously undocumented changes since 0.3.0: closest-match suggestions for unknown preset ids, two-row axis labels clamped to the plot bounds, the timezone artifact removed from the first daily label, and the React peer relaxed to `>=18`.

The peer on `trendcraft` stays `>=0.3.0`. Chart imports six core symbols (`NormalizedCandle`, `createLiveCandle`, `getAlternatingSwingPoints`, `indicatorPresets`, `klinger`, `srZones`) and all six exist in 0.3.0, so there is nothing here that requires a newer core.

## `@trendcraft/mcp` 0.3.0

No tool signatures change and no source changes beyond documentation — but this is a minor, not a patch, because `trendcraft` is a regular dependency here rather than a peer. The published range moves from `^0.4.0` to `^0.5.0`, and since `^0.4.0` cannot resolve 0.5.0, republishing is the only way existing users receive any of the core fixes. The values the tools return therefore change materially: Sharpe/Sortino, Cornish-Fisher VaR, the MAR metric, variance-derived indicators at high price levels, and every time-bucketed indicator when candles are stamped in epoch seconds. A patch bump would signal "nothing meaningful changed".

The changelog also records the tool-description corrections made since 0.2.0. Those descriptions are handed to the model on the other side of the protocol and shape the calls it makes, so they are part of the product surface rather than internal documentation.

## Documentation fix

`docs(mcp)` adds `confirmedAt` / `confirmedIdx` to the `rsiDivergence` output example in `EXAMPLES.md`, which had not followed the shape change in core 0.5.0, and spells out the distinction that matters to callers: `time` anchors the pivot, `confirmedAt` is the first bar at which the divergence could actually have been seen. It also notes that `firedAt` for divergence events carries the pivot time, not the confirmation time.

## After merge

Tag all three on the merge commit, then publish serially so the dependency chain resolves:

```
core-v0.5.0  →  publish trendcraft  →  wait for npm  →
chart-v0.4.0 →  publish @trendcraft/chart              →
mcp-v0.3.0   →  publish @trendcraft/mcp
```

`@trendcraft/mcp` declares `trendcraft` as `workspace:^`, which resolves at publish time. Confirm afterwards that `npm view @trendcraft/mcp@0.3.0 dependencies` shows `^0.5.0` — if it still reads `^0.4.0`, none of the core fixes reach mcp users.

## Verification

core 6,422 tests, chart 934, mcp 83 all pass; `tsc --noEmit` clean in all three; all three packages build.