### PR TITLE
fix(core): refuse a poisoned recursive snapshot instead of reviving it as a number

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -262,6 +262,54 @@ Swing-level values and sweep detection change. Indicators that build on the
 `isSwingHigh` / `isSwingLow` flags — Fibonacci levels, channel lines,
 pitchfork, S/R zones, pattern detection — are untouched.
 
+### Fixed — a poisoned recursive snapshot is refused instead of reviving as a number
+
+A bad tick — a zero or negative price — can push a recursive indicator's
+running value to `Infinity` or `NaN`. While the indicator keeps running that is
+at least obvious, because the output is non-finite too. Persisting it is not:
+`JSON.stringify` writes both as `null`, and the arithmetic in the resumed run
+coerces that `null` to `0`. The series stops looking broken and starts looking
+like data.
+
+`createMcGinleyDynamic` resumed from such a snapshot emitted a constant `0`
+from then on, where the run it continued was emitting `NaN`.
+`createEwmaVolatility` was worse: `lambda * null` is 0, so the recursion
+re-seeded itself from the next return and produced volatility figures in a
+realistic range — 7.4, 8.0, 8.5 — while the uninterrupted run stayed at
+`Infinity`.
+
+Both now refuse to resume such a snapshot, with the usual `re-warm required`
+error, and they check every number the state carries rather than only the
+headline one. `createMcGinleyDynamic` validates the warm-up total as well: it
+is the recursive state until warm-up ends, and `null + price` is a number, so a
+poisoned total used to come back as an average seeded from the bars after the
+bad tick alone. `createEwmaVolatility` validates the previous price as well: as
+`null` it reads as "no candle seen yet", which silently drops the next bar's
+return. The check is a shared helper, `requireFiniteState`, so this guard reads
+like the other resume policies. Snapshots taken before warm-up are unaffected —
+`null` is a legitimate value there, and each field is only checked from the
+point the state itself says it must hold a number.
+
+Neither the streaming nor the batch form produces the non-finite value in the
+first place any more. A step counts as a zero return whenever its log return is
+not a finite number. Non-positive prices were already treated that way in
+`ewmaVolatilityFromCandles`; `Infinity` was not, because it passes a "price is
+positive" test, and `ln(Infinity / price)` poisoned the estimate just the same.
+Nor were two finite prices far enough apart for their ratio to overflow — a
+tick at `Number.MIN_VALUE` next to one at `Number.MAX_VALUE` did it — so the
+result is what gets checked, not only the inputs. Batch and streaming share one
+helper for that decision now, so they agree bar for bar across a bad tick, and
+`garch.ts`'s `ewmaVolatilityFromCandles` returns finite volatility where it used
+to return `NaN`.
+
+Tolerating a bad tick holds across persistence as well. `createEwmaVolatility`
+kept the offending price as its "previous price", so a snapshot taken on that
+bar came back from JSON with the field nulled and could not be resumed — the
+one bar where a caller might most want to save. It now stores `0` for a price
+it cannot use, which survives the round trip and is rejected by the same rule
+when the next return is computed, so an interrupted run and an uninterrupted
+one produce identical values.
+
 ## [0.5.0] - 2026-07-26
 
 ### Read this first — your numbers will change

--- a/packages/core/src/indicators/incremental/__tests__/poisoned-recursive-state.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/poisoned-recursive-state.test.ts
@@ -1,0 +1,327 @@
+/**
+ * A recursive accumulator that has gone non-finite must not come back from
+ * JSON as a plausible number.
+ *
+ * A bad tick — a zero price, a negative one — can push a recursive indicator's
+ * running value to `Infinity` or `NaN`. While the indicator keeps running that
+ * is obvious: the output is non-finite too. It does not survive persistence,
+ * though. `JSON.stringify` writes both as `null`, and arithmetic on the
+ * revived `null` coerces it to 0, so the resumed indicator emits numbers that
+ * look like data while its uninterrupted twin emits nothing usable.
+ *
+ * Resuming from such a snapshot is now refused. The companion fix is to stop
+ * producing the non-finite value in the first place where the batch indicator
+ * already does — see the Ewma section below.
+ */
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../../types";
+import { logReturnOrZero } from "../../../utils/statistics";
+import { ewmaVolatilityFromCandles } from "../../volatility/garch";
+import { createMcGinleyDynamic } from "../moving-average/mcginley-dynamic";
+import { createEwmaVolatility } from "../volatility/ewma-volatility";
+
+const DAY = 86_400_000;
+const START = 1_700_000_000_000;
+
+function candle(i: number, close: number): NormalizedCandle {
+  return {
+    time: START + i * DAY,
+    open: close,
+    high: close + 1,
+    low: Math.max(0, close - 1),
+    close,
+    volume: 1000,
+  };
+}
+
+/** Persist a snapshot the way a caller would. */
+function throughJson<T>(snapshot: T): T {
+  return JSON.parse(JSON.stringify(snapshot)) as T;
+}
+
+/** A rising series with one zero-price tick at `badIdx`. */
+function seriesWithBadTick(length: number, badIdx: number): NormalizedCandle[] {
+  const out: NormalizedCandle[] = [];
+  for (let i = 0; i < length; i++) {
+    out.push(candle(i, i === badIdx ? 0 : 100 + i * 0.5));
+  }
+  return out;
+}
+
+describe("logReturnOrZero — the rule both forms share", () => {
+  it("returns a finite number for every pair of prices", () => {
+    const MIN = Number.MIN_VALUE;
+    const MAX = Number.MAX_VALUE;
+    const prices = [
+      0,
+      -1,
+      MIN,
+      1e-300,
+      0.5,
+      100,
+      1e300,
+      MAX,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      Number.NaN,
+    ];
+    for (const previous of prices) {
+      for (const current of prices) {
+        const value = logReturnOrZero(previous, current);
+        expect({ previous, current, finite: Number.isFinite(value) }).toEqual({
+          previous,
+          current,
+          finite: true,
+        });
+      }
+    }
+  });
+
+  it("returns 0 when the ratio itself overflows or flushes to zero", () => {
+    // Both prices are usable; their quotient is not.
+    expect(Number.MAX_VALUE / Number.MIN_VALUE).toBe(Number.POSITIVE_INFINITY);
+    expect(Number.MIN_VALUE / Number.MAX_VALUE).toBe(0);
+    expect(logReturnOrZero(Number.MIN_VALUE, Number.MAX_VALUE)).toBe(0);
+    expect(logReturnOrZero(Number.MAX_VALUE, Number.MIN_VALUE)).toBe(0);
+  });
+
+  it("still computes ordinary returns", () => {
+    expect(logReturnOrZero(100, 101)).toBeCloseTo(Math.log(1.01), 15);
+    expect(logReturnOrZero(101, 100)).toBeCloseTo(-Math.log(1.01), 15);
+    expect(logReturnOrZero(100, 100)).toBe(0);
+  });
+});
+
+describe("McGinley Dynamic — poisoned state is refused on resume", () => {
+  const period = 14;
+
+  it("refuses a snapshot whose running value went non-finite", () => {
+    const candles = seriesWithBadTick(32, 30);
+    const live = createMcGinleyDynamic({ period });
+    for (const c of candles) live.next(c);
+
+    // The uninterrupted run is visibly broken, which is the point: the value
+    // is non-finite rather than a number a caller might trust.
+    const uninterrupted = live.next(candle(32, 116)).value;
+    expect(Number.isFinite(uninterrupted)).toBe(false);
+
+    const persisted = throughJson(live.getState());
+    expect(persisted.state.prevMd).toBeNull();
+
+    expect(() => createMcGinleyDynamic({ period }, { fromState: persisted })).toThrow(
+      /re-warm required.*prevMd/s,
+    );
+  });
+
+  it("refuses a snapshot whose warm-up total went non-finite", () => {
+    // Before warm-up completes the recursive state is `sum`, not `prevMd`.
+    // An infinite price makes it infinite, JSON makes that null, and
+    // `null + price` is a number — so the resumed run seeds its average from
+    // a total that lost every bar before the bad tick.
+    const live = createMcGinleyDynamic({ period });
+    for (let i = 0; i < 5; i++) live.next(candle(i, 100 + i));
+    live.next({ ...candle(5, 100), close: Number.POSITIVE_INFINITY });
+    for (let i = 6; i < 10; i++) live.next(candle(i, 100 + i));
+
+    const persisted = throughJson(live.getState());
+    expect(persisted.state.sum).toBeNull();
+    expect(persisted.state.count).toBe(10);
+
+    expect(() => createMcGinleyDynamic({ period }, { fromState: persisted })).toThrow(
+      /re-warm required.*sum/s,
+    );
+  });
+
+  it("resumes a healthy snapshot, before and after warm-up", () => {
+    const candles: NormalizedCandle[] = [];
+    for (let i = 0; i < 40; i++) candles.push(candle(i, 100 + i * 0.5));
+
+    // Mid warm-up: prevMd is legitimately null and must not be mistaken for
+    // a serialized non-finite value.
+    const early = createMcGinleyDynamic({ period });
+    for (let i = 0; i < period - 1; i++) early.next(candles[i]);
+    const earlySnapshot = throughJson(early.getState());
+    expect(earlySnapshot.state.prevMd).toBeNull();
+    const earlyResumed = createMcGinleyDynamic({ period }, { fromState: earlySnapshot });
+
+    // Warmed up: resume and continue in step with the uninterrupted run.
+    const live = createMcGinleyDynamic({ period });
+    for (let i = 0; i < 30; i++) live.next(candles[i]);
+    const resumed = createMcGinleyDynamic({ period }, { fromState: throughJson(live.getState()) });
+    for (let i = 30; i < candles.length; i++) {
+      expect(resumed.next(candles[i]).value).toBe(live.next(candles[i]).value);
+    }
+    expect(earlyResumed.next(candles[period - 1]).value).not.toBeNull();
+  });
+});
+
+describe("EWMA volatility — a bad tick no longer poisons the recursion", () => {
+  const options = { lambda: 0.94, seedSize: 10 };
+
+  it("keeps emitting finite volatility across a zero-price tick", () => {
+    const candles = seriesWithBadTick(40, 30);
+    const live = createEwmaVolatility(options);
+    const values = candles.map((c) => live.next(c).value);
+
+    const emitted = values.slice(options.seedSize).filter((v): v is number => v !== null);
+    expect(emitted.length).toBeGreaterThan(0);
+    expect(emitted.every((v) => Number.isFinite(v))).toBe(true);
+  });
+
+  it("matches the batch indicator bar for bar across that tick", () => {
+    const candles = seriesWithBadTick(40, 30);
+    const live = createEwmaVolatility(options);
+    const liveValues = candles.map((c) => live.next(c).value);
+
+    // Batch emits one entry per return, at candles[i + 1].time.
+    const batch = ewmaVolatilityFromCandles(candles, { lambda: options.lambda });
+    const batchByTime = new Map(batch.map((p) => [p.time, p.value]));
+
+    // Batch seeds from the first `seedSize` returns with lookahead, so it has
+    // values where the live indicator is still gated to null. Compare from the
+    // bar the live one starts emitting.
+    let compared = 0;
+    for (let i = options.seedSize; i < candles.length; i++) {
+      const expected = batchByTime.get(candles[i].time);
+      expect(liveValues[i]).toBeCloseTo(expected as number, 10);
+      compared++;
+    }
+    expect(compared).toBe(candles.length - options.seedSize);
+  });
+
+  it("survives an infinite price, in step with the batch indicator", () => {
+    // `Infinity > 0` is true, so a "price is positive" test lets an infinite
+    // tick through and `ln(Infinity / price)` poisons the recursion. Both
+    // implementations require a usable price, not merely a positive one.
+    const candles: NormalizedCandle[] = [];
+    for (let i = 0; i < 30; i++) candles.push(candle(i, 100 + i * 0.5));
+    candles[20] = { ...candles[20], close: Number.POSITIVE_INFINITY };
+
+    const live = createEwmaVolatility(options);
+    const liveValues = candles.map((c) => live.next(c).value);
+    const emitted = liveValues.slice(options.seedSize).filter((v): v is number => v !== null);
+    expect(emitted.length).toBeGreaterThan(0);
+    expect(emitted.every((v) => Number.isFinite(v))).toBe(true);
+
+    const batchByTime = new Map(
+      ewmaVolatilityFromCandles(candles, { lambda: options.lambda }).map((p) => [p.time, p.value]),
+    );
+    for (let i = options.seedSize; i < candles.length; i++) {
+      expect(liveValues[i]).toBeCloseTo(batchByTime.get(candles[i].time) as number, 10);
+    }
+  });
+
+  it("survives a price jump whose ratio overflows", () => {
+    // Neither price is rejected on its own — the quotient is what breaks.
+    const candles: NormalizedCandle[] = [];
+    for (let i = 0; i < 30; i++) candles.push(candle(i, 100 + i * 0.5));
+    candles[20] = { ...candles[20], close: Number.MIN_VALUE };
+    candles[21] = { ...candles[21], close: Number.MAX_VALUE };
+
+    const live = createEwmaVolatility(options);
+    const liveValues = candles.map((c) => live.next(c).value);
+    const emitted = liveValues.slice(options.seedSize).filter((v): v is number => v !== null);
+    expect(emitted.every((v) => Number.isFinite(v))).toBe(true);
+    expect(Number.isFinite(live.getState().state.prevVariance as number)).toBe(true);
+
+    const batchByTime = new Map(
+      ewmaVolatilityFromCandles(candles, { lambda: options.lambda }).map((p) => [p.time, p.value]),
+    );
+    for (let i = options.seedSize; i < candles.length; i++) {
+      // A return of ln(MIN_VALUE / 100) is around -700, so the volatility here
+      // runs to six figures: compare relatively, not to a fixed decimal place.
+      const expected = batchByTime.get(candles[i].time) as number;
+      const relative = Math.abs((liveValues[i] as number) - expected) / Math.abs(expected);
+      expect({ bar: i, withinTolerance: relative < 1e-12 }).toEqual({
+        bar: i,
+        withinTolerance: true,
+      });
+    }
+  });
+
+  it("stays resumable when the snapshot is taken right after a bad tick", () => {
+    // Tolerating a bad tick has to hold across persistence too: the price is
+    // not carried into the state as `Infinity`, which JSON would turn into a
+    // null the resumed run reads as "no candle seen yet".
+    const candles: NormalizedCandle[] = [];
+    for (let i = 0; i < 20; i++) candles.push(candle(i, 100 + i * 0.5));
+    candles[19] = { ...candles[19], close: Number.POSITIVE_INFINITY };
+
+    const live = createEwmaVolatility(options);
+    for (const c of candles) live.next(c);
+
+    const persisted = throughJson(live.getState());
+    expect(persisted.state.prevPrice).toBe(0);
+    expect(persisted.state.count).toBe(candles.length);
+
+    const resumed = createEwmaVolatility(options, { fromState: persisted });
+    const rest: NormalizedCandle[] = [];
+    for (let i = 20; i < 30; i++) rest.push(candle(i, 100 + i * 0.5));
+    for (const c of rest) {
+      const fromResumed = resumed.next(c).value;
+      const uninterrupted = live.next(c).value;
+      expect({ time: c.time, value: fromResumed }).toEqual({
+        time: c.time,
+        value: uninterrupted,
+      });
+      expect(Number.isFinite(fromResumed as number)).toBe(true);
+    }
+
+    // And both agree with the batch indicator over the whole series.
+    const all = [...candles, ...rest];
+    const batchByTime = new Map(
+      ewmaVolatilityFromCandles(all, { lambda: options.lambda }).map((p) => [p.time, p.value]),
+    );
+    const fresh = createEwmaVolatility(options);
+    for (let i = 0; i < all.length; i++) {
+      const value = fresh.next(all[i]).value;
+      if (i >= options.seedSize) {
+        expect(value).toBeCloseTo(batchByTime.get(all[i].time) as number, 10);
+      }
+    }
+  });
+
+  it("refuses a snapshot from a version that stored the bad tick itself", () => {
+    // Nothing this version writes can produce it, but a snapshot from before
+    // the normalization can: `prevPrice` came back as null with candles
+    // already consumed, which would silently drop the next bar's return.
+    const live = createEwmaVolatility(options);
+    for (let i = 0; i < 20; i++) live.next(candle(i, 100 + i * 0.5));
+    const healthy = throughJson(live.getState());
+    const legacy = { ...healthy, state: { ...healthy.state, prevPrice: null } };
+
+    expect(() => createEwmaVolatility(options, { fromState: legacy })).toThrow(
+      /re-warm required.*prevPrice/s,
+    );
+  });
+
+  it("refuses a snapshot whose running variance went non-finite", () => {
+    // Hand-built: a snapshot that a pre-fix run would have written.
+    const candles: NormalizedCandle[] = [];
+    for (let i = 0; i < 20; i++) candles.push(candle(i, 100 + i * 0.5));
+    const live = createEwmaVolatility(options);
+    for (const c of candles) live.next(c);
+
+    const healthy = throughJson(live.getState());
+    const poisoned = {
+      ...healthy,
+      state: { ...healthy.state, prevVariance: null },
+    };
+
+    expect(() => createEwmaVolatility(options, { fromState: poisoned })).toThrow(
+      /re-warm required.*prevVariance/s,
+    );
+
+    // A seed return that came back as null is refused for the same reason.
+    const poisonedSeed = {
+      ...healthy,
+      state: { ...healthy.state, seedReturns: [0.01, null, 0.02] as unknown as number[] },
+    };
+    expect(() => createEwmaVolatility(options, { fromState: poisonedSeed })).toThrow(
+      /re-warm required.*seedReturns/s,
+    );
+
+    // The healthy snapshot still resumes.
+    expect(() => createEwmaVolatility(options, { fromState: healthy })).not.toThrow();
+  });
+});

--- a/packages/core/src/indicators/incremental/moving-average/mcginley-dynamic.ts
+++ b/packages/core/src/indicators/incremental/moving-average/mcginley-dynamic.ts
@@ -27,6 +27,13 @@
  * to `[0.5, 2.0]`; trendcraft does not, to remain bar-for-bar
  * faithful to the published formula.
  *
+ * A run that has been pushed to a non-finite `prevMd` that way keeps
+ * emitting non-finite values, which is at least visible. Its snapshot
+ * is not: JSON writes the non-finite value as `null`, and the resumed
+ * run would coerce that to 0 and emit a plausible constant forever. So
+ * resuming a warmed-up snapshot whose `prevMd` is not a finite number
+ * is refused (`requireFiniteState`).
+ *
  * Seeding asymmetry note (intentional): the batch sibling produces
  * its first non-null value at index `period - 1` (`if i === period - 1`),
  * while this incremental factory uses a post-incremented `count` so
@@ -38,7 +45,12 @@
  */
 
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireFiniteState,
+  resolveResume,
+} from "../state-contract";
 import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
@@ -99,6 +111,17 @@ export function createMcGinleyDynamic(
   let count: number;
 
   if (state !== null) {
+    // Every number this state carries, with the point in the indicator's life
+    // from which it must hold one. JSON writes a non-finite value as `null`,
+    // and both fields have a coercion waiting for them: `null + price` is a
+    // number, so a poisoned warm-up total would seed the average from a sum
+    // that lost its history, and the update below would turn a `null` prevMd
+    // into a constant 0 — either way a visibly broken series comes back
+    // looking like data.
+    requireFiniteState("mcginleyDynamic", { sum: state.sum, count: state.count });
+    if (state.count >= period) {
+      requireFiniteState("mcginleyDynamic", { prevMd: state.prevMd });
+    }
     prevMd = state.prevMd;
     sum = state.sum;
     count = state.count;

--- a/packages/core/src/indicators/incremental/state-contract.ts
+++ b/packages/core/src/indicators/incremental/state-contract.ts
@@ -345,6 +345,55 @@ export function requireParam<TParams, K extends keyof TParams>(
   return narrowed;
 }
 
+/**
+ * Refuse a snapshot whose recursive accumulator is not a finite number.
+ *
+ * A recursive indicator that meets a bad tick (a zero or negative price, an
+ * infinity) can carry `Infinity` or `NaN` in its state from then on. That is
+ * visible while the indicator keeps running — the output is non-finite too —
+ * but it does not survive `JSON.stringify`, which writes both as `null`. A
+ * resumed indicator then reads `null` where it expects a number, and the
+ * arithmetic that follows coerces it to `0`: the output stops being obviously
+ * broken and becomes a plausible-looking number instead.
+ *
+ * Call this at resume time for every field that MUST hold a number at that
+ * point in the indicator's life. Fields that are legitimately `null` before
+ * warm-up completes must not be passed until the state says warm-up is done —
+ * the check cannot tell an unwarmed `null` from a serialized `NaN`.
+ *
+ * @param indicator - indicator name, for the error message
+ * @param fields - field name → value, as read from the snapshot
+ * @throws if any field is `null`, `undefined`, or a non-finite number
+ *
+ * @example
+ * ```ts
+ * const period = 14;
+ * const state: { prevMd: number | null; count: number } | null = {
+ *   prevMd: null,
+ *   count: 20,
+ * };
+ *
+ * // Throws: past warm-up `prevMd` cannot legitimately be null.
+ * if (state !== null && state.count >= period) {
+ *   requireFiniteState("mcginleyDynamic", { prevMd: state.prevMd });
+ * }
+ * ```
+ */
+export function requireFiniteState(
+  indicator: string,
+  fields: Record<string, number | null | undefined>,
+): void {
+  for (const [name, value] of Object.entries(fields)) {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      throw new Error(
+        `${indicator}: incompatible snapshot, re-warm required (${name} is ${String(
+          value,
+        )}, not a finite number — the run that wrote this snapshot had already been poisoned by a bad tick)`,
+      );
+    }
+  }
+}
+
 // ---- Internal helpers ----
 
 function mergeParams<TParams extends Record<string, unknown>>(

--- a/packages/core/src/indicators/incremental/volatility/ewma-volatility.ts
+++ b/packages/core/src/indicators/incremental/volatility/ewma-volatility.ts
@@ -37,11 +37,33 @@
  * has a stable estimate" *and* leaving the post-seed series ~10 EWMA
  * updates behind the batch sibling indefinitely. The combined seed
  * suppression + replay fixes both issues.
+ *
+ * Bad ticks: a step whose log return is not a finite number counts as
+ * a zero return — a price that is zero, negative or non-finite, and
+ * also two finite prices whose ratio overflows. `logReturnOrZero` owns
+ * that rule for both this indicator and
+ * `ewmaVolatilityFromCandles`, so the two stay aligned and the
+ * recursion never goes non-finite from an undefined logarithm.
+ *
+ * That tolerance extends to the snapshot: a non-finite price is not
+ * carried into the state (`JSON.stringify` would write it as `null`,
+ * which a resumed run reads as "no candle seen yet"), it is stored as
+ * `0` — a value `logReturnOrZero` rejects identically, so the next
+ * return is 0 whether the run was interrupted or not. A snapshot that
+ * still carries a non-finite value, written before that was true, is
+ * refused on resume rather than revived as the 0 that JSON's `null`
+ * would coerce to.
  */
 
 import { type AnnualizationOptions, annualizationFactor } from "../../../calendar";
 import type { NormalizedCandle, PriceSource } from "../../../types";
-import { type IndicatorSnapshot, makeSnapshot, resolveResume } from "../state-contract";
+import { logReturnOrZero } from "../../../utils/statistics";
+import {
+  type IndicatorSnapshot,
+  makeSnapshot,
+  requireFiniteState,
+  resolveResume,
+} from "../state-contract";
 import type { IncrementalIndicator } from "../types";
 import { getSourcePrice } from "../utils";
 
@@ -195,6 +217,24 @@ export function createEwmaVolatility(
   let count: number;
 
   if (state !== null) {
+    // Every number this state carries, with the point in the indicator's life
+    // from which it must hold one. JSON writes a non-finite value as `null`,
+    // and each of these has a coercion waiting for it: `lambda * null` is 0
+    // (re-seeds the recursion, and the volatility it then reports looks
+    // entirely realistic), a null seed return quietly changes the seed
+    // variance, and a null `prevPrice` reads as "no candle seen yet", which
+    // drops the next bar's return instead.
+    requireFiniteState("ewmaVolatility", { count: state.count });
+    if (state.count > 0) {
+      requireFiniteState("ewmaVolatility", { prevPrice: state.prevPrice });
+    }
+    if (state.seedDone) {
+      requireFiniteState("ewmaVolatility", { prevVariance: state.prevVariance });
+    }
+    requireFiniteState(
+      "ewmaVolatility",
+      Object.fromEntries(state.seedReturns.map((r, i) => [`seedReturns[${i}]`, r])),
+    );
     prevPrice = state.prevPrice;
     prevVariance = state.prevVariance;
     seedReturns = [...state.seedReturns];
@@ -247,17 +287,32 @@ export function createEwmaVolatility(
     return Math.sqrt(Math.max(0, variance)) * annualFactor;
   }
 
+  /**
+   * The form of a price this indicator is willing to carry forward.
+   *
+   * A non-finite tick is tolerated — it counts as a zero return — but storing
+   * it would break the snapshot: `JSON.stringify` writes `Infinity` and `NaN`
+   * as `null`, and a resumed run reads that as "no candle seen yet" and drops
+   * the next bar's return. `0` stands in for it: `logReturnOrZero` rejects a
+   * zero previous price exactly as it rejects the value being replaced, so the
+   * next return is 0 either way and a resumed run computes what the
+   * uninterrupted one does.
+   */
+  function storablePrice(price: number): number {
+    return Number.isFinite(price) ? price : 0;
+  }
+
   const indicator: IncrementalIndicator<number | null, IndicatorSnapshot<EwmaVolatilityState>> = {
     next(candle: NormalizedCandle) {
       count++;
-      const price = getSourcePrice(candle, source);
+      const price = storablePrice(getSourcePrice(candle, source));
 
       if (prevPrice === null) {
         prevPrice = price;
         return { time: candle.time, value: null };
       }
 
-      const logReturn = Math.log(price / prevPrice);
+      const logReturn = logReturnOrZero(prevPrice, price);
       prevPrice = price;
 
       if (!seedDone) {
@@ -291,13 +346,13 @@ export function createEwmaVolatility(
     },
 
     peek(candle: NormalizedCandle) {
-      const price = getSourcePrice(candle, source);
+      const price = storablePrice(getSourcePrice(candle, source));
 
       if (prevPrice === null) {
         return { time: candle.time, value: null };
       }
 
-      const logReturn = Math.log(price / prevPrice);
+      const logReturn = logReturnOrZero(prevPrice, price);
 
       if (!seedDone) {
         const peekReturns = [...seedReturns, logReturn];

--- a/packages/core/src/indicators/volatility/garch.ts
+++ b/packages/core/src/indicators/volatility/garch.ts
@@ -12,6 +12,7 @@ import { type AnnualizationOptions, annualizationFactor } from "../../calendar";
 import { getPrice, isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, PriceSource, Series } from "../../types";
+import { logReturnOrZero } from "../../utils/statistics";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -455,7 +456,7 @@ export function ewmaVolatilityFromCandles(
   for (let i = 1; i < normalized.length; i++) {
     const prev = getPrice(normalized[i - 1], source);
     const cur = getPrice(normalized[i], source);
-    returns[i - 1] = prev > 0 && cur > 0 ? Math.log(cur / prev) : 0;
+    returns[i - 1] = logReturnOrZero(prev, cur);
   }
 
   const vol = ewmaVolatility(returns, options);

--- a/packages/core/src/manifest/entries/volatility.ts
+++ b/packages/core/src/manifest/entries/volatility.ts
@@ -313,6 +313,7 @@ export const VOLATILITY_MANIFESTS: IndicatorManifest[] = [
       "Single-parameter (λ) — convenient but inflexible compared to GARCH",
       "λ = 0.94 is RiskMetrics' daily standard; 0.97 is canonical for monthly. Don't change without reason",
       "Exponential weighting means very old returns still carry tiny weight — no clean cutoff window",
+      "When returns are derived from candles (`ewmaVolatilityFromCandles`, `createEwmaVolatility`), a step counts as a zero return whenever its log return is not a finite number — a price that is zero, negative or non-finite, and also two finite prices far enough apart that their ratio overflows. A bad tick dampens the estimate instead of breaking the recursion",
     ],
     synergy: ["GARCH for richer volatility modeling when EWMA's single λ isn't sufficient"],
     marketRegime: ["volatile", "low-volatility"],

--- a/packages/core/src/utils/statistics.ts
+++ b/packages/core/src/utils/statistics.ts
@@ -5,6 +5,46 @@
  */
 
 /**
+ * Log return of one step, with a defined answer for prices a logarithm is not
+ * defined on.
+ *
+ * A price that is zero, negative, or not finite makes `Math.log` return
+ * `-Infinity` or `NaN`. Feeding that into a recursive estimator poisons it for
+ * the rest of the run, so such a step counts as a zero return instead: a bad
+ * tick dampens the estimate rather than destroying it.
+ *
+ * Single owner for that rule — batch (`ewmaVolatilityFromCandles`) and
+ * streaming (`createEwmaVolatility`) must agree bar for bar, and they only do
+ * so while they share this decision.
+ *
+ * Two prices can each be usable and still produce a ratio that is not: the
+ * quotient overflows to `Infinity` (or flushes to 0) once the two are ~1e308
+ * apart, so the result is checked rather than the inputs alone. The ratio is
+ * kept — computing `ln(current) - ln(previous)` instead would avoid the
+ * overflow but lose precision on every ordinary bar, where the two logarithms
+ * are nearly equal and cancel: on 12345.6789 → 12345.679 that form is about
+ * 55x further from the true value than this one.
+ *
+ * @param previous - previous price
+ * @param current - current price
+ * @returns `ln(current / previous)`, or 0 if that is not a finite number
+ *
+ * @example
+ * ```ts
+ * logReturnOrZero(100, 101); // 0.00995...
+ * logReturnOrZero(0, 101); // 0 — no return is defined from a zero price
+ * logReturnOrZero(100, Number.POSITIVE_INFINITY); // 0
+ * logReturnOrZero(Number.MIN_VALUE, Number.MAX_VALUE); // 0 — ratio overflows
+ * ```
+ */
+export function logReturnOrZero(previous: number, current: number): number {
+  if (!Number.isFinite(previous) || previous <= 0) return 0;
+  if (!Number.isFinite(current) || current <= 0) return 0;
+  const logReturn = Math.log(current / previous);
+  return Number.isFinite(logReturn) ? logReturn : 0;
+}
+
+/**
  * Compute ranks for a numeric array, handling ties with average rank
  *
  * @param values - Array of numeric values


### PR DESCRIPTION
## The bug

A bad tick — a zero or negative price — can push a recursive indicator's running value to `Infinity` or `NaN`. While the indicator keeps running that is at least obvious, because the output is non-finite too. Persisting it is not: `JSON.stringify` writes both as `null`, and the arithmetic in the resumed run coerces that `null` to `0`. The series stops looking broken and starts looking like data.

```
McGinley Dynamic, period 14, zero-price tick at bar 30
  bar 32  uninterrupted: NaN     resumed from JSON: 0        (and 0 forever after)

EWMA volatility, lambda 0.94, same tick
  bar 32  uninterrupted: Infinity  resumed from JSON: 7.42
  bar 33  uninterrupted: Infinity  resumed from JSON: 7.97
  bar 34  uninterrupted: Infinity  resumed from JSON: 8.53
```

The EWMA case is the worse one: `lambda * null` is 0, so the recursion re-seeds itself from the next return and the figures it then reports are entirely plausible.

## The fix

**Refuse such a snapshot, checking every number the state carries.** Not only the headline accumulator — the fields beside it have coercions waiting for them too, and each is checked from the point the state itself says it must hold a number:

| field | null is legitimate | what a revived null does |
| --- | --- | --- |
| `prevMd` (McGinley) | before warm-up | recursive update yields a constant 0 |
| `sum` (McGinley) | never | `null + price` is a number, so the average is seeded from the bars after the bad tick alone |
| `prevPrice` (EWMA) | before the first candle | reads as "no candle seen yet"; the next bar's return is dropped |
| `prevVariance` (EWMA) | before seeding completes | `lambda * null` is 0; the recursion re-seeds |
| `seedReturns[]` (EWMA) | never, per element | changes the seed variance |

The guard is a shared helper, `requireFiniteState`, so it reads like the other resume policies and produces the same `re-warm required` error.

**Stop producing the non-finite value in the first place.** A step counts as a zero return whenever its log return is not a finite number: a price that is zero, negative or non-finite, and also two finite prices whose ratio overflows (`Number.MIN_VALUE` next to `Number.MAX_VALUE`). Non-positive prices were already treated that way in `ewmaVolatilityFromCandles`; `Infinity` was not, because it passes a "price is positive" test, and `ln(Infinity / price)` poisoned the estimate just the same. Batch and streaming share one helper for the rule now — `logReturnOrZero` — so they agree bar for bar across a bad tick, and `ewmaVolatilityFromCandles` returns finite volatility where it used to return `NaN`.

The ratio form is kept rather than `ln(current) - ln(previous)`. The difference form avoids the overflow but cancels on every ordinary bar, where the two logarithms are nearly equal; measured against `log1p` on four near-1 ratios it was less accurate on three, by up to ~55x (12345.6789 → 12345.679: 6.9e-16 vs 1.2e-17).

**Tolerating a bad tick holds across persistence too.** `createEwmaVolatility` kept the offending price as its previous price, so a snapshot taken on that bar came back from JSON with the field nulled and could not be resumed — the one bar where a caller might most want to save. A price it cannot use is stored as `0`, which survives the round trip and is rejected by the same rule when the next return is computed, so an interrupted run and an uninterrupted one produce identical values.

`createMcGinleyDynamic` is deliberately not given the same treatment: it does not tolerate bad ticks (its documentation says to reject them upstream, and its output stays non-finite), so refusing the snapshot is consistent with what the live run does.

## Test plan

13 new tests in `poisoned-recursive-state.test.ts`:

- `logReturnOrZero` returns a finite number for all 121 pairs drawn from `0, -1, MIN_VALUE, 1e-300, 0.5, 100, 1e300, MAX_VALUE, ±Infinity, NaN`; returns 0 where the ratio overflows or flushes to zero; still computes ordinary returns.
- McGinley refuses a snapshot whose running value went non-finite, and one whose warm-up total did; resumes a healthy snapshot both mid warm-up and after it, in step with the uninterrupted run.
- EWMA keeps emitting finite volatility across a zero-price tick, an infinite price, and a `MIN_VALUE → MAX_VALUE` jump, matching `ewmaVolatilityFromCandles` bar for bar in each case (relatively, where the values run to six figures).
- EWMA stays resumable when the snapshot is taken right after a bad tick: resumed and uninterrupted runs agree on every following bar.
- EWMA refuses a hand-built snapshot with a nulled running variance, a nulled seed return, or a nulled previous price — the shapes an older version could write.

Each fails without its source change; the negative check was run per change rather than for the file as a whole.

Verification: `pnpm test` in core (373 files, 6571 tests), chart (84 files, 934 tests) and mcp (9 files, 83 tests); `npx tsc --noEmit --ignoreDeprecations 6.0`; `pnpm build`; `npx biome check` on the touched files.