### PR TITLE
fix(core): keep snapshot numbers JSON has no syntax for

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -310,6 +310,55 @@ it cannot use, which survives the round trip and is rejected by the same rule
 when the next return is computed, so an interrupted run and an uninterrupted
 one produce identical values.
 
+### Fixed — snapshots keep the numbers JSON has no syntax for
+
+`JSON.stringify` writes `NaN`, `Infinity` and `-Infinity` as `null`, and drops
+the sign of `-0`. Every incremental indicator promises a JSON-serializable
+snapshot, so a state that had gone non-finite — a bad tick is enough — came
+back from persistence with a `null` where a number belonged. The arithmetic on
+resume then coerced that `null` to `0`, and the indicator carried on emitting
+numbers that no uninterrupted run would produce. A probe across the whole
+incremental registry found **71 of 94** indicators behaving that way.
+
+Snapshots now carry those four values through a tagged encoding, so a run
+resumed from JSON matches one resumed from the object in memory, which matches
+one that was never interrupted. `createEma` fed a `NaN` price keeps reporting
+`NaN` after a round trip, where it used to report `16`.
+
+Nothing about the runtime shape of a snapshot changes: `state` still holds
+plain numbers, `Object.keys` is unchanged, spreading and resuming from
+`getState()` behave as before, and a state whose numbers are all ordinary
+serializes to exactly the same bytes as it did. The encoding rides on a
+non-enumerable `toJSON`, so the `JSON.stringify(snapshot)` a caller already
+writes is enough — as is `JSON.stringify(snapshot.state)`, or stringifying a
+spread of the snapshot.
+
+Two paths cannot carry a function and so cannot carry the hook:
+`structuredClone`, and spreading the state object itself. `structuredClone`
+keeps non-finite numbers natively, so resuming from a clone was never affected;
+serializing one now has an explicit route:
+
+```ts
+import {
+  serializeIndicatorSnapshot,
+  deserializeIndicatorSnapshot,
+} from "trendcraft/incremental";
+
+const text = serializeIndicatorSnapshot(structuredClone(ema.getState()));
+const restored = deserializeIndicatorSnapshot<EmaState>(text);
+```
+
+(They live with the rest of the streaming API, so they are also reachable as
+`incremental.serializeIndicatorSnapshot` from the main entry point.)
+
+A snapshot carrying the reserved `$trendcraft` key in any shape this codec does
+not write is rejected rather than read as data.
+
+Refusing to resume stays an indicator's own decision, separate from transport:
+`createMcGinleyDynamic` still refuses a snapshot whose running value is not
+finite, because that state can only ever produce `NaN` again — and it now
+refuses identically whether the snapshot arrived as an object or as JSON.
+
 ## [0.5.0] - 2026-07-26
 
 ### Read this first — your numbers will change

--- a/packages/core/src/indicators/incremental/__tests__/poisoned-recursive-state.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/poisoned-recursive-state.test.ts
@@ -18,6 +18,7 @@ import type { NormalizedCandle } from "../../../types";
 import { logReturnOrZero } from "../../../utils/statistics";
 import { ewmaVolatilityFromCandles } from "../../volatility/garch";
 import { createMcGinleyDynamic } from "../moving-average/mcginley-dynamic";
+import { deserializeIndicatorSnapshot } from "../state-contract";
 import { createEwmaVolatility } from "../volatility/ewma-volatility";
 
 const DAY = 86_400_000;
@@ -105,10 +106,18 @@ describe("McGinley Dynamic — poisoned state is refused on resume", () => {
     const uninterrupted = live.next(candle(32, 116)).value;
     expect(Number.isFinite(uninterrupted)).toBe(false);
 
-    const persisted = throughJson(live.getState());
-    expect(persisted.state.prevMd).toBeNull();
+    // The snapshot carries the non-finite value through JSON now, so the
+    // resumed run is refused for the same reason the in-memory one is —
+    // refusing is McGinley's own policy, not an artefact of the transport.
+    const text = JSON.stringify(live.getState());
+    const persisted = JSON.parse(text) as ReturnType<typeof live.getState>;
+    const decoded = deserializeIndicatorSnapshot<{ prevMd: number }>(text);
+    expect(Number.isNaN(decoded.state.prevMd)).toBe(true);
 
     expect(() => createMcGinleyDynamic({ period }, { fromState: persisted })).toThrow(
+      /re-warm required.*prevMd/s,
+    );
+    expect(() => createMcGinleyDynamic({ period }, { fromState: live.getState() })).toThrow(
       /re-warm required.*prevMd/s,
     );
   });
@@ -123,9 +132,11 @@ describe("McGinley Dynamic — poisoned state is refused on resume", () => {
     live.next({ ...candle(5, 100), close: Number.POSITIVE_INFINITY });
     for (let i = 6; i < 10; i++) live.next(candle(i, 100 + i));
 
-    const persisted = throughJson(live.getState());
-    expect(persisted.state.sum).toBeNull();
-    expect(persisted.state.count).toBe(10);
+    const text = JSON.stringify(live.getState());
+    const persisted = JSON.parse(text) as ReturnType<typeof live.getState>;
+    const decoded = deserializeIndicatorSnapshot<{ sum: number; count: number }>(text);
+    expect(decoded.state.sum).toBe(Number.POSITIVE_INFINITY);
+    expect(decoded.state.count).toBe(10);
 
     expect(() => createMcGinleyDynamic({ period }, { fromState: persisted })).toThrow(
       /re-warm required.*sum/s,

--- a/packages/core/src/indicators/incremental/__tests__/snapshot-json-codec.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/snapshot-json-codec.test.ts
@@ -1,0 +1,263 @@
+/**
+ * A snapshot has to mean the same thing after a trip through JSON.
+ *
+ * `JSON.stringify` has no syntax for `NaN`, `Infinity` or `-Infinity` — it
+ * writes all three as `null` — and it drops the sign of `-0`. A resumed
+ * indicator then read a `null` where a number belonged, and the arithmetic
+ * that followed coerced it to `0`: the output stopped looking broken and
+ * started looking like data. The state contract now carries those values
+ * through a tagged encoding, so an interrupted run and an uninterrupted one
+ * agree bar for bar.
+ */
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../../types";
+import { createEma, type EmaState } from "../moving-average/ema";
+import {
+  decodeSnapshotValue,
+  deserializeIndicatorSnapshot,
+  encodeSnapshotValue,
+  type IndicatorSnapshot,
+  makeSnapshot,
+  serializeIndicatorSnapshot,
+} from "../state-contract";
+
+const DAY = 86_400_000;
+const START = 1_700_000_000_000;
+
+function candle(i: number, close: number): NormalizedCandle {
+  return {
+    time: START + i * DAY,
+    open: close,
+    high: close * 1.01,
+    low: close * 0.99,
+    close,
+    volume: 1000,
+  };
+}
+
+describe("snapshot value codec", () => {
+  it("round-trips every number JSON cannot represent", () => {
+    const state = {
+      nan: Number.NaN,
+      inf: Number.POSITIVE_INFINITY,
+      negInf: Number.NEGATIVE_INFINITY,
+      negZero: -0,
+      zero: 0,
+      ordinary: 1.5,
+    };
+
+    const restored = decodeSnapshotValue(
+      JSON.parse(JSON.stringify(encodeSnapshotValue(state))),
+    ) as typeof state;
+
+    expect(Number.isNaN(restored.nan)).toBe(true);
+    expect(restored.inf).toBe(Number.POSITIVE_INFINITY);
+    expect(restored.negInf).toBe(Number.NEGATIVE_INFINITY);
+    expect(Object.is(restored.negZero, -0)).toBe(true);
+    expect(Object.is(restored.zero, 0)).toBe(true);
+    expect(restored.ordinary).toBe(1.5);
+  });
+
+  it("reaches values nested in objects and arrays", () => {
+    const state = {
+      buffer: [1, Number.NaN, 3],
+      inner: { deep: { value: Number.NEGATIVE_INFINITY }, list: [{ v: Number.POSITIVE_INFINITY }] },
+      count: 2,
+    };
+
+    const restored = decodeSnapshotValue(
+      JSON.parse(JSON.stringify(encodeSnapshotValue(state))),
+    ) as typeof state;
+
+    expect(Number.isNaN(restored.buffer[1])).toBe(true);
+    expect(restored.buffer[0]).toBe(1);
+    expect(restored.inner.deep.value).toBe(Number.NEGATIVE_INFINITY);
+    expect(restored.inner.list[0].v).toBe(Number.POSITIVE_INFINITY);
+    expect(restored.count).toBe(2);
+  });
+
+  it("leaves the input untouched", () => {
+    const state = { prev: Number.NaN, buffer: [Number.POSITIVE_INFINITY] };
+    const encoded = encodeSnapshotValue(state);
+
+    expect(Number.isNaN(state.prev)).toBe(true);
+    expect(state.buffer[0]).toBe(Number.POSITIVE_INFINITY);
+    expect(encoded).not.toBe(state);
+  });
+
+  it("encodes an ordinary state to the same bytes as plain JSON", () => {
+    const state = { prev: 1.25, buffer: [1, 2, 3], nested: { a: -1, b: null }, done: true };
+    expect(JSON.stringify(encodeSnapshotValue(state))).toBe(JSON.stringify(state));
+  });
+
+  it("refuses a malformed tag rather than reading it as data", () => {
+    const cases: Array<[string, unknown]> = [
+      ["unknown value", { $trendcraft: { type: "number", value: "Nope", version: 1 } }],
+      ["unknown type", { $trendcraft: { type: "bigint", value: "NaN", version: 1 } }],
+      ["wrong version", { $trendcraft: { type: "number", value: "NaN", version: 2 } }],
+      ["non-string value", { $trendcraft: { type: "number", value: 0, version: 1 } }],
+      ["tag is not an object", { $trendcraft: "NaN" }],
+      [
+        "extra sibling key",
+        { $trendcraft: { type: "number", value: "NaN", version: 1 }, other: 1 },
+      ],
+      [
+        "extra key inside the tag",
+        { $trendcraft: { type: "number", value: "NaN", version: 1, extra: true } },
+      ],
+      ["missing key inside the tag", { $trendcraft: { type: "number", value: "NaN" } }],
+      // A name that only exists on Object.prototype: a lookup would answer
+      // with the inherited function and put it where a number belongs.
+      [
+        "inherited property name",
+        { $trendcraft: { type: "number", value: "toString", version: 1 } },
+      ],
+      ["constructor", { $trendcraft: { type: "number", value: "constructor", version: 1 } }],
+      ["__proto__", { $trendcraft: { type: "number", value: "__proto__", version: 1 } }],
+      ["valueOf", { $trendcraft: { type: "number", value: "valueOf", version: 1 } }],
+    ];
+    for (const [label, value] of cases) {
+      expect(() => decodeSnapshotValue(value), label).toThrow(/invalid snapshot wire format/);
+    }
+  });
+
+  it("returns the same object when there is nothing to decode", () => {
+    // Identity matters: `resolveResume` hands the decoded state to the
+    // indicator, and resuming from an object should keep handing over that
+    // object. A raw NaN is the interesting case — comparing decoded values
+    // with `!==` would call it a change and rebuild the parent.
+    const withRawNaN = { prev: Number.NaN, buffer: [1, Number.NaN], count: 3 };
+    expect(decodeSnapshotValue(withRawNaN)).toBe(withRawNaN);
+    expect(decodeSnapshotValue(withRawNaN.buffer)).toBe(withRawNaN.buffer);
+
+    const ordinary = { prev: 1, nested: { a: [1, 2] } };
+    expect(decodeSnapshotValue(ordinary)).toBe(ordinary);
+
+    const tagged = { prev: { $trendcraft: { type: "number", value: "NaN", version: 1 } } };
+    expect(decodeSnapshotValue(tagged)).not.toBe(tagged);
+  });
+
+  it("reports a circular structure instead of hanging", () => {
+    const state: Record<string, unknown> = { count: 1 };
+    state.self = state;
+    expect(() => encodeSnapshotValue(state)).toThrow(/Maximum call stack|circular/i);
+  });
+});
+
+describe("snapshot persistence paths", () => {
+  /** An EMA whose recursive value has been pushed to NaN by a bad tick. */
+  function poisonedEma() {
+    const ema = createEma({ period: 5 });
+    for (let i = 0; i < 10; i++) ema.next(candle(i, 100 + i));
+    ema.next({ ...candle(10, 100), close: Number.NaN });
+    return ema;
+  }
+
+  it("keeps JSON.stringify(snapshot) lossless", () => {
+    const ema = poisonedEma();
+    const text = JSON.stringify(ema.getState());
+    expect(text).toContain("$trendcraft");
+
+    const resumed = createEma({ period: 5 }, { fromState: JSON.parse(text) });
+    const uninterrupted = ema.next(candle(11, 110)).value;
+    const afterResume = resumed.next(candle(11, 110)).value;
+    expect(Object.is(afterResume, uninterrupted)).toBe(true);
+    expect(Number.isNaN(afterResume as number)).toBe(true);
+  });
+
+  it("survives spreading the snapshot, which keeps the same state object", () => {
+    const snapshot = poisonedEma().getState();
+    expect(JSON.stringify({ ...snapshot })).toContain("$trendcraft");
+    expect(JSON.stringify(snapshot.state)).toContain("$trendcraft");
+  });
+
+  it("covers structuredClone through the explicit codec", () => {
+    const ema = poisonedEma();
+    const snapshot = ema.getState();
+
+    // structuredClone keeps NaN natively, so resuming from the clone is fine.
+    const cloned = structuredClone(snapshot);
+    const fromClone = createEma({ period: 5 }, { fromState: cloned });
+
+    // Serializing the clone needs the explicit codec: the hook is a function
+    // and functions are not cloned.
+    expect(JSON.stringify(cloned)).not.toContain("$trendcraft");
+    const text = serializeIndicatorSnapshot(cloned);
+    expect(text).toContain("$trendcraft");
+    const fromText = createEma(
+      { period: 5 },
+      { fromState: deserializeIndicatorSnapshot<EmaState>(text) },
+    );
+
+    const uninterrupted = ema.next(candle(11, 110)).value;
+    expect(Object.is(fromClone.next(candle(11, 110)).value, uninterrupted)).toBe(true);
+    expect(Object.is(fromText.next(candle(11, 110)).value, uninterrupted)).toBe(true);
+  });
+
+  it("keeps a deserialized snapshot persistable", () => {
+    // What comes back from the deserializer is a snapshot like any other, so
+    // storing it again with plain JSON.stringify must not be the step that
+    // loses the values the codec exists to keep.
+    const ema = poisonedEma();
+    const first = serializeIndicatorSnapshot(ema.getState());
+    const restored = deserializeIndicatorSnapshot<EmaState>(first);
+    expect(Number.isNaN(restored.state.prevEma as number)).toBe(true);
+
+    const second = JSON.stringify(restored);
+    expect(second).toContain("$trendcraft");
+    expect(second).toBe(first);
+
+    const resumed = createEma({ period: 5 }, { fromState: JSON.parse(second) });
+    const uninterrupted = ema.next(candle(11, 110)).value;
+    expect(Object.is(resumed.next(candle(11, 110)).value, uninterrupted)).toBe(true);
+
+    // And the cycle is stable however many times it is repeated.
+    const third = serializeIndicatorSnapshot(deserializeIndicatorSnapshot<EmaState>(second));
+    expect(third).toBe(first);
+  });
+
+  it("leaves the runtime state a plain object of numbers", () => {
+    const snapshot = poisonedEma().getState();
+    expect(typeof snapshot.state.prevEma).toBe("number");
+    expect(Number.isNaN(snapshot.state.prevEma as number)).toBe(true);
+    expect(Object.keys(snapshot.state)).not.toContain("toJSON");
+    expect(Object.prototype.propertyIsEnumerable.call(snapshot.state, "toJSON")).toBe(false);
+  });
+
+  it("serializes a healthy snapshot to the same bytes as before the codec existed", () => {
+    const ema = createEma({ period: 5 });
+    for (let i = 0; i < 10; i++) ema.next(candle(i, 100 + i));
+    const snapshot = ema.getState();
+    const plain = { meta: snapshot.meta, state: { ...snapshot.state } };
+    expect(JSON.stringify(snapshot)).toBe(JSON.stringify(plain));
+  });
+
+  it("refuses a state that already owns a toJSON", () => {
+    expect(() => makeSnapshot("proto", 1, {}, { value: 1, toJSON: () => ({ value: 1 }) })).toThrow(
+      /defines its own toJSON/,
+    );
+  });
+
+  it("refuses a state that cannot take the hook", () => {
+    expect(() => makeSnapshot("proto", 1, {}, Object.freeze({ value: 1 }))).toThrow(
+      /not extensible/,
+    );
+  });
+
+  it("resumes identically from the object and from its JSON", () => {
+    const ema = poisonedEma();
+    const snapshot: IndicatorSnapshot<unknown> = ema.getState();
+
+    const direct = createEma({ period: 5 }, { fromState: snapshot as never });
+    const viaJson = createEma(
+      { period: 5 },
+      { fromState: JSON.parse(JSON.stringify(snapshot)) as never },
+    );
+
+    for (let i = 11; i < 16; i++) {
+      const a = direct.next(candle(i, 100 + i)).value;
+      const b = viaJson.next(candle(i, 100 + i)).value;
+      expect(Object.is(a, b)).toBe(true);
+    }
+  });
+});

--- a/packages/core/src/indicators/incremental/__tests__/snapshot-json-parity.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/snapshot-json-parity.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Every incremental indicator must resume the same way from a snapshot object
+ * and from that snapshot's JSON.
+ *
+ * This started as a one-off probe after two indicators were found reviving a
+ * poisoned state as plausible numbers. It is a test because the failure is
+ * invisible otherwise: the run keeps producing output, it is simply not the
+ * output the uninterrupted run produces. Feeding a bad tick is what makes the
+ * difference observable, since JSON is only lossy for the values a bad tick
+ * creates.
+ */
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle } from "../../../types";
+import * as incremental from "../index";
+
+/** Only what this harness calls; the registry is heterogeneous by nature. */
+type ProbeIndicator = {
+  next(candle: NormalizedCandle): { value: unknown };
+  getState(): { meta: unknown; state: unknown };
+};
+type ProbeFactory = (
+  options: Record<string, unknown>,
+  warmUpOptions?: { fromState?: unknown },
+) => ProbeIndicator;
+
+const DAY = 86_400_000;
+const START = 1_700_000_000_000;
+
+function candle(i: number, close: number): NormalizedCandle {
+  const finite = Number.isFinite(close);
+  return {
+    time: START + i * DAY,
+    open: close,
+    high: finite ? close * 1.01 : close,
+    low: finite ? close * 0.99 : close,
+    close,
+    volume: 1000,
+  };
+}
+
+/** Option bags tried in order; the first one that constructs is used. */
+const OPTION_BAGS: Array<Record<string, unknown>> = [
+  {},
+  { period: 14 },
+  { period: 14, signalPeriod: 9 },
+  { fastPeriod: 12, slowPeriod: 26, signalPeriod: 9 },
+  { shortPeriod: 5, longPeriod: 20 },
+];
+
+const BAD_TICKS: Array<[string, number]> = [
+  ["zero", 0],
+  ["negative", -5],
+  ["+Infinity", Number.POSITIVE_INFINITY],
+  ["-Infinity", Number.NEGATIVE_INFINITY],
+  ["NaN", Number.NaN],
+];
+
+/** NaN-aware, sign-of-zero-aware structural comparison. */
+function sameValue(a: unknown, b: unknown): boolean {
+  if (typeof a === "number" || typeof b === "number") return Object.is(a, b);
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((item, i) => sameValue(item, b[i]));
+  }
+  if (a === null || b === null || typeof a !== "object" || typeof b !== "object") {
+    return Object.is(a, b);
+  }
+  const aKeys = Object.keys(a as object).sort();
+  const bKeys = Object.keys(b as object).sort();
+  if (aKeys.length !== bKeys.length || aKeys.some((k, i) => k !== bKeys[i])) return false;
+  return aKeys.every((k) =>
+    sameValue((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]),
+  );
+}
+
+function construct(
+  factory: ProbeFactory,
+): { instance: ProbeIndicator; options: Record<string, unknown> } | null {
+  for (const options of OPTION_BAGS) {
+    try {
+      const instance = factory(options) as Partial<ProbeIndicator> | undefined;
+      if (typeof instance?.next === "function" && typeof instance?.getState === "function") {
+        return { instance: instance as ProbeIndicator, options };
+      }
+    } catch {
+      // try the next bag
+    }
+  }
+  return null;
+}
+
+const factories = Object.entries(incremental)
+  .filter(([name, value]) => name.startsWith("create") && typeof value === "function")
+  .sort(([a], [b]) => a.localeCompare(b)) as unknown as Array<[string, ProbeFactory]>;
+
+describe("resuming from JSON matches resuming from the object", () => {
+  it("covers the whole incremental registry", () => {
+    expect(factories.length).toBeGreaterThan(80);
+  });
+
+  for (const [name, factory] of factories) {
+    it(`${name}`, () => {
+      const built = construct(factory);
+      if (built === null) return; // needs options this harness does not know
+
+      for (const [label, bad] of BAD_TICKS) {
+        for (const snapshotAt of [27, 40]) {
+          const candles: NormalizedCandle[] = [];
+          for (let i = 0; i < snapshotAt; i++) {
+            candles.push(candle(i, i === 25 ? bad : 100 + i * 0.5));
+          }
+
+          const live = factory(built.options);
+          for (const c of candles) live.next(c);
+          const snapshot = live.getState();
+
+          // Resume from the object and from its JSON. Either both work, or
+          // both refuse for the same reason — a per-indicator policy is fine,
+          // a difference between the two paths is not.
+          let fromObject: ProbeIndicator | null = null;
+          let objectError: string | null = null;
+          try {
+            fromObject = factory(built.options, { fromState: snapshot });
+          } catch (e) {
+            objectError = (e as Error).message;
+          }
+
+          let fromJson: ProbeIndicator | null = null;
+          let jsonError: string | null = null;
+          try {
+            fromJson = factory(built.options, {
+              fromState: JSON.parse(JSON.stringify(snapshot)),
+            });
+          } catch (e) {
+            jsonError = (e as Error).message;
+          }
+
+          const where = `${name} / ${label} / snapshot at ${snapshotAt}`;
+          expect({ where, refused: objectError !== null }).toEqual({
+            where,
+            refused: jsonError !== null,
+          });
+          if (objectError !== null) {
+            expect({ where, message: objectError }).toEqual({ where, message: jsonError });
+            continue;
+          }
+
+          for (let i = snapshotAt; i < snapshotAt + 5; i++) {
+            const c = candle(i, 100 + i * 0.5);
+            const expected = live.next(c).value;
+            const viaObject = (fromObject as ProbeIndicator).next(c).value;
+            const viaJson = (fromJson as ProbeIndicator).next(c).value;
+            expect({ where, bar: i, matches: sameValue(viaObject, expected) }).toEqual({
+              where,
+              bar: i,
+              matches: true,
+            });
+            expect({ where, bar: i, matches: sameValue(viaJson, expected) }).toEqual({
+              where,
+              bar: i,
+              matches: true,
+            });
+          }
+        }
+      }
+    });
+  }
+});

--- a/packages/core/src/indicators/incremental/index.ts
+++ b/packages/core/src/indicators/incremental/index.ts
@@ -185,6 +185,13 @@ export { createLiquiditySweep } from "./smc/liquidity-sweep";
 // the snapshot type. (Distinct from the looser `streaming` snapshot
 // type of the same name; this is the per-indicator state envelope.)
 export type { IndicatorSnapshot, SnapshotMeta } from "./state-contract";
+// Persisting a snapshot: `JSON.stringify` already keeps every value, these
+// cover the paths that drop the hook it relies on (`structuredClone`, or a
+// storage layer that rebuilds the object before serializing it).
+export {
+  deserializeIndicatorSnapshot,
+  serializeIndicatorSnapshot,
+} from "./state-contract";
 export type { IchimokuState, IchimokuValue as IncrementalIchimokuValue } from "./trend/ichimoku";
 export { createIchimoku } from "./trend/ichimoku";
 export type {

--- a/packages/core/src/indicators/incremental/state-contract.ts
+++ b/packages/core/src/indicators/incremental/state-contract.ts
@@ -214,6 +214,11 @@ export function resolveResume<TParams extends Record<string, unknown>, TState>(
     );
   }
 
+  // Restore values JSON has no syntax for. A snapshot that never went through
+  // JSON decodes to itself, so resuming from `getState()` directly and
+  // resuming from its JSON produce the same state.
+  const restored = decodeSnapshotValue(fromState.state) as TState;
+
   // Merge: defaults < snapshot.params < explicit options.
   const params = mergeParams(defaults, fromState.meta.params, options);
 
@@ -222,7 +227,7 @@ export function resolveResume<TParams extends Record<string, unknown>, TState>(
   const changedKeys = diffParams(snapshotParams, params);
 
   if (changedKeys.length === 0) {
-    return { params, state: fromState.state, reconfigured: false };
+    return { params, state: restored, reconfigured: false };
   }
 
   // Source change is always a refuse — the input series differs, so
@@ -246,11 +251,11 @@ export function resolveResume<TParams extends Record<string, unknown>, TState>(
   if (stateShapingChanges.length === 0) {
     // Only resume-invariant params changed — resume the saved state
     // verbatim, no buffer rebuild needed.
-    return { params, state: fromState.state, reconfigured: false };
+    return { params, state: restored, reconfigured: false };
   }
 
   if (category === "windowed" || category === "event") {
-    return { params, state: fromState.state, reconfigured: true };
+    return { params, state: restored, reconfigured: true };
   }
 
   // recursive / mixed / cascaded: any state-shaping param change
@@ -282,6 +287,12 @@ export function buildMeta(
 
 /**
  * Wrap an indicator's bare state in the standard envelope.
+ *
+ * The state carries a non-enumerable `toJSON` so that `JSON.stringify` — the
+ * call a caller persisting a snapshot already writes — keeps values JSON has
+ * no syntax for. See {@link encodeSnapshotValue}. Nothing else about the state
+ * changes: property access, `Object.keys`, spreading and resuming from the
+ * object directly all behave exactly as before, and the numbers stay numbers.
  */
 export function makeSnapshot<TState>(
   indicator: string,
@@ -289,7 +300,236 @@ export function makeSnapshot<TState>(
   params: Record<string, unknown>,
   state: TState,
 ): IndicatorSnapshot<TState> {
-  return { meta: buildMeta(indicator, version, params), state };
+  return { meta: buildMeta(indicator, version, params), state: attachStateCodec(state) };
+}
+
+// ---- JSON codec for values JSON cannot represent ----
+
+/** Reserved key. Never produced for a state whose numbers are all ordinary. */
+const CODEC_KEY = "$trendcraft";
+
+/** Bumped only if the encoding itself changes shape. */
+const CODEC_VERSION = 1;
+
+/** The four values, as a closed set. A lookup would also answer for
+ * `"toString"` and every other name inherited from `Object.prototype`, and
+ * hand back the function it found. */
+function specialValue(name: string): number | undefined {
+  switch (name) {
+    case "NaN":
+      return Number.NaN;
+    case "Infinity":
+      return Number.POSITIVE_INFINITY;
+    case "-Infinity":
+      return Number.NEGATIVE_INFINITY;
+    case "-0":
+      return -0;
+    default:
+      return undefined;
+  }
+}
+
+function specialName(value: number): string | null {
+  if (Number.isNaN(value)) return "NaN";
+  if (value === Number.POSITIVE_INFINITY) return "Infinity";
+  if (value === Number.NEGATIVE_INFINITY) return "-Infinity";
+  if (Object.is(value, -0)) return "-0";
+  return null;
+}
+
+/**
+ * Rewrite a snapshot state into a JSON-safe structure.
+ *
+ * `JSON.stringify` writes `NaN`, `Infinity` and `-Infinity` as `null` and
+ * drops the sign of `-0`. A resumed indicator then reads a `null` where a
+ * number belongs, and the arithmetic that follows coerces it to `0` — the
+ * output stops looking broken and starts looking like data. Each of those four
+ * values is written as a tagged object instead and read back exactly.
+ *
+ * The input is not modified; a new structure is returned. A state whose
+ * numbers are all ordinary encodes to a structure that serializes to the same
+ * bytes as before this existed.
+ *
+ * @param value - any part of a snapshot state
+ * @returns the JSON-safe equivalent
+ *
+ * @example
+ * ```ts
+ * encodeSnapshotValue({ prevEma: Number.NaN, count: 3 });
+ * // { prevEma: { $trendcraft: { type: "number", value: "NaN", version: 1 } }, count: 3 }
+ * ```
+ */
+export function encodeSnapshotValue(value: unknown): unknown {
+  if (typeof value === "number") {
+    const name = specialName(value);
+    if (name === null) return value;
+    return { [CODEC_KEY]: { type: "number", value: name, version: CODEC_VERSION } };
+  }
+  if (Array.isArray(value)) return value.map(encodeSnapshotValue);
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = encodeSnapshotValue(inner);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Inverse of {@link encodeSnapshotValue}.
+ *
+ * A tag is only honored when it is exactly the shape this codec writes.
+ * Anything else carrying the reserved key is refused rather than passed
+ * through as data: a snapshot that half-matches is a corrupted wire format,
+ * and reading it as an ordinary object would put an object where the
+ * indicator expects a number.
+ *
+ * @param value - a parsed snapshot state, or any part of one
+ * @returns the same structure with tagged values restored
+ * @throws if the reserved key appears in any other shape
+ */
+export function decodeSnapshotValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const out = value.map((item) => {
+      const decoded = decodeSnapshotValue(item);
+      if (!Object.is(decoded, item)) changed = true;
+      return decoded;
+    });
+    // A state with nothing to decode is returned as-is, so resuming from an
+    // object keeps handing the indicator the very object it was given.
+    return changed ? out : value;
+  }
+  if (value === null || typeof value !== "object") return value;
+
+  const obj = value as Record<string, unknown>;
+  if (CODEC_KEY in obj) {
+    const keys = Object.keys(obj);
+    if (keys.length !== 1) {
+      throw new Error(
+        `invalid snapshot wire format: "${CODEC_KEY}" alongside other keys (${keys.join(", ")})`,
+      );
+    }
+    const tag = obj[CODEC_KEY];
+    if (tag === null || typeof tag !== "object" || Array.isArray(tag)) {
+      throw new Error(`invalid snapshot wire format: "${CODEC_KEY}" must hold an object`);
+    }
+    const tagKeys = Object.keys(tag).sort();
+    if (tagKeys.length !== 3 || tagKeys.join(",") !== "type,value,version") {
+      throw new Error(
+        `invalid snapshot wire format: tag must hold exactly type, value and version (got ${tagKeys.join(", ")})`,
+      );
+    }
+    const { type, value: name, version } = tag as Record<string, unknown>;
+    if (type !== "number") {
+      throw new Error(`invalid snapshot wire format: unknown tag type ${JSON.stringify(type)}`);
+    }
+    if (version !== CODEC_VERSION) {
+      throw new Error(
+        `invalid snapshot wire format: tag version ${JSON.stringify(version)} (this build writes ${CODEC_VERSION})`,
+      );
+    }
+    const restored = typeof name === "string" ? specialValue(name) : undefined;
+    if (restored === undefined) {
+      throw new Error(`invalid snapshot wire format: unknown tag value ${JSON.stringify(name)}`);
+    }
+    return restored;
+  }
+
+  const out: Record<string, unknown> = {};
+  let changed = false;
+  for (const [key, inner] of Object.entries(obj)) {
+    const decoded = decodeSnapshotValue(inner);
+    if (!Object.is(decoded, inner)) changed = true;
+    out[key] = decoded;
+  }
+  return changed ? out : value;
+}
+
+/**
+ * Give a state object the `toJSON` that runs the codec.
+ *
+ * Non-enumerable, so it is invisible to `Object.keys`, spreading and equality
+ * checks. It does not survive `structuredClone` or being spread into a fresh
+ * object — functions are not copied by either — which is what
+ * {@link serializeIndicatorSnapshot} is for.
+ */
+function attachStateCodec<TState>(state: TState): TState {
+  if (state === null || typeof state !== "object") return state;
+  if (Object.hasOwn(state as object, "toJSON")) {
+    throw new Error(
+      "indicator state defines its own toJSON; the snapshot codec would have to overwrite it",
+    );
+  }
+  if (!Object.isExtensible(state)) {
+    throw new Error("indicator state is not extensible; the snapshot codec cannot be attached");
+  }
+  Object.defineProperty(state, "toJSON", {
+    value(this: TState) {
+      const plain: Record<string, unknown> = {};
+      for (const [key, inner] of Object.entries(this as object)) plain[key] = inner;
+      return encodeSnapshotValue(plain);
+    },
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+  return state;
+}
+
+/**
+ * Persist a snapshot, keeping every number exactly.
+ *
+ * `JSON.stringify(snapshot)` already goes through the same codec. Use this
+ * when the snapshot has been copied in a way that drops the hook it relies on
+ * — `structuredClone`, spreading the state itself, or a storage layer that
+ * rebuilds the object before serializing it.
+ *
+ * @param snapshot - a snapshot from `getState()`
+ * @returns JSON text that {@link deserializeIndicatorSnapshot} reads back exactly
+ *
+ * @example
+ * ```ts
+ * const ema = createEma({ period: 12 });
+ * const text = serializeIndicatorSnapshot(ema.getState());
+ * const restored = deserializeIndicatorSnapshot<EmaState>(text);
+ * createEma({ period: 12 }, { fromState: restored });
+ * ```
+ */
+export function serializeIndicatorSnapshot<TState>(snapshot: IndicatorSnapshot<TState>): string {
+  return JSON.stringify({
+    meta: snapshot.meta,
+    state: encodeSnapshotValue(snapshot.state),
+  });
+}
+
+/**
+ * Read back what {@link serializeIndicatorSnapshot} wrote.
+ *
+ * Plain `JSON.parse` works too — `resolveResume` decodes tags on the way in —
+ * but this pairs with the explicit serializer and fails on a corrupted wire
+ * format at the point of reading rather than at resume.
+ *
+ * The state type is the caller's to declare, the way `JSON.parse` leaves it:
+ * `deserializeIndicatorSnapshot<EmaState>(text)` types the result, and
+ * omitting it leaves the state `unknown`.
+ *
+ * @param json - JSON text produced by `serializeIndicatorSnapshot` or `JSON.stringify`
+ * @returns the snapshot, with every tagged value restored
+ * @throws if the text is not valid JSON or carries a malformed tag
+ */
+export function deserializeIndicatorSnapshot<TState = unknown>(
+  json: string,
+): IndicatorSnapshot<TState> {
+  const parsed = JSON.parse(json) as { meta: SnapshotMeta; state: unknown };
+  // The result is an `IndicatorSnapshot` like any other, so it carries the
+  // hook too: deserializing and then persisting again with `JSON.stringify`
+  // must not be the step that loses the values this codec exists to keep.
+  return {
+    meta: parsed.meta,
+    state: attachStateCodec(decodeSnapshotValue(parsed.state)) as TState,
+  };
 }
 
 /**


### PR DESCRIPTION
## The bug

`JSON.stringify` writes `NaN`, `Infinity` and `-Infinity` as `null`, and drops the sign of `-0`. Every incremental indicator promises a JSON-serializable snapshot, so a state that had gone non-finite — a bad tick is enough — came back from persistence with a `null` where a number belonged. The arithmetic on resume then coerced that `null` to `0`, and the indicator carried on emitting numbers that no uninterrupted run would produce.

```
createEma({ period: 5 }), NaN price at bar 10

  bar 11  uninterrupted: NaN     resumed from JSON: 16
```

A probe across the whole incremental registry — every factory, five bad-tick shapes, snapshots taken immediately after the tick and fifteen bars later — found **71 of 94** indicators behaving that way.

## The fix

A lossless JSON codec at the state-contract layer, so the runtime representation of a snapshot and its JSON representation are separate concerns.

The four values JSON cannot carry are written as a self-describing tag, so a snapshot identifies its own wire format:

```json
{ "$trendcraft": { "type": "number", "value": "NaN", "version": 1 } }
```

**Nothing about the runtime shape changes.** `state` still holds plain numbers, `Object.keys` is unchanged, spreading and resuming from `getState()` behave as before, and a state whose numbers are all ordinary serializes to exactly the same bytes as it did. The encoding rides on a non-enumerable `toJSON` attached to the state object, which covers the calls a caller already writes:

| path | keeps the values |
| --- | --- |
| `JSON.stringify(snapshot)` | yes |
| `JSON.stringify({ ...snapshot })` | yes — spreading copies `state` by reference |
| `JSON.stringify(snapshot.state)` | yes |
| resume from `getState()` directly | yes, unchanged |
| `structuredClone(snapshot)` then resume | yes — `structuredClone` keeps non-finite numbers natively |
| `structuredClone(snapshot)` then `JSON.stringify` | needs the explicit codec below |
| `JSON.stringify({ ...snapshot.state })` | needs the explicit codec below |

Attaching the hook to the state rather than to the snapshot root is what covers rows 2 and 3; a function cannot survive `structuredClone` or being spread into a fresh object, which is what rows 6 and 7 are about:

```ts
import {
  serializeIndicatorSnapshot,
  deserializeIndicatorSnapshot,
} from "trendcraft/incremental";

const text = serializeIndicatorSnapshot(structuredClone(ema.getState()));
const restored = deserializeIndicatorSnapshot<EmaState>(text);
```

Both share one encoder with the implicit hook. What the deserializer returns is a snapshot like any other, hook included, so persisting it again with plain `JSON.stringify` is not the step that loses the values.

Decoding is strict. The reserved key is honored only in exactly the shape this codec writes — one key outside, three inside, a known type, the current version, and one of the four value names matched by a `switch` rather than a lookup, which would also answer for `"toString"` and hand back the inherited function. Anything else is refused as a corrupted wire format rather than read as data. A state with nothing to decode is returned by reference, compared with `Object.is` so a raw `NaN` does not count as a change.

Refusing to resume stays an indicator's own decision, separate from transport: `createMcGinleyDynamic` still refuses a snapshot whose running value is not finite, because that state can only ever produce `NaN` again — and it now refuses identically whether the snapshot arrived as an object or as JSON.

Indicator schema versions are untouched: a healthy snapshot's bytes are unchanged, and the tag is self-identifying, so old snapshots stay readable.

## Test plan

**Codec, 16 tests** — round trip of all four values; nested objects and arrays; input left unmodified; an ordinary state encoding to byte-identical JSON; eleven malformed-tag shapes refused (unknown value, unknown type, wrong version, non-string value, tag not an object, extra sibling key, extra key inside the tag, missing key inside the tag, and the inherited names `toString`, `constructor`, `__proto__`, `valueOf`); reference identity preserved when there is nothing to decode, including for a raw `NaN`; circular structures reported; each persistence path from the table above; `serialize → deserialize → JSON.stringify` reproducing the original text and staying stable over repeated cycles; a state that already owns a `toJSON`, or is frozen, refused at `makeSnapshot`.

**Registry parity, 95 tests** — every factory, five bad ticks (zero, negative, ±Infinity, NaN), snapshots at two points. Each asserts that resuming from the object and resuming from its JSON either both continue and agree with the uninterrupted run bar for bar, or both refuse with the same message. Comparison is `Object.is`-based, so `NaN`, `-0` and the sign of `Infinity` are all distinguished.

Without the codec, 71 of those 95 fail — the same 71 the probe found. Each other fix in this change was negative-checked on its own.

Verification: `pnpm test` in core (375 files, 6682 tests), chart (84 files, 934 tests) and mcp (9 files, 83 tests); `npx tsc --noEmit --ignoreDeprecations 6.0`; `pnpm build`; `npx biome check`. Both documented import paths were type-checked from a consumer's position.

## Not in this change

Whether the library should reject non-finite candle input at all is a separate policy question, tracked on its own.