### PR TITLE
feat(core): anchor vwap and twap to a trading session

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## [Unreleased]
 
+### Added — `session` option on `vwap` and `twap`
+
+Both averages restart at UTC midnight, which is not when any exchange's trading
+day begins. For US equities it falls at 19:00 or 20:00 New York time — after
+the close — so a single reset period runs from one day's post-market through
+the next day's pre-market, regular session and post-market, mixing extended
+hours into the figure and never restarting at the open. The reset lines up with
+a trading day only for markets that happen to open near 00:00 UTC.
+
+Passing a `SessionDefinition` anchors the average to that session instead:
+
+```ts
+const nyVwap = vwap(candles, {
+  session: {
+    name: "regular",
+    startHour: 9, startMinute: 30,
+    endHour: 16, endMinute: 0,
+    timezone: "America/New_York",
+  },
+});
+```
+
+The average then restarts when the session does, in the session's own
+timezone, and only bars inside it contribute. Bars outside the window, and bars
+inside one of its breaks, return `null` and leave the running totals untouched
+— so a lunch break pauses the average rather than restarting it, and the value
+after the break continues from where trading left off. Sessions that cross
+midnight stay whole, as do sessions running through a DST change.
+
+Combining `session` with `resetPeriod: "rolling"` (or a bar count, or
+`sessionResetPeriod` on `twap`) throws, naming both options: a session brings
+its own boundaries, so honoring one of the two silently would report a figure
+the caller did not ask for.
+
+Without `session`, both indicators behave exactly as before.
+
 ### Fixed — sessions restart on the next day in regular-hours-only data
 
 `detectSessions`, `sessionStats` and `sessionBreakout` decided that one

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -758,19 +758,33 @@ const custom = choppinessIndex(candles, { period: 7 });
 出来高加重平均価格。
 
 ```typescript
-// セッションVWAP（日次リセット）
+// セッションVWAP（UTC 0時リセット）
 const result = vwap(candles);
 
 // ローリングVWAP（20期間）
 const rolling = vwap(candles, { resetPeriod: 'rolling', period: 20 });
+
+// 取引セッションに紐付け：寄付でリセットし、時間外バーを除外
+const nyVwap = vwap(candles, {
+  session: { name: 'regular', startHour: 9, startMinute: 30, endHour: 16, endMinute: 0, timezone: 'America/New_York' },
+});
 ```
 
 **オプション:**
 | オプション | 型 | デフォルト | 説明 |
 |------------|------|---------|------|
-| `resetPeriod` | `'session' \| 'rolling' \| number` | `'session'` | リセット期間タイプ |
+| `resetPeriod` | `'session' \| 'rolling' \| number` | `'session'` | リセット期間タイプ。`session` とは併用不可 |
 | `period` | `number` | `20` | ローリングVWAP期間 |
 | `bandMultipliers` | `number[]` | — | 追加σバンドの倍率（例：`[2, 3]` で±2σ、±3σ） |
+| `session` | `SessionDefinition` | — | 取引セッションに紐付ける（下記参照） |
+
+**セッション紐付け**
+
+`session` を指定しない場合、平均は UTC 0時でリセットされますが、これはどの取引所の取引開始時刻でもありません。米国株ではニューヨーク時間の 19:00 / 20:00、つまり引け後にあたります。そのため1つのリセット期間が、ある日のポストマーケットから翌日のプレマーケット・通常取引・ポストマーケットまでを1つにまとめてしまい、時間外バーが混ざったまま寄付でリセットされません。
+
+`session` を指定すると、平均はセッションのタイムゾーンで、セッション開始時にリセットされ、セッション内のバーだけが対象になります。window 外のバーと break 内のバーは `null` を返し、累積値を変更しません。したがって昼休みは平均を「一時停止」させるだけでリセットしません。深夜を跨ぐセッションも、DST 切り替え日を跨ぐセッションも1つのまま保たれます。
+
+`session` と `resetPeriod: 'rolling'` または本数指定の併用は、どちらかを黙って優先するのではなくエラーになります。
 
 **戻り値:** `Series<VwapValue>`
 
@@ -1085,12 +1099,18 @@ TWAP（時間加重平均価格） — セッション内のTypical Priceの均�
 ```typescript
 const result = twap(candles);
 const fixed = twap(candles, { sessionResetPeriod: 30 });
+
+// セッションVWAPと同様に取引セッションへ紐付け
+const nyTwap = twap(candles, {
+  session: { name: 'regular', startHour: 9, startMinute: 30, endHour: 16, endMinute: 0, timezone: 'America/New_York' },
+});
 ```
 
 **オプション:**
 | オプション | 型 | デフォルト | 説明 |
 |-----------|------|-----------|------|
-| `sessionResetPeriod` | `'session' \| number` | `'session'` | セッションリセット期間 |
+| `sessionResetPeriod` | `'session' \| number` | `'session'` | セッションリセット期間。`session` とは併用不可 |
+| `session` | `SessionDefinition` | — | 取引セッションに紐付ける — 意味論は [`vwap`](#vwapcandles-options) と同じ |
 
 **戻り値:** `Series<number | null>`
 

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -758,19 +758,33 @@ const custom = choppinessIndex(candles, { period: 7 });
 Volume Weighted Average Price.
 
 ```typescript
-// Session VWAP (resets daily)
+// Session VWAP (resets at UTC midnight)
 const result = vwap(candles);
 
 // Rolling VWAP over 20 periods
 const rolling = vwap(candles, { resetPeriod: 'rolling', period: 20 });
+
+// Anchored to a trading session: resets at the open, ignores extended hours
+const nyVwap = vwap(candles, {
+  session: { name: 'regular', startHour: 9, startMinute: 30, endHour: 16, endMinute: 0, timezone: 'America/New_York' },
+});
 ```
 
 **Options:**
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `resetPeriod` | `'session' \| 'rolling' \| number` | `'session'` | Reset period type |
+| `resetPeriod` | `'session' \| 'rolling' \| number` | `'session'` | Reset period type. Cannot be combined with `session` |
 | `period` | `number` | `20` | Period for rolling VWAP |
 | `bandMultipliers` | `number[]` | — | Additional σ-band multipliers (e.g., `[2, 3]` for ±2σ, ±3σ) |
+| `session` | `SessionDefinition` | — | Anchor the average to a trading session (see below) |
+
+**Session anchoring**
+
+Without `session`, the average restarts at UTC midnight, which is not when any exchange's trading day begins. For US equities that is 19:00 or 20:00 New York time — after the close — so one reset period runs from a day's post-market through the next day's pre-market, regular session and post-market: extended-hours bars are mixed in, and the average never restarts at the open.
+
+With `session`, the average restarts when the session does, in the session's own timezone, and only bars inside it contribute. Bars outside the window, and bars inside one of its breaks, return `null` and leave the running totals untouched, so a lunch break pauses the average rather than restarting it. Sessions that cross midnight stay whole, as do sessions running through a DST change.
+
+Combining `session` with `resetPeriod: 'rolling'` or a bar count throws, rather than silently honoring one of them.
 
 **Returns:** `Series<VwapValue>`
 
@@ -1101,12 +1115,18 @@ Time-Weighted Average Price — equal-weighted average of typical prices within 
 ```typescript
 const result = twap(candles);
 const fixed = twap(candles, { sessionResetPeriod: 30 });
+
+// Anchored to a trading session, like session VWAP
+const nyTwap = twap(candles, {
+  session: { name: 'regular', startHour: 9, startMinute: 30, endHour: 16, endMinute: 0, timezone: 'America/New_York' },
+});
 ```
 
 **Options:**
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `sessionResetPeriod` | `'session' \| number` | `'session'` | Reset at each day or every N candles |
+| `sessionResetPeriod` | `'session' \| number` | `'session'` | Reset at each day or every N candles. Cannot be combined with `session` |
+| `session` | `SessionDefinition` | — | Anchor the average to a trading session — same semantics as [`vwap`](#vwapcandles-options) |
 
 **Returns:** `Series<number | null>`
 

--- a/packages/core/src/indicators/session/session-definition.ts
+++ b/packages/core/src/indicators/session/session-definition.ts
@@ -350,6 +350,39 @@ export function resolveSessionMembership(
 }
 
 /**
+ * Reject a reset option that contradicts an explicit `session`.
+ *
+ * An indicator given a `session` takes its boundaries from that session, so a
+ * rolling window or a fixed bar count has nothing left to mean. Accepting both
+ * and silently honoring one would report a figure the caller did not ask for —
+ * the same failure as ignoring an option outright.
+ *
+ * Indicators name this option differently (`resetPeriod`, `sessionResetPeriod`)
+ * and default it differently (`"session"`, `"day"`), hence the parameters.
+ *
+ * @param indicator - Indicator name, for the error message
+ * @param optionName - The reset option's key in that indicator's options
+ * @param value - The reset option's effective value
+ * @param sessionDefault - The value meaning "one session per day", which is the
+ *   only value compatible with an explicit session
+ */
+export function assertSessionResetCompatible(
+  indicator: string,
+  optionName: string,
+  value: string | number,
+  sessionDefault: string,
+): void {
+  if (value === sessionDefault) return;
+
+  const kept = typeof value === "number" ? `resetting every ${value} bars` : `the "${value}" reset`;
+  throw new Error(
+    `${indicator}: \`${optionName}: ${JSON.stringify(value)}\` cannot be combined with \`session\` — ` +
+      `a session defines its own reset boundaries. Drop \`${optionName}\` to use the session, ` +
+      `or drop \`session\` to keep ${kept}.`,
+  );
+}
+
+/**
  * Check if (hour, minute) falls inside any of the given breaks.
  */
 export function isInAnyBreak(hour: number, minute: number, breaks: SessionBreak[]): boolean {

--- a/packages/core/src/indicators/volume/__tests__/session-anchored-vwap-twap.test.ts
+++ b/packages/core/src/indicators/volume/__tests__/session-anchored-vwap-twap.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../../types";
+import type { SessionDefinition } from "../../session/session-definition";
+import { twap } from "../twap";
+import { vwap } from "../vwap";
+
+/** New York cash session, 09:30-16:00 local. */
+const NY_REGULAR: SessionDefinition = {
+  name: "regular",
+  startHour: 9,
+  startMinute: 30,
+  endHour: 16,
+  endMinute: 0,
+  timezone: "America/New_York",
+};
+
+/** Tokyo-style session with a lunch break. */
+const WITH_LUNCH: SessionDefinition = {
+  name: "tokyo",
+  startHour: 9,
+  startMinute: 0,
+  endHour: 15,
+  endMinute: 0,
+  breaks: [{ startHour: 11, startMinute: 30, endHour: 12, endMinute: 30 }],
+  timezone: "Asia/Tokyo",
+};
+
+/** Runs across midnight, in New York local time. */
+const NY_OVERNIGHT: SessionDefinition = {
+  name: "overnight",
+  startHour: 22,
+  startMinute: 0,
+  endHour: 6,
+  endMinute: 0,
+  timezone: "America/New_York",
+};
+
+function bar(time: number, price: number, volume = 1000): NormalizedCandle {
+  return { time, open: price, high: price, low: price, close: price, volume };
+}
+
+/**
+ * Two New York trading days including pre- and post-market bars, so the
+ * session boundary is genuinely narrower than the calendar day.
+ *
+ * Per day (UTC, January so New York is EST = UTC-5):
+ *   12:00 pre-market, 14:30 open, 17:00 midday, 20:30 close-ish, 22:00 post
+ */
+function twoDaysWithExtendedHours(): NormalizedCandle[] {
+  const candles: NormalizedCandle[] = [];
+
+  for (const [dayIndex, day] of [2, 3].entries()) {
+    const base = 100 + dayIndex * 100;
+    candles.push(bar(Date.UTC(2024, 0, day, 12, 0), base + 1)); // pre-market
+    candles.push(bar(Date.UTC(2024, 0, day, 14, 30), base + 10)); // 09:30 open
+    candles.push(bar(Date.UTC(2024, 0, day, 17, 0), base + 20)); // 12:00
+    candles.push(bar(Date.UTC(2024, 0, day, 20, 30), base + 30)); // 15:30
+    candles.push(bar(Date.UTC(2024, 0, day, 22, 0), base + 99)); // post-market
+  }
+
+  return candles;
+}
+
+describe("session-anchored VWAP", () => {
+  it("excludes bars outside the session and restarts each day", () => {
+    const result = vwap(twoDaysWithExtendedHours(), { session: NY_REGULAR });
+
+    // Pre- and post-market bars contribute nothing and report nothing.
+    expect(result[0].value.vwap).toBeNull();
+    expect(result[4].value.vwap).toBeNull();
+    expect(result[5].value.vwap).toBeNull();
+    expect(result[9].value.vwap).toBeNull();
+
+    // Day 1, in-session: 110, then (110+120)/2, then (110+120+130)/3.
+    expect(result[1].value.vwap).toBeCloseTo(110, 10);
+    expect(result[2].value.vwap).toBeCloseTo(115, 10);
+    expect(result[3].value.vwap).toBeCloseTo(120, 10);
+
+    // Day 2 starts over rather than carrying day 1 forward.
+    expect(result[6].value.vwap).toBeCloseTo(210, 10);
+    expect(result[7].value.vwap).toBeCloseTo(215, 10);
+    expect(result[8].value.vwap).toBeCloseTo(220, 10);
+  });
+
+  it("differs from the UTC-midnight default, which folds in extended hours", () => {
+    const candles = twoDaysWithExtendedHours();
+    const withSession = vwap(candles, { session: NY_REGULAR });
+    const utcDefault = vwap(candles);
+
+    // The default averages the pre-market bar into the day and never resets at
+    // the session open, so the two disagree on the same bar.
+    expect(utcDefault[3].value.vwap).not.toBeCloseTo(withSession[3].value.vwap as number, 6);
+    // 22:00 UTC is still 17:00 in New York — the same calendar day for the
+    // default, which therefore reports a value where the session reports none.
+    expect(utcDefault[4].value.vwap).not.toBeNull();
+    expect(withSession[4].value.vwap).toBeNull();
+  });
+
+  it("weights by volume within the session", () => {
+    const candles = [
+      bar(Date.UTC(2024, 0, 2, 14, 30), 100, 1),
+      bar(Date.UTC(2024, 0, 2, 15, 30), 200, 3),
+    ];
+    const result = vwap(candles, { session: NY_REGULAR });
+
+    // (100*1 + 200*3) / 4
+    expect(result[1].value.vwap).toBeCloseTo(175, 10);
+  });
+
+  it("pauses through a lunch break without restarting", () => {
+    // 00:00 UTC = 09:00 Tokyo. The break runs 11:30-12:30 local.
+    const candles = [
+      bar(Date.UTC(2024, 0, 2, 0, 0), 100), // 09:00
+      bar(Date.UTC(2024, 0, 2, 2, 0), 200), // 11:00
+      bar(Date.UTC(2024, 0, 2, 3, 0), 999), // 12:00 — inside the break
+      bar(Date.UTC(2024, 0, 2, 4, 0), 300), // 13:00
+    ];
+    const result = vwap(candles, { session: WITH_LUNCH });
+
+    expect(result[1].value.vwap).toBeCloseTo(150, 10);
+    // The break bar reports nothing and must not enter the average.
+    expect(result[2].value.vwap).toBeNull();
+    // Resumes from the pre-break totals: (100 + 200 + 300) / 3.
+    expect(result[3].value.vwap).toBeCloseTo(200, 10);
+  });
+
+  it("keeps one average across midnight", () => {
+    // 03:00 UTC = 22:00 New York (session open), 08:00 UTC = 03:00 next day.
+    const candles = [bar(Date.UTC(2024, 0, 3, 3, 0), 100), bar(Date.UTC(2024, 0, 3, 8, 0), 200)];
+    const result = vwap(candles, { session: NY_OVERNIGHT });
+
+    expect(result[0].value.vwap).toBeCloseTo(100, 10);
+    // Same session — averaged together, not restarted at 00:00.
+    expect(result[1].value.vwap).toBeCloseTo(150, 10);
+  });
+
+  it("keeps one average across a DST fall-back", () => {
+    // 2024-11-03: New York rewinds 02:00 EDT to 01:00 EST. Both bars are
+    // inside the session that opened at 22:00 on 11-02.
+    const candles = [
+      bar(Date.UTC(2024, 10, 3, 5, 30), 100), // 01:30 EDT
+      bar(Date.UTC(2024, 10, 3, 6, 30), 200), // 01:30 EST, an hour later
+    ];
+    const result = vwap(candles, { session: NY_OVERNIGHT });
+
+    expect(result[1].value.vwap).toBeCloseTo(150, 10);
+  });
+
+  it("leaves the default behavior untouched when no session is given", () => {
+    const candles = twoDaysWithExtendedHours();
+
+    expect(vwap(candles)).toEqual(vwap(candles, { resetPeriod: "session" }));
+  });
+
+  it("rejects a reset period that contradicts the session", () => {
+    const candles = twoDaysWithExtendedHours();
+
+    expect(() => vwap(candles, { session: NY_REGULAR, resetPeriod: "rolling", period: 3 })).toThrow(
+      /cannot be combined with `session`/,
+    );
+    expect(() => vwap(candles, { session: NY_REGULAR, resetPeriod: 5 })).toThrow(
+      /cannot be combined with `session`/,
+    );
+  });
+
+  it("still emits bands inside the session", () => {
+    const candles = [
+      bar(Date.UTC(2024, 0, 2, 14, 30), 100),
+      bar(Date.UTC(2024, 0, 2, 15, 30), 200),
+    ];
+    const result = vwap(candles, { session: NY_REGULAR, bandMultipliers: [2] });
+
+    expect(result[1].value.upper).not.toBeNull();
+    expect(result[1].value.bands).toHaveLength(1);
+    // Out-of-session bars carry the same shape as a warm-up bar: no bands.
+    const outside = vwap([bar(Date.UTC(2024, 0, 2, 12, 0), 100)], {
+      session: NY_REGULAR,
+      bandMultipliers: [2],
+    });
+    expect(outside[0].value).toEqual({ vwap: null, upper: null, lower: null });
+  });
+});
+
+describe("session-anchored TWAP", () => {
+  it("excludes bars outside the session and restarts each day", () => {
+    const result = twap(twoDaysWithExtendedHours(), { session: NY_REGULAR });
+
+    expect(result[0].value).toBeNull();
+    expect(result[4].value).toBeNull();
+
+    expect(result[1].value).toBeCloseTo(110, 10);
+    expect(result[2].value).toBeCloseTo(115, 10);
+    expect(result[3].value).toBeCloseTo(120, 10);
+
+    expect(result[6].value).toBeCloseTo(210, 10);
+    expect(result[8].value).toBeCloseTo(220, 10);
+  });
+
+  it("ignores volume, unlike VWAP", () => {
+    const candles = [
+      bar(Date.UTC(2024, 0, 2, 14, 30), 100, 1),
+      bar(Date.UTC(2024, 0, 2, 15, 30), 200, 3),
+    ];
+
+    expect(twap(candles, { session: NY_REGULAR })[1].value).toBeCloseTo(150, 10);
+    expect(vwap(candles, { session: NY_REGULAR })[1].value.vwap).toBeCloseTo(175, 10);
+  });
+
+  it("pauses through a lunch break without restarting", () => {
+    const candles = [
+      bar(Date.UTC(2024, 0, 2, 0, 0), 100),
+      bar(Date.UTC(2024, 0, 2, 2, 0), 200),
+      bar(Date.UTC(2024, 0, 2, 3, 0), 999),
+      bar(Date.UTC(2024, 0, 2, 4, 0), 300),
+    ];
+    const result = twap(candles, { session: WITH_LUNCH });
+
+    expect(result[2].value).toBeNull();
+    expect(result[3].value).toBeCloseTo(200, 10);
+  });
+
+  it("keeps one average across midnight and a DST fall-back", () => {
+    const acrossMidnight = twap(
+      [bar(Date.UTC(2024, 0, 3, 3, 0), 100), bar(Date.UTC(2024, 0, 3, 8, 0), 200)],
+      { session: NY_OVERNIGHT },
+    );
+    expect(acrossMidnight[1].value).toBeCloseTo(150, 10);
+
+    const acrossDst = twap(
+      [bar(Date.UTC(2024, 10, 3, 5, 30), 100), bar(Date.UTC(2024, 10, 3, 6, 30), 200)],
+      { session: NY_OVERNIGHT },
+    );
+    expect(acrossDst[1].value).toBeCloseTo(150, 10);
+  });
+
+  it("leaves the default behavior untouched when no session is given", () => {
+    const candles = twoDaysWithExtendedHours();
+
+    expect(twap(candles)).toEqual(twap(candles, { sessionResetPeriod: "session" }));
+  });
+
+  it("rejects a reset period that contradicts the session", () => {
+    expect(() =>
+      twap(twoDaysWithExtendedHours(), { session: NY_REGULAR, sessionResetPeriod: 5 }),
+    ).toThrow(/cannot be combined with `session`/);
+  });
+});

--- a/packages/core/src/indicators/volume/twap.ts
+++ b/packages/core/src/indicators/volume/twap.ts
@@ -7,6 +7,11 @@
 
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import type { Candle, NormalizedCandle, Series } from "../../types";
+import {
+  assertSessionResetCompatible,
+  resolveSessionMembership,
+  type SessionDefinition,
+} from "../session/session-definition";
 
 /**
  * TWAP options
@@ -16,8 +21,26 @@ export type TwapOptions = {
    * Session reset logic:
    * - 'session': Reset at the start of each day (default)
    * - number: Reset every N candles
+   *
+   * Cannot be combined with `session`, which brings its own boundaries.
    */
   sessionResetPeriod?: "session" | number;
+  /**
+   * Trading session the average belongs to.
+   *
+   * Without it, the average restarts at UTC midnight, which is not when any
+   * exchange's trading day begins — for US equities it is 19:00 or 20:00 New
+   * York time, after the close — so one reset period runs from a day's
+   * post-market through the next day's pre-market, regular session and
+   * post-market. With it, the average restarts when the session does, in the
+   * session's own timezone, and only bars inside the session contribute: bars
+   * outside the window, and bars inside one of its breaks, produce `null` and
+   * leave the running totals untouched.
+   *
+   * Handles sessions that cross midnight and days when the clock shifts for
+   * DST.
+   */
+  session?: SessionDefinition;
 };
 
 /**
@@ -39,7 +62,11 @@ export function twap(
   candles: Candle[] | NormalizedCandle[],
   options: TwapOptions = {},
 ): Series<number | null> {
-  const { sessionResetPeriod = "session" } = options;
+  const { sessionResetPeriod = "session", session } = options;
+
+  if (session) {
+    assertSessionResetCompatible("twap", "sessionResetPeriod", sessionResetPeriod, "session");
+  }
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
 
@@ -54,6 +81,36 @@ export function twap(
   let count = 0;
   let lastDayIndex = -1;
   let sessionStart = 0;
+
+  if (session) {
+    // Session-anchored: the average covers one session occurrence, restarting
+    // when the session does rather than at UTC midnight.
+    let currentOccurrence = -1;
+
+    for (const c of normalized) {
+      const membership = resolveSessionMembership(c.time, session);
+
+      if (!membership.active) {
+        // Outside the window, or inside a break: not part of the session's
+        // average, and must not move the running totals either.
+        result.push({ time: c.time, value: null });
+        continue;
+      }
+
+      if (membership.occurrenceKey !== currentOccurrence) {
+        cumTp = 0;
+        count = 0;
+        currentOccurrence = membership.occurrenceKey;
+      }
+
+      cumTp += (c.high + c.low + c.close) / 3;
+      count++;
+
+      result.push({ time: c.time, value: cumTp / count });
+    }
+
+    return result;
+  }
 
   for (let i = 0; i < normalized.length; i++) {
     const c = normalized[i];

--- a/packages/core/src/indicators/volume/vwap.ts
+++ b/packages/core/src/indicators/volume/vwap.ts
@@ -9,6 +9,11 @@ import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, Series } from "../../types";
 import { VWAP_META } from "../indicator-meta";
+import {
+  assertSessionResetCompatible,
+  resolveSessionMembership,
+  type SessionDefinition,
+} from "../session/session-definition";
 
 /**
  * VWAP options
@@ -19,10 +24,28 @@ export type VwapOptions = {
    * - 'session': Reset at the start of each day (default)
    * - 'rolling': Rolling VWAP over specified period
    * - number: Reset every N candles
+   *
+   * Cannot be combined with `session`, which brings its own boundaries.
    */
   resetPeriod?: "session" | "rolling" | number;
   /** Period for rolling VWAP (only used when resetPeriod is 'rolling') */
   period?: number;
+  /**
+   * Trading session the VWAP belongs to.
+   *
+   * Without it, the average restarts at UTC midnight, which is not when any
+   * exchange's trading day begins — for US equities it is 19:00 or 20:00 New
+   * York time, after the close — so one reset period runs from a day's
+   * post-market through the next day's pre-market, regular session and
+   * post-market. With it, the average restarts when the session does, in the
+   * session's own timezone, and only bars inside the session contribute: bars
+   * outside the window, and bars inside one of its breaks, produce `null` and
+   * leave the running totals untouched.
+   *
+   * Handles sessions that cross midnight and days when the clock shifts for
+   * DST.
+   */
+  session?: SessionDefinition;
   /**
    * Band multipliers for additional standard deviation bands.
    * Each value creates an upper/lower band at that multiple of σ.
@@ -120,11 +143,33 @@ function calcVwapStdDev(
   return Math.sqrt(sumSquaredDiff / totalVolume);
 }
 
+/**
+ * Build the emitted value from a window's running totals
+ */
+function valueFromTotals(
+  tpvHistory: { tp: number; volume: number }[],
+  cumulativeTpv: number,
+  cumulativeVolume: number,
+  bandMultipliers: number[] | undefined,
+): VwapValue {
+  const vwapValue = cumulativeVolume > 0 ? cumulativeTpv / cumulativeVolume : null;
+  const stdDev =
+    vwapValue !== null && cumulativeVolume > 0
+      ? calcVwapStdDev(tpvHistory, vwapValue, cumulativeVolume)
+      : null;
+
+  return buildVwapValue(vwapValue, stdDev, bandMultipliers);
+}
+
 export function vwap(
   candles: Candle[] | NormalizedCandle[],
   options: VwapOptions = {},
 ): Series<VwapValue> {
-  const { resetPeriod = "session", period = 20, bandMultipliers } = options;
+  const { resetPeriod = "session", period = 20, bandMultipliers, session } = options;
+
+  if (session) {
+    assertSessionResetCompatible("vwap", "resetPeriod", resetPeriod, "session");
+  }
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
 
@@ -153,15 +198,47 @@ export function vwap(
         cumulativeVolume += candle.volume;
       }
 
-      const vwapValue = cumulativeVolume > 0 ? cumulativeTpv / cumulativeVolume : null;
-      const stdDev =
-        vwapValue !== null && cumulativeVolume > 0
-          ? calcVwapStdDev(tpvHistory, vwapValue, cumulativeVolume)
-          : null;
-
       result.push({
         time: normalized[i].time,
-        value: buildVwapValue(vwapValue, stdDev, bandMultipliers),
+        value: valueFromTotals(tpvHistory, cumulativeTpv, cumulativeVolume, bandMultipliers),
+      });
+    }
+  } else if (session) {
+    // Session-anchored: the average covers one session occurrence, restarting
+    // when the session does rather than at UTC midnight.
+    let cumulativeTpv = 0;
+    let cumulativeVolume = 0;
+    let tpvHistory: { tp: number; volume: number }[] = [];
+    let currentOccurrence = -1;
+
+    for (const candle of normalized) {
+      const membership = resolveSessionMembership(candle.time, session);
+
+      if (!membership.active) {
+        // Outside the window, or inside a break: not part of the session's
+        // average, and must not move the running totals either.
+        result.push({
+          time: candle.time,
+          value: buildVwapValue(null, null, bandMultipliers),
+        });
+        continue;
+      }
+
+      if (membership.occurrenceKey !== currentOccurrence) {
+        cumulativeTpv = 0;
+        cumulativeVolume = 0;
+        tpvHistory = [];
+        currentOccurrence = membership.occurrenceKey;
+      }
+
+      const tp = (candle.high + candle.low + candle.close) / 3;
+      cumulativeTpv += tp * candle.volume;
+      cumulativeVolume += candle.volume;
+      tpvHistory.push({ tp, volume: candle.volume });
+
+      result.push({
+        time: candle.time,
+        value: valueFromTotals(tpvHistory, cumulativeTpv, cumulativeVolume, bandMultipliers),
       });
     }
   } else {
@@ -199,15 +276,9 @@ export function vwap(
       cumulativeVolume += candle.volume;
       tpvHistory.push({ tp, volume: candle.volume });
 
-      const vwapValue = cumulativeVolume > 0 ? cumulativeTpv / cumulativeVolume : null;
-      const stdDev =
-        vwapValue !== null && cumulativeVolume > 0
-          ? calcVwapStdDev(tpvHistory, vwapValue, cumulativeVolume)
-          : null;
-
       result.push({
         time: candle.time,
-        value: buildVwapValue(vwapValue, stdDev, bandMultipliers),
+        value: valueFromTotals(tpvHistory, cumulativeTpv, cumulativeVolume, bandMultipliers),
       });
     }
   }

--- a/packages/core/src/manifest/entries/volume.ts
+++ b/packages/core/src/manifest/entries/volume.ts
@@ -17,6 +17,7 @@ export const VOLUME_MANIFESTS: IndicatorManifest[] = [
       "Pullback to VWAP in trend = continuation entry zone",
     ],
     pitfalls: [
+      "Without `session`, the reset is at UTC midnight — 19:00/20:00 New York, after the close — so one period runs from a day's post-market through the next day's pre-market, regular session and post-market. Pass `session` to anchor it to the actual trading day",
       "Session-reset VWAP loses most of its intended relevance across multiple days; trendcraft offers `resetPeriod: 'rolling' | number` for non-session use",
       "Less useful pre-market or in low-volume sessions",
       "Anchored variants (anchoredVwap) are often more meaningful for multi-day context",
@@ -28,10 +29,12 @@ export const VOLUME_MANIFESTS: IndicatorManifest[] = [
     timeframe: ["intraday"],
     paramHints: {
       resetPeriod:
-        "'session' default (resets per trading day). 'rolling' for windowed VWAP, or number for fixed N-bar reset",
+        "'session' default (resets per trading day). 'rolling' for windowed VWAP, or number for fixed N-bar reset. Cannot be combined with `session`",
       period: "Used only when resetPeriod='rolling' — sets the rolling window length",
       bandMultipliers:
         "Extra ±N σ band pairs beyond the default ±1σ (e.g. [2, 3] adds ±2σ and ±3σ)",
+      session:
+        "SessionDefinition to anchor the average to a real trading session, in its own timezone. Only in-session bars contribute; out-of-session and break bars return null without moving the totals. Handles midnight-crossing sessions and DST",
     },
   },
   {
@@ -196,13 +199,16 @@ export const VOLUME_MANIFESTS: IndicatorManifest[] = [
       "TWAP and VWAP can diverge meaningfully on event days when volume is concentrated",
       "Not a market-direction reference; primarily an execution benchmark",
       "Resets per session by default — meaningless on multi-day timeframes without anchoring",
+      "Without `session`, the reset is at UTC midnight — 19:00/20:00 New York, after the close — so one period runs from a day's post-market through the next day's pre-market, regular session and post-market. Pass `session` to anchor it to the actual trading day",
     ],
     synergy: ["VWAP for cross-check; large TWAP-VWAP gap signals uneven volume distribution"],
     marketRegime: ["ranging"],
     timeframe: ["intraday"],
     paramHints: {
       sessionResetPeriod:
-        "'session' default (resets per trading day). Pass a number for fixed N-bar reset",
+        "'session' default (resets per trading day). Pass a number for fixed N-bar reset. Cannot be combined with `session`",
+      session:
+        "SessionDefinition to anchor the average to a real trading session, in its own timezone. Only in-session bars contribute; out-of-session and break bars return null without moving the totals. Handles midnight-crossing sessions and DST",
     },
   },
   {


### PR DESCRIPTION
## Problem

`vwap` and `twap` restart at UTC midnight, which is not when any exchange's trading day begins.

For US equities it falls at 19:00 or 20:00 New York time — after the close. One reset period therefore runs from a day's post-market through the next day's pre-market, its regular session, and its post-market: extended-hours bars are mixed into the figure, and the average never restarts at the open. The reset lines up with a trading day only for markets that happen to open near 00:00 UTC.

## Fix

Passing a `SessionDefinition` anchors the average to that session:

```ts
const nyVwap = vwap(candles, {
  session: {
    name: "regular",
    startHour: 9, startMinute: 30,
    endHour: 16, endMinute: 0,
    timezone: "America/New_York",
  },
});
```

| | Without `session` | With `session` |
| --- | --- | --- |
| Restarts at | UTC midnight | The session open, in its own timezone |
| Out-of-session bars | Included | `null`, totals untouched |
| Break bars | Included | `null`, totals untouched — the average pauses, then continues |
| Midnight-crossing session | Split at 00:00 | Stays whole |
| DST change day | Split | Stays whole |

Both properties in the last two rows follow from the occurrence key the session detectors already use, rather than from anything new.

Combining `session` with `resetPeriod: "rolling"`, a bar count, or `twap`'s `sessionResetPeriod` throws with both options named. A session brings its own boundaries, so silently honoring one of the two would report a figure the caller did not ask for.

The three indicators taking this option name it differently (`resetPeriod`, `sessionResetPeriod`) and default it differently (`"session"`, `"day"`), so the conflict check lives in one place as `assertSessionResetCompatible(indicator, optionName, value, default)`. The opening range will use the same helper.

**Without `session`, both indicators behave exactly as before** — pinned by a test asserting the default output is identical.

## Test plan

15 new tests. VWAP (9): excludes pre/post-market bars and restarts each day with hand-computed averages (110 / 115 / 120, then 210 / 215 / 220); disagrees with the UTC default on the same bar; volume weighting inside the session; a lunch break pausing rather than restarting the average (`(100+200+300)/3` after the break bar is skipped); one average across midnight; one average across a DST fall-back; default output unchanged; conflicting reset options rejected; bands still emitted, with out-of-session bars carrying the warm-up shape.

TWAP (6): the same day-restart and exclusion behavior, ignoring volume where VWAP weights by it, break pausing, midnight and DST, unchanged default, conflicting option rejected.

Probe: letting out-of-session bars move the running totals while still reporting `null` fails 3 of the tests, so "leave the totals untouched" is genuinely pinned rather than incidental.

Verification:

- `pnpm test` (core): 370 files / 6510 tests passed
- `npx tsc --noEmit --ignoreDeprecations 6.0`: clean
- `pnpm build` (core): success
- `npx biome check` on touched files: clean

## Docs

`API.md` / `API.ja.md` gain a "session anchoring" section on `vwap`, with `twap` pointing at it. The indicator manifest gains `paramHints.session` for both, and its `pitfalls` now state what the UTC-midnight default actually does — that text is handed to a model and shapes the calls it makes, so a stale description there has consequences.