### PR TITLE
refactor(core): single owner for where a bar sits in a session

### DIFF
--- a/packages/core/src/indicators/session/__tests__/session-membership.test.ts
+++ b/packages/core/src/indicators/session/__tests__/session-membership.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import type { SessionDefinition } from "../session-definition";
+import { resolveSessionMembership } from "../session-definition";
+
+/** New York cash session, with an artificial mid-session break. */
+const NY_REGULAR: SessionDefinition = {
+  name: "regular",
+  startHour: 9,
+  startMinute: 30,
+  endHour: 16,
+  endMinute: 0,
+  timezone: "America/New_York",
+};
+
+const NY_WITH_BREAK: SessionDefinition = {
+  ...NY_REGULAR,
+  breaks: [{ startHour: 12, startMinute: 0, endHour: 13, endMinute: 0 }],
+};
+
+/** Runs across midnight, in New York local time. */
+const NY_OVERNIGHT: SessionDefinition = {
+  name: "overnight",
+  startHour: 22,
+  startMinute: 0,
+  endHour: 6,
+  endMinute: 0,
+  timezone: "America/New_York",
+};
+
+describe("resolveSessionMembership", () => {
+  describe("inside the window", () => {
+    it("reports elapsed minutes from the session open", () => {
+      // 2024-01-02 15:00 UTC = 10:00 New York, 30 minutes after the 09:30 open.
+      const m = resolveSessionMembership(Date.UTC(2024, 0, 2, 15, 0), NY_REGULAR);
+
+      expect(m.inWindow).toBe(true);
+      expect(m.inBreak).toBe(false);
+      expect(m.active).toBe(true);
+      expect(m.elapsedMinutes).toBe(30);
+    });
+
+    it("reports zero elapsed minutes on the opening bar", () => {
+      const m = resolveSessionMembership(Date.UTC(2024, 0, 2, 14, 30), NY_REGULAR);
+
+      expect(m.elapsedMinutes).toBe(0);
+      expect(m.active).toBe(true);
+    });
+
+    it("counts elapsed minutes continuously across midnight", () => {
+      // 22:00 open; 01:00 local the next morning is three hours in.
+      const open = resolveSessionMembership(Date.UTC(2024, 0, 3, 3, 0), NY_OVERNIGHT);
+      const later = resolveSessionMembership(Date.UTC(2024, 0, 3, 6, 0), NY_OVERNIGHT);
+
+      expect(open.elapsedMinutes).toBe(0);
+      expect(later.elapsedMinutes).toBe(180);
+    });
+  });
+
+  describe("inside a break", () => {
+    it("stays in the window but is not active", () => {
+      // 17:30 UTC = 12:30 New York, inside the 12:00-13:00 break.
+      const m = resolveSessionMembership(Date.UTC(2024, 0, 2, 17, 30), NY_WITH_BREAK);
+
+      expect(m.inWindow).toBe(true);
+      expect(m.inBreak).toBe(true);
+      expect(m.active).toBe(false);
+      // Elapsed time keeps running through the break — the session has not
+      // restarted, it has paused.
+      expect(m.elapsedMinutes).toBe(180);
+    });
+
+    it("becomes active again after the break ends", () => {
+      const m = resolveSessionMembership(Date.UTC(2024, 0, 2, 18, 0), NY_WITH_BREAK);
+
+      expect(m.inBreak).toBe(false);
+      expect(m.active).toBe(true);
+    });
+  });
+
+  describe("outside the window", () => {
+    it("reports nothing usable rather than a stale position", () => {
+      // 13:00 UTC = 08:00 New York, before the open.
+      const m = resolveSessionMembership(Date.UTC(2024, 0, 2, 13, 0), NY_REGULAR);
+
+      expect(m).toEqual({
+        occurrenceKey: -1,
+        elapsedMinutes: -1,
+        inWindow: false,
+        inBreak: false,
+        active: false,
+      });
+    });
+  });
+
+  describe("occurrenceKey", () => {
+    it("is stable within one day and changes on the next", () => {
+      const morning = resolveSessionMembership(Date.UTC(2024, 0, 2, 14, 30), NY_REGULAR);
+      const afternoon = resolveSessionMembership(Date.UTC(2024, 0, 2, 20, 0), NY_REGULAR);
+      const nextDay = resolveSessionMembership(Date.UTC(2024, 0, 3, 14, 30), NY_REGULAR);
+
+      expect(afternoon.occurrenceKey).toBe(morning.occurrenceKey);
+      expect(nextDay.occurrenceKey).not.toBe(morning.occurrenceKey);
+    });
+
+    it("attributes post-midnight bars back to the day the session opened", () => {
+      // Both belong to the session that opened at 22:00 on 2024-01-02 local.
+      const beforeMidnight = resolveSessionMembership(Date.UTC(2024, 0, 3, 3, 0), NY_OVERNIGHT);
+      const afterMidnight = resolveSessionMembership(Date.UTC(2024, 0, 3, 8, 0), NY_OVERNIGHT);
+
+      expect(afterMidnight.occurrenceKey).toBe(beforeMidnight.occurrenceKey);
+    });
+
+    it("survives a DST fall-back, where the local clock repeats an hour", () => {
+      // New York rewinds 02:00 EDT to 01:00 EST on 2024-11-03. Both of these
+      // read 01:30 locally, an hour apart in real time.
+      const beforeRewind = resolveSessionMembership(Date.UTC(2024, 10, 3, 5, 30), NY_OVERNIGHT);
+      const afterRewind = resolveSessionMembership(Date.UTC(2024, 10, 3, 6, 30), NY_OVERNIGHT);
+
+      expect(afterRewind.occurrenceKey).toBe(beforeRewind.occurrenceKey);
+      // Elapsed minutes are clock-derived, so an hour of real time passes
+      // without them advancing.
+      expect(afterRewind.elapsedMinutes).toBe(beforeRewind.elapsedMinutes);
+    });
+
+    it("holds while elapsed minutes run backwards across the repeated hour", () => {
+      // 01:30 EDT, then half an hour later 01:00 EST: the clock has gone back,
+      // so elapsed minutes shrink. This is the case that made an elapsed-time
+      // comparison split one session in two, and why occurrenceKey — not
+      // elapsedMinutes — identifies an occurrence.
+      const beforeRewind = resolveSessionMembership(Date.UTC(2024, 10, 3, 5, 30), NY_OVERNIGHT);
+      const afterRewind = resolveSessionMembership(Date.UTC(2024, 10, 3, 6, 0), NY_OVERNIGHT);
+
+      expect(afterRewind.elapsedMinutes).toBeLessThan(beforeRewind.elapsedMinutes);
+      expect(afterRewind.occurrenceKey).toBe(beforeRewind.occurrenceKey);
+    });
+  });
+});

--- a/packages/core/src/indicators/session/session-breakout.ts
+++ b/packages/core/src/indicators/session/session-breakout.ts
@@ -11,12 +11,10 @@ import { tagSeries } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, Series } from "../../types";
 import {
   getIctSessions,
-  isInAnyBreak,
-  isInSessionWindow,
+  resolveSessionMembership,
   type SessionDefinition,
-  sessionOccurrenceKey,
+  type SessionMembership,
 } from "./session-definition";
-import { getTzDateTime, type TzDateTime } from "./tz-utils";
 
 /**
  * Options for sessionBreakout
@@ -91,30 +89,18 @@ export function sessionBreakout(
     // Determine session using the outer window; bars inside a break remain
     // attached to the session but do not update its range. Each session's
     // own timezone is honored.
-    let matchedSession: SessionDefinition | null = null;
-    let matchedHour = 0;
-    let matchedMinute = 0;
-    let matchedLocal: TzDateTime | null = null;
+    let matchedName: string | null = null;
+    let membership: SessionMembership | null = null;
     for (const session of sessionDefs) {
-      const local = getTzDateTime(candle.time, session.timezone);
-      if (isInSessionWindow(local.hour, local.minute, session)) {
-        matchedSession = session;
-        matchedHour = local.hour;
-        matchedMinute = local.minute;
-        matchedLocal = local;
+      const resolved = resolveSessionMembership(candle.time, session);
+      if (resolved.inWindow) {
+        matchedName = session.name;
+        membership = resolved;
         break;
       }
     }
-    const matchedName = matchedSession?.name ?? null;
-    const inBreak =
-      matchedSession !== null &&
-      matchedSession.breaks !== undefined &&
-      isInAnyBreak(matchedHour, matchedMinute, matchedSession.breaks);
-
-    const occurrence =
-      matchedSession === null || matchedLocal === null
-        ? -1
-        : sessionOccurrenceKey(matchedLocal, matchedSession);
+    const inBreak = membership?.inBreak ?? false;
+    const occurrence = membership?.occurrenceKey ?? -1;
 
     // The same session starting again — the day it opened on changed. Data
     // holding only in-session bars never leaves the window, so without this the

--- a/packages/core/src/indicators/session/session-definition.ts
+++ b/packages/core/src/indicators/session/session-definition.ts
@@ -264,6 +264,90 @@ export function sessionOccurrenceKey(dt: TzDateTime, session: SessionDefinition)
 }
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const MINUTES_PER_DAY = 24 * 60;
+
+/**
+ * Where a bar sits relative to one session.
+ *
+ * Single owner of the four questions every session-aware indicator asks: which
+ * timezone the bar reads in, whether it is inside the window, whether it is in
+ * a break, and which occurrence of the session it belongs to. Answering them
+ * separately in each indicator is how they drifted apart in the first place.
+ */
+export type SessionMembership = {
+  /**
+   * Identifies the occurrence (see `sessionOccurrenceKey`), or `-1` when the
+   * bar is outside the window.
+   */
+  occurrenceKey: number;
+  /**
+   * Minutes since the session opened, or `-1` when the bar is outside the
+   * window.
+   *
+   * Read from the local clock, so it rewinds during a DST fall-back — never
+   * use it to tell one occurrence from another. `occurrenceKey` is the field
+   * for that. Its purpose is measuring position *within* an occurrence, such
+   * as an opening range.
+   */
+  elapsedMinutes: number;
+  /** Inside the session's outer window, breaks included. */
+  inWindow: boolean;
+  /** Inside one of the session's breaks. */
+  inBreak: boolean;
+  /** Inside the session and trading — `inWindow && !inBreak`. */
+  active: boolean;
+};
+
+const OUTSIDE_SESSION: SessionMembership = {
+  occurrenceKey: -1,
+  elapsedMinutes: -1,
+  inWindow: false,
+  inBreak: false,
+  active: false,
+};
+
+/**
+ * Resolve where a bar sits relative to a session, in that session's own
+ * timezone.
+ *
+ * @param epochMs - Bar time in UTC epoch milliseconds
+ * @param session - The session to test the bar against
+ *
+ * @example
+ * ```ts
+ * const nyOpen: SessionDefinition = {
+ *   ...defineSession("NY", 9, 30, 16, 0),
+ *   timezone: "America/New_York",
+ * };
+ * // 15:00 UTC = 10:00 in New York, half an hour after the open
+ * const m = resolveSessionMembership(Date.UTC(2024, 0, 2, 15, 0), nyOpen);
+ * // => { elapsedMinutes: 30, inWindow: true, inBreak: false, active: true, occurrenceKey: ... }
+ * ```
+ */
+export function resolveSessionMembership(
+  epochMs: number,
+  session: SessionDefinition,
+): SessionMembership {
+  const local = getTzDateTime(epochMs, session.timezone);
+
+  if (!isInSessionWindow(local.hour, local.minute, session)) {
+    return OUTSIDE_SESSION;
+  }
+
+  const inBreak =
+    session.breaks !== undefined && isInAnyBreak(local.hour, local.minute, session.breaks);
+  const startMinutes = session.startHour * 60 + session.startMinute;
+  const elapsedMinutes =
+    (local.hour * 60 + local.minute - startMinutes + MINUTES_PER_DAY) % MINUTES_PER_DAY;
+
+  return {
+    occurrenceKey: sessionOccurrenceKey(local, session),
+    elapsedMinutes,
+    inWindow: true,
+    inBreak,
+    active: !inBreak,
+  };
+}
 
 /**
  * Check if (hour, minute) falls inside any of the given breaks.
@@ -341,28 +425,18 @@ export function detectSessions(
     // Find the session whose outer window contains this candle (break-agnostic),
     // evaluating each session in its own configured timezone.
     let anchorSession: SessionDefinition | null = null;
-    let anchorHour = 0;
-    let anchorMinute = 0;
-    let anchorLocal: TzDateTime | null = null;
+    let anchorMembership: SessionMembership = OUTSIDE_SESSION;
     for (const session of sessionDefs) {
-      const local = getTzDateTime(candle.time, session.timezone);
-      if (isInSessionWindow(local.hour, local.minute, session)) {
+      const membership = resolveSessionMembership(candle.time, session);
+      if (membership.inWindow) {
         anchorSession = session;
-        anchorHour = local.hour;
-        anchorMinute = local.minute;
-        anchorLocal = local;
+        anchorMembership = membership;
         break;
       }
     }
-    const inBreak =
-      anchorSession !== null &&
-      anchorSession.breaks !== undefined &&
-      isInAnyBreak(anchorHour, anchorMinute, anchorSession.breaks);
+    const inBreak = anchorMembership.inBreak;
     const anchorName = anchorSession?.name ?? null;
-    const occurrence =
-      anchorSession === null || anchorLocal === null
-        ? -1
-        : sessionOccurrenceKey(anchorLocal, anchorSession);
+    const occurrence = anchorMembership.occurrenceKey;
 
     // A new occurrence of the same session — the day it opened on changed.
     // Without this, a series carrying only in-session bars never leaves the

--- a/packages/core/src/indicators/session/session-stats.ts
+++ b/packages/core/src/indicators/session/session-stats.ts
@@ -9,12 +9,9 @@ import { isNormalized, normalizeCandles } from "../../core/normalize";
 import type { Candle, NormalizedCandle } from "../../types";
 import {
   getIctSessions,
-  isInAnyBreak,
-  isInSessionWindow,
+  resolveSessionMembership,
   type SessionDefinition,
-  sessionOccurrenceKey,
 } from "./session-definition";
-import { getTzDateTime } from "./tz-utils";
 
 /**
  * Options for sessionStats
@@ -103,20 +100,19 @@ export function sessionStats(
 
   for (const candle of normalized) {
     for (const session of sessionDefs) {
-      const local = getTzDateTime(candle.time, session.timezone);
-      const { hour, minute } = local;
-      // Use the outer window for occurrence boundary detection, so a lunch break
-      // does not split one session into two occurrences.
-      const inWindow = isInSessionWindow(hour, minute, session);
-      const inBreak =
-        inWindow && session.breaks !== undefined && isInAnyBreak(hour, minute, session.breaks);
+      // The outer window drives occurrence boundaries, so a lunch break does
+      // not split one session into two occurrences.
+      const {
+        inWindow,
+        inBreak,
+        occurrenceKey: occurrence,
+      } = resolveSessionMembership(candle.time, session);
       const wasInWindow = prevSession.get(session.name) ?? false;
 
       // The same session starting again — the day it opened on changed. Data
       // holding only in-session bars never leaves the window, so without this
       // every day merges into one long occurrence and the averages describe the
       // whole series rather than a session.
-      const occurrence = inWindow ? sessionOccurrenceKey(local, session) : -1;
       const rolledOver =
         inWindow && wasInWindow && occurrence !== (prevOccurrence.get(session.name) ?? -1);
       prevOccurrence.set(session.name, occurrence);


### PR DESCRIPTION
## Why

`detectSessions`, `sessionBreakout` and `sessionStats` each answered the same four questions independently: which timezone the bar reads in, whether it is inside the window, whether it is in a break, and which occurrence of the session it belongs to.

That duplication is how they drifted apart — the recent day-rollover fix had to be applied three times over, once per file, with the same reasoning re-derived each time. Session-aware VWAP, TWAP and opening range would have made it five.

## What

`resolveSessionMembership(epochMs, session)` answers all four:

```ts
type SessionMembership = {
  occurrenceKey: number;    // -1 outside the window
  elapsedMinutes: number;   // -1 outside the window
  inWindow: boolean;
  inBreak: boolean;
  active: boolean;          // inWindow && !inBreak
};
```

The three callers now read fields off it. **No behavior change** — the existing 48 session tests pass untouched.

The insertions outnumber the deletions because of the helper body and its JSDoc; every call site got shorter (`session-breakout.ts` roughly halves its per-bar block).

### `elapsedMinutes` and DST

The membership also exposes the position inside an occurrence, which a session-aware opening range needs. It is derived from the local clock, so across a DST fall-back it stalls and then runs *backwards*: New York reads 01:30 EDT, then 01:00 EST half an hour later.

Using it to tell one occurrence from another is precisely the mistake that split an overnight session in two. The JSDoc says so, and a test pins the behavior:

```ts
expect(afterRewind.elapsedMinutes).toBeLessThan(beforeRewind.elapsedMinutes);
expect(afterRewind.occurrenceKey).toBe(beforeRewind.occurrenceKey);
```

### Placement

Kept inside `session-definition.ts`. The membership needs `isInSessionWindow` and `sessionOccurrenceKey`, and `detectSessions` needs the membership, so a separate module would introduce a cycle. The file goes from 414 to 470 lines, inside the 500-line guideline.

Not exported from the session barrel — it is an internal helper.

## Test plan

10 new unit tests covering: elapsed minutes from the open, zero at the opening bar, continuity across midnight, break bars staying in-window but inactive, elapsed time continuing to run through a break, everything reading `-1`/`false` outside the window, occurrence stability within a day, post-midnight bars attributed back to the opening day, and the two DST fall-back cases.

Verification:

- `pnpm test` (core): 369 files / 6495 tests passed
- `npx tsc --noEmit --ignoreDeprecations 6.0`: clean
- `pnpm build` (core): success
- `npx biome check` on the touched directory: clean

No CHANGELOG entry: the public API is unchanged and there is nothing for a consumer to act on. The session option this prepares for lands in follow-up PRs, which will carry the entry.