### PR TITLE
fix(core): incremental FVG peek honors maxActiveFvgs; same-bar fills listed oldest-first

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+### Fixed — incremental Fair Value Gap: `peek` honors `maxActiveFvgs`; same-bar fills listed oldest-first
+
+Two streaming/batch mismatches in `createFairValueGap`:
+
+- `peek()` did not apply the `maxActiveFvgs` cap when previewing a bar that
+  forms a new gap while the active list is already full, so it reported one
+  more active gap than the `next()` it is supposed to preview — including the
+  zone `next()` evicts. `peek` is now implemented by running the real `next()`
+  against a copy of the state, so it structurally cannot drift from it again.
+- When several gaps of the same direction filled on a single bar, `filledFvgs`
+  listed them newest-first, while the batch `fairValueGap` lists them in
+  insertion (oldest-first) order. The incremental detector now matches the
+  batch order.
+
+Values are otherwise unchanged: gap detection, fill detection, and the active
+lists after each bar are identical to before. Snapshots keep their schema
+version and resume without a re-warm.
+
 ### Breaking — incremental `vwap` and `twap` snapshots need a re-warm
 
 `createVwap` and `createTwap` take the same `session` option as their batch

--- a/packages/core/src/indicators/incremental/__tests__/price-wyckoff-indicators.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/price-wyckoff-indicators.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, expect, it } from "vitest";
 import type { NormalizedCandle } from "../../../types";
+import { fairValueGap } from "../../price/fair-value-gap";
 import { gapAnalysis } from "../../price/gap-analysis";
 import { highestLowest } from "../../price/highest-lowest";
 import { openingRange } from "../../price/opening-range";
@@ -269,6 +270,132 @@ describe("FVG incremental", () => {
       const v2 = ind2.next(candles[i]).value;
       expect(v1.newBullishFvg).toBe(v2.newBullishFvg);
       expect(v1.newBearishFvg).toBe(v2.newBearishFvg);
+    }
+  });
+
+  function fvgCandle(
+    i: number,
+    open: number,
+    high: number,
+    low: number,
+    close: number,
+  ): NormalizedCandle {
+    return { time: 1700000000000 + i * 60000, open, high, low, close, volume: 1000 };
+  }
+
+  // The batch series stores live gap objects in historical entries, so gap
+  // fields (`filled` etc.) mutate retroactively when a gap fills later.
+  // Project each bar down to the fields that are stable at emission time
+  // so batch-vs-incremental comparison is not polluted by that aliasing.
+  function fvgProjection(v: FvgValueShape) {
+    return {
+      newBullishFvg: v.newBullishFvg,
+      newBearishFvg: v.newBearishFvg,
+      newFvg: v.newFvg ? [v.newFvg.type, v.newFvg.startIndex, v.newFvg.high, v.newFvg.low] : null,
+      activeBullish: v.activeBullishFvgs.map((g) => g.startIndex),
+      activeBearish: v.activeBearishFvgs.map((g) => g.startIndex),
+      // full data, order-sensitive: a filled gap is never mutated again
+      filledFvgs: v.filledFvgs,
+    };
+  }
+  type FvgValueShape = ReturnType<typeof fairValueGap>[number]["value"];
+
+  it("peek matches next when a new FVG forms while the active list is at maxActiveFvgs", () => {
+    // Monotonic uptrend: every bar from i=2 on opens a new, never-filled
+    // bullish FVG, so the active list reaches the cap at i = cap + 1 and
+    // next() starts evicting the oldest gap on every later bar.
+    const cap = 10;
+    const uptrend: NormalizedCandle[] = [];
+    for (let i = 0; i < cap + 4; i++) {
+      const base = 100 + i * 10;
+      uptrend.push(fvgCandle(i, base, base + 4, base, base + 4));
+    }
+    const ind = createFairValueGap({ maxActiveFvgs: cap });
+    let capBarsSeen = 0;
+    for (const candle of uptrend) {
+      const peeked = ind.peek(candle);
+      const advanced = ind.next(candle);
+      expect(fvgProjection(peeked.value)).toEqual(fvgProjection(advanced.value));
+      expect(peeked.value.activeBullishFvgs.length).toBeLessThanOrEqual(cap);
+      if (advanced.value.activeBullishFvgs.length === cap) capBarsSeen++;
+    }
+    // Make sure the fixture actually exercised the cap boundary
+    expect(capBarsSeen).toBeGreaterThanOrEqual(3);
+  });
+
+  it("lists same-bar multiple fills oldest-first, matching batch order", () => {
+    // Bars 2 and 3 each open a bearish FVG; bar 4 rallies through both
+    // zones so both fill on the same bar. Batch fills in insertion
+    // (oldest-first) order, and the incremental result must match.
+    const doubleFill = [
+      fvgCandle(0, 100, 101, 99, 100),
+      fvgCandle(1, 100, 101, 99, 100),
+      fvgCandle(2, 90, 91, 89, 90),
+      fvgCandle(3, 80, 81, 79, 80),
+      fvgCandle(4, 80, 105, 80, 104),
+    ];
+    const batch = fairValueGap(doubleFill, {});
+    const ind = createFairValueGap({});
+    const perBar = doubleFill.map((c) => {
+      const peeked = ind.peek(c).value;
+      const advanced = ind.next(c).value;
+      return { peeked, advanced };
+    });
+    expect(perBar[4].advanced.filledFvgs.map((g) => g.startIndex)).toEqual([2, 3]);
+    expect(perBar[4].advanced.filledFvgs).toEqual(batch[4].value.filledFvgs);
+    expect(perBar[4].peeked.filledFvgs).toEqual(batch[4].value.filledFvgs);
+  });
+
+  it("peek does not stamp fills onto gaps aliased into previous results", () => {
+    // next() returns shallow copies of the active lists, so the gap
+    // objects inside earlier results alias live state. A peek that
+    // would fill a gap must not mutate those — the fill never happened.
+    const cs = [
+      fvgCandle(0, 100, 101, 100, 101),
+      fvgCandle(1, 103, 104, 103, 104),
+      fvgCandle(2, 106, 107, 105, 107), // bullish FVG zone 101-105
+    ];
+    const ind = createFairValueGap({});
+    let lastActive: FvgValueShape["activeBullishFvgs"] = [];
+    for (const c of cs) lastActive = ind.next(c).value.activeBullishFvgs;
+    expect(lastActive).toHaveLength(1);
+    const filler = fvgCandle(3, 104, 105, 100, 104); // low 100 enters the zone
+    const peeked = ind.peek(filler).value;
+    expect(peeked.filledFvgs).toHaveLength(1);
+    expect(lastActive[0].filled).toBe(false);
+    expect(lastActive[0].filledIndex).toBeNull();
+    // the real next() still detects the same fill
+    expect(ind.next(filler).value.filledFvgs).toHaveLength(1);
+  });
+
+  it("matches batch bar-by-bar across caps and fill modes (randomized)", () => {
+    let seed = 123456789;
+    const rnd = () => {
+      seed = (seed * 16807) % 2147483647;
+      return seed / 2147483647;
+    };
+    for (const maxActiveFvgs of [1, 2, 10]) {
+      for (const partialFill of [true, false]) {
+        const walk: NormalizedCandle[] = [];
+        let price = 100;
+        for (let i = 0; i < 300; i++) {
+          const drift = (rnd() - 0.48) * 6;
+          const open = price;
+          const close = price * (1 + drift / 100);
+          const high = Math.max(open, close) * (1 + rnd() * 0.02);
+          const low = Math.min(open, close) * (1 - rnd() * 0.02);
+          walk.push(fvgCandle(i, open, high, low, close));
+          price = close;
+        }
+        const batch = fairValueGap(walk, { maxActiveFvgs, partialFill });
+        const ind = createFairValueGap({ maxActiveFvgs, partialFill });
+        for (let i = 0; i < walk.length; i++) {
+          const peeked = ind.peek(walk[i]).value;
+          const advanced = ind.next(walk[i]).value;
+          expect(fvgProjection(peeked)).toEqual(fvgProjection(advanced));
+          expect(fvgProjection(advanced)).toEqual(fvgProjection(batch[i].value));
+        }
+      }
     }
   });
 });

--- a/packages/core/src/indicators/incremental/price/fair-value-gap.ts
+++ b/packages/core/src/indicators/incremental/price/fair-value-gap.ts
@@ -74,15 +74,6 @@ type FairValueGapParams = {
   partialFill: boolean;
 };
 
-const emptyValue: FvgValue = {
-  newBullishFvg: false,
-  newBearishFvg: false,
-  newFvg: null,
-  activeBullishFvgs: [],
-  activeBearishFvgs: [],
-  filledFvgs: [],
-};
-
 /**
  * Create an incremental Fair Value Gap detector
  *
@@ -143,39 +134,43 @@ export function createFairValueGap(
     count = 0;
   }
 
-  function checkFills(
-    candle: NormalizedCandle,
-    bullish: FvgGap[],
-    bearish: FvgGap[],
-    barIndex: number,
-  ): FvgGap[] {
+  function checkFills(candle: NormalizedCandle, barIndex: number): FvgGap[] {
     const filled: FvgGap[] = [];
 
+    // Iterate oldest-first and rebuild the survivor lists so that when
+    // several gaps fill on one bar, `filledFvgs` lists them in insertion
+    // order within each direction (bullish scanned first) — the same
+    // order the batch implementation produces.
+
     // Bullish FVG filled when price drops into the gap zone
-    for (let i = bullish.length - 1; i >= 0; i--) {
-      const g = bullish[i];
+    const remainingBullish: FvgGap[] = [];
+    for (const g of activeBullishFvgs) {
       const isFilled = partialFill ? candle.low <= g.high : candle.low <= g.low;
       if (isFilled) {
         g.filled = true;
         g.filledIndex = barIndex;
         g.filledTime = candle.time;
         filled.push(g);
-        bullish.splice(i, 1);
+      } else {
+        remainingBullish.push(g);
       }
     }
+    activeBullishFvgs = remainingBullish;
 
     // Bearish FVG filled when price rises into the gap zone
-    for (let i = bearish.length - 1; i >= 0; i--) {
-      const g = bearish[i];
+    const remainingBearish: FvgGap[] = [];
+    for (const g of activeBearishFvgs) {
       const isFilled = partialFill ? candle.high >= g.low : candle.high >= g.high;
       if (isFilled) {
         g.filled = true;
         g.filledIndex = barIndex;
         g.filledTime = candle.time;
         filled.push(g);
-        bearish.splice(i, 1);
+      } else {
+        remainingBearish.push(g);
       }
     }
+    activeBearishFvgs = remainingBearish;
 
     return filled;
   }
@@ -186,7 +181,7 @@ export function createFairValueGap(
       const barIndex = count - 1;
 
       // Check fills on active FVGs
-      const filledFvgs = checkFills(candle, activeBullishFvgs, activeBearishFvgs, barIndex);
+      const filledFvgs = checkFills(candle, barIndex);
 
       let newBullishFvg = false;
       let newBearishFvg = false;
@@ -262,107 +257,34 @@ export function createFairValueGap(
     },
 
     peek(candle: NormalizedCandle) {
-      if (prev2 === null || prev1 === null) {
-        return { time: candle.time, value: emptyValue };
-      }
-
-      // `next` increments `count` then uses `barIndex = count - 1`, so
-      // the bar index of the incoming candle equals the current
-      // (pre-increment) `count`.
-      const barIndex = count;
-
-      // Simulate fill check without mutating. Mirror `next`'s
-      // `checkFills` exactly — including the reverse iteration order,
-      // which determines `filledFvgs` ordering — so peek matches next.
-      const peekFilledFvgs: FvgGap[] = [];
-      for (let i = activeBullishFvgs.length - 1; i >= 0; i--) {
-        const g = activeBullishFvgs[i];
-        const isFilled = partialFill ? candle.low <= g.high : candle.low <= g.low;
-        if (isFilled)
-          peekFilledFvgs.push({
-            ...g,
-            filled: true,
-            filledIndex: barIndex,
-            filledTime: candle.time,
-          });
-      }
-      for (let i = activeBearishFvgs.length - 1; i >= 0; i--) {
-        const g = activeBearishFvgs[i];
-        const isFilled = partialFill ? candle.high >= g.low : candle.high >= g.high;
-        if (isFilled)
-          peekFilledFvgs.push({
-            ...g,
-            filled: true,
-            filledIndex: barIndex,
-            filledTime: candle.time,
-          });
-      }
-
-      let newBullishFvg = false;
-      let newBearishFvg = false;
-      let newFvg: FvgGap | null = null;
-
-      if (candle.low > prev2.high) {
-        const gapSize = candle.low - prev2.high;
-        const gapPct = prev2.high > 0 ? (gapSize / prev2.high) * 100 : 0;
-        if (gapPct >= minGapPercent) {
-          newBullishFvg = true;
-          newFvg = {
-            type: "bullish",
-            high: candle.low,
-            low: prev2.high,
-            startIndex: barIndex,
-            startTime: candle.time,
-            filled: false,
-            filledIndex: null,
-            filledTime: null,
-          };
-        }
-      }
-
-      if (candle.high < prev2.low) {
-        const gapSize = prev2.low - candle.high;
-        const gapPct = prev2.low > 0 ? (gapSize / prev2.low) * 100 : 0;
-        if (gapPct >= minGapPercent) {
-          newBearishFvg = true;
-          newFvg = {
-            type: "bearish",
-            high: prev2.low,
-            low: candle.high,
-            startIndex: barIndex,
-            startTime: candle.time,
-            filled: false,
-            filledIndex: null,
-            filledTime: null,
-          };
-        }
-      }
-
-      // Remaining active after simulated fills
-      const remainBullish = activeBullishFvgs.filter(
-        (g) => !(partialFill ? candle.low <= g.high : candle.low <= g.low),
-      );
-      const remainBearish = activeBearishFvgs.filter(
-        (g) => !(partialFill ? candle.high >= g.low : candle.high >= g.high),
-      );
-
-      return {
-        time: candle.time,
-        value: {
-          newBullishFvg,
-          newBearishFvg,
-          newFvg,
-          activeBullishFvgs:
-            newBullishFvg && newFvg?.type === "bullish"
-              ? [...remainBullish, newFvg]
-              : remainBullish,
-          activeBearishFvgs:
-            newBearishFvg && newFvg?.type === "bearish"
-              ? [...remainBearish, newFvg]
-              : remainBearish,
-          filledFvgs: peekFilledFvgs,
-        },
+      // Run the real `next()` against a deep copy of the state, then put
+      // the original state back. A hand-maintained mirror of `next` is
+      // where peek/next drift comes from (the previous mirror missed the
+      // `maxActiveFvgs` cap); this keeps peek structurally identical to
+      // next. The copy must be swapped in BEFORE `next` runs: filling
+      // mutates gap objects, and the live ones are aliased into the
+      // active lists of previously returned values — a peek must not
+      // stamp those with a fill that never happened.
+      const original = {
+        prev2,
+        prev1,
+        activeBullishFvgs,
+        activeBearishFvgs,
+        count,
       };
+      const copy = indicator.getState().state;
+      prev2 = copy.prev2;
+      prev1 = copy.prev1;
+      activeBullishFvgs = copy.activeBullishFvgs;
+      activeBearishFvgs = copy.activeBearishFvgs;
+      count = copy.count;
+      const result = indicator.next(candle);
+      prev2 = original.prev2;
+      prev1 = original.prev1;
+      activeBullishFvgs = original.activeBullishFvgs;
+      activeBearishFvgs = original.activeBearishFvgs;
+      count = original.count;
+      return result;
     },
 
     getState(): IndicatorSnapshot<FairValueGapState> {


### PR DESCRIPTION
## Problem

Two mismatches between the incremental Fair Value Gap detector (`createFairValueGap`) and its batch counterpart (`fairValueGap`):

**1. `peek()` ignored the `maxActiveFvgs` cap (peek ≠ next).**
`next()` trims the active gap lists to `maxActiveFvgs` (default 10) after pushing a newly detected gap; `peek()`'s hand-maintained preview built `[...remaining, newFvg]` with no cap. With 10 active same-direction gaps and an 11th forming, `peek` reported 11 active gaps — including the zone `next()` evicts — violating the "peek previews next without advancing state" contract. Repro on a 14-bar monotonic uptrend (a new unfilled bullish FVG every bar from i=2):

```
i=12  peek.activeBullish=11  next.activeBullish=10   <-- peek != next
i=13  peek.activeBullish=11  next.activeBullish=10   <-- peek != next
```

**2. Same-bar multiple fills were listed newest-first, batch lists them oldest-first.**
When several gaps of one direction fill on a single bar, the batch `fairValueGap` reports them in insertion (oldest-first) order via its filter pass; the incremental `checkFills()` iterated newest-first for splice safety, producing the same set in reversed order. `filledFvgs[0]` ("oldest gap reclaimed") answered differently batch vs streaming. In a randomized sweep (24 runs x 300 bars across cap {1,2,3,10} x partialFill {on,off}), 43/14,400 bars diverged — all of them on this ordering.

## Fix

- `peek()` is now implemented by running the real `next()` against a deep copy of the state (via `getState()`) and then restoring the original. This removes the ~100-line hand-maintained mirror — the class of bug where the mirror silently drifts from `next()` can no longer occur. The copy is swapped in **before** `next()` runs: filling mutates gap objects, and the live objects are aliased into the active lists of previously returned values, so a preview must not stamp them with a fill that never happened.
- `checkFills()` iterates oldest-first and rebuilds the survivor lists, so `filledFvgs` matches the batch order (insertion order within each direction, bullish scanned first).

Gap detection, fill detection, and the post-bar active lists are unchanged. Snapshots keep schema v1 and resume without a re-warm.

## Test plan

New regression tests in `price-wyckoff-indicators.test.ts` (all fail without the fix except the noted guard):

- **peek == next at the cap boundary**: 14-bar uptrend with `maxActiveFvgs: 10`; every bar asserts peek's projection equals next's, with ≥3 bars exercising the full list. Failed before with 11 vs 10.
- **Same-bar double fill, oldest-first**: two bearish gaps filled by one rally bar; asserts `filledFvgs` startIndexes `[2, 3]` and deep-equality with the batch result for both `next` and `peek`. Failed before with `[3, 2]`.
- **Randomized bar-by-bar parity**: 6 seeded random walks (300 bars each) across cap {1, 2, 10} x partialFill {on, off}; every bar asserts peek == next == batch on an aliasing-safe projection (detection flags, new-gap identity, active-list membership/order, full order-sensitive `filledFvgs`). 43/14,400 bars diverged before; 0 after.
- **Peek mutation guard**: after peeking a bar that would fill a gap, the gap object captured from an earlier `next()` result still reads `filled: false` (guards the snapshot-restore implementation; the old copy-based mirror also passed this).

Verification: core 6,686/6,686 tests (375 files), chart 934/934, mcp 83/83, `tsc --noEmit` clean, `pnpm build` pass, Biome clean on touched files. Negative check run twice (before and after review polish): parking the fix makes exactly the three parity tests fail.