### PR TITLE
fix(core): restart sessions on the next day in regular-hours-only data

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## [Unreleased]
 
+### Fixed — sessions restart on the next day in regular-hours-only data
+
+`detectSessions`, `sessionStats` and `sessionBreakout` decided that one
+occurrence of a session had ended by watching bars fall outside its window.
+That never happens in a series that contains only in-session bars — the shape
+most vendors return for regular trading hours — so every day ran together as a
+single unbroken session:
+
+- `detectSessions` kept counting `barIndex` upward across days (0..11 over two
+  six-bar days instead of 0..5 twice) and held `sessionOpen`, `sessionHigh` and
+  `sessionLow` at the first day's values for the whole series.
+- `sessionStats` merged every day into one occurrence, so `avgRange` reported
+  the spread of the entire series rather than a typical session, and
+  `avgVolume` summed all the bars in it.
+- `sessionBreakout` never completed a session, so no range was ever published
+  and `rangeHigh`/`rangeLow` stayed `null` for every bar — the indicator
+  produced nothing at all.
+
+A new occurrence is now recognised when the local calendar day the session
+opened on changes, which needs no out-of-session bar to be present. Bars before
+the open of a window that crosses midnight are attributed back to the previous
+day, so `22:00`-`06:00` reads as one continuous session rather than being split
+at `00:00`. Keying off the day rather than the clock also keeps a session whole
+across a DST fall-back, where the local clock rewinds an hour and repeats it —
+a New York overnight session running through 2024-11-03 is one session, not
+two.
+
+Sessions are unchanged for data that does contain out-of-session bars.
+
 ### Breaking — partial exit percentages outside `(0, 100]` are rejected
 
 `sellPercent` is a fraction of the shares currently held, but nothing checked

--- a/packages/core/src/indicators/session/__tests__/session-day-rollover.test.ts
+++ b/packages/core/src/indicators/session/__tests__/session-day-rollover.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../../types";
+import { sessionBreakout } from "../session-breakout";
+import type { SessionDefinition } from "../session-definition";
+import { detectSessions } from "../session-definition";
+import { sessionStats } from "../session-stats";
+
+const HOUR = 60 * 60 * 1000;
+
+/** Regular US cash session, expressed in New York time. */
+const NY_REGULAR: SessionDefinition = {
+  name: "regular",
+  startHour: 9,
+  startMinute: 30,
+  endHour: 16,
+  endMinute: 0,
+  timezone: "America/New_York",
+};
+
+/** A session that runs across UTC midnight. */
+const OVERNIGHT: SessionDefinition = {
+  name: "overnight",
+  startHour: 22,
+  startMinute: 0,
+  endHour: 6,
+  endMinute: 0,
+};
+
+/** The same overnight window, but anchored to New York's local clock. */
+const NY_OVERNIGHT: SessionDefinition = { ...OVERNIGHT, timezone: "America/New_York" };
+
+/**
+ * Half-hourly bars spanning New York's DST fall-back, inside one overnight
+ * session. On 2024-11-03 the local clock rewinds 02:00 EDT to 01:00 EST, so
+ * 05:00 UTC and 06:00 UTC are both "01:00" locally.
+ *
+ * Starts at 02:00 UTC (22:00 EDT on 11-02, the session open) and runs to
+ * 08:00 UTC (03:00 EST), still inside the window.
+ */
+function nyDstFallBackBars(): NormalizedCandle[] {
+  return Array.from({ length: 13 }, (_, i) => {
+    const price = 100 + i;
+    return {
+      time: Date.UTC(2024, 10, 3, 2, 0) + i * 30 * 60 * 1000,
+      open: price,
+      high: price + 1,
+      low: price - 1,
+      close: price,
+      volume: 1000,
+    };
+  });
+}
+
+/**
+ * Two trading days of bars that exist ONLY inside the session — the shape a
+ * data vendor returns when it ships regular-hours bars. Six hourly bars per
+ * day starting at 09:30 New York (14:30 UTC in January).
+ */
+function inSessionOnlyBars(): NormalizedCandle[] {
+  const candles: NormalizedCandle[] = [];
+
+  for (const day of [2, 3]) {
+    for (let h = 0; h < 6; h++) {
+      const price = 100 + day + h;
+      candles.push({
+        time: Date.UTC(2024, 0, day, 14, 30) + h * HOUR,
+        open: price,
+        high: price + 1,
+        low: price - 1,
+        close: price,
+        volume: 1000,
+      });
+    }
+  }
+
+  return candles;
+}
+
+/**
+ * One overnight session (22:00 to 05:00 UTC) plus the first bar of the next
+ * one. The UTC calendar day changes in the middle of the first session.
+ */
+function overnightBars(): NormalizedCandle[] {
+  const start = Date.UTC(2024, 0, 2, 22, 0);
+
+  return Array.from({ length: 9 }, (_, i) => {
+    // 22:00..05:00 is 8 bars; the 9th jumps to the next session's 22:00.
+    const time = i < 8 ? start + i * HOUR : start + 24 * HOUR;
+    const price = 100 + i;
+    return {
+      time,
+      open: price,
+      high: price + 1,
+      low: price - 1,
+      close: price,
+      volume: 1000,
+    };
+  });
+}
+
+describe("session rollover with in-session-only data", () => {
+  describe("detectSessions", () => {
+    it("restarts the session on the next day", () => {
+      // Detecting the boundary by watching bars leave the window cannot work
+      // here: no bar is ever outside it. barIndex previously ran 0..11 across
+      // both days and sessionOpen stayed at the first day's open.
+      const result = detectSessions(inSessionOnlyBars(), [NY_REGULAR]);
+
+      expect(result.map((r) => r.value.barIndex)).toEqual([0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5]);
+      expect(result.map((r) => r.value.sessionOpen)).toEqual([
+        102, 102, 102, 102, 102, 102, 103, 103, 103, 103, 103, 103,
+      ]);
+      // Each day's high is its last bar's high, not the whole series'.
+      expect(result[5].value.sessionHigh).toBe(108);
+      expect(result[11].value.sessionHigh).toBe(109);
+    });
+
+    it("keeps a session that crosses midnight in one piece", () => {
+      // Why the boundary is the day the session OPENED on rather than the date
+      // printed on each bar: this session spans two calendar dates.
+      const result = detectSessions(overnightBars(), [OVERNIGHT]);
+
+      expect(result.slice(0, 8).map((r) => r.value.barIndex)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+      expect(result.slice(0, 8).every((r) => r.value.sessionOpen === 100)).toBe(true);
+      // The next 22:00 bar starts a new occurrence.
+      expect(result[8].value.barIndex).toBe(0);
+      expect(result[8].value.sessionOpen).toBe(108);
+    });
+  });
+
+  describe("sessionStats", () => {
+    it("counts each day as its own occurrence", () => {
+      // Previously both days merged into one occurrence, so avgRange reported
+      // the whole series' spread (109 - 101 = 8) and avgVolume summed 12 bars.
+      const [stats] = sessionStats(inSessionOnlyBars(), { sessions: [NY_REGULAR] });
+
+      expect(stats.session).toBe("regular");
+      // Day 1: high 108, low 101. Day 2: high 109, low 102. Both span 7.
+      expect(stats.avgRange).toBe(7);
+      expect(stats.avgVolume).toBe(6000);
+      expect(stats.barCount).toBe(12);
+    });
+  });
+
+  describe("sessionBreakout", () => {
+    it("publishes the first day's range once the second day opens", () => {
+      // The session never appeared to end, so no range was ever completed and
+      // every bar carried a null range.
+      const result = sessionBreakout(inSessionOnlyBars(), { sessions: [NY_REGULAR] });
+
+      expect(result.slice(0, 6).every((r) => r.value.rangeHigh === null)).toBe(true);
+      expect(result[6].value.fromSession).toBe("regular");
+      expect(result[6].value.rangeHigh).toBe(108);
+      expect(result[6].value.rangeLow).toBe(101);
+    });
+
+    it("flags a breakout above the previous day's range", () => {
+      const result = sessionBreakout(inSessionOnlyBars(), { sessions: [NY_REGULAR] });
+
+      // Day 2 closes climb 103..108; the day-1 high is 108, so the last bars
+      // do not exceed it, but the range is live rather than null.
+      expect(result[11].value.rangeHigh).toBe(108);
+      expect(result[11].value.breakout).toBeNull();
+    });
+  });
+});
+
+describe("DST fall-back inside one session", () => {
+  // The local clock repeats an hour, so elapsed local time moves backwards
+  // mid-session. Anything keying off the clock alone splits the session here;
+  // the day it opened on does not change.
+
+  it("detectSessions keeps one session across the repeated hour", () => {
+    const result = detectSessions(nyDstFallBackBars(), [NY_OVERNIGHT]);
+
+    expect(result.map((r) => r.value.barIndex)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    expect(result.every((r) => r.value.sessionOpen === 100)).toBe(true);
+    expect(result[12].value.sessionHigh).toBe(113);
+  });
+
+  it("sessionStats reports one occurrence, not two", () => {
+    const [stats] = sessionStats(nyDstFallBackBars(), { sessions: [NY_OVERNIGHT] });
+
+    // One occurrence spanning high 113 and low 99. Split at the repeated hour,
+    // the two halves would average (9 + 6) / 2 = 7.5 instead.
+    expect(stats.avgRange).toBe(14);
+    expect(stats.avgVolume).toBe(13000);
+    expect(stats.barCount).toBe(13);
+  });
+
+  it("sessionBreakout does not publish a range mid-session", () => {
+    const result = sessionBreakout(nyDstFallBackBars(), { sessions: [NY_OVERNIGHT] });
+
+    // The session has not ended, so there is no completed range to break out of.
+    expect(result.every((r) => r.value.rangeHigh === null)).toBe(true);
+    expect(result.every((r) => r.value.breakout === null)).toBe(true);
+  });
+});
+
+describe("session rollover with out-of-session bars present", () => {
+  it("still detects the boundary the original way", () => {
+    // Regression guard: when the data does contain bars outside the window,
+    // the in/out transition alone already found the boundary and must keep
+    // producing the same result.
+    const candles: NormalizedCandle[] = [];
+    for (const day of [2, 3]) {
+      // 12:00 UTC = 07:00 New York — before the open.
+      for (const hoursFromMidnightUtc of [12, 14.5, 15.5, 21]) {
+        const time = Date.UTC(2024, 0, day) + hoursFromMidnightUtc * HOUR;
+        const price = 100 + day;
+        candles.push({
+          time,
+          open: price,
+          high: price + 1,
+          low: price - 1,
+          close: price,
+          volume: 1000,
+        });
+      }
+    }
+
+    const result = detectSessions(candles, [NY_REGULAR]);
+
+    // Per day: out, in (barIndex 0), in (barIndex 1), out.
+    expect(result.map((r) => r.value.session)).toEqual([
+      null,
+      "regular",
+      "regular",
+      null,
+      null,
+      "regular",
+      "regular",
+      null,
+    ]);
+    expect(result.map((r) => r.value.barIndex)).toEqual([0, 0, 1, 0, 0, 0, 1, 0]);
+  });
+});

--- a/packages/core/src/indicators/session/__tests__/tz-utils.test.ts
+++ b/packages/core/src/indicators/session/__tests__/tz-utils.test.ts
@@ -5,7 +5,37 @@
 import { describe, expect, it } from "vitest";
 import type { Candle } from "../../../types";
 import { detectSessions } from "../session-definition";
-import { getTzHourMinute } from "../tz-utils";
+import { getTzDateTime, getTzHourMinute } from "../tz-utils";
+
+describe("getTzDateTime", () => {
+  it("returns the UTC date and time when timezone is omitted or 'UTC'", () => {
+    const t = Date.UTC(2026, 0, 15, 13, 45, 0);
+    const expected = { year: 2026, month: 1, day: 15, hour: 13, minute: 45 };
+    expect(getTzDateTime(t)).toEqual(expected);
+    expect(getTzDateTime(t, "UTC")).toEqual(expected);
+  });
+
+  it("reports the local calendar date, which can differ from the UTC one", () => {
+    // 2026-01-15 02:30 UTC is still 2026-01-14 in New York.
+    expect(getTzDateTime(Date.UTC(2026, 0, 15, 2, 30), "America/New_York")).toEqual({
+      year: 2026,
+      month: 1,
+      day: 14,
+      hour: 21,
+      minute: 30,
+    });
+  });
+
+  it("keeps the date stable across a DST fall-back, when the clock repeats", () => {
+    // New York rewinds 02:00 EDT to 01:00 EST on 2024-11-03: both of these
+    // read 01:30 locally, an hour apart in real time, on the same date.
+    const beforeRewind = getTzDateTime(Date.UTC(2024, 10, 3, 5, 30), "America/New_York");
+    const afterRewind = getTzDateTime(Date.UTC(2024, 10, 3, 6, 30), "America/New_York");
+
+    expect(beforeRewind).toEqual({ year: 2024, month: 11, day: 3, hour: 1, minute: 30 });
+    expect(afterRewind).toEqual(beforeRewind);
+  });
+});
 
 describe("getTzHourMinute", () => {
   it("returns UTC hour/minute when timezone is omitted or 'UTC'", () => {

--- a/packages/core/src/indicators/session/session-breakout.ts
+++ b/packages/core/src/indicators/session/session-breakout.ts
@@ -14,8 +14,9 @@ import {
   isInAnyBreak,
   isInSessionWindow,
   type SessionDefinition,
+  sessionOccurrenceKey,
 } from "./session-definition";
-import { getTzHourMinute } from "./tz-utils";
+import { getTzDateTime, type TzDateTime } from "./tz-utils";
 
 /**
  * Options for sessionBreakout
@@ -79,6 +80,7 @@ export function sessionBreakout(
   let activeSessionName: string | null = null;
   let activeHigh = Number.NEGATIVE_INFINITY;
   let activeLow = Number.POSITIVE_INFINITY;
+  let activeOccurrence = -1;
 
   // Most recent completed session range
   let completedSessionName: string | null = null;
@@ -92,12 +94,14 @@ export function sessionBreakout(
     let matchedSession: SessionDefinition | null = null;
     let matchedHour = 0;
     let matchedMinute = 0;
+    let matchedLocal: TzDateTime | null = null;
     for (const session of sessionDefs) {
-      const { hour, minute } = getTzHourMinute(candle.time, session.timezone);
-      if (isInSessionWindow(hour, minute, session)) {
+      const local = getTzDateTime(candle.time, session.timezone);
+      if (isInSessionWindow(local.hour, local.minute, session)) {
         matchedSession = session;
-        matchedHour = hour;
-        matchedMinute = minute;
+        matchedHour = local.hour;
+        matchedMinute = local.minute;
+        matchedLocal = local;
         break;
       }
     }
@@ -107,8 +111,20 @@ export function sessionBreakout(
       matchedSession.breaks !== undefined &&
       isInAnyBreak(matchedHour, matchedMinute, matchedSession.breaks);
 
+    const occurrence =
+      matchedSession === null || matchedLocal === null
+        ? -1
+        : sessionOccurrenceKey(matchedLocal, matchedSession);
+
+    // The same session starting again — the day it opened on changed. Data
+    // holding only in-session bars never leaves the window, so without this the
+    // session never completes and no range is ever published.
+    const rolledOver =
+      matchedName !== null && matchedName === activeSessionName && occurrence !== activeOccurrence;
+    activeOccurrence = occurrence;
+
     // Handle session transitions
-    if (matchedName !== activeSessionName) {
+    if (matchedName !== activeSessionName || rolledOver) {
       // If we had an active session and it just ended, save its range
       if (activeSessionName !== null && activeHigh !== Number.NEGATIVE_INFINITY) {
         completedSessionName = activeSessionName;

--- a/packages/core/src/indicators/session/session-definition.ts
+++ b/packages/core/src/indicators/session/session-definition.ts
@@ -10,7 +10,7 @@
 
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import type { Candle, NormalizedCandle, Series } from "../../types";
-import { getTzHourMinute } from "./tz-utils";
+import { getTzDateTime, type TzDateTime } from "./tz-utils";
 
 /**
  * An intra-session break (e.g. lunch break on JPX/HKEX).
@@ -229,6 +229,43 @@ export function isInSessionWindow(
 }
 
 /**
+ * Identifies which occurrence of a session a bar belongs to: the local
+ * calendar day the session opened on, as epoch milliseconds at UTC midnight so
+ * that occurrences compare as plain numbers.
+ *
+ * Used to tell one occurrence from the next. Watching bars leave the window
+ * only works when the data contains out-of-session bars; a series holding
+ * regular-hours bars only never leaves, so every day would merge into a single
+ * unbroken session.
+ *
+ * Two properties make this the day the session *started* rather than the day
+ * printed on the bar:
+ *
+ * - A window that crosses midnight stays one session. For `22:00`-`06:00`, the
+ *   bars from midnight to 06:00 are attributed back to the previous day, so the
+ *   session does not split at `00:00`.
+ * - A DST fall-back does not split a session. The local clock repeats an hour
+ *   — New York runs 01:30 EDT then 01:00 EST — so elapsed local time can move
+ *   backwards inside one session, but the calendar day it started on does not.
+ *
+ * @param dt - Local date and time of the bar, in the session's timezone
+ * @param session - The session the bar falls inside
+ */
+export function sessionOccurrenceKey(dt: TzDateTime, session: SessionDefinition): number {
+  const localDay = Date.UTC(dt.year, dt.month - 1, dt.day);
+  const startMinutes = session.startHour * 60 + session.startMinute;
+  const endMinutes = session.endHour * 60 + session.endMinute;
+  const crossesMidnight = startMinutes > endMinutes;
+
+  if (crossesMidnight && dt.hour * 60 + dt.minute < startMinutes) {
+    return localDay - MS_PER_DAY;
+  }
+  return localDay;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
  * Check if (hour, minute) falls inside any of the given breaks.
  */
 export function isInAnyBreak(hour: number, minute: number, breaks: SessionBreak[]): boolean {
@@ -298,6 +335,7 @@ export function detectSessions(
   let sessionOpen: number | null = null;
   let sessionHigh: number | null = null;
   let sessionLow: number | null = null;
+  let currentOccurrence = -1;
 
   for (const candle of normalized) {
     // Find the session whose outer window contains this candle (break-agnostic),
@@ -305,12 +343,14 @@ export function detectSessions(
     let anchorSession: SessionDefinition | null = null;
     let anchorHour = 0;
     let anchorMinute = 0;
+    let anchorLocal: TzDateTime | null = null;
     for (const session of sessionDefs) {
-      const { hour, minute } = getTzHourMinute(candle.time, session.timezone);
-      if (isInSessionWindow(hour, minute, session)) {
+      const local = getTzDateTime(candle.time, session.timezone);
+      if (isInSessionWindow(local.hour, local.minute, session)) {
         anchorSession = session;
-        anchorHour = hour;
-        anchorMinute = minute;
+        anchorHour = local.hour;
+        anchorMinute = local.minute;
+        anchorLocal = local;
         break;
       }
     }
@@ -319,9 +359,20 @@ export function detectSessions(
       anchorSession.breaks !== undefined &&
       isInAnyBreak(anchorHour, anchorMinute, anchorSession.breaks);
     const anchorName = anchorSession?.name ?? null;
+    const occurrence =
+      anchorSession === null || anchorLocal === null
+        ? -1
+        : sessionOccurrenceKey(anchorLocal, anchorSession);
+
+    // A new occurrence of the same session — the day it opened on changed.
+    // Without this, a series carrying only in-session bars never leaves the
+    // window and every day runs together as one session.
+    const rolledOver =
+      anchorName !== null && anchorName === currentSessionName && occurrence !== currentOccurrence;
+    currentOccurrence = occurrence;
 
     // Session anchor changed (new session entered, or fell outside everything)
-    if (anchorName !== currentSessionName) {
+    if (anchorName !== currentSessionName || rolledOver) {
       currentSessionName = anchorName;
       barIndex = 0;
       if (anchorName !== null && !inBreak) {

--- a/packages/core/src/indicators/session/session-stats.ts
+++ b/packages/core/src/indicators/session/session-stats.ts
@@ -12,8 +12,9 @@ import {
   isInAnyBreak,
   isInSessionWindow,
   type SessionDefinition,
+  sessionOccurrenceKey,
 } from "./session-definition";
-import { getTzHourMinute } from "./tz-utils";
+import { getTzDateTime } from "./tz-utils";
 
 /**
  * Options for sessionStats
@@ -92,15 +93,18 @@ export function sessionStats(
   // Track current occurrence per session
   const currentOcc = new Map<string, SessionOccurrence | null>();
   const prevSession = new Map<string, boolean>();
+  const prevOccurrence = new Map<string, number>();
 
   for (const session of sessionDefs) {
     currentOcc.set(session.name, null);
     prevSession.set(session.name, false);
+    prevOccurrence.set(session.name, -1);
   }
 
   for (const candle of normalized) {
     for (const session of sessionDefs) {
-      const { hour, minute } = getTzHourMinute(candle.time, session.timezone);
+      const local = getTzDateTime(candle.time, session.timezone);
+      const { hour, minute } = local;
       // Use the outer window for occurrence boundary detection, so a lunch break
       // does not split one session into two occurrences.
       const inWindow = isInSessionWindow(hour, minute, session);
@@ -108,8 +112,26 @@ export function sessionStats(
         inWindow && session.breaks !== undefined && isInAnyBreak(hour, minute, session.breaks);
       const wasInWindow = prevSession.get(session.name) ?? false;
 
+      // The same session starting again — the day it opened on changed. Data
+      // holding only in-session bars never leaves the window, so without this
+      // every day merges into one long occurrence and the averages describe the
+      // whole series rather than a session.
+      const occurrence = inWindow ? sessionOccurrenceKey(local, session) : -1;
+      const rolledOver =
+        inWindow && wasInWindow && occurrence !== (prevOccurrence.get(session.name) ?? -1);
+      prevOccurrence.set(session.name, occurrence);
+
+      if (rolledOver) {
+        // Close the previous occurrence before the new one starts.
+        const finished = currentOcc.get(session.name);
+        if (finished && finished.totalBars > 0) {
+          occurrences.get(session.name)?.push(finished);
+        }
+        currentOcc.set(session.name, null);
+      }
+
       if (inWindow) {
-        if (!wasInWindow) {
+        if (!wasInWindow || rolledOver) {
           // New session occurrence starts. Seed with this bar unless it is in a break.
           const occ: SessionOccurrence = inBreak
             ? {

--- a/packages/core/src/indicators/session/tz-utils.ts
+++ b/packages/core/src/indicators/session/tz-utils.ts
@@ -2,18 +2,81 @@
  * Timezone utilities for session detection.
  *
  * Uses the runtime's built-in `Intl.DateTimeFormat` (zero external deps)
- * to convert a UTC epoch ms into local hour/minute for any IANA timezone.
+ * to convert a UTC epoch ms into local date/time for any IANA timezone.
  * DST is handled automatically by the runtime's tzdata.
  */
 
 /**
+ * Local calendar date and clock time in some timezone.
+ *
+ * `month` is 1-based, matching how a date is written rather than
+ * `Date.getMonth()`.
+ */
+export type TzDateTime = {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+};
+
+/**
+ * Returns the local date and time for the given UTC epoch milliseconds in the
+ * specified IANA timezone (e.g. "America/New_York", "Asia/Tokyo").
+ *
+ * - For "UTC" (or empty / undefined input), uses the native getUTC* accessors
+ *   to avoid the Intl.DateTimeFormat allocation cost.
+ * - For other zones, uses Intl.DateTimeFormat.formatToParts with DST applied
+ *   automatically.
+ *
+ * The calendar date matters as much as the clock time: on a DST fall-back day
+ * the local clock repeats an hour, so the time alone cannot tell one part of a
+ * session from another, while the date it belongs to still can.
+ *
+ * @param epochMs - Time in UTC epoch milliseconds
+ * @param timezone - IANA timezone identifier (default "UTC")
+ *
+ * @example
+ * ```ts
+ * // 2026-03-01 14:00 UTC = 09:00 New York EST (winter)
+ * getTzDateTime(Date.UTC(2026, 2, 1, 14, 0), "America/New_York");
+ * // => { year: 2026, month: 3, day: 1, hour: 9, minute: 0 }
+ * ```
+ */
+export function getTzDateTime(epochMs: number, timezone = "UTC"): TzDateTime {
+  if (!timezone || timezone === "UTC") {
+    const d = new Date(epochMs);
+    return {
+      year: d.getUTCFullYear(),
+      month: d.getUTCMonth() + 1,
+      day: d.getUTCDate(),
+      hour: d.getUTCHours(),
+      minute: d.getUTCMinutes(),
+    };
+  }
+
+  const fmt = getCachedFormatter(timezone);
+  const parts = fmt.formatToParts(epochMs);
+  let year = 0;
+  let month = 1;
+  let day = 1;
+  let hour = 0;
+  let minute = 0;
+  for (const p of parts) {
+    if (p.type === "hour") hour = Number(p.value);
+    else if (p.type === "minute") minute = Number(p.value);
+    else if (p.type === "year") year = Number(p.value);
+    else if (p.type === "month") month = Number(p.value);
+    else if (p.type === "day") day = Number(p.value);
+  }
+  // Some locales render midnight as "24" — normalize to 0.
+  if (hour === 24) hour = 0;
+  return { year, month, day, hour, minute };
+}
+
+/**
  * Returns the local { hour, minute } for the given UTC epoch milliseconds
  * in the specified IANA timezone (e.g. "America/New_York", "Asia/Tokyo").
- *
- * - For "UTC" (or empty / undefined input), uses native getUTCHours/Minutes
- *   to avoid the Intl.DateTimeFormat allocation cost.
- * - For other zones, uses Intl.DateTimeFormat.formatToParts to extract
- *   the hour and minute fields with DST applied automatically.
  *
  * @param epochMs - Time in UTC epoch milliseconds
  * @param timezone - IANA timezone identifier (default "UTC")
@@ -33,21 +96,7 @@ export function getTzHourMinute(
   epochMs: number,
   timezone = "UTC",
 ): { hour: number; minute: number } {
-  if (!timezone || timezone === "UTC") {
-    const d = new Date(epochMs);
-    return { hour: d.getUTCHours(), minute: d.getUTCMinutes() };
-  }
-
-  const fmt = getCachedFormatter(timezone);
-  const parts = fmt.formatToParts(epochMs);
-  let hour = 0;
-  let minute = 0;
-  for (const p of parts) {
-    if (p.type === "hour") hour = Number(p.value);
-    else if (p.type === "minute") minute = Number(p.value);
-  }
-  // Some locales render midnight as "24" — normalize to 0.
-  if (hour === 24) hour = 0;
+  const { hour, minute } = getTzDateTime(epochMs, timezone);
   return { hour, minute };
 }
 
@@ -58,6 +107,9 @@ function getCachedFormatter(timezone: string): Intl.DateTimeFormat {
   if (!fmt) {
     fmt = new Intl.DateTimeFormat("en-US", {
       timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
       hour: "2-digit",
       minute: "2-digit",
       hour12: false,


### PR DESCRIPTION
## Problem

`detectSessions`, `sessionStats` and `sessionBreakout` decided that one occurrence of a session had ended by watching bars fall outside its window. That never happens in a series containing only in-session bars — the shape most vendors return for regular trading hours — so every day ran together as a single unbroken session.

Measured over two six-bar days of a New York 09:30-16:00 session:

| Function | Before | After |
| --- | --- | --- |
| `detectSessions` | `barIndex` ran 0..11 across both days; `sessionOpen` stayed at day 1's open for the whole series | 0..5 twice; `sessionOpen` 102 then 103 |
| `sessionStats` | one merged occurrence: `avgRange` 8 (the series' spread), `avgVolume` 12000 | two occurrences: `avgRange` 7, `avgVolume` 6000 |
| `sessionBreakout` | `rangeHigh`/`rangeLow` `null` on every bar — the indicator produced nothing | day 1's range (108/101) published once day 2 opens |

## Fix

A new occurrence is recognised when the local calendar day the session *opened on* changes. That needs no out-of-session bar to be present.

Keying off the opening day rather than the date printed on each bar is what keeps two other cases whole:

- **A window that crosses midnight.** Bars before the open are attributed back to the previous day, so `22:00`-`06:00` stays one session instead of splitting at `00:00`.
- **A DST fall-back.** The local clock rewinds an hour and repeats it, so elapsed local time moves backwards mid-session. A New York overnight session running through 2024-11-03 reads 01:30 EDT then 01:00 EST — the clock goes back, the day it opened on does not.

`tz-utils` gains `getTzDateTime`, returning the local calendar date alongside the clock time; `getTzHourMinute` is now a thin wrapper over it. The date fields come from the same cached `Intl.DateTimeFormat`, so the number of `formatToParts` calls per bar is unchanged and the public signature is untouched.

Sessions are unchanged for data that does contain out-of-session bars.

## Test plan

12 new tests: 6 for in-session-only data, 3 for the DST fall-back (half-hourly bars, all three functions), and 3 unit tests for `getTzDateTime`.

Both halves of the design are proven to be guarded, by reverting each in isolation:

| Probe | Failing tests |
| --- | --- |
| Drop the crosses-midnight attribution (use the raw calendar day) | 4 — the overnight test and all three DST tests |
| Key off elapsed clock time inside the window instead of the date | 6 — including all three DST tests |

Negative check: reverting the four sources fails 8 of the 21 tests in the two files; the guard covering data that *does* contain out-of-session bars passes either way, as it should.

Verification:

- `pnpm test` (core): 368 files / 6485 tests passed
- `npx tsc --noEmit --ignoreDeprecations 6.0`: clean
- `pnpm build` (core): success
- `npx biome check` on the touched directory: clean
- `pnpm test` (mcp / chart): 83 / 934 tests passed