### PR TITLE
fix(core): size scaled-entry tranches from the cycle's own capital

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed — `runBacktestScaled` sizes every tranche from the capital the trade cycle actually has
+
+In the multi-tranche path, the first tranche was sized from the capital
+available when the position opened, but every additional tranche was sized
+from the backtest's *initial* capital. The two agree only for the first trade
+cycle; after any closed trade the tranche weights no longer sum to the capital
+committed to the new cycle.
+
+After a profitable cycle the position was under-invested and the shortfall sat
+in reserve doing nothing; after a losing cycle the later tranches spent more
+than had been reserved for them, driving the reserve negative and inflating
+the position. Either way P&L was computed from the wrong exposure. With
+100,000 of capital, two equal tranches, a first cycle bought at 100 and sold
+at 110, and a second cycle bought at 110 and sold back at 100, the run should
+end exactly where it started at 100,000; it reported 100,454.55, having
+invested 55,000 and 50,000 into a cycle that had 110,000 to deploy.
+
+Each position now records the capital it committed when it opened, and every
+tranche of that position is weighted against it. The final tranche takes
+whatever is still reserved, so rounding in the weights (1/3 + 1/3 + 1/3 falls
+a hair short of 1 in binary floating point) can no longer strand a sliver of
+capital outside the market.
+
+Multi-tranche results change for any backtest that closes more than one trade.
+
 ## [0.5.0] - 2026-07-26
 
 ### Read this first — your numbers will change

--- a/packages/core/src/backtest/__tests__/scaled-entry.test.ts
+++ b/packages/core/src/backtest/__tests__/scaled-entry.test.ts
@@ -68,6 +68,34 @@ function generateDipPattern(count: number, startPrice = 100): NormalizedCandle[]
   return candles;
 }
 
+/**
+ * Build flat candles (open = high = low = close) from a close series, so that
+ * every fill price in a test is exactly the listed number.
+ */
+function flatCandles(closes: number[]): NormalizedCandle[] {
+  const baseTime = Date.UTC(2024, 0, 1);
+
+  return closes.map((close, i) => ({
+    time: baseTime + i * 24 * 60 * 60 * 1000,
+    open: close,
+    high: close,
+    low: close,
+    close,
+    volume: 1000000,
+  }));
+}
+
+/**
+ * Condition that fires on an explicit list of bar indices
+ */
+function firesAt(name: string, indices: number[]): PresetCondition {
+  return {
+    type: "preset",
+    name,
+    evaluate: (_indicators, _candle, index) => indices.includes(index),
+  };
+}
+
 // Simple condition: always true after first candle
 const alwaysEnter: PresetCondition = {
   type: "preset",
@@ -315,6 +343,87 @@ describe("Scaled Entry Backtest", () => {
 
         // Commission should reduce returns
         expect(resultWithCommission.totalReturn).toBeLessThan(resultNoCommission.totalReturn);
+      });
+    });
+
+    describe("capital allocation across trade cycles", () => {
+      it("should size later cycles' tranches from the capital available at that cycle", () => {
+        // Cycle 1 buys both tranches at 100 and exits at 110, turning 100,000
+        // into 110,000. Cycle 2 must therefore commit 55,000 + 55,000 at 110
+        // (1,000 shares) and, exiting at 100, end at exactly 100,000.
+        // Sizing the second tranche from the initial capital instead invests
+        // only 50,000, leaving 5,000 reserved and ending at 100,454.55.
+        const candles = flatCandles([100, 100, 100, 110, 110, 110, 100]);
+        const result = runBacktestScaled(
+          candles,
+          firesAt("enter", [1, 2, 4, 5]),
+          firesAt("exit", [3, 6]),
+          {
+            capital: 100000,
+            fillMode: "same-bar-close",
+            scaledEntry: {
+              tranches: 2,
+              strategy: "equal",
+              intervalType: "signal",
+            },
+          },
+        );
+
+        expect(result.tradeCount).toBe(2);
+        expect(result.trades[0].exitPrice).toBe(110);
+        expect(result.trades[1].entryPrice).toBe(110);
+        expect(result.finalCapital).toBeCloseTo(100000, 6);
+      });
+
+      it("should not overdraw reserved capital after a losing cycle", () => {
+        // Mirror image: cycle 1 loses 10%, so cycle 2 has 90,000 and each
+        // tranche is 45,000. Sizing from the initial capital would spend
+        // 50,000 on the second tranche — 5,000 more than was reserved for it —
+        // and end at 100,555.56 instead of 100,000.
+        const candles = flatCandles([100, 100, 100, 90, 90, 90, 100]);
+        const result = runBacktestScaled(
+          candles,
+          firesAt("enter", [1, 2, 4, 5]),
+          firesAt("exit", [3, 6]),
+          {
+            capital: 100000,
+            fillMode: "same-bar-close",
+            scaledEntry: {
+              tranches: 2,
+              strategy: "equal",
+              intervalType: "signal",
+            },
+          },
+        );
+
+        expect(result.tradeCount).toBe(2);
+        expect(result.trades[0].exitPrice).toBe(90);
+        expect(result.finalCapital).toBeCloseTo(100000, 6);
+      });
+
+      it("should invest a later cycle fully across three tranches", () => {
+        // Same shape with three equal tranches: cycle 2 starts from 110,000
+        // and buys 1,000 shares at 110, so exiting at 100 returns exactly the
+        // original capital. Weighting against the initial capital leaves
+        // 6,666.67 reserved and ends at 100,606.06.
+        const candles = flatCandles([100, 100, 100, 100, 110, 110, 110, 110, 100]);
+        const result = runBacktestScaled(
+          candles,
+          firesAt("enter", [1, 2, 3, 5, 6, 7]),
+          firesAt("exit", [4, 8]),
+          {
+            capital: 100000,
+            fillMode: "same-bar-close",
+            scaledEntry: {
+              tranches: 3,
+              strategy: "equal",
+              intervalType: "signal",
+            },
+          },
+        );
+
+        expect(result.tradeCount).toBe(2);
+        expect(result.finalCapital).toBeCloseTo(100000, 6);
       });
     });
 

--- a/packages/core/src/backtest/scaled-entry.ts
+++ b/packages/core/src/backtest/scaled-entry.ts
@@ -77,6 +77,12 @@ type ScaledPosition = {
   entryAtr: number | null;
   /** Capital reserved for remaining tranches */
   reservedCapital: number;
+  /**
+   * Capital available when this position opened. Every tranche of this
+   * position is sized from it, so the tranche weights always sum back to the
+   * capital actually committed to this trade cycle.
+   */
+  committedCapital: number;
 };
 
 /**
@@ -245,6 +251,7 @@ export function runBacktestScaled(
       partialTaken: false,
       entryAtr,
       reservedCapital: currentCapital - trancheCapital,
+      committedCapital: currentCapital,
     };
 
     currentCapital = 0; // All capital (including reserved) is committed
@@ -254,7 +261,17 @@ export function runBacktestScaled(
   function addTranche(pos: ScaledPosition, entryPrice: number, time: number): void {
     const trancheIndex = pos.tranches.length;
     const trancheWeight = trancheWeights[trancheIndex];
-    const trancheCapital = capital * trancheWeight;
+    // Size from the capital this position committed, not from the backtest's
+    // initial capital: once a trade cycle has closed at a profit or a loss the
+    // two differ, and weighting against the initial capital either strands
+    // reserved capital or overdraws it.
+    // The final tranche takes whatever is still reserved so that rounding in
+    // the weights (1/3 + 1/3 + 1/3 < 1 in binary floating point) cannot leave
+    // a sliver of capital uninvested.
+    const trancheCapital =
+      trancheIndex === pos.targetTranches - 1
+        ? pos.reservedCapital
+        : pos.committedCapital * trancheWeight;
     const entryCommission = commission + trancheCapital * (commissionRate / 100);
     const shares = (trancheCapital - entryCommission) / entryPrice;
 


### PR DESCRIPTION
## Problem

In the multi-tranche path of `runBacktestScaled` (`scaledEntry.tranches >= 2`), the first tranche is sized from the capital available when the position opens, but every additional tranche is sized from the backtest's **initial** capital. The two agree only for the first trade cycle.

After any closed trade the tranche weights no longer sum to the capital committed to the new cycle:

- **After a profitable cycle** the position is under-invested; the shortfall stays in reserve and never enters the market.
- **After a losing cycle** later tranches spend more than was reserved for them, driving the reserve negative and inflating the position.

Either way, P&L is computed from the wrong exposure.

### Repro

Capital 100,000, two equal tranches, `fillMode: "same-bar-close"`, no commission or slippage:

| Cycle | Entry | Exit | Expected |
| --- | --- | --- | --- |
| 1 | both tranches at 100 | 110 | 110,000 |
| 2 | both tranches at 110 | 100 | back to 100,000 |

The second cycle has 110,000 to deploy and should commit 55,000 + 55,000 (1,000 shares), so selling at 100 returns exactly the original capital.

Actual `finalCapital` = **100,454.55** — the second tranche took 50,000 instead of 55,000, leaving 5,000 stranded in reserve. Mirroring the run with a losing first cycle (100 -> 90, then 90 -> 100) reports **100,555.56**, the second tranche having overdrawn its reserve by 5,000.

## Fix

Each `ScaledPosition` now records the capital it committed when it opened, and every tranche of that position is weighted against it. `addTranche` no longer reads the backtest's initial capital.

The final tranche takes whatever is still reserved. Rounding in the weights (`1/3 + 1/3 + 1/3` falls a hair short of 1 in binary floating point) could otherwise leave a sliver of capital outside the market.

## Behavior change

Multi-tranche results change for any backtest that closes more than one trade. Previous results sized later cycles against stale capital; the new numbers reflect the capital actually available. Documented under `[Unreleased]` in the core changelog.

## Test plan

Three regression tests in a new `capital allocation across trade cycles` block, each asserting a hand-computed `finalCapital`:

1. Profitable first cycle, two equal tranches -> exactly 100,000 (was 100,454.55)
2. Losing first cycle, two equal tranches -> exactly 100,000 (was 100,555.56)
3. Profitable first cycle, three equal tranches -> exactly 100,000 (was 100,606.06)

Negative check: with the source fix reverted, all three fail with the values above; with the fix, all pass.

Verification:

- `pnpm test` (core): 365 files / 6425 tests passed
- `npx tsc --noEmit --ignoreDeprecations 6.0`: clean
- `pnpm build` (core): success
- `npx biome check` on touched files: clean
- `pnpm test` (mcp): 9 files / 83 tests passed