### PR TITLE
feat(core): measure the opening range from a trading session's open

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,14 +2,38 @@
 
 ## [Unreleased]
 
+### Added — `session` option on `openingRange`
+
+The opening range was measured from the first bar of each UTC calendar day.
+For regular-hours-only data that bar is usually the open, so the two agree.
+Once the series carries extended hours it is not: UTC midnight is 19:00 or
+20:00 in New York, so the UTC day begins with a post-market bar, the "opening
+range" is built from it, and every breakout is measured against that.
+
+Passing a `SessionDefinition` measures the range from the session's official
+open instead, in its own timezone, covering its first `minutes`. Bars outside
+the session, and bars inside one of its breaks, report `null`.
+
+A day whose open was never observed reports no range at all. A series starting
+at 09:45 does not get a fresh 30-minute range measured from there: a range
+built from part of the window would be quoted as if it were the whole one, and
+breakouts would be checked against a level the market never set. The next
+session, once its open is observed, behaves normally.
+
+Combining `session` with a bar-count `sessionResetPeriod` throws; leaving it at
+its `"day"` default is what a session run expects. Without `session`, the
+indicator behaves exactly as before.
+
 ### Added — `session` option on `vwap` and `twap`
 
-Both averages restart at UTC midnight, which is not when any exchange's trading
-day begins. For US equities it falls at 19:00 or 20:00 New York time — after
-the close — so a single reset period runs from one day's post-market through
-the next day's pre-market, regular session and post-market, mixing extended
-hours into the figure and never restarting at the open. The reset lines up with
-a trading day only for markets that happen to open near 00:00 UTC.
+Both averages restart at UTC midnight rather than at a session boundary. For a
+series limited to regular trading hours the two often coincide — a US equity
+day sits inside one UTC date — but it breaks once the series carries extended
+hours: UTC midnight is 19:00 or 20:00 in New York, part-way through the
+post-market, so a single reset period runs from there through the next day's
+pre-market, regular session and post-market, mixing extended hours into the
+figure and never restarting at the open. It never lines up for a session that
+itself crosses UTC midnight, whatever the data contains.
 
 Passing a `SessionDefinition` anchors the average to that session instead:
 
@@ -31,10 +55,11 @@ inside one of its breaks, return `null` and leave the running totals untouched
 after the break continues from where trading left off. Sessions that cross
 midnight stay whole, as do sessions running through a DST change.
 
-Combining `session` with `resetPeriod: "rolling"` (or a bar count, or
-`sessionResetPeriod` on `twap`) throws, naming both options: a session brings
-its own boundaries, so honoring one of the two silently would report a figure
-the caller did not ask for.
+Combining `session` with `resetPeriod: "rolling"`, a bar count, or a bar-count
+`sessionResetPeriod` on `twap` throws, naming both options: a session brings its
+own boundaries, so honoring one of the two silently would report a figure the
+caller did not ask for. Leaving the reset option at its `"session"` default is
+what a session run expects.
 
 Without `session`, both indicators behave exactly as before.
 

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -773,14 +773,14 @@ const nyVwap = vwap(candles, {
 **オプション:**
 | オプション | 型 | デフォルト | 説明 |
 |------------|------|---------|------|
-| `resetPeriod` | `'session' \| 'rolling' \| number` | `'session'` | リセット期間タイプ。`session` とは併用不可 |
+| `resetPeriod` | `'session' \| 'rolling' \| number` | `'session'` | リセット期間タイプ。`session` と併用できるのは既定の `'session'` のみ |
 | `period` | `number` | `20` | ローリングVWAP期間 |
 | `bandMultipliers` | `number[]` | — | 追加σバンドの倍率（例：`[2, 3]` で±2σ、±3σ） |
 | `session` | `SessionDefinition` | — | 取引セッションに紐付ける（下記参照） |
 
 **セッション紐付け**
 
-`session` を指定しない場合、平均は UTC 0時でリセットされますが、これはどの取引所の取引開始時刻でもありません。米国株ではニューヨーク時間の 19:00 / 20:00、つまり引け後にあたります。そのため1つのリセット期間が、ある日のポストマーケットから翌日のプレマーケット・通常取引・ポストマーケットまでを1つにまとめてしまい、時間外バーが混ざったまま寄付でリセットされません。
+`session` を指定しない場合、平均はセッションの境界ではなく UTC 0時でリセットされます。通常取引時間のみの系列であれば両者はしばしば一致します（米国株の1日は1つの UTC 日に収まるため）。しかし時間外バーを含む系列では崩れます。UTC 0時はニューヨーク時間の 19:00 / 20:00、つまりポストマーケットの途中にあたるため、1つのリセット期間がそこから翌日のプレマーケット・通常取引・ポストマーケットまでを1つにまとめてしまい、時間外バーが混ざったまま寄付でリセットされません。UTC 0時を跨ぐセッションでは、データの内容にかかわらず一致しません。
 
 `session` を指定すると、平均はセッションのタイムゾーンで、セッション開始時にリセットされ、セッション内のバーだけが対象になります。window 外のバーと break 内のバーは `null` を返し、累積値を変更しません。したがって昼休みは平均を「一時停止」させるだけでリセットしません。深夜を跨ぐセッションも、DST 切り替え日を跨ぐセッションも1つのまま保たれます。
 
@@ -1109,7 +1109,7 @@ const nyTwap = twap(candles, {
 **オプション:**
 | オプション | 型 | デフォルト | 説明 |
 |-----------|------|-----------|------|
-| `sessionResetPeriod` | `'session' \| number` | `'session'` | セッションリセット期間。`session` とは併用不可 |
+| `sessionResetPeriod` | `'session' \| number` | `'session'` | セッションリセット期間。`session` と併用できるのは既定の `'session'` のみ |
 | `session` | `SessionDefinition` | — | 取引セッションに紐付ける — 意味論は [`vwap`](#vwapcandles-options) と同じ |
 
 **戻り値:** `Series<number | null>`
@@ -1635,13 +1635,28 @@ interface FibonacciRetracementValue {
 ```typescript
 const result = openingRange(candles);
 const custom = openingRange(candles, { minutes: 15, sessionResetPeriod: 'day' });
+
+// UTC 暦日の最初のバーではなく、実際のセッション寄付から計測
+const nyOrb = openingRange(candles, {
+  minutes: 30,
+  session: { name: 'regular', startHour: 9, startMinute: 30, endHour: 16, endMinute: 0, timezone: 'America/New_York' },
+});
 ```
 
 **オプション:**
 | オプション | 型 | デフォルト | 説明 |
 |-----------|------|-----------|------|
 | `minutes` | `number` | `30` | オープニングレンジの時間（分） |
-| `sessionResetPeriod` | `'day' \| number` | `'day'` | セッションリセット方式 |
+| `sessionResetPeriod` | `'day' \| number` | `'day'` | セッションリセット方式。`session` と併用できるのは既定の `'day'` のみ |
+| `session` | `SessionDefinition` | — | 取引セッションの寄付からレンジを計測する（下記参照） |
+
+**セッション紐付け**
+
+`session` を指定しない場合、レンジは UTC 暦日の最初のバーから計測されます。通常取引時間のみのデータであれば、そのバーは通常は寄付なので両者は一致します。しかし時間外バーを含む系列では一致しません。UTC 0時はニューヨーク時間の 19:00 / 20:00 にあたるため、UTC 日はポストマーケットのバーから始まり、「オープニングレンジ」がそこから作られてしまいます。
+
+`session` を指定すると、レンジはセッションのタイムゾーンにおける公式な寄付から `minutes` 分を対象にします。セッション外のバーと break 内のバーは `null` を返します。
+
+寄付を観測していない日は、**レンジを一切報告しません**。系列が 09:45 から始まる場合、そこから改めて30分を計測することはしません。window の一部だけで作ったレンジを「オープニングレンジ」として提示すると、市場が実際には付けていない水準でブレイクアウトを判定することになるためです。翌日、寄付が観測されれば通常どおり機能します。
 
 **戻り値:** `Series<OpeningRangeValue>`
 

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -773,14 +773,14 @@ const nyVwap = vwap(candles, {
 **Options:**
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `resetPeriod` | `'session' \| 'rolling' \| number` | `'session'` | Reset period type. Cannot be combined with `session` |
+| `resetPeriod` | `'session' \| 'rolling' \| number` | `'session'` | Reset period type. Only the default `'session'` may be combined with `session` |
 | `period` | `number` | `20` | Period for rolling VWAP |
 | `bandMultipliers` | `number[]` | — | Additional σ-band multipliers (e.g., `[2, 3]` for ±2σ, ±3σ) |
 | `session` | `SessionDefinition` | — | Anchor the average to a trading session (see below) |
 
 **Session anchoring**
 
-Without `session`, the average restarts at UTC midnight, which is not when any exchange's trading day begins. For US equities that is 19:00 or 20:00 New York time — after the close — so one reset period runs from a day's post-market through the next day's pre-market, regular session and post-market: extended-hours bars are mixed in, and the average never restarts at the open.
+Without `session`, the average restarts at UTC midnight rather than at a session boundary. For a series limited to regular trading hours the two often coincide — a US equity day sits inside one UTC date — but it breaks once the series carries extended hours: UTC midnight is 19:00 or 20:00 in New York, part-way through the post-market, so one reset period runs from there through the next day's pre-market, regular session and post-market. It never lines up for a session that itself crosses UTC midnight.
 
 With `session`, the average restarts when the session does, in the session's own timezone, and only bars inside it contribute. Bars outside the window, and bars inside one of its breaks, return `null` and leave the running totals untouched, so a lunch break pauses the average rather than restarting it. Sessions that cross midnight stay whole, as do sessions running through a DST change.
 
@@ -1125,7 +1125,7 @@ const nyTwap = twap(candles, {
 **Options:**
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `sessionResetPeriod` | `'session' \| number` | `'session'` | Reset at each day or every N candles. Cannot be combined with `session` |
+| `sessionResetPeriod` | `'session' \| number` | `'session'` | Reset at each day or every N candles. Only the default `'session'` may be combined with `session` |
 | `session` | `SessionDefinition` | — | Anchor the average to a trading session — same semantics as [`vwap`](#vwapcandles-options) |
 
 **Returns:** `Series<number | null>`
@@ -1659,13 +1659,28 @@ Opening Range Breakout (ORB) — detects the opening range of a session and iden
 ```typescript
 const result = openingRange(candles);
 const custom = openingRange(candles, { minutes: 15, sessionResetPeriod: 'day' });
+
+// Measured from a real session open rather than the first bar of the UTC day
+const nyOrb = openingRange(candles, {
+  minutes: 30,
+  session: { name: 'regular', startHour: 9, startMinute: 30, endHour: 16, endMinute: 0, timezone: 'America/New_York' },
+});
 ```
 
 **Options:**
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `minutes` | `number` | `30` | Opening range duration in minutes |
-| `sessionResetPeriod` | `'day' \| number` | `'day'` | Session reset mode |
+| `sessionResetPeriod` | `'day' \| number` | `'day'` | Session reset mode. Only the default `'day'` may be combined with `session` |
+| `session` | `SessionDefinition` | — | Measure the range from a trading session's open (see below) |
+
+**Session anchoring**
+
+Without `session`, the range is measured from the first bar of each UTC calendar day. For regular-hours-only data that bar is usually the open, so the two agree. Once the series carries extended hours it is not: UTC midnight is 19:00 or 20:00 in New York, so the UTC day begins with a post-market bar and the "opening range" is built from it.
+
+With `session`, the range covers the first `minutes` of the session, measured from its official open in the session's own timezone. Bars outside the session, and bars inside one of its breaks, report `null`.
+
+A day whose open was never observed reports **no range at all**. If a series starts at 09:45, it does not get a fresh 30-minute range measured from there: a range built from part of the window would be quoted as if it were the whole one, and breakouts would be measured against a level the market never set. The next day, once an open is observed, the range works normally.
 
 **Returns:** `Series<OpeningRangeValue>`
 

--- a/packages/core/src/indicators/__tests__/session-anchored-opening-range.test.ts
+++ b/packages/core/src/indicators/__tests__/session-anchored-opening-range.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../types";
+import { openingRange } from "../price/opening-range";
+import type { SessionDefinition } from "../session/session-definition";
+
+const MINUTE = 60 * 1000;
+
+/** New York cash session, 09:30-16:00 local. */
+const NY_REGULAR: SessionDefinition = {
+  name: "regular",
+  startHour: 9,
+  startMinute: 30,
+  endHour: 16,
+  endMinute: 0,
+  timezone: "America/New_York",
+};
+
+/** Runs across midnight, in New York local time. */
+const NY_OVERNIGHT: SessionDefinition = {
+  name: "overnight",
+  startHour: 22,
+  startMinute: 0,
+  endHour: 6,
+  endMinute: 0,
+  timezone: "America/New_York",
+};
+
+function bar(time: number, high: number, low: number, close = (high + low) / 2): NormalizedCandle {
+  return { time, open: close, high, low, close, volume: 1000 };
+}
+
+/** 14:30 UTC = 09:30 New York in January (EST). */
+function nyOpenUtc(day: number): number {
+  return Date.UTC(2024, 0, day, 14, 30);
+}
+
+describe("session-anchored opening range", () => {
+  it("measures the range from the session open, ignoring pre-market bars", () => {
+    const open = nyOpenUtc(2);
+    const candles = [
+      // Pre-market: a wide bar that must not enter the range.
+      bar(open - 60 * MINUTE, 500, 1),
+      bar(open, 105, 95),
+      bar(open + 10 * MINUTE, 110, 100),
+      bar(open + 25 * MINUTE, 108, 102),
+      // Past the 30-minute range.
+      bar(open + 35 * MINUTE, 120, 118, 119),
+    ];
+
+    const result = openingRange(candles, { session: NY_REGULAR, minutes: 30 });
+
+    expect(result[0].value).toEqual({ high: null, low: null, breakout: null });
+    // Range builds over the first three in-session bars: high 110, low 95.
+    expect(result[3].value.high).toBe(110);
+    expect(result[3].value.low).toBe(95);
+    // The pre-market 500/1 bar is nowhere in it.
+    expect(result[4].value.high).toBe(110);
+    expect(result[4].value.breakout).toBe("above");
+  });
+
+  it("reports no range for a day whose open was never observed", () => {
+    // Data starts 15 minutes into the session. Measuring a fresh 30 minutes
+    // from here would quote a range the market never set as the opening one.
+    const open = nyOpenUtc(2);
+    const candles = [
+      bar(open + 15 * MINUTE, 110, 100),
+      bar(open + 25 * MINUTE, 115, 105),
+      bar(open + 45 * MINUTE, 130, 125, 128),
+    ];
+
+    const result = openingRange(candles, { session: NY_REGULAR, minutes: 30 });
+
+    expect(result.every((r) => r.value.high === null)).toBe(true);
+    expect(result.every((r) => r.value.breakout === null)).toBe(true);
+  });
+
+  it("recovers on the next day, once an open is observed", () => {
+    const day1 = nyOpenUtc(2);
+    const day2 = nyOpenUtc(3);
+    const candles = [
+      // Day 1 starts late — no range.
+      bar(day1 + 15 * MINUTE, 110, 100),
+      bar(day1 + 60 * MINUTE, 130, 125, 128),
+      // Day 2 starts at the open.
+      bar(day2, 205, 195),
+      bar(day2 + 40 * MINUTE, 220, 218, 219),
+    ];
+
+    const result = openingRange(candles, { session: NY_REGULAR, minutes: 30 });
+
+    expect(result[0].value.high).toBeNull();
+    expect(result[1].value.high).toBeNull();
+    expect(result[2].value.high).toBe(205);
+    expect(result[3].value.high).toBe(205);
+    expect(result[3].value.breakout).toBe("above");
+  });
+
+  it("restarts the range each session day", () => {
+    const day1 = nyOpenUtc(2);
+    const day2 = nyOpenUtc(3);
+    const candles = [
+      bar(day1, 105, 95),
+      bar(day1 + 60 * MINUTE, 150, 140, 145),
+      bar(day2, 205, 195),
+      bar(day2 + 60 * MINUTE, 250, 240, 245),
+    ];
+
+    const result = openingRange(candles, { session: NY_REGULAR, minutes: 30 });
+
+    expect(result[1].value.high).toBe(105);
+    // Day 2's range is its own, not day 1's carried forward.
+    expect(result[3].value.high).toBe(205);
+    expect(result[3].value.low).toBe(195);
+  });
+
+  it("reports null outside the session", () => {
+    const open = nyOpenUtc(2);
+    const candles = [
+      bar(open, 105, 95),
+      bar(open + 40 * MINUTE, 110, 100, 108),
+      // 21:00 UTC = 16:00 New York — the session has closed.
+      bar(Date.UTC(2024, 0, 2, 21, 30), 200, 190, 195),
+    ];
+
+    const result = openingRange(candles, { session: NY_REGULAR, minutes: 30 });
+
+    expect(result[1].value.high).toBe(105);
+    expect(result[2].value).toEqual({ high: null, low: null, breakout: null });
+  });
+
+  it("detects a breakout below the range", () => {
+    const open = nyOpenUtc(2);
+    const candles = [bar(open, 105, 95), bar(open + 40 * MINUTE, 94, 90, 92)];
+
+    const result = openingRange(candles, { session: NY_REGULAR, minutes: 30 });
+
+    expect(result[1].value.breakout).toBe("below");
+  });
+
+  it("measures a session that crosses midnight from its own open", () => {
+    // 03:00 UTC = 22:00 New York, the session open.
+    const open = Date.UTC(2024, 0, 3, 3, 0);
+    const candles = [
+      bar(open, 105, 95),
+      bar(open + 20 * MINUTE, 108, 98),
+      // 05:00 UTC = midnight local — well past the 30-minute range, and not a
+      // new session.
+      bar(open + 120 * MINUTE, 120, 118, 119),
+    ];
+
+    const result = openingRange(candles, { session: NY_OVERNIGHT, minutes: 30 });
+
+    expect(result[1].value.high).toBe(108);
+    expect(result[2].value.high).toBe(108);
+    expect(result[2].value.breakout).toBe("above");
+  });
+
+  it("leaves the default behavior untouched when no session is given", () => {
+    const open = nyOpenUtc(2);
+    const candles = [bar(open, 105, 95), bar(open + 40 * MINUTE, 110, 100, 108)];
+
+    expect(openingRange(candles)).toEqual(openingRange(candles, { sessionResetPeriod: "day" }));
+  });
+
+  it("rejects a reset period that contradicts the session", () => {
+    const candles = [bar(nyOpenUtc(2), 105, 95)];
+
+    expect(() => openingRange(candles, { session: NY_REGULAR, sessionResetPeriod: 78 })).toThrow(
+      /cannot be combined with `session`/,
+    );
+  });
+
+  describe("a range window no bar can fall into", () => {
+    // `minutes` of zero, negative or NaN leaves the range unformed. Reporting
+    // the untouched sentinels would emit ±Infinity as a price level and make
+    // every close a breakout "above" it.
+    const open = nyOpenUtc(2);
+    const candles = [bar(open, 105, 95), bar(open + 40 * MINUTE, 110, 100, 108)];
+
+    for (const minutes of [0, -5, Number.NaN]) {
+      it(`reports no range for minutes: ${minutes}`, () => {
+        const result = openingRange(candles, { session: NY_REGULAR, minutes });
+
+        for (const point of result) {
+          expect(point.value).toEqual({ high: null, low: null, breakout: null });
+        }
+      });
+
+      it(`matches the non-session path for minutes: ${minutes}`, () => {
+        const withSession = openingRange(candles, { session: NY_REGULAR, minutes });
+        const withoutSession = openingRange(candles, { minutes });
+
+        expect(withSession.map((p) => p.value)).toEqual(withoutSession.map((p) => p.value));
+      });
+    }
+  });
+});

--- a/packages/core/src/indicators/price/opening-range.ts
+++ b/packages/core/src/indicators/price/opening-range.ts
@@ -8,6 +8,11 @@
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, Series } from "../../types";
+import {
+  assertSessionResetCompatible,
+  resolveSessionMembership,
+  type SessionDefinition,
+} from "../session/session-definition";
 
 /**
  * Opening Range options
@@ -19,8 +24,30 @@ export type OpeningRangeOptions = {
    * How sessions are determined:
    * - 'day': Reset at the start of each calendar day (default)
    * - number: Reset every N candles (useful for fixed-interval data)
+   *
+   * Only the default `'day'` may be combined with `session`, which brings its
+   * own boundaries; a bar count throws.
    */
   sessionResetPeriod?: "day" | number;
+  /**
+   * Trading session whose open the range is measured from.
+   *
+   * Without it, the range is measured from the first bar of each UTC calendar
+   * day. For regular-hours-only data that bar is usually the open, so the two
+   * agree. Once the series carries extended hours it is not: UTC midnight is
+   * 19:00 or 20:00 in New York, so the UTC day begins with a post-market bar
+   * and the "opening range" is built from it.
+   *
+   * With it, the range covers the first `minutes` of the session, measured from
+   * the session's official open rather than from whichever bar happens to come
+   * first. A series starting at 09:45 does not get a fresh 30-minute range;
+   * having missed the open, that day reports no range at all, since a range
+   * built from part of the window would be quoted as if it were the whole one.
+   *
+   * Bars outside the session, and bars inside one of its breaks, report
+   * `null`.
+   */
+  session?: SessionDefinition;
 };
 
 /**
@@ -62,7 +89,11 @@ export function openingRange(
   candles: Candle[] | NormalizedCandle[],
   options: OpeningRangeOptions = {},
 ): Series<OpeningRangeValue> {
-  const { minutes = 30, sessionResetPeriod = "day" } = options;
+  const { minutes = 30, sessionResetPeriod = "day", session } = options;
+
+  if (session) {
+    assertSessionResetCompatible("openingRange", "sessionResetPeriod", sessionResetPeriod, "day");
+  }
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
 
@@ -73,6 +104,71 @@ export function openingRange(
   const result: Series<OpeningRangeValue> = [];
   const MS_PER_DAY = 86400000;
   const openingRangeMs = minutes * 60 * 1000;
+  const NO_RANGE: OpeningRangeValue = { high: null, low: null, breakout: null };
+
+  if (session) {
+    // Session-anchored: the range covers the first `minutes` of the session,
+    // measured from its official open.
+    let currentOccurrence = -1;
+    let sawSessionOpen = false;
+    let orHigh = Number.NEGATIVE_INFINITY;
+    let orLow = Number.POSITIVE_INFINITY;
+
+    for (const candle of normalized) {
+      const membership = resolveSessionMembership(candle.time, session);
+
+      if (!membership.active) {
+        result.push({ time: candle.time, value: { ...NO_RANGE } });
+        continue;
+      }
+
+      if (membership.occurrenceKey !== currentOccurrence) {
+        currentOccurrence = membership.occurrenceKey;
+        orHigh = Number.NEGATIVE_INFINITY;
+        orLow = Number.POSITIVE_INFINITY;
+        // Only a range that starts at the open is an opening range. When the
+        // data begins mid-session, a range built from what is left would be
+        // quoted as if it covered the whole window, and breakouts would be
+        // measured against a level the market never actually set.
+        sawSessionOpen = membership.elapsedMinutes === 0;
+      }
+
+      if (!sawSessionOpen) {
+        result.push({ time: candle.time, value: { ...NO_RANGE } });
+        continue;
+      }
+
+      if (membership.elapsedMinutes < minutes) {
+        if (candle.high > orHigh) orHigh = candle.high;
+        if (candle.low < orLow) orLow = candle.low;
+
+        result.push({
+          time: candle.time,
+          value: { high: orHigh, low: orLow, breakout: null },
+        });
+        continue;
+      }
+
+      if (orHigh === Number.NEGATIVE_INFINITY || orLow === Number.POSITIVE_INFINITY) {
+        // No bar ever fell inside the range window — `minutes` is zero,
+        // negative or NaN. There is no level to break out of, so report none
+        // rather than the untouched sentinels.
+        result.push({ time: candle.time, value: { ...NO_RANGE } });
+        continue;
+      }
+
+      let breakout: "above" | "below" | null = null;
+      if (candle.close > orHigh) {
+        breakout = "above";
+      } else if (candle.close < orLow) {
+        breakout = "below";
+      }
+
+      result.push({ time: candle.time, value: { high: orHigh, low: orLow, breakout } });
+    }
+
+    return tagSeries(result, { kind: "openingRange", overlay: true, label: "ORB" });
+  }
 
   let sessionStartTime = -1;
   let lastDayIndex = -1;

--- a/packages/core/src/indicators/volume/twap.ts
+++ b/packages/core/src/indicators/volume/twap.ts
@@ -22,17 +22,22 @@ export type TwapOptions = {
    * - 'session': Reset at the start of each day (default)
    * - number: Reset every N candles
    *
-   * Cannot be combined with `session`, which brings its own boundaries.
+   * Only the default `'session'` may be combined with `session`, which brings
+   * its own boundaries; a bar count throws.
    */
   sessionResetPeriod?: "session" | number;
   /**
    * Trading session the average belongs to.
    *
-   * Without it, the average restarts at UTC midnight, which is not when any
-   * exchange's trading day begins — for US equities it is 19:00 or 20:00 New
-   * York time, after the close — so one reset period runs from a day's
-   * post-market through the next day's pre-market, regular session and
-   * post-market. With it, the average restarts when the session does, in the
+   * Without it, the average restarts at UTC midnight rather than at a session
+   * boundary. For a series limited to regular trading hours the two often
+   * coincide — a US equity day sits inside one UTC date — but it breaks once
+   * the series carries extended hours: UTC midnight is 19:00 or 20:00 in New
+   * York, part-way through the post-market, so one reset period runs from
+   * there through the next day's pre-market, regular session and post-market.
+   * It never lines up for a session that itself crosses UTC midnight.
+   *
+   * With it, the average restarts when the session does, in the
    * session's own timezone, and only bars inside the session contribute: bars
    * outside the window, and bars inside one of its breaks, produce `null` and
    * leave the running totals untouched.

--- a/packages/core/src/indicators/volume/vwap.ts
+++ b/packages/core/src/indicators/volume/vwap.ts
@@ -25,7 +25,8 @@ export type VwapOptions = {
    * - 'rolling': Rolling VWAP over specified period
    * - number: Reset every N candles
    *
-   * Cannot be combined with `session`, which brings its own boundaries.
+   * Only the default `'session'` may be combined with `session`, which brings
+   * its own boundaries; `'rolling'` and bar counts throw.
    */
   resetPeriod?: "session" | "rolling" | number;
   /** Period for rolling VWAP (only used when resetPeriod is 'rolling') */
@@ -33,11 +34,15 @@ export type VwapOptions = {
   /**
    * Trading session the VWAP belongs to.
    *
-   * Without it, the average restarts at UTC midnight, which is not when any
-   * exchange's trading day begins — for US equities it is 19:00 or 20:00 New
-   * York time, after the close — so one reset period runs from a day's
-   * post-market through the next day's pre-market, regular session and
-   * post-market. With it, the average restarts when the session does, in the
+   * Without it, the average restarts at UTC midnight rather than at a session
+   * boundary. For a series limited to regular trading hours the two often
+   * coincide — a US equity day sits inside one UTC date — but it breaks once
+   * the series carries extended hours: UTC midnight is 19:00 or 20:00 in New
+   * York, part-way through the post-market, so one reset period runs from
+   * there through the next day's pre-market, regular session and post-market.
+   * It never lines up for a session that itself crosses UTC midnight.
+   *
+   * With it, the average restarts when the session does, in the
    * session's own timezone, and only bars inside the session contribute: bars
    * outside the window, and bars inside one of its breaks, produce `null` and
    * leave the running totals untouched.

--- a/packages/core/src/manifest/entries/price.ts
+++ b/packages/core/src/manifest/entries/price.ts
@@ -141,6 +141,7 @@ export const PRICE_MANIFESTS: IndicatorManifest[] = [
       "Range size matters: very tight opening range = high probability of false breakout (compression)",
       "30-minute default is one of several conventions — 15-minute and 60-minute also widely used; results differ materially",
       "Less useful in low-volatility sessions or on instruments without clear session boundaries",
+      "Without `session`, the range starts at the first bar of each UTC calendar day. RTH-only data usually starts at the open; with extended hours the UTC day begins with a post-market bar and the 'opening range' is built from it. Pass `session` to measure it from the real open",
     ],
     synergy: [
       "VWAP for institutional cost reference within the session",
@@ -151,7 +152,9 @@ export const PRICE_MANIFESTS: IndicatorManifest[] = [
     paramHints: {
       minutes: "30 default. Other common conventions: 5, 15, 60",
       sessionResetPeriod:
-        "'day' default (CALENDAR-day reset, not exchange session). Pass a number for fixed N-bar reset",
+        "'day' default (CALENDAR-day reset, not exchange session). Pass a number for fixed N-bar reset. Only the default 'day' may be combined with `session`; a number throws",
+      session:
+        "SessionDefinition to measure the range from a real session open, in its own timezone. Out-of-session and break bars return null. A day whose open was not observed (data starting mid-session) reports no range rather than a partial one measured from the first available bar",
     },
   },
   {

--- a/packages/core/src/manifest/entries/volume.ts
+++ b/packages/core/src/manifest/entries/volume.ts
@@ -17,7 +17,7 @@ export const VOLUME_MANIFESTS: IndicatorManifest[] = [
       "Pullback to VWAP in trend = continuation entry zone",
     ],
     pitfalls: [
-      "Without `session`, the reset is at UTC midnight — 19:00/20:00 New York, after the close — so one period runs from a day's post-market through the next day's pre-market, regular session and post-market. Pass `session` to anchor it to the actual trading day",
+      "Without `session`, the reset is at UTC midnight, not a session boundary. RTH-only data often coincides; with extended hours it does not — UTC midnight is 19:00/20:00 New York, so one period runs from a day's post-market through the next day's pre-market, regular session and post-market. Pass `session` to anchor it to the actual trading day, and for any session crossing UTC midnight",
       "Session-reset VWAP loses most of its intended relevance across multiple days; trendcraft offers `resetPeriod: 'rolling' | number` for non-session use",
       "Less useful pre-market or in low-volume sessions",
       "Anchored variants (anchoredVwap) are often more meaningful for multi-day context",
@@ -29,7 +29,7 @@ export const VOLUME_MANIFESTS: IndicatorManifest[] = [
     timeframe: ["intraday"],
     paramHints: {
       resetPeriod:
-        "'session' default (resets per trading day). 'rolling' for windowed VWAP, or number for fixed N-bar reset. Cannot be combined with `session`",
+        "'session' default (resets per trading day). 'rolling' for windowed VWAP, or number for fixed N-bar reset. Only the default 'session' may be combined with `session`; 'rolling' and numbers throw",
       period: "Used only when resetPeriod='rolling' — sets the rolling window length",
       bandMultipliers:
         "Extra ±N σ band pairs beyond the default ±1σ (e.g. [2, 3] adds ±2σ and ±3σ)",
@@ -199,14 +199,14 @@ export const VOLUME_MANIFESTS: IndicatorManifest[] = [
       "TWAP and VWAP can diverge meaningfully on event days when volume is concentrated",
       "Not a market-direction reference; primarily an execution benchmark",
       "Resets per session by default — meaningless on multi-day timeframes without anchoring",
-      "Without `session`, the reset is at UTC midnight — 19:00/20:00 New York, after the close — so one period runs from a day's post-market through the next day's pre-market, regular session and post-market. Pass `session` to anchor it to the actual trading day",
+      "Without `session`, the reset is at UTC midnight, not a session boundary. RTH-only data often coincides; with extended hours it does not — UTC midnight is 19:00/20:00 New York, so one period runs from a day's post-market through the next day's pre-market, regular session and post-market. Pass `session` to anchor it to the actual trading day, and for any session crossing UTC midnight",
     ],
     synergy: ["VWAP for cross-check; large TWAP-VWAP gap signals uneven volume distribution"],
     marketRegime: ["ranging"],
     timeframe: ["intraday"],
     paramHints: {
       sessionResetPeriod:
-        "'session' default (resets per trading day). Pass a number for fixed N-bar reset. Cannot be combined with `session`",
+        "'session' default (resets per trading day). Pass a number for fixed N-bar reset. Only the default 'session' may be combined with `session`; a number throws",
       session:
         "SessionDefinition to anchor the average to a real trading session, in its own timezone. Only in-session bars contribute; out-of-session and break bars return null without moving the totals. Handles midnight-crossing sessions and DST",
     },


### PR DESCRIPTION
## Problem

`openingRange` measures the range from the first bar of each UTC calendar day.

For regular-hours-only data that bar is usually the open, so the two agree. Once the series carries extended hours it does not: UTC midnight is 19:00 or 20:00 in New York, so the UTC day begins with a post-market bar, the "opening range" is built from it, and every breakout is measured against that level.

## Fix

Passing a `SessionDefinition` measures the range from the session's official open instead, in its own timezone, covering its first `minutes`:

```ts
const nyOrb = openingRange(candles, {
  minutes: 30,
  session: {
    name: "regular",
    startHour: 9, startMinute: 30,
    endHour: 16, endMinute: 0,
    timezone: "America/New_York",
  },
});
```

Bars outside the session, and bars inside one of its breaks, report `null`.

### A day whose open was never observed reports no range

A series starting at 09:45 does not get a fresh 30-minute range measured from there. A range built from part of the window would be quoted as if it were the whole one, and breakouts would be checked against a level the market never set. The next session, once its open is observed, behaves normally.

This falls out of measuring elapsed time from the session's start rather than from whichever bar arrives first — the `elapsedMinutes` field added with the shared session membership helper.

### Unformed ranges

`minutes` of zero, negative or `NaN` leaves no bar able to fall inside the window. The session path now reports no range there, matching what the calendar-day path already did. Without the guard the untouched sentinels leaked out as ±Infinity price levels, which also made every close a breakout `"above"`.

Combining `session` with a bar-count `sessionResetPeriod` throws; leaving it at its `"day"` default is what a session run expects. **Without `session`, the indicator behaves exactly as before** — pinned by a test.

## Also: wording on `vwap` / `twap`

The `session` documentation added for those two claimed the UTC-midnight default lands mid-session for most exchanges. That was wrong in two ways, and is corrected here: UTC midnight is *after* the US close, not mid-session, and for regular-hours-only data the default coincides with the trading day rather than breaking. The claim now states the conditions under which it diverges — extended hours present, or a session that itself crosses UTC midnight.

## Test plan

15 new tests.

Session anchoring (9): the range ignores pre-market bars and forms from the open (high 110 / low 95 with a 500/1 pre-market bar present); a day starting 15 minutes late reports nothing; the next day recovers; the range restarts each session day; out-of-session bars report `null`; breakouts below the range; a midnight-crossing session measured from its own open; the default path unchanged; a conflicting reset period rejected.

Unformed range (6): `minutes` of `0`, `-5` and `NaN` each report `{ high: null, low: null, breakout: null }` on every bar, **and** produce output identical to the non-session path — so the two paths cannot drift apart on degenerate input.

Probes, each reverted after checking:

| Probe | Failing tests |
| --- | --- |
| Treat a mid-session start as if it were the open | 2 |
| Remove the unformed-range guard | 6 |

Verification:

- `pnpm test` (core): 371 files / 6525 tests passed
- `npx tsc --noEmit --ignoreDeprecations 6.0`: clean
- `pnpm build` (core): success
- `npx biome check` on touched files: clean

## Docs

`API.md` / `API.ja.md` gain a session-anchoring section on `openingRange`. The indicator manifest gains `paramHints.session` and a pitfall describing what the calendar-day default does — that text reaches a model and shapes the calls it makes.