### PR TITLE
fix(core): adopt swing levels when the pivot is confirmed, not when it prints

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -218,6 +218,43 @@ capital outside the market.
 
 Multi-tranche results change for any backtest that closes more than one trade.
 
+### Fixed — swing levels are adopted when the pivot is confirmed, not when it prints
+
+`swingPoints` reports two different things: `isSwingHigh` / `isSwingLow` mark
+the pivot bar itself, and `swingHighPrice` / `swingLowPrice` /
+`swingHighIndex` / `swingLowIndex` trail the most recent swing level. A pivot
+is decided by the `rightBars` bars that follow it, so it is only knowable that
+many bars later — but the trailing fields were updated on the pivot bar. Read
+bar by bar, as a backtest or any per-bar consumer does, they handed out a level
+the market had not confirmed yet. On a 200-bar random walk with the default
+5/5, 103 of the 200 bars disagreed with a run that ended at that bar.
+
+The trailing fields now adopt a pivot at `pivotIndex + rightBars`, so a run
+over the whole series and a run that stops at bar `k` report the same levels at
+bar `k`. `swingHighIndex` / `swingLowIndex` are therefore at least `rightBars`.
+`isSwingHigh` / `isSwingLow` keep marking the pivot bar and stay retrospective
+— that is what draws a swing marker on the chart at the right place — and this
+is now stated in their documentation.
+
+`liquiditySweep` read those trailing fields once per bar, so it replaced its
+tracked swing high and low at the pivot bar as well. A newer, still-unconfirmed
+pivot could hide an older level that price was in fact sweeping. With
+`swingPeriod: 2`, a swing high of 105 confirmed earlier and an outside bar
+printing a 110 pivot that only confirms two bars later, the next bar trading up
+to 107 reported nothing, while a run ending at that bar reported a bearish
+sweep of 105. It now promotes a pivot to a tracked level at
+`pivotIndex + swingPeriod`, and the two runs agree.
+
+Bars emitted by `liquiditySweep` are also snapshots now. `sweep` and the
+entries in `recentSweeps` used to be the live sweep objects, which keep being
+mutated while they wait for recovery, so a recovery several bars later
+retroactively set `recovered` and `recoveredIndex` on bars that had already
+been emitted.
+
+Swing-level values and sweep detection change. Indicators that build on the
+`isSwingHigh` / `isSwingLow` flags — Fibonacci levels, channel lines,
+pitchfork, S/R zones, pattern detection — are untouched.
+
 ## [0.5.0] - 2026-07-26
 
 ### Read this first — your numbers will change

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -245,11 +245,18 @@ to 107 reported nothing, while a run ending at that bar reported a bearish
 sweep of 105. It now promotes a pivot to a tracked level at
 `pivotIndex + swingPeriod`, and the two runs agree.
 
-Bars emitted by `liquiditySweep` are also snapshots now. `sweep` and the
-entries in `recentSweeps` used to be the live sweep objects, which keep being
-mutated while they wait for recovery, so a recovery several bars later
-retroactively set `recovered` and `recoveredIndex` on bars that had already
-been emitted.
+`createLiquiditySweep`, the streaming counterpart, adopted a newly confirmed
+pivot *before* judging the bar that confirmed it, so it missed a sweep of the
+older level on that bar — the case above, where the bar trades above the level
+still being tracked and below the pivot it is confirming. It now judges the bar
+first and adopts afterwards, matching the batch indicator bar by bar. A bar
+cannot break the pivot it confirms: swing detection is strict, so every bar in
+the confirmation window is below it.
+
+Bars emitted by both indicators are also snapshots now. `sweep` and the entries
+in `recentSweeps` used to be the live sweep objects, which keep being mutated
+while they wait for recovery, so a recovery several bars later retroactively set
+`recovered` and `recoveredIndex` on bars that had already been emitted.
 
 Swing-level values and sweep detection change. Indicators that build on the
 `isSwingHigh` / `isSwingLow` flags — Fibonacci levels, channel lines,

--- a/packages/core/src/indicators/__tests__/swing-points.test.ts
+++ b/packages/core/src/indicators/__tests__/swing-points.test.ts
@@ -108,6 +108,77 @@ describe("swingPoints", () => {
     expect(hasSwingHigh).toBe(false);
   });
 
+  describe("trailing levels are knowable at the bar they are reported on", () => {
+    it("adopts a pivot only once its confirmation window has closed", () => {
+      // Pivot high at index 1, confirmed by the bars up to index 4.
+      const candles = makeCandles([
+        { o: 100, h: 105, l: 99, c: 104 }, // 0
+        { o: 104, h: 120, l: 103, c: 118 }, // 1 - pivot high at 120
+        { o: 118, h: 110, l: 108, c: 109 }, // 2
+        { o: 109, h: 108, l: 106, c: 107 }, // 3
+        { o: 107, h: 106, l: 104, c: 105 }, // 4 - pivot confirmable here
+        { o: 105, h: 107, l: 103, c: 106 }, // 5
+      ]);
+
+      const result = swingPoints(candles, { leftBars: 1, rightBars: 3 });
+
+      expect(result[1].value.isSwingHigh).toBe(true);
+      // The pivot bar itself, and every bar inside the confirmation window,
+      // still report the previous (here: no) swing level.
+      expect(result[1].value.swingHighPrice).toBeNull();
+      expect(result[2].value.swingHighPrice).toBeNull();
+      expect(result[3].value.swingHighPrice).toBeNull();
+      expect(result[4].value.swingHighPrice).toBe(120);
+      expect(result[4].value.swingHighIndex).toBe(3);
+      expect(result[5].value.swingHighIndex).toBe(4);
+    });
+
+    it("reports the same trailing levels as a run that ends at that bar", () => {
+      // Deterministic random walk.
+      let seed = 42;
+      const random = () => {
+        seed = (seed * 16807) % 2147483647;
+        return seed / 2147483647;
+      };
+      const rows: Array<{ o: number; h: number; l: number; c: number }> = [];
+      let price = 100;
+      for (let i = 0; i < 200; i++) {
+        const open = price;
+        const close = price * (1 + (random() - 0.5) * 0.06);
+        rows.push({
+          o: open,
+          h: Math.max(open, close) * (1 + random() * 0.02),
+          l: Math.min(open, close) * (1 - random() * 0.02),
+          c: close,
+        });
+        price = close;
+      }
+      const candles = makeCandles(rows);
+      const options = { leftBars: 5, rightBars: 5 };
+
+      const full = swingPoints(candles, options);
+      const mismatches: number[] = [];
+      for (let k = 0; k < candles.length; k++) {
+        const prefix = swingPoints(candles.slice(0, k + 1), options);
+        const a = full[k].value;
+        const b = prefix[k].value;
+        if (
+          a.swingHighPrice !== b.swingHighPrice ||
+          a.swingLowPrice !== b.swingLowPrice ||
+          a.swingHighIndex !== b.swingHighIndex ||
+          a.swingLowIndex !== b.swingLowIndex
+        ) {
+          mismatches.push(k);
+        }
+      }
+
+      expect(mismatches).toEqual([]);
+      // Guard against a series with no swings at all making this vacuous.
+      expect(full.some((r) => r.value.swingHighPrice !== null)).toBe(true);
+      expect(full.some((r) => r.value.swingLowPrice !== null)).toBe(true);
+    });
+  });
+
   describe("getSwingHighs", () => {
     it("should return array of swing high points", () => {
       const candles = makeCandles([

--- a/packages/core/src/indicators/incremental/__tests__/liquidity-sweep.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/liquidity-sweep.test.ts
@@ -1,9 +1,10 @@
 /**
  * Parity tests for incremental Liquidity Sweep vs batch.
  *
- * The batch implementation uses look-ahead (it consults `swings[i].isSwingHigh`
- * which itself peeks `swingPeriod` bars into the future), so the live indicator
- * cannot match batch bar-by-bar. Instead we verify:
+ * Both sides adopt a swing level once its pivot is confirmed, so they agree
+ * bar by bar. We verify:
+ *  - Detection matches on every bar, including a confirmation bar that sweeps
+ *    the level tracked before it.
  *  - The set of detected sweeps (keyed by sweepIndex + type) is identical once
  *    both sides finish processing.
  *  - Recovery indices agree on every sweep that both sides detect.
@@ -83,9 +84,84 @@ function collectBatch(
   return map;
 }
 
+function describeSweep(value: {
+  isSweep: boolean;
+  sweep: { type: string; sweptLevel: number } | null;
+}) {
+  return {
+    isSweep: value.isSweep,
+    type: value.sweep?.type ?? null,
+    level: value.sweep?.sweptLevel ?? null,
+  };
+}
+
 describe("createLiquiditySweep", () => {
   const candles = generateCandles(400);
   const opts = { swingPeriod: 3, maxRecoveryBars: 4, maxTrackedSweeps: 10 };
+
+  it("sweeps the older level on a bar that also confirms a new pivot", () => {
+    // Swing high 105 at bar 1 (confirmed at bar 2) and swing low 94 at bar 2
+    // (confirmed at bar 3). Bar 4 is an outside bar: it sweeps the low, which
+    // suppresses the bearish check, so 105 survives even though bar 4 traded
+    // through it. Bar 4 is also a pivot high at 110, confirmed on bar 5 — and
+    // bar 5 trades to 107, above the still-tracked 105 and below the 110 it is
+    // confirming. Adopting 110 before judging bar 5 would hide that sweep.
+    const rows = [
+      { o: 99, h: 100, l: 98, c: 99 }, // 0
+      { o: 99, h: 105, l: 96, c: 104 }, // 1 - pivot high 105
+      { o: 104, h: 103, l: 94, c: 100 }, // 2 - pivot low 94
+      { o: 100, h: 104, l: 95, c: 103 }, // 3
+      { o: 103, h: 110, l: 90, c: 100 }, // 4 - outside bar: sweeps 94; pivot high 110
+      { o: 100, h: 107, l: 93, c: 100 }, // 5 - sweeps 105 while confirming 110
+      { o: 100, h: 106, l: 94, c: 101 }, // 6
+    ];
+    const fixture: NormalizedCandle[] = rows.map((d, i) => ({
+      time: 1700000000000 + i * 86400000,
+      open: d.o,
+      high: d.h,
+      low: d.l,
+      close: d.c,
+      volume: 1000,
+    }));
+    const options = { swingPeriod: 1, maxRecoveryBars: 3, minSweepDepth: 0 };
+
+    const batch = liquiditySweep(fixture, options);
+    expect(batch[4].value.sweep?.type).toBe("bullish");
+    expect(batch[4].value.sweep?.sweptLevel).toBe(94);
+    expect(batch[5].value.sweep?.type).toBe("bearish");
+    expect(batch[5].value.sweep?.sweptLevel).toBe(105);
+
+    const live = createLiquiditySweep(options);
+    for (let i = 0; i < fixture.length; i++) {
+      const value = live.next(fixture[i]).value;
+      expect({ bar: i, ...describeSweep(value) }).toEqual({
+        bar: i,
+        ...describeSweep(batch[i].value),
+      });
+    }
+  });
+
+  it("detects the same sweeps as batch on every bar", () => {
+    let compared = 0;
+    let sweeps = 0;
+    for (const swingPeriod of [1, 2, 3, 5]) {
+      const options = { swingPeriod, maxRecoveryBars: 3, minSweepDepth: 0 };
+      const batch = liquiditySweep(candles, options);
+      const live = createLiquiditySweep(options);
+      for (let i = 0; i < candles.length; i++) {
+        const value = live.next(candles[i]).value;
+        expect({ bar: i, swingPeriod, ...describeSweep(value) }).toEqual({
+          bar: i,
+          swingPeriod,
+          ...describeSweep(batch[i].value),
+        });
+        compared++;
+        if (batch[i].value.isSweep) sweeps++;
+      }
+    }
+    expect(compared).toBe(candles.length * 4);
+    expect(sweeps).toBeGreaterThan(0);
+  });
 
   it("detects the same set of sweeps as batch", () => {
     const liveMap = collectLive(candles, opts);

--- a/packages/core/src/indicators/incremental/smc/liquidity-sweep.ts
+++ b/packages/core/src/indicators/incremental/smc/liquidity-sweep.ts
@@ -13,15 +13,18 @@
  *
  *   1. Drives an internal `createSwingPoints` for confirmation (delayed).
  *   2. Holds the last `swingPeriod + 1` candles in a ring.
- *   3. When a swing is confirmed at step `t` (for bar `mid = t - swingPeriod`),
+ *   3. Judges the current bar against the levels tracked before it, and only
+ *      then adopts a swing this bar confirms — the order matters, because a
+ *      bar that confirms a new pivot can itself sweep the older level.
+ *   4. When a swing is confirmed at step `t` (for bar `mid = t - swingPeriod`),
  *      it scans the buffered bars `(mid, t]` against the new level to detect
  *      any sweep that already occurred in that window — `sweep.sweepIndex /
  *      sweepTime` reflect the actual bar.
- *   4. Recovery checks always run against the current bar.
+ *   5. Recovery checks always run against the current bar.
  *
- * The set of sweeps observed by the live indicator eventually matches batch,
- * but emission lags real time by up to `swingPeriod` bars. Tests compare the
- * multiset of detected sweeps after both sides finish processing.
+ * The batch indicator adopts levels at the same point, so the two agree bar by
+ * bar; a sweep is still only reported once the level it broke was confirmed,
+ * which is what a live feed can know.
  *
  * State category: **Mixed** (an inner `createSwingPoints` snapshot
  * plus a `swingPeriod + 1` scan ring buffer). The buffer capacity and
@@ -241,6 +244,31 @@ export function createLiquiditySweep(
 
       const confirmedSwingIdx = idx - swingPeriod;
 
+      // The current bar is judged against the levels that were already
+      // tracked when it opened. A pivot that this very bar confirms is adopted
+      // afterwards: it was not an established level while the bar traded, and
+      // by the strict-inequality rule of swing detection this bar cannot break
+      // it anyway. Adopting it first would hide a sweep of the older level.
+      const currentBar = buffer.newest();
+      if (newSweep === null && recentSwingLow) {
+        const sweep = trySweep(recentSwingLow, currentBar, "bullish");
+        if (sweep) {
+          newSweep = sweep;
+          if (sweep.recovered) recoveredThisBar.push(sweep);
+          pushSweep(sweep);
+          recentSwingLow = null;
+        }
+      }
+      if (newSweep === null && recentSwingHigh) {
+        const sweep = trySweep(recentSwingHigh, currentBar, "bearish");
+        if (sweep) {
+          newSweep = sweep;
+          if (sweep.recovered) recoveredThisBar.push(sweep);
+          pushSweep(sweep);
+          recentSwingHigh = null;
+        }
+      }
+
       // Process newly-confirmed swings. Outside bars can confirm both a high
       // and a low on the same step, so each side runs an independent backfill
       // scan. If a backfill produces a sweep the swing tracker is reset (it
@@ -276,27 +304,6 @@ export function createLiquiditySweep(
         }
       }
 
-      // Current bar against any pre-existing tracked swing (set in earlier steps).
-      const currentBar = buffer.newest();
-      if (newSweep === null && recentSwingLow) {
-        const sweep = trySweep(recentSwingLow, currentBar, "bullish");
-        if (sweep) {
-          newSweep = sweep;
-          if (sweep.recovered) recoveredThisBar.push(sweep);
-          pushSweep(sweep);
-          recentSwingLow = null;
-        }
-      }
-      if (newSweep === null && recentSwingHigh) {
-        const sweep = trySweep(recentSwingHigh, currentBar, "bearish");
-        if (sweep) {
-          newSweep = sweep;
-          if (sweep.recovered) recoveredThisBar.push(sweep);
-          pushSweep(sweep);
-          recentSwingHigh = null;
-        }
-      }
-
       // Delayed recovery on previously tracked unrecovered sweeps.
       const survivors: LiquiditySweep[] = [];
       for (const sweep of recentSweeps) {
@@ -319,13 +326,15 @@ export function createLiquiditySweep(
       }
       recentSweeps = survivors;
 
+      // Emit copies: a sweep object keeps being mutated while it waits for
+      // recovery, and a value already handed out must not change.
       return {
         time: candle.time,
         value: {
           isSweep: newSweep !== null,
-          sweep: newSweep,
+          sweep: newSweep === null ? null : { ...newSweep },
           recentSweeps: recentSweeps.map((s) => ({ ...s })),
-          recoveredThisBar,
+          recoveredThisBar: recoveredThisBar.map((s) => ({ ...s })),
         },
       };
     },

--- a/packages/core/src/indicators/price/swing-points.ts
+++ b/packages/core/src/indicators/price/swing-points.ts
@@ -14,17 +14,22 @@ import type { Candle, NormalizedCandle, Series } from "../../types";
  * Swing point detection result
  */
 export type SwingPointValue = {
-  /** Is this bar a confirmed swing high? */
+  /**
+   * Is this bar a swing high?
+   *
+   * Retrospective marker: it sits on the pivot bar itself, which only becomes
+   * knowable `rightBars` bars later.
+   */
   isSwingHigh: boolean;
-  /** Is this bar a confirmed swing low? */
+  /** Is this bar a swing low? Retrospective, like `isSwingHigh`. */
   isSwingLow: boolean;
-  /** Price of the most recent swing high */
+  /** Price of the most recent swing high confirmed as of this bar */
   swingHighPrice: number | null;
-  /** Price of the most recent swing low */
+  /** Price of the most recent swing low confirmed as of this bar */
   swingLowPrice: number | null;
-  /** Bars since the most recent swing high */
+  /** Bars since the most recent swing high confirmed as of this bar (at least `rightBars`) */
   swingHighIndex: number | null;
-  /** Bars since the most recent swing low */
+  /** Bars since the most recent swing low confirmed as of this bar (at least `rightBars`) */
   swingLowIndex: number | null;
 };
 
@@ -49,7 +54,15 @@ export type SwingPointOptions = {
  * - The bar's low is lower than all bars within leftBars to the left
  * - The bar's low is lower than all bars within rightBars to the right
  *
- * Note: Swing points are confirmed with a delay of rightBars.
+ * Note: Swing points are confirmed with a delay of rightBars. The two field
+ * groups are on different time bases:
+ *
+ * - `isSwingHigh` / `isSwingLow` mark the pivot bar itself, so they are
+ *   retrospective — reading them while stepping through the series exposes
+ *   what the following `rightBars` bars did.
+ * - `swingHighPrice` / `swingLowPrice` / `swingHighIndex` / `swingLowIndex`
+ *   only adopt a pivot once its confirmation window has closed, so they hold
+ *   what was knowable at that bar and can be read bar by bar.
  *
  * @param candles - Array of candles (raw or normalized)
  * @param options - Swing point options
@@ -130,14 +143,19 @@ export function swingPoints(
   let lastSwingLowIdx: number | null = null;
 
   for (let i = 0; i < normalized.length; i++) {
-    // Update tracking when we pass a swing point
-    if (swingHighs[i]) {
-      lastSwingHighPrice = normalized[i].high;
-      lastSwingHighIdx = i;
-    }
-    if (swingLows[i]) {
-      lastSwingLowPrice = normalized[i].low;
-      lastSwingLowIdx = i;
+    // Adopt a pivot only once its confirmation window has closed: a pivot at
+    // index p reads bars up to p + rightBars, so bar p + rightBars is the
+    // first bar from which it is knowable.
+    const confirmedIdx = i - rightBars;
+    if (confirmedIdx >= 0) {
+      if (swingHighs[confirmedIdx]) {
+        lastSwingHighPrice = normalized[confirmedIdx].high;
+        lastSwingHighIdx = confirmedIdx;
+      }
+      if (swingLows[confirmedIdx]) {
+        lastSwingLowPrice = normalized[confirmedIdx].low;
+        lastSwingLowIdx = confirmedIdx;
+      }
     }
 
     result.push({

--- a/packages/core/src/indicators/smc/__tests__/liquidity-sweep.test.ts
+++ b/packages/core/src/indicators/smc/__tests__/liquidity-sweep.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from "vitest";
 import type { NormalizedCandle } from "../../../types";
-import { getRecoveredSweeps, hasRecentSweepSignal, liquiditySweep } from "../liquidity-sweep";
+import {
+  getRecoveredSweeps,
+  hasRecentSweepSignal,
+  type LiquiditySweepValue,
+  liquiditySweep,
+} from "../liquidity-sweep";
+
+const describeSweep = (value: LiquiditySweepValue) => ({
+  isSweep: value.isSweep,
+  type: value.sweep?.type ?? null,
+  level: value.sweep?.sweptLevel ?? null,
+});
 
 const makeCandles = (
   data: Array<{ o: number; h: number; l: number; c: number }>,
@@ -199,6 +210,108 @@ describe("liquiditySweep", () => {
 
       const sweepBar = result.find((r) => r.value.isSweep);
       expect(sweepBar).toBeUndefined();
+    });
+  });
+
+  describe("Swing levels are adopted only once confirmable", () => {
+    it("still sweeps the old level while a newer pivot is unconfirmed", () => {
+      // Pivot high 105 at bar 2 (confirmable at bar 4) and pivot low 90 at
+      // bar 5 (confirmable at bar 7). Bar 8 is an outside bar: it sweeps the
+      // low, and is itself a pivot high at 110 — confirmable only at bar 10.
+      // Bar 9 trades at 107: above the still-active 105, below the unconfirmed
+      // 110. It is a sweep of 105.
+      const candles = makeCandles([
+        { o: 99, h: 100, l: 98, c: 99 }, // 0
+        { o: 99, h: 101, l: 97, c: 100 }, // 1
+        { o: 100, h: 105, l: 96, c: 104 }, // 2 - pivot high 105
+        { o: 101, h: 102, l: 95, c: 100 }, // 3
+        { o: 100, h: 103, l: 94, c: 101 }, // 4
+        { o: 101, h: 104, l: 90, c: 95 }, // 5 - pivot low 90
+        { o: 95, h: 105, l: 93, c: 100 }, // 6
+        { o: 100, h: 104, l: 92, c: 97 }, // 7
+        { o: 97, h: 110, l: 85, c: 95 }, // 8 - sweeps 90; pivot high 110 + pivot low 85
+        { o: 95, h: 107, l: 88, c: 100 }, // 9 - sweeps 105
+        { o: 100, h: 106, l: 89, c: 101 }, // 10 - bar 8's pivots confirmable here
+      ]);
+      const options = { swingPeriod: 2, maxRecoveryBars: 3, minSweepDepth: 0 };
+
+      const result = liquiditySweep(candles, options);
+
+      expect(result[8].value.sweep?.type).toBe("bullish");
+      expect(result[8].value.sweep?.sweptLevel).toBe(90);
+      expect(result[9].value.sweep?.type).toBe("bearish");
+      expect(result[9].value.sweep?.sweptLevel).toBe(105);
+
+      // Same answer as a run that only has the bars up to and including bar 9.
+      const upTo9 = liquiditySweep(candles.slice(0, 10), options);
+      expect(upTo9[9].value.sweep?.type).toBe("bearish");
+      expect(upTo9[9].value.sweep?.sweptLevel).toBe(105);
+    });
+
+    it("detects the same sweeps as runs that end at each bar", () => {
+      let seed = 7;
+      const random = () => {
+        seed = (seed * 16807) % 2147483647;
+        return seed / 2147483647;
+      };
+      const rows: Array<{ o: number; h: number; l: number; c: number }> = [];
+      let price = 100;
+      for (let i = 0; i < 120; i++) {
+        const open = price;
+        const close = price * (1 + (random() - 0.5) * 0.06);
+        rows.push({
+          o: open,
+          h: Math.max(open, close) * (1 + random() * 0.02),
+          l: Math.min(open, close) * (1 - random() * 0.02),
+          c: close,
+        });
+        price = close;
+      }
+      const candles = makeCandles(rows);
+
+      let sweepsSeen = 0;
+      for (const swingPeriod of [1, 2, 3]) {
+        const options = { swingPeriod, maxRecoveryBars: 3, minSweepDepth: 0 };
+        const full = liquiditySweep(candles, options);
+        for (let k = 0; k < candles.length; k++) {
+          const prefix = liquiditySweep(candles.slice(0, k + 1), options);
+          expect({ bar: k, swingPeriod, ...describeSweep(full[k].value) }).toEqual({
+            bar: k,
+            swingPeriod,
+            ...describeSweep(prefix[k].value),
+          });
+          if (full[k].value.isSweep) sweepsSeen++;
+        }
+      }
+      expect(sweepsSeen).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Emitted bars are snapshots", () => {
+    it("does not backdate a later recovery into earlier bars", () => {
+      const candles = makeCandles([
+        { o: 100, h: 102, l: 99, c: 101 }, // 0
+        { o: 101, h: 103, l: 100, c: 102 }, // 1
+        { o: 102, h: 104, l: 90, c: 92 }, // 2 - swing low at 90
+        { o: 92, h: 98, l: 91, c: 96 }, // 3
+        { o: 96, h: 100, l: 95, c: 99 }, // 4
+        { o: 99, h: 102, l: 98, c: 101 }, // 5
+        { o: 101, h: 103, l: 100, c: 102 }, // 6
+        { o: 102, h: 103, l: 85, c: 87 }, // 7 - breaks below 90, closes below
+        { o: 87, h: 95, l: 86, c: 93 }, // 8 - recovers above 90
+      ]);
+
+      const result = liquiditySweep(candles, { swingPeriod: 1 });
+
+      const sweepBar = result.findIndex((r) => r.value.isSweep);
+      expect(sweepBar).toBeGreaterThanOrEqual(0);
+      expect(result[sweepBar].value.sweep?.recovered).toBe(false);
+      expect(result[sweepBar].value.recentSweeps[0].recovered).toBe(false);
+
+      const recoveryBar = result.findIndex((r) => r.value.recoveredThisBar.length > 0);
+      expect(recoveryBar).toBeGreaterThan(sweepBar);
+      expect(result[recoveryBar].value.recentSweeps[0].recovered).toBe(true);
+      expect(result[recoveryBar].value.recentSweeps[0].recoveredIndex).toBe(recoveryBar);
     });
   });
 

--- a/packages/core/src/indicators/smc/liquidity-sweep.ts
+++ b/packages/core/src/indicators/smc/liquidity-sweep.ts
@@ -77,7 +77,12 @@ export type LiquiditySweepValue = {
   isSweep: boolean;
   /** New sweep detected on this bar */
   sweep: LiquiditySweep | null;
-  /** Recent sweeps (both recovered and unrecovered) */
+  /**
+   * Recent sweeps (both recovered and unrecovered), as of this bar.
+   *
+   * A snapshot: a sweep that recovers on a later bar keeps `recovered: false`
+   * in the bars emitted before that.
+   */
   recentSweeps: LiquiditySweep[];
   /** Sweeps that recovered on this bar (good entry signals) */
   recoveredThisBar: LiquiditySweep[];
@@ -163,7 +168,6 @@ export function liquiditySweep(
 
   for (let i = 0; i < normalized.length; i++) {
     const candle = normalized[i];
-    const swing = swings[i]?.value;
 
     let newSweep: LiquiditySweep | null = null;
     const recoveredThisBar: LiquiditySweep[] = [];
@@ -255,22 +259,29 @@ export function liquiditySweep(
       }
     }
 
-    // Update tracked swing levels for next iteration
-    // (After sweep checks to avoid overwriting the level we just swept)
-    if (swing?.isSwingHigh && swing.swingHighPrice !== null) {
-      recentSwingHigh = { level: swing.swingHighPrice, index: i };
+    // Update tracked swing levels for next iteration.
+    // A pivot at index `confirmedIdx` reads bars up to `confirmedIdx +
+    // swingPeriod`, so it is adopted on this bar and not on the pivot bar
+    // itself — until then the previous level stays active and can be swept.
+    // (After the sweep checks, to avoid overwriting the level we just swept.)
+    const confirmedIdx = i - swingPeriod;
+    const confirmed = confirmedIdx >= 0 ? swings[confirmedIdx]?.value : undefined;
+    if (confirmed?.isSwingHigh) {
+      recentSwingHigh = { level: normalized[confirmedIdx].high, index: confirmedIdx };
     }
-    if (swing?.isSwingLow && swing.swingLowPrice !== null) {
-      recentSwingLow = { level: swing.swingLowPrice, index: i };
+    if (confirmed?.isSwingLow) {
+      recentSwingLow = { level: normalized[confirmedIdx].low, index: confirmedIdx };
     }
 
+    // Emit copies: a sweep object keeps being mutated while it waits for
+    // recovery, and bars already emitted must not change under the consumer.
     result.push({
       time: candle.time,
       value: {
         isSweep: newSweep !== null,
-        sweep: newSweep,
-        recentSweeps: [...recentSweeps],
-        recoveredThisBar,
+        sweep: newSweep === null ? null : { ...newSweep },
+        recentSweeps: recentSweeps.map((sweep) => ({ ...sweep })),
+        recoveredThisBar: recoveredThisBar.map((sweep) => ({ ...sweep })),
       },
     });
   }

--- a/packages/core/src/manifest/entries/price.ts
+++ b/packages/core/src/manifest/entries/price.ts
@@ -201,10 +201,11 @@ export const PRICE_MANIFESTS: IndicatorManifest[] = [
     signals: [
       "isSwingHigh === true = confirmed swing high (potential resistance)",
       "isSwingLow === true = confirmed swing low (potential support)",
-      "swingHighPrice / swingLowPrice expose the most recent swing levels for downstream logic",
+      "swingHighPrice / swingLowPrice expose the most recent level already confirmed at that bar",
     ],
     pitfalls: [
       "CONFIRMATION lag: swing point identified `rightBars` bars AFTER it forms. Not real-time",
+      "isSwingHigh/isSwingLow sit ON the pivot bar, so they are retrospective; the trailing level fields (swingHighPrice etc.) adopt a pivot only `rightBars` later and can be read bar by bar",
       "Larger leftBars/rightBars = stricter swings (fewer, more meaningful); smaller = noise-prone",
       "Default 5/5 is moderate strictness — Bill Williams' 2/2 is the looser fractal convention",
       "Test fixtures need enough bars: with leftBars=1, rightBars=1, need 7+ candles for 3 alternating swings",

--- a/packages/core/src/manifest/entries/specialized.ts
+++ b/packages/core/src/manifest/entries/specialized.ts
@@ -97,6 +97,7 @@ export const SPECIALIZED_MANIFESTS: IndicatorManifest[] = [
     pitfalls: [
       "Sweeps look identical to genuine breakouts in real-time — confirmation requires recovery",
       "trendcraft impl marks `recovered=true` when the bar that broke the level closes back past it. Multi-bar recoveries (sweep on bar N, recovery on bar N+1) need different logic",
+      "A swing level becomes sweepable `swingPeriod` bars after its pivot prints (that is when the pivot is confirmed), so a sweep of an older level can still fire while a newer pivot is unconfirmed",
       "Most 'sweeps' at minor swings are noise — focus on sweeps at major equal-highs/lows where stops cluster",
       "Combine with order-flow context: a sweep without follow-through reversal is just a trend continuation",
     ],


### PR DESCRIPTION
## The bug

`swingPoints` reports two different things in one value:

- `isSwingHigh` / `isSwingLow` mark the pivot bar itself.
- `swingHighPrice` / `swingLowPrice` / `swingHighIndex` / `swingLowIndex` trail the most recent swing level.

A pivot is decided by the `rightBars` bars that follow it, so it is only knowable that many bars later. The trailing fields, however, were updated on the pivot bar, so a consumer stepping through the series bar by bar was handed a level the market had not confirmed yet. On a 200-bar random walk with the default 5/5, **103 of the 200 bars** reported different trailing levels than a run that ended at that bar.

`liquiditySweep` reads those fields once per bar, so it inherited the leak: it replaced its tracked swing high and low at the pivot bar, and a newer, still-unconfirmed pivot could hide an older level that price was in fact sweeping. Concretely, with `swingPeriod: 2`:

```
bar 2: swing high 105          (confirmed at bar 4)
bar 5: swing low 90            (confirmed at bar 7)
bar 8: outside bar, high 110 / low 85
       -> sweeps the low at 90; is itself a pivot high at 110, confirmable only at bar 10
bar 9: trades up to 107        (above the active 105, below the unconfirmed 110)

before: bar 9 reports no sweep      (it was already tracking the unconfirmed 110)
after:  bar 9 reports bearish sweep of 105, which is what a run ending at bar 9 sees
```

Separately, the bars `liquiditySweep` emits were not snapshots: `sweep` and the entries in `recentSweeps` were the live sweep objects, which keep being mutated while they wait for recovery. A recovery several bars later retroactively set `recovered` and `recoveredIndex` on bars that had already been emitted, so a stored series changed under the consumer.

## The fix

- `swingPoints` adopts a pivot into the trailing fields at `pivotIndex + rightBars`. `swingHighIndex` / `swingLowIndex` are therefore at least `rightBars`. `isSwingHigh` / `isSwingLow` are unchanged — they still mark the pivot bar, which is what draws a swing marker in the right place — and their documentation now says they are retrospective.
- `liquiditySweep` promotes a pivot to a tracked level at `pivotIndex + swingPeriod`, after judging the current bar.
- Both indicators emit copies of the sweep objects, so an emitted value no longer changes.
- Manifest entries for both indicators state the confirmation offset.

### Streaming counterpart

Making the batch path causal exposed an ordering difference in `createLiquiditySweep`: it adopted a newly confirmed pivot *before* judging the bar that confirmed it, so on that bar it compared price against the level it was in the middle of confirming instead of the level it had been tracking. A bar can never break the pivot it confirms — swing detection is strict, so every bar in the confirmation window is below it — which means adopting first only hides a sweep of the older level.

Both sides now judge the bar first and adopt afterwards. Before the change the two disagreed on **10 bars out of 64,000** compared across `swingPeriod` 1, 2, 3 and 5; after it they agree on every bar.

Values change for the `swingPoints` trailing fields and for sweep detection. Indicators that build on the `isSwingHigh` / `isSwingLow` flags — Fibonacci levels, channel lines, pitchfork, S/R zones, pattern detection — are untouched; they were already reading whole-series markers.

## Test plan

New tests (7):

- `swingPoints` does not expose a pivot before its confirmation window closes (leftBars 1 / rightBars 3: the pivot bar and both bars inside the window still report the previous level).
- `swingPoints` prefix consistency: for a 200-bar deterministic walk, every bar's trailing fields equal those of a run ending at that bar. 103 bars mismatched before the fix, 0 after.
- `liquiditySweep` still sweeps the old level while a newer pivot is unconfirmed — the bar-9 case above, checked against both the full run and a run ending at bar 9.
- `liquiditySweep` prefix consistency across `swingPeriod` 1/2/3 over 120 bars.
- `liquiditySweep` does not backdate a later recovery into earlier bars.
- Batch and streaming agree on a confirmation bar that sweeps the older level (hand-built fixture, `swingPeriod: 1`).
- Batch and streaming agree on every bar of a 400-bar series across `swingPeriod` 1/2/3/5.

The deterministic fixtures are what pin the two bugs: each fails without its source change. The randomized prefix-consistency and parity sweeps are guard rails — the divergences they target are rare enough that random search does not reliably hit them.

Verification: `pnpm test` in core (372 files, 6558 tests), chart (84 files, 934 tests) and mcp (9 files, 83 tests); `npx tsc --noEmit --ignoreDeprecations 6.0`; `pnpm build`; `npx biome check` on the touched files.