### PR TITLE
fix(core)!: reject options the scaled-entry multi-tranche path ignores

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## [Unreleased]
 
+### Breaking — `runBacktestScaled` rejects the options its multi-tranche engine does not implement
+
+With two or more tranches, `runBacktestScaled` runs a second engine that never
+grew the feature set of `runBacktest`. It accepted the full `BacktestOptions`
+surface anyway and quietly ignored most of it, so a backtest could be
+configured one way and executed another — `direction: "short"` in particular
+behaved exactly like a long position and reported the inverse P&L as though it
+were real.
+
+Fourteen options are now rejected with an error naming them, instead of being
+ignored, when `scaledEntry.tranches >= 2`:
+
+`direction`, `atrTrailingStop`, `breakevenStop`, `scaleOut`, `timeExit`,
+`slippageModel`, `orderType`, `orderTTL`, `timeInForce`, `volumeConstraint`,
+`margin`, `sizing`, `fundamentals`, `validateData`
+
+The last two are the quietest of the set: `fundamentals` left PER/PBR
+conditions unable to fire, and `validateData: true` reported nothing because no
+validation ran.
+
+Runs with a single tranche are unaffected — they delegate to `runBacktest`,
+which implements everything — so `ScaledBacktestOptions` still accepts these
+keys. Whether an option is honored depends on `scaledEntry.tranches`, a value
+rather than a type, so the check is a runtime one.
+
+If you were passing one of these with two or more tranches, the result you were
+reading did not reflect it. Call `runBacktest` directly, or use `tranches: 1`.
+
+Support for short positions in the multi-tranche path is tracked separately;
+implementing it removes `direction` from the rejected list.
+
 ### Fixed — `runBacktestScaled` sizes every tranche from the capital the trade cycle actually has
 
 In the multi-tranche path, the first tranche was sized from the capital

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -4448,6 +4448,14 @@ const result = runBacktestScaled(candles, goldenCrossCondition(), deadCrossCondi
 | `signal` | 各エントリーシグナルでトランシェ追加 |
 | `price` | 最初のエントリーから `priceInterval` % 価格変動でトランシェ追加 |
 
+**2トランシェ以上で未対応のオプション:**
+
+マルチトランシェ経路は `runBacktest` とは別のエンジンで、そのオプションの一部しか実装していません。`scaledEntry.tranches >= 2` の場合、以下は黙って無視されるのではなくエラーになります:
+
+`direction`, `atrTrailingStop`, `breakevenStop`, `scaleOut`, `timeExit`, `slippageModel`, `orderType`, `orderTTL`, `timeInForce`, `volumeConstraint`, `margin`, `sizing`, `fundamentals`, `validateData`
+
+`ScaledBacktestOptions` 型はこれらを受け付けたままです。有効になるかどうかは `scaledEntry.tranches` という値に依存し、型では表現できないためです。使用したい場合は `runBacktest` を直接呼ぶか、`tranches: 1` で実行してください（`runBacktest` に委譲され、すべてのオプションが有効になります）。
+
 ---
 
 ## ストリーミング

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -4491,6 +4491,14 @@ const result = runBacktestScaled(candles, goldenCrossCondition(), deadCrossCondi
 | `signal` | Add tranche on each entry signal |
 | `price` | Add tranche when price drops by `priceInterval` % from first entry |
 
+**Options not supported with 2+ tranches:**
+
+The multi-tranche path is a separate engine from `runBacktest` and implements only part of its options. When `scaledEntry.tranches >= 2`, these throw rather than being silently ignored:
+
+`direction`, `atrTrailingStop`, `breakevenStop`, `scaleOut`, `timeExit`, `slippageModel`, `orderType`, `orderTTL`, `timeInForce`, `volumeConstraint`, `margin`, `sizing`, `fundamentals`, `validateData`
+
+`ScaledBacktestOptions` still accepts them, because whether they are honored depends on `scaledEntry.tranches` — a value, not a type. To use them, call `runBacktest` directly, or run with `tranches: 1`, which delegates to `runBacktest` and honors all of them.
+
 ---
 
 ## Streaming

--- a/packages/core/docs/GUIDE.ja.md
+++ b/packages/core/docs/GUIDE.ja.md
@@ -2203,6 +2203,8 @@ const result2 = runBacktestScaled(candles, goldenCrossCondition(), deadCrossCond
 });
 ```
 
+> **注意:** 2トランシェ以上では `runBacktest` とは別のエンジンで動作し、`BacktestOptions` の一部しか実装していません。`direction`, `margin`, `sizing`, `scaleOut`, `timeExit`, `orderType` などは適用されずエラーになります（全リストは API リファレンス参照）。必要な場合は `runBacktest`（または `tranches: 1`）を使ってください。
+
 ### 戦略の選び方
 
 | 戦略 | 適した状況 |

--- a/packages/core/docs/GUIDE.md
+++ b/packages/core/docs/GUIDE.md
@@ -2208,6 +2208,8 @@ const result2 = runBacktestScaled(candles, goldenCrossCondition(), deadCrossCond
 });
 ```
 
+> **Note:** With 2 or more tranches this runs a separate engine from `runBacktest`, and it implements only part of `BacktestOptions`. `direction`, `margin`, `sizing`, `scaleOut`, `timeExit`, `orderType` and several others throw rather than being applied — see the API reference for the full list. Use `runBacktest` (or `tranches: 1`) when you need them.
+
 ### When to Use Each Strategy
 
 | Strategy | Best For |

--- a/packages/core/src/backtest/__tests__/scaled-entry-option-support.test.ts
+++ b/packages/core/src/backtest/__tests__/scaled-entry-option-support.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle, PresetCondition } from "../../types";
+import type { MtfBacktestOptions } from "../engine";
+import type { ScaledBacktestOptions } from "../scaled-entry";
+import { runBacktestScaled } from "../scaled-entry";
+
+/**
+ * Options the multi-tranche path of `runBacktestScaled` implements.
+ *
+ * Classified against `MtfBacktestOptions` rather than `BacktestOptions`:
+ * `fundamentals` and `validateData` live only on the former, and a run that
+ * silently drops them is exactly the failure this file guards against.
+ */
+const IMPLEMENTED_OPTIONS = [
+  "capital",
+  "commission",
+  "commissionRate",
+  "slippage",
+  "stopLoss",
+  "takeProfit",
+  "trailingStop",
+  "partialTakeProfit",
+  "taxRate",
+  "fillMode",
+  "slTpMode",
+  "benchmark",
+  "mtfTimeframes",
+  "atrRisk",
+] as const satisfies readonly (keyof MtfBacktestOptions)[];
+
+/**
+ * Options the multi-tranche path does not implement and therefore rejects.
+ * Mirrors the list inside `scaled-entry.ts`: this table is the specification,
+ * so moving an option between the two lists here is a deliberate act.
+ */
+const UNSUPPORTED_OPTIONS = [
+  "direction",
+  "atrTrailingStop",
+  "breakevenStop",
+  "scaleOut",
+  "timeExit",
+  "slippageModel",
+  "orderType",
+  "orderTTL",
+  "timeInForce",
+  "volumeConstraint",
+  "margin",
+  "sizing",
+  "fundamentals",
+  "validateData",
+] as const satisfies readonly (keyof MtfBacktestOptions)[];
+
+/**
+ * Compile-time exhaustiveness guard: every option `runBacktest` accepts must
+ * appear in exactly one of the two tables above. Adding one without deciding
+ * whether the multi-tranche engine honors it fails the type check here rather
+ * than silently escaping both the runtime rejection and this test file.
+ *
+ * "Exactly one" needs both directions — an option listed twice would otherwise
+ * satisfy the exhaustiveness check while claiming to be both honored and
+ * rejected.
+ */
+type AssertNever<T extends never> = T;
+
+type UnclassifiedOption = Exclude<
+  keyof MtfBacktestOptions,
+  (typeof IMPLEMENTED_OPTIONS)[number] | (typeof UNSUPPORTED_OPTIONS)[number]
+>;
+type _EveryBacktestOptionIsClassified = AssertNever<UnclassifiedOption>;
+
+type DoublyClassifiedOption = Extract<
+  (typeof IMPLEMENTED_OPTIONS)[number],
+  (typeof UNSUPPORTED_OPTIONS)[number]
+>;
+type _NoBacktestOptionIsClassifiedTwice = AssertNever<DoublyClassifiedOption>;
+
+/**
+ * A realistic value for each unsupported option. Typed against
+ * `MtfBacktestOptions` so the compiler — not the author — guarantees these are
+ * well-formed configs and not shapes that would be rejected for being invalid.
+ */
+const SAMPLE_UNSUPPORTED_VALUES: Required<
+  Pick<MtfBacktestOptions, (typeof UNSUPPORTED_OPTIONS)[number]>
+> = {
+  direction: "short",
+  atrTrailingStop: { multiplier: 2 },
+  breakevenStop: { threshold: 5 },
+  scaleOut: { levels: [{ threshold: 5, sellPercent: 50 }] },
+  timeExit: { maxHoldDays: 10 },
+  slippageModel: { type: "fixed", percent: 0.1 },
+  orderType: { type: "market" },
+  orderTTL: 5,
+  timeInForce: "day",
+  volumeConstraint: { maxVolumePercent: 10 },
+  margin: { leverage: 2, maintenanceMargin: 0.25, marginCallAction: "liquidate" },
+  sizing: { method: "fixed-fractional", fractionPercent: 50 },
+  fundamentals: [{ time: Date.UTC(2024, 0, 1), per: 15, pbr: 1.2 }],
+  validateData: true,
+};
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function candles(count: number): NormalizedCandle[] {
+  const baseTime = Date.UTC(2024, 0, 1);
+
+  return Array.from({ length: count }, (_, i) => {
+    const price = 100 + i;
+    return {
+      time: baseTime + i * DAY,
+      open: price,
+      high: price + 1,
+      low: price - 1,
+      close: price,
+      volume: 1000000,
+    };
+  });
+}
+
+const enterAt1: PresetCondition = {
+  type: "preset",
+  name: "enterAt1",
+  evaluate: (_indicators, _candle, index) => index === 1,
+};
+
+const neverExit: PresetCondition = {
+  type: "preset",
+  name: "neverExit",
+  evaluate: () => false,
+};
+
+function runWith(extra: Record<string, unknown>, tranches = 2) {
+  return runBacktestScaled(candles(30), enterAt1, neverExit, {
+    capital: 100000,
+    scaledEntry: { tranches, strategy: "equal", intervalType: "signal" },
+    ...extra,
+  } as ScaledBacktestOptions);
+}
+
+describe("runBacktestScaled option support", () => {
+  describe("options the multi-tranche path does not implement", () => {
+    for (const key of UNSUPPORTED_OPTIONS) {
+      it(`rejects ${key} instead of ignoring it`, () => {
+        expect(() => runWith({ [key]: SAMPLE_UNSUPPORTED_VALUES[key] })).toThrow(
+          new RegExp(`does not implement.*\\b${key}\\b`),
+        );
+      });
+    }
+
+    it("names every offending option in one message", () => {
+      expect(() =>
+        runWith({
+          direction: SAMPLE_UNSUPPORTED_VALUES.direction,
+          margin: SAMPLE_UNSUPPORTED_VALUES.margin,
+          sizing: SAMPLE_UNSUPPORTED_VALUES.sizing,
+        }),
+      ).toThrow(/does not implement direction, margin, sizing\b/);
+    });
+
+    it("ignores keys that are present but undefined", () => {
+      expect(() => runWith({ direction: undefined, margin: undefined })).not.toThrow();
+    });
+  });
+
+  describe("options the multi-tranche path implements", () => {
+    for (const key of IMPLEMENTED_OPTIONS) {
+      it(`accepts ${key}`, () => {
+        // `capital` is already set by the base options; the rest only need to
+        // be present, since the assertion here is that they are not rejected.
+        expect(() => runWith({ [key]: key === "capital" ? 100000 : undefined })).not.toThrow();
+      });
+    }
+  });
+
+  describe("single-tranche runs are unaffected", () => {
+    it("honors an unsupported option when tranches is 1", () => {
+      // With one tranche the run is delegated to runBacktest, which implements
+      // every option — so rejecting there would break working callers.
+      const short = runWith({ direction: "short" }, 1);
+      const long = runWith({}, 1);
+
+      expect(short.tradeCount).toBe(1);
+      expect(long.tradeCount).toBe(1);
+      // Prices rise over the window, so the two directions cannot agree.
+      expect(short.totalReturnPercent).not.toBeCloseTo(long.totalReturnPercent, 6);
+    });
+
+    it("rejects the same option once tranches reaches 2", () => {
+      expect(() => runWith({ direction: "short" }, 2)).toThrow(/does not implement direction/);
+    });
+
+    it("still validates data when asked to, unlike the multi-tranche path", () => {
+      const broken = candles(30);
+      // high < low: the validator's OHLC consistency check must reject this.
+      broken[10] = { ...broken[10], high: 50, low: 200 };
+
+      // Annotated rather than cast: `validateData` has to actually be part of
+      // ScaledBacktestOptions for this to compile.
+      const options: ScaledBacktestOptions = {
+        capital: 100000,
+        validateData: true,
+        scaledEntry: { tranches: 1, strategy: "equal", intervalType: "signal" },
+      };
+
+      expect(() => runBacktestScaled(broken, enterAt1, neverExit, options)).toThrow(
+        /Data validation failed/,
+      );
+    });
+  });
+
+  describe("type surface", () => {
+    it("accepts every rejectable option at the type level, because one tranche honors them", () => {
+      // The rejection depends on scaledEntry.tranches, a value rather than a
+      // type. Omitting these keys from ScaledBacktestOptions would forbid them
+      // for the single-tranche calls that do support them — this compiles, and
+      // must keep compiling, for the documented workaround to be usable from
+      // TypeScript. Every key the runtime check can reject is spread in, so a
+      // key missing from the type fails the build rather than this assertion.
+      const options: ScaledBacktestOptions = {
+        capital: 100000,
+        ...SAMPLE_UNSUPPORTED_VALUES,
+        scaledEntry: { tranches: 1, strategy: "equal", intervalType: "signal" },
+      };
+
+      expect(options.direction).toBe("short");
+      expect(options.fundamentals).toHaveLength(1);
+      expect(options.validateData).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/backtest/scaled-entry-utils.ts
+++ b/packages/core/src/backtest/scaled-entry-utils.ts
@@ -5,14 +5,9 @@
  * statistics calculation, slippage, and standard backtest delegation.
  */
 
-import type {
-  BacktestOptions,
-  BacktestResult,
-  BacktestSettings,
-  Condition,
-  NormalizedCandle,
-} from "../types";
+import type { BacktestResult, BacktestSettings, Condition, NormalizedCandle } from "../types";
 import type { ExtendedCondition } from "./conditions";
+import type { MtfBacktestOptions } from "./engine";
 import { runBacktest } from "./engine";
 import {
   type BacktestSpanInfo,
@@ -27,13 +22,18 @@ import {
 export const MS_PER_DAY = ENGINE_MS_PER_DAY;
 
 /**
- * Standard (non-scaled) backtest - delegates to main engine
+ * Standard (non-scaled) backtest - delegates to main engine.
+ *
+ * Takes the full `MtfBacktestOptions` surface: this is the path a
+ * single-tranche `runBacktestScaled` call takes, and everything the main
+ * engine implements — MTF timeframes, fundamentals, data validation — reaches
+ * it through here.
  */
 export function runStandardBacktest(
   candles: NormalizedCandle[],
   entryCondition: Condition | ExtendedCondition,
   exitCondition: Condition | ExtendedCondition,
-  options: BacktestOptions,
+  options: MtfBacktestOptions,
 ): BacktestResult {
   return runBacktest(candles, entryCondition, exitCondition, options);
 }

--- a/packages/core/src/backtest/scaled-entry.ts
+++ b/packages/core/src/backtest/scaled-entry.ts
@@ -9,8 +9,6 @@
 import { buildMtfSetup, updateMtfIndices } from "../core/mtf-context";
 import { atr } from "../indicators/volatility/atr";
 import type {
-  AtrRiskOptions,
-  BacktestOptions,
   BacktestResult,
   BacktestSettings,
   Condition,
@@ -19,11 +17,11 @@ import type {
   NormalizedCandle,
   ScaledEntryConfig,
   SlTpMode,
-  TimeframeShorthand,
   Trade,
 } from "../types";
 import type { ExtendedCondition } from "./conditions";
 import { evaluateCondition, seedBenchmark } from "./conditions";
+import type { MtfBacktestOptions } from "./engine";
 import { checkProfitTrigger, checkStopTrigger } from "./engine-utils";
 import {
   applySlippage,
@@ -34,16 +32,74 @@ import {
 } from "./scaled-entry-utils";
 
 /**
- * Extended backtest options with scaled entry support
+ * Options the multi-tranche path does not implement.
+ *
+ * With a single tranche `runBacktestScaled` delegates to `runBacktest`, which
+ * implements all of them. The multi-tranche path is a second engine that never
+ * grew the same features, and accepting these options silently produced
+ * plausible but wrong results: a `direction: "short"` run, for instance,
+ * behaved exactly like a long one and reported the inverse P&L as if it were
+ * real.
+ *
+ * Covers the whole option surface `runBacktest` accepts, not just
+ * `BacktestOptions`: `fundamentals` and `validateData` reach the single-tranche
+ * path through delegation, so leaving them out would mean a run that asked for
+ * data validation and never got it.
+ *
+ * Deliberately enforced at runtime only. Whether an option is honored depends
+ * on `scaledEntry.tranches`, which is a value, not a type — omitting these keys
+ * from `ScaledBacktestOptions` would also forbid them for the single-tranche
+ * calls that do support them.
  */
-export type ScaledBacktestOptions = BacktestOptions & {
-  /** Timeframes to include for MTF conditions */
-  mtfTimeframes?: TimeframeShorthand[];
-  /** ATR-based risk management options */
-  atrRisk?: AtrRiskOptions;
+const UNSUPPORTED_MULTI_TRANCHE_OPTIONS = [
+  "direction",
+  "atrTrailingStop",
+  "breakevenStop",
+  "scaleOut",
+  "timeExit",
+  "slippageModel",
+  "orderType",
+  "orderTTL",
+  "timeInForce",
+  "volumeConstraint",
+  "margin",
+  "sizing",
+  "fundamentals",
+  "validateData",
+] as const satisfies readonly (keyof MtfBacktestOptions)[];
+
+/**
+ * Extended backtest options with scaled entry support.
+ *
+ * Accepts everything `runBacktest` accepts, because a single-tranche run
+ * delegates to it and honors all of it. With `scaledEntry.tranches >= 2` the
+ * options in `UNSUPPORTED_MULTI_TRANCHE_OPTIONS` are rejected at runtime
+ * instead.
+ */
+export type ScaledBacktestOptions = MtfBacktestOptions & {
   /** Scaled entry configuration */
   scaledEntry?: ScaledEntryConfig;
 };
+
+/**
+ * Reject options the multi-tranche path would otherwise ignore.
+ *
+ * Only called once the run is known to take the multi-tranche path: with one
+ * tranche the options are handed to `runBacktest`, which honors them.
+ */
+function assertMultiTrancheOptionsSupported(options: ScaledBacktestOptions): void {
+  const provided = UNSUPPORTED_MULTI_TRANCHE_OPTIONS.filter(
+    (key) => (options as Record<string, unknown>)[key] !== undefined,
+  );
+
+  if (provided.length > 0) {
+    throw new Error(
+      `runBacktestScaled does not implement ${provided.join(", ")} when scaledEntry.tranches >= 2. ` +
+        "The multi-tranche engine would ignore these options and report results as if they had " +
+        "been applied. Remove them, or run with a single tranche to use them via runBacktest.",
+    );
+  }
+}
 
 /**
  * Single entry tranche record
@@ -182,6 +238,10 @@ export function runBacktestScaled(
     // Use standard backtest logic
     return runStandardBacktest(candles, entryCondition, exitCondition, options);
   }
+
+  // Past this point the run takes the multi-tranche path, which implements
+  // only part of BacktestOptions.
+  assertMultiTrancheOptionsSupported(options);
 
   const { tranches, strategy, intervalType, priceInterval = -2 } = scaledEntry;
 


### PR DESCRIPTION
## Problem

With `scaledEntry.tranches >= 2`, `runBacktestScaled` runs a second engine that never grew the feature set of `runBacktest`. It accepted the full option surface anyway and quietly ignored most of it, so a backtest could be configured one way and executed another.

`direction: "short"` was the worst case. The public type accepted it, the single-tranche fallback honored it, but the multi-tranche implementation never read it — all entry slippage, SL/TP formulas, trailing peaks and return math are hard-coded long. A short run over falling closes reported a loss where the same strategy through `runBacktest` was profitable, and nothing in the result said the direction had been dropped.

Two options were quieter still:

- `fundamentals` — PER/PBR conditions could never fire, so a strategy gated on them silently evaluated to `false`.
- `validateData: true` — no validation ran, and the run reported no problems with data that had never been checked.

## Fix

Fourteen options now throw an error naming them, instead of being ignored, once the run takes the multi-tranche path:

`direction`, `atrTrailingStop`, `breakevenStop`, `scaleOut`, `timeExit`, `slippageModel`, `orderType`, `orderTTL`, `timeInForce`, `volumeConstraint`, `margin`, `sizing`, `fundamentals`, `validateData`

A single list owns the gap. The runtime check reads it, and implementing one of these options means deleting it from there.

### Why the check is at runtime rather than in the type

Whether an option is honored depends on `scaledEntry.tranches` — a value, not a type. A single-tranche run delegates to `runBacktest`, which implements all of them, so omitting these keys from `ScaledBacktestOptions` would forbid them for exactly the calls that do support them, and would make the documented workaround (`tranches: 1`) unusable from TypeScript.

`ScaledBacktestOptions` now derives from `MtfBacktestOptions` instead of `BacktestOptions`, so every option the delegation honors is expressible. This also removes a duplicated declaration of `mtfTimeframes`/`atrRisk`. `runStandardBacktest` takes `MtfBacktestOptions` for the same reason: it is the delegation target, and `fundamentals`/`validateData` already travelled through it at runtime while being dropped from its signature.

## Behavior change

Calls that passed any of these fourteen options with two or more tranches now throw where they previously returned a result. That result did not reflect the option. Use `runBacktest` directly, or `tranches: 1`.

Short support in the multi-tranche path is tracked separately; implementing it removes `direction` from the list.

## Test plan

New test file classifying every option `runBacktest` accepts as implemented (14) or unsupported (14), with three compile-time guards proven to fire:

| Guard | Probe | Compiler error |
| --- | --- | --- |
| No option left unclassified | add a key to `MtfBacktestOptions` | `TS2344: Type '"probeUnclassifiedOption"' does not satisfy the constraint 'never'` |
| No option classified twice | list `direction` in both tables | `TS2344: Type '"direction"' does not satisfy the constraint 'never'` |
| Every rejectable option is expressible in the type | drop `fundamentals` from `ScaledBacktestOptions` | `TS2339: Property 'fundamentals' does not exist on type 'ScaledBacktestOptions'` |

Sample values for the rejected options are typed as `Required<Pick<MtfBacktestOptions, …>>`, so the compiler guarantees they are well-formed configs rather than shapes that would be refused for being invalid.

Runtime coverage (34 tests): each of the 14 options rejected individually; all offenders named in one message; keys present but `undefined` ignored; each of the 14 implemented options accepted; `direction: "short"` still honored at `tranches: 1` and rejected at `tranches: 2`; `validateData: true` still failing on inconsistent OHLC at `tranches: 1`.

Negative check: with the source change reverted, 16 of the 34 fail.

Verification:

- `pnpm test` (core): 366 files / 6459 tests passed
- `npx tsc --noEmit --ignoreDeprecations 6.0`: clean
- `pnpm build` (core): success
- `npx biome check` on touched files: clean

Two unrelated tests (`plugin.test.ts`, `screener.test.ts`) intermittently hit the 5s timeout under load. They pass standalone and are unaffected by this change — reverting it reproduces the same intermittency.

## Docs

`API.md` / `API.ja.md` list the rejected options and explain why the type still accepts them; `GUIDE.md` / `GUIDE.ja.md` carry a short note pointing at the same.