### PR TITLE
fix(core)!: close the position on a 100% partial exit; validate sell percentages

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 ## [Unreleased]
 
+### Breaking — partial exit percentages outside `(0, 100]` are rejected
+
+`sellPercent` is a fraction of the shares currently held, but nothing checked
+it. `scaleOut.levels[].sellPercent: 150` sold half again as many shares as the
+position owned and credited the account for all of them: 100,000 of capital
+finished a five-bar run at 164,973, out of thin air. Zero and `NaN` were
+accepted just as quietly.
+
+`partialTakeProfit.sellPercent` and every `scaleOut.levels[].sellPercent` are
+now validated at the entry points — `runBacktest`, `runBacktestScaled` and
+`createPositionTracker` — and values at or below zero, above 100, or `NaN`
+throw with the offending option named. `100` remains valid everywhere and means
+"close what is left", as the `scaleOut` documentation already showed.
+
+### Fixed — a 100% partial take profit closes the position instead of emptying it
+
+`partialTakeProfit.sellPercent: 100` sold every share, then left the position
+open with none in it. The next exit — or the end of the data — "closed" that
+empty position a second time, charging another exit commission and appending a
+trade with no shares and no return, which then contaminated the aggregate
+metrics.
+
+All three engines that implement partial exits were affected: `runBacktest`,
+the multi-tranche path of `runBacktestScaled`, and the streaming
+`createPositionTracker`. Each now closes the position when the sale empties it,
+and reports the trade as a full exit rather than a partial one — matching what
+`scaleOut` already did in the same situation.
+
+`runBacktestScaled` additionally releases the capital reserved for tranches
+that will now never be entered. A run with 100,000 of capital, two equal
+tranches and a 100% partial take profit finished at 104,969 with 50,000 of the
+reserve still stranded; it now finishes at 104,979 with the reserve returned.
+
+### Breaking — `UpdatePriceResult.position` is typed `ManagedPosition | null`
+
+`updatePrice()` has always returned `null` for `position` on the bar that
+closes a position, and when no position was open — the field was simply typed
+as though it could not. The cast that hid this is gone, so callers reading
+`result.position` now have to handle `null`, which is what the value has been
+all along.
+
+This was not only cosmetic: on a bar where a 100% partial take profit closed
+the position, `updatePrice()` returned `{}` — a spread of the nulled position —
+and the declared type meant nothing flagged it. Reading `result.position.shares`
+gave `undefined` rather than failing.
+
 ### Breaking — `runBacktestScaled` rejects the options its multi-tranche engine does not implement
 
 With two or more tranches, `runBacktestScaled` runs a second engine that never

--- a/packages/core/src/backtest/__tests__/partial-exit-validation.test.ts
+++ b/packages/core/src/backtest/__tests__/partial-exit-validation.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle, PresetCondition } from "../../types";
+import { runBacktest } from "../engine";
+import { runBacktestScaled } from "../scaled-entry";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Flat candles (open = high = low = close) so every fill price in a test is
+ * exactly the listed number.
+ */
+function flatCandles(closes: number[]): NormalizedCandle[] {
+  const baseTime = Date.UTC(2024, 0, 1);
+
+  return closes.map((close, i) => ({
+    time: baseTime + i * DAY,
+    open: close,
+    high: close,
+    low: close,
+    close,
+    volume: 1000000,
+  }));
+}
+
+const enterAtBar1: PresetCondition = {
+  type: "preset",
+  name: "enterAtBar1",
+  evaluate: (_indicators, _candle, index) => index === 1,
+};
+
+const neverExit: PresetCondition = {
+  type: "preset",
+  name: "neverExit",
+  evaluate: () => false,
+};
+
+// Enter at 100, then rise past the +5% partial take profit threshold.
+const RISE_PAST_THRESHOLD = [100, 100, 110, 110, 110];
+
+describe("partial exits", () => {
+  describe("sellPercent: 100 closes the position", () => {
+    it("records one trade in the standard engine, not a zero-share second one", () => {
+      // 100,000 buys (100,000 - 10 commission) / 100 = 999.9 shares. Selling
+      // all of them at 110 returns 109,989 less a 10 exit commission.
+      // Leaving the emptied position open charged a second exit commission and
+      // appended a trade with no shares and a null return.
+      const result = runBacktest(flatCandles(RISE_PAST_THRESHOLD), enterAtBar1, neverExit, {
+        capital: 100000,
+        commission: 10,
+        fillMode: "same-bar-close",
+        partialTakeProfit: { threshold: 5, sellPercent: 100 },
+      });
+
+      expect(result.tradeCount).toBe(1);
+      expect(result.trades[0].exitReason).toBe("partialTakeProfit");
+      expect(result.trades[0].isPartial).toBeFalsy();
+      expect(result.finalCapital).toBeCloseTo(109979, 6);
+    });
+
+    it("records one trade in the scaled engine and releases the reserved capital", () => {
+      // Tranche 1 commits 50,000 of the 100,000, buying (50,000 - 10) / 100 =
+      // 499.9 shares; 50,000 stays reserved for a tranche that is never
+      // entered. Selling everything at 110 returns 54,989 less a 10 exit
+      // commission, plus the released reserve.
+      const result = runBacktestScaled(flatCandles(RISE_PAST_THRESHOLD), enterAtBar1, neverExit, {
+        capital: 100000,
+        commission: 10,
+        fillMode: "same-bar-close",
+        partialTakeProfit: { threshold: 5, sellPercent: 100 },
+        scaledEntry: { tranches: 2, strategy: "equal", intervalType: "signal" },
+      });
+
+      expect(result.tradeCount).toBe(1);
+      expect(result.trades[0].exitReason).toBe("partialTakeProfit");
+      expect(result.trades[0].isPartial).toBeFalsy();
+      expect(result.finalCapital).toBeCloseTo(104979, 6);
+    });
+
+    it("still takes a real partial exit below 100", () => {
+      const result = runBacktest(flatCandles(RISE_PAST_THRESHOLD), enterAtBar1, neverExit, {
+        capital: 100000,
+        commission: 10,
+        fillMode: "same-bar-close",
+        partialTakeProfit: { threshold: 5, sellPercent: 50 },
+      });
+
+      // Partial exit, then the remainder closes at the end of the data.
+      expect(result.tradeCount).toBe(2);
+      expect(result.trades[0].isPartial).toBe(true);
+      expect(result.trades[0].exitPercent).toBe(50);
+      expect(result.trades[1].exitReason).toBe("endOfData");
+    });
+  });
+
+  describe("sell percentages outside (0, 100] are rejected", () => {
+    const candles = flatCandles(RISE_PAST_THRESHOLD);
+
+    for (const sellPercent of [150, 100.5, 0, -10, Number.NaN]) {
+      it(`rejects partialTakeProfit.sellPercent: ${sellPercent}`, () => {
+        expect(() =>
+          runBacktest(candles, enterAtBar1, neverExit, {
+            capital: 100000,
+            partialTakeProfit: { threshold: 5, sellPercent },
+          }),
+        ).toThrow(/partialTakeProfit\.sellPercent must be greater than 0 and at most 100/);
+      });
+    }
+
+    it("rejects an over-100 scale-out level, which sold shares the position never held", () => {
+      // Selling 150% of the position at a profit credited the account for
+      // shares it did not own: 100,000 of capital ended the run at 164,973.
+      expect(() =>
+        runBacktest(candles, enterAtBar1, neverExit, {
+          capital: 100000,
+          commission: 10,
+          fillMode: "same-bar-close",
+          scaleOut: { levels: [{ threshold: 5, sellPercent: 150 }] },
+        }),
+      ).toThrow(/scaleOut\.levels\[0\]\.sellPercent must be greater than 0 and at most 100/);
+    });
+
+    it("names the offending scale-out level", () => {
+      expect(() =>
+        runBacktest(candles, enterAtBar1, neverExit, {
+          capital: 100000,
+          scaleOut: {
+            levels: [
+              { threshold: 5, sellPercent: 50 },
+              { threshold: 10, sellPercent: 0 },
+            ],
+          },
+        }),
+      ).toThrow(/scaleOut\.levels\[1\]\.sellPercent/);
+    });
+
+    it("keeps accepting 100 on a scale-out level, which means 'sell the rest'", () => {
+      expect(() =>
+        runBacktest(candles, enterAtBar1, neverExit, {
+          capital: 100000,
+          scaleOut: { levels: [{ threshold: 5, sellPercent: 100 }] },
+        }),
+      ).not.toThrow();
+    });
+
+    it("rejects through the scaled entry point as well", () => {
+      expect(() =>
+        runBacktestScaled(candles, enterAtBar1, neverExit, {
+          capital: 100000,
+          partialTakeProfit: { threshold: 5, sellPercent: 150 },
+          scaledEntry: { tranches: 2, strategy: "equal", intervalType: "signal" },
+        }),
+      ).toThrow(/partialTakeProfit\.sellPercent must be greater than 0 and at most 100/);
+    });
+  });
+});

--- a/packages/core/src/backtest/engine-utils.ts
+++ b/packages/core/src/backtest/engine-utils.ts
@@ -14,13 +14,50 @@ import type {
   DrawdownPeriod,
   ExitReason,
   NormalizedCandle,
+  PartialTakeProfitConfig,
   PositionDirection,
+  ScaleOutConfig,
   SlTpMode,
   Trade,
   VolumeConstraint,
 } from "../types";
 
 export const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Validate the configured partial exits.
+ *
+ * A sell percentage is a fraction of the shares currently held, so `100`
+ * legitimately means "close what is left" — engines treat it as a full close
+ * rather than leaving a zero-share position open. Anything above it would sell
+ * shares the position does not hold, and anything at or below zero is not an
+ * exit at all; both are rejected here instead of producing a trade whose size
+ * has no relationship to the position.
+ */
+export function assertValidPartialExits(options: {
+  partialTakeProfit?: PartialTakeProfitConfig;
+  scaleOut?: ScaleOutConfig;
+}): void {
+  if (options.partialTakeProfit) {
+    assertValidSellPercent(options.partialTakeProfit.sellPercent, "partialTakeProfit.sellPercent");
+  }
+
+  const levels = options.scaleOut?.levels ?? [];
+  for (let i = 0; i < levels.length; i++) {
+    assertValidSellPercent(levels[i].sellPercent, `scaleOut.levels[${i}].sellPercent`);
+  }
+}
+
+function assertValidSellPercent(sellPercent: number, optionPath: string): void {
+  // Written as a negated range so NaN — which fails every comparison — is
+  // rejected rather than slipping through as "not out of range".
+  if (!(sellPercent > 0 && sellPercent <= 100)) {
+    throw new Error(
+      `${optionPath} must be greater than 0 and at most 100 (got ${sellPercent}). ` +
+        "100 closes the remaining position; a larger value would sell shares the position does not hold.",
+    );
+  }
+}
 
 /**
  * Position state for tracking open trades

--- a/packages/core/src/backtest/engine.ts
+++ b/packages/core/src/backtest/engine.ts
@@ -32,6 +32,7 @@ import type { Position } from "./engine-utils";
 import {
   applySlippage,
   applyVolumeConstraint,
+  assertValidPartialExits,
   calculateStats,
   calculateTradeClose,
   checkProfitTriggerDirectional,
@@ -163,6 +164,8 @@ export function runBacktest(
       ? { sizing: sizing.method === "custom" ? { method: "custom" as const } : sizing }
       : {}),
   };
+
+  assertValidPartialExits(options);
 
   // Validate input data if requested
   const validateDataOpt = (options as MtfBacktestOptions).validateData;
@@ -877,6 +880,7 @@ export function runBacktest(
         if (partialTrigger) {
           const partialExitPrice = partialTrigger.price;
           const sharesToSell = position.shares * (partialTakeProfit.sellPercent / 100);
+          const sharesRemaining = position.shares - sharesToSell;
 
           const partialSlip = getSlippage(candle, i);
           const result = calculateTradeClose({
@@ -885,7 +889,7 @@ export function runBacktest(
             exitPrice: partialExitPrice,
             exitReason: "partialTakeProfit",
             sharesToClose: sharesToSell,
-            isPartial: true,
+            isPartial: sharesRemaining > 0,
             exitPercent: partialTakeProfit.sellPercent,
             commission,
             commissionRate,
@@ -900,9 +904,23 @@ export function runBacktest(
           returns.push(result.returnPercent / 100);
           trackDrawdown(candle.time, i);
 
-          position.shares -= sharesToSell;
+          position.shares = sharesRemaining;
           position.partialTaken = true;
+
+          // `sellPercent: 100` sells the whole position: close it here rather
+          // than carrying a zero-share position that would be "closed" a
+          // second time later, charging another exit commission and recording
+          // a trade with no shares in it.
+          if (sharesRemaining <= 0) {
+            position = null;
+          }
         }
+      }
+
+      // Skip remaining checks if the partial take profit closed the position
+      if (position === null) {
+        equityCurve[i] = markToMarketEquity(candle.close);
+        continue;
       }
 
       // Scale-out check

--- a/packages/core/src/backtest/scaled-entry.ts
+++ b/packages/core/src/backtest/scaled-entry.ts
@@ -22,7 +22,7 @@ import type {
 import type { ExtendedCondition } from "./conditions";
 import { evaluateCondition, seedBenchmark } from "./conditions";
 import type { MtfBacktestOptions } from "./engine";
-import { checkProfitTrigger, checkStopTrigger } from "./engine-utils";
+import { assertValidPartialExits, checkProfitTrigger, checkStopTrigger } from "./engine-utils";
 import {
   applySlippage,
   calculateStats,
@@ -242,6 +242,7 @@ export function runBacktestScaled(
   // Past this point the run takes the multi-tranche path, which implements
   // only part of BacktestOptions.
   assertMultiTrancheOptionsSupported(options);
+  assertValidPartialExits(options);
 
   const { tranches, strategy, intervalType, priceInterval = -2 } = scaledEntry;
 
@@ -545,6 +546,13 @@ export function runBacktestScaled(
         if (partialTrigger) {
           const sellFraction = partialTakeProfit.sellPercent / 100;
           const sharesToSell = position.totalShares * sellFraction;
+          // `sellPercent: 100` sells the whole position. Treat it as a full
+          // close — release the capital reserved for tranches that will now
+          // never be entered, and do not mark the trade partial — rather than
+          // carrying a zero-share position that gets "closed" a second time
+          // later, charging another exit commission on a trade with no shares.
+          const closesPosition = position.totalShares - sharesToSell <= 0;
+
           closeShares(
             position,
             partialTrigger.price,
@@ -553,22 +561,34 @@ export function runBacktestScaled(
             sharesToSell,
             {
               withSlippage: true,
-              releaseReserved: false,
-              partial: { exitPercent: partialTakeProfit.sellPercent },
+              releaseReserved: closesPosition,
+              ...(closesPosition
+                ? {}
+                : { partial: { exitPercent: partialTakeProfit.sellPercent } }),
             },
           );
 
-          // Scale every tranche by the sold fraction so per-tranche shares
-          // stay in sync with totalShares. Selling at market does not change
-          // the remaining shares' average cost, and a later addTranche()
-          // recomputes the average from tranches — leaving the sold shares
-          // in place would weight the old cost basis as if nothing was sold.
-          for (const tranche of position.tranches) {
-            tranche.shares *= 1 - sellFraction;
+          if (closesPosition) {
+            position = null;
+          } else {
+            // Scale every tranche by the sold fraction so per-tranche shares
+            // stay in sync with totalShares. Selling at market does not change
+            // the remaining shares' average cost, and a later addTranche()
+            // recomputes the average from tranches — leaving the sold shares
+            // in place would weight the old cost basis as if nothing was sold.
+            for (const tranche of position.tranches) {
+              tranche.shares *= 1 - sellFraction;
+            }
+            position.totalShares -= sharesToSell;
+            position.partialTaken = true;
           }
-          position.totalShares -= sharesToSell;
-          position.partialTaken = true;
         }
+      }
+
+      // A 100% partial take profit closes the position outright; the remaining
+      // per-bar management has nothing left to manage.
+      if (position === null) {
+        continue;
       }
 
       // Trailing stop check

--- a/packages/core/src/streaming/position-manager/__tests__/partial-tp-breakeven.test.ts
+++ b/packages/core/src/streaming/position-manager/__tests__/partial-tp-breakeven.test.ts
@@ -56,6 +56,46 @@ describe("Partial Take Profit", () => {
     expect(tracker.getPosition()!.shares).toBe(50);
   });
 
+  it("should close the position when sellPercent is 100", () => {
+    // Selling the whole position left a zero-share position open, which a
+    // later exit would "close" a second time — charging another commission
+    // and recording a trade with no shares in it.
+    const tracker = createPositionTracker({
+      capital: 100_000,
+      partialTakeProfit: { threshold: 5, sellPercent: 100 },
+    });
+    tracker.openPosition(100, 100, 1000);
+
+    const result = tracker.updatePrice(makeCandle({ close: 106, high: 106, low: 100, time: 2000 }));
+
+    expect(result.partialFills).toHaveLength(1);
+    expect(result.partialFills[0].fill.shares).toBe(100);
+    // A close of the whole position is not a partial exit.
+    expect(result.partialFills[0].trade.isPartial).toBe(false);
+    expect(tracker.getPosition()).toBeNull();
+    // The bar's result must report the close too — it previously carried a
+    // spread of the nulled position, i.e. an empty object typed as a position.
+    expect(result.position).toBeNull();
+    expect(result.triggered).toBe(result.partialFills[0].fill);
+
+    // A later bar has nothing left to close.
+    const after = tracker.updatePrice(makeCandle({ close: 120, high: 120, low: 118, time: 3000 }));
+    expect(after.partialFills).toHaveLength(0);
+    expect(after.triggered).toBeNull();
+    expect(tracker.getTrades()).toHaveLength(1);
+  });
+
+  it("should reject a sellPercent outside (0, 100]", () => {
+    for (const sellPercent of [150, 0, -10, Number.NaN]) {
+      expect(() =>
+        createPositionTracker({
+          capital: 100_000,
+          partialTakeProfit: { threshold: 5, sellPercent },
+        }),
+      ).toThrow(/partialTakeProfit\.sellPercent must be greater than 0 and at most 100/);
+    }
+  });
+
   it("should allow full TP after partial TP", () => {
     const tracker = createPositionTracker({
       capital: 100_000,

--- a/packages/core/src/streaming/position-manager/position-tracker.ts
+++ b/packages/core/src/streaming/position-manager/position-tracker.ts
@@ -17,7 +17,11 @@
  * ```
  */
 
-import { applySlippage, calculateTradeClose } from "../../backtest/engine-utils";
+import {
+  applySlippage,
+  assertValidPartialExits,
+  calculateTradeClose,
+} from "../../backtest/engine-utils";
 import type {
   BreakevenStopConfig,
   ExitReason,
@@ -108,6 +112,8 @@ export function createPositionTracker(
   const maxTradeHistory = options.maxTradeHistory ?? 1000;
   const partialTakeProfit: PartialTakeProfitConfig | undefined = options.partialTakeProfit;
   const breakevenStop: BreakevenStopConfig | undefined = options.breakevenStop;
+
+  assertValidPartialExits({ partialTakeProfit });
 
   // Mutable state
   let position: ManagedPosition | null = fromState?.position ?? null;
@@ -281,6 +287,7 @@ export function createPositionTracker(
     }
 
     const sharesToSell = position.shares * (sellPercent / 100);
+    const sharesRemaining = position.shares - sharesToSell;
 
     const result = calculateTradeClose({
       position: positionSnapshot(position),
@@ -288,7 +295,7 @@ export function createPositionTracker(
       exitPrice,
       exitReason: "partialTakeProfit",
       sharesToClose: sharesToSell,
-      isPartial: true,
+      isPartial: sharesRemaining > 0,
       exitPercent: sellPercent,
       commission,
       commissionRate,
@@ -304,9 +311,16 @@ export function createPositionTracker(
       reason: "partial-take-profit",
     };
 
-    position.shares -= sharesToSell;
+    position.shares = sharesRemaining;
     position.partialTaken = true;
     recordTrade(result.netProceeds, result.trade);
+
+    // `sellPercent: 100` sells the whole position: close it here rather than
+    // leaving a zero-share position open for a later exit to "close" again.
+    if (sharesRemaining <= 0) {
+      position = null;
+      updateUnrealized(0);
+    }
 
     return { fill, trade: result.trade };
   }
@@ -362,11 +376,7 @@ export function createPositionTracker(
 
     updatePrice(candle: NormalizedCandle): UpdatePriceResult {
       if (!position) {
-        return {
-          position: null as unknown as ManagedPosition,
-          triggered: null,
-          partialFills: [],
-        };
+        return { position: null, triggered: null, partialFills: [] };
       }
 
       const partialFills: PartialFillResult[] = [];
@@ -395,11 +405,7 @@ export function createPositionTracker(
 
       /** Helper to build a closed-position result */
       function closedResult(fill: FillRecord): UpdatePriceResult {
-        return {
-          position: null as unknown as ManagedPosition,
-          triggered: fill,
-          partialFills,
-        };
+        return { position: null, triggered: fill, partialFills };
       }
 
       // Check stop loss (adverse price hit)
@@ -418,9 +424,19 @@ export function createPositionTracker(
       if (partialTakeProfit && !position.partialTaken) {
         const thresholdPrice = favorablePrice(position.entryPrice, partialTakeProfit.threshold);
         if (hitFavorable(candle, thresholdPrice)) {
-          partialFills.push(
-            executePartialClose(thresholdPrice, candle.time, partialTakeProfit.sellPercent),
+          const partialFill = executePartialClose(
+            thresholdPrice,
+            candle.time,
+            partialTakeProfit.sellPercent,
           );
+          partialFills.push(partialFill);
+
+          // `sellPercent: 100` closes the position. Report it the same way as
+          // any other close, rather than falling through to the checks below
+          // and returning a spread of a null position.
+          if (!position) {
+            return closedResult(partialFill.fill);
+          }
         }
       }
 

--- a/packages/core/src/streaming/position-manager/types.ts
+++ b/packages/core/src/streaming/position-manager/types.ts
@@ -233,7 +233,11 @@ export type PartialFillResult = {
  * Result of updatePrice when SL/TP/trailing is triggered
  */
 export type UpdatePriceResult = {
-  position: ManagedPosition;
+  /**
+   * The position after the bar, or `null` when there is none — because the bar
+   * closed it, or because none was open to begin with.
+   */
+  position: ManagedPosition | null;
   triggered: FillRecord | null;
   partialFills: PartialFillResult[];
 };

--- a/packages/core/src/types/backtest.ts
+++ b/packages/core/src/types/backtest.ts
@@ -97,7 +97,12 @@ export type Trade = {
 export type PartialTakeProfitConfig = {
   /** Profit threshold in percent to trigger partial exit (e.g., 5 = +5%) */
   threshold: number;
-  /** Percentage of position to sell (e.g., 50 = sell 50% of position) */
+  /**
+   * Percentage of position to sell (e.g., 50 = sell 50% of position).
+   *
+   * Must be greater than 0 and at most 100; anything else throws. `100` closes
+   * the position outright rather than leaving an empty one open.
+   */
   sellPercent: number;
 };
 
@@ -140,7 +145,12 @@ export type BreakevenStopConfig = {
 export type ScaleOutLevel = {
   /** Profit threshold in percent to trigger this level (e.g., 5 = +5%) */
   threshold: number;
-  /** Percentage of remaining position to sell (e.g., 33 = sell 33%) */
+  /**
+   * Percentage of remaining position to sell (e.g., 33 = sell 33%).
+   *
+   * Must be greater than 0 and at most 100; anything else throws. `100` sells
+   * whatever is left, closing the position.
+   */
   sellPercent: number;
 };
 


### PR DESCRIPTION
## Problem 1 — `sellPercent: 100` emptied the position instead of closing it

`partialTakeProfit.sellPercent: 100` sold every share, then left the position open with none in it. The next exit — or the end of the data — "closed" that empty position a second time: another exit commission was charged, and a trade with no shares and no return was appended, contaminating the aggregate metrics.

All three engines that implement partial exits had it:

| Engine | Symptom with `sellPercent: 100` |
| --- | --- |
| `runBacktest` | 2 trades instead of 1; final capital 109,969 instead of 109,979 |
| `runBacktestScaled` (2 tranches) | 2 trades; final capital 104,969 with 50,000 stranded in reserve |
| `createPositionTracker` (streaming) | position stayed open with 0 shares; `result.position` was `{}` |

The same file already had the correct shape: `scaleOut` closes the position when a level empties it (`sharesRemaining <= 0 → position = null`) and marks the trade `isPartial: sharesRemaining > 0`. `partialTakeProfit` now does the same in all three engines, and the scaled engine additionally releases the capital reserved for tranches that will never be entered.

## Problem 2 — nothing validated the percentage

`scaleOut.levels[].sellPercent: 150` sold half again as many shares as the position held and credited the account for all of them. Over five bars, 100,000 of capital finished at **164,973** — money from nowhere. `0` and `NaN` were accepted just as quietly.

`partialTakeProfit.sellPercent` and every `scaleOut.levels[].sellPercent` are now validated at the three entry points (`runBacktest`, `runBacktestScaled`, `createPositionTracker`). Values at or below zero, above 100, or `NaN` throw with the offending option named, including the index (`scaleOut.levels[1].sellPercent`). `100` remains valid and means "close what is left", which is what the `ScaleOutConfig` documentation already showed.

The range test is written as a negated comparison so `NaN` — which fails every comparison — is rejected rather than slipping through as "not out of range".

## Problem 3 — the streaming result reported a phantom position

On the bar where a 100% partial exit closed the position, `updatePrice()` fell through to `return { position: { ...position } }`. Spreading a nulled position yields `{}`, so callers got an empty object where `getPosition()` correctly returned `null`; `result.position.shares` read `undefined` instead of failing.

The declared type could not catch this: `UpdatePriceResult.position` was `ManagedPosition`, while two code paths already returned `null` behind a `null as unknown as ManagedPosition` cast. The cast is gone and the field is now `ManagedPosition | null` — what the value has always been at runtime.

## Behavior changes

- `sellPercent: 100` produces one trade where it previously produced two; final capital differs by one exit commission (plus any stranded reserve in the scaled engine).
- Sell percentages outside `(0, 100]` now throw where they previously returned a result computed from an impossible position size.
- Callers reading `UpdatePriceResult.position` must handle `null`.

## Test plan

14 new tests. Backtest side (12), with hand-computed `finalCapital` asserted exactly:

- `sellPercent: 100` yields 1 trade, `isPartial` unset, final capital 109,979 (standard) / 104,979 (scaled, reserve released)
- `sellPercent: 50` still takes a real partial exit followed by an `endOfData` close — regression guard
- `150`, `100.5`, `0`, `-10`, `NaN` rejected for `partialTakeProfit`, through both entry points
- `scaleOut` level of 150 rejected (the 164,973 case); the offending index is named; `100` on a level still accepted

Streaming side (2): a 100% partial exit closes the position, reports `position: null` and `triggered` set to the partial fill, records exactly one trade, and does nothing on later bars; out-of-range percentages are rejected at `createPositionTracker`.

Negative checks: reverting the backtest sources fails 12 of the 12 applicable tests; reverting the tracker fails 2. Removing only the tracker's early return reproduces the reported symptom exactly — `AssertionError: expected {} to be null`.

Verification:

- `pnpm test` (core): 367 files / 6473 tests passed
- `npx tsc --noEmit --ignoreDeprecations 6.0`: clean
- `pnpm build` (core): success
- `npx biome check` on the 8 touched files: clean
- `pnpm test` (mcp / chart): 83 / 934 tests passed