### PR TITLE
fix(core): incremental Weis Wave keeps bar-0 volume in the first wave

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+### Fixed — incremental Weis Wave: bar-0 volume no longer drops out of the first wave
+
+When a stream's first move was downward, `createWeisWave` treated the second
+bar as a direction reversal — it had provisionally labeled bar 0 "up" — and
+reset the wave, so `waveVolume` was understated by exactly bar 0's volume on
+every bar of the first wave. With a `threshold` set and an opening drift of
+sub-threshold down moves, the direction also stayed "up" indefinitely, because
+only the reversal path (which the threshold gates) could correct it.
+
+The first observed move now defines the initial wave direction, with no
+threshold applied and no reset — the same seeding the batch `weisWave` uses.
+`waveVolume` now matches batch on every bar, and `direction` from bar 1 on.
+Bar 0's direction is the one value a streaming consumer cannot reproduce: the
+batch labels bar 0 using the bar0→bar1 move, which has not happened yet when
+the incremental must emit, so bar 0 stays provisionally "up".
+
+Snapshots keep schema v1. A snapshot written by an earlier version *during the
+first wave* of a down-starting stream carries the understated total; resume it
+and the understatement persists until the first reversal. Re-warm from history
+to get corrected values. Streams whose first move was upward were never
+affected.
+
 ### Fixed — incremental Fair Value Gap: `peek` honors `maxActiveFvgs`; same-bar fills listed oldest-first
 
 Two streaming/batch mismatches in `createFairValueGap`:

--- a/packages/core/src/indicators/incremental/__tests__/volume-indicators.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/volume-indicators.test.ts
@@ -174,23 +174,78 @@ describe("CVD incremental", () => {
 describe("Weis Wave incremental", () => {
   const extractWave = (v: unknown) => (v as { waveVolume: number } | null)?.waveVolume ?? null;
 
-  it("matches batch output from bar 2 onward (waveVolume)", () => {
-    // Bar 0 direction differs: batch looks ahead to bar 1, incremental defaults to 'up'
-    // From bar 2 onward the wave state has converged
-    const batch = weisWave(candles);
-    const ind = createWeisWave();
-    const incr = candles.map((c) => ind.next(c));
+  function makeCandle(i: number, close: number, volume = 1000): NormalizedCandle {
+    return {
+      time: 1700000000000 + i * 60000,
+      open: close,
+      high: close + 0.5,
+      low: close - 0.5,
+      close,
+      volume,
+    };
+  }
 
-    let matchCount = 0;
-    for (let i = 2; i < batch.length; i++) {
-      const bv = extractWave(batch[i].value);
-      const iv = extractWave(incr[i].value);
-      if (bv !== null && iv !== null) {
-        expect(Math.abs(bv - iv)).toBeLessThan(1e-8);
-        matchCount++;
+  // Bar 0 direction can differ by construction: batch seeds it from the
+  // bar0->bar1 move, which a streaming consumer has not seen yet, so the
+  // incremental labels bar 0 "up" provisionally. Everything else —
+  // waveVolume on every bar, direction from bar 1 on — must match batch.
+  function expectBatchParity(
+    stream: NormalizedCandle[],
+    opts: { method?: "close" | "highlow"; threshold?: number } = {},
+  ) {
+    const batch = weisWave(stream, opts);
+    const ind = createWeisWave(opts);
+    for (let i = 0; i < stream.length; i++) {
+      const peeked = ind.peek(stream[i]).value;
+      const advanced = ind.next(stream[i]).value;
+      expect(peeked).toEqual(advanced);
+      expect(advanced.waveVolume).toBeCloseTo(batch[i].value.waveVolume, 8);
+      if (i >= 1) {
+        expect(advanced.direction).toBe(batch[i].value.direction);
       }
     }
-    expect(matchCount).toBeGreaterThan(batch.length / 2);
+  }
+
+  it("matches batch on waveVolume (all bars) and direction (bar 1 on)", () => {
+    expectBatchParity(candles);
+    expectBatchParity(candles, { method: "highlow" });
+    expectBatchParity(candles, { threshold: 0.5 });
+  });
+
+  it("keeps bar-0 volume in the first wave when the stream starts with a down move", () => {
+    // Falling market: the whole stream is one down wave. The first
+    // observed move must be adopted as the initial direction, not
+    // treated as a reversal that resets the wave and drops bar 0.
+    const falling = Array.from({ length: 10 }, (_, i) => makeCandle(i, 100 - i));
+    expectBatchParity(falling);
+    const ind = createWeisWave();
+    const values = falling.map((c) => ind.next(c).value);
+    expect(values[1]).toEqual({ waveVolume: 2000, direction: "down" });
+    expect(values[9]).toEqual({ waveVolume: 10000, direction: "down" });
+  });
+
+  it("adopts the first move as initial direction even when it is under the threshold", () => {
+    // Batch seeds bar-0 direction from the first move with no threshold
+    // applied; the incremental must do the same on the second bar, or a
+    // stream of sub-threshold down moves stays labeled "up" forever.
+    const drifting = Array.from({ length: 4 }, (_, i) => makeCandle(i, 100 - i * 0.1));
+    expectBatchParity(drifting, { threshold: 0.5 });
+    const ind = createWeisWave({ threshold: 0.5 });
+    const values = drifting.map((c) => ind.next(c).value);
+    expect(values[3]).toEqual({ waveVolume: 4000, direction: "down" });
+  });
+
+  it("resumes from a bar-0 snapshot through a JSON round trip without dropping bar 0", () => {
+    const falling = Array.from({ length: 10 }, (_, i) => makeCandle(i, 100 - i));
+    const batch = weisWave(falling);
+    const ind1 = createWeisWave();
+    ind1.next(falling[0]);
+    const snap = JSON.parse(JSON.stringify(ind1.getState()));
+    const ind2 = createWeisWave({}, { fromState: snap });
+    for (let i = 1; i < falling.length; i++) {
+      const v = ind2.next(falling[i]).value;
+      expect(v).toEqual(batch[i].value);
+    }
   });
 
   it("peek does not mutate state", () => {

--- a/packages/core/src/indicators/incremental/volume/weis-wave.ts
+++ b/packages/core/src/indicators/incremental/volume/weis-wave.ts
@@ -119,7 +119,9 @@ export function createWeisWave(
 
   function processCandle(candle: NormalizedCandle): WeisWaveValue {
     if (prevCandle === null) {
-      // First bar
+      // First bar. The batch indicator seeds bar-0 direction from the
+      // bar0->bar1 move, which a streaming consumer cannot see yet, so
+      // "up" is a provisional label until the first move is observed.
       waveVolume = candle.volume;
       direction = "up";
       prevCandle = { close: candle.close, high: candle.high, low: candle.low };
@@ -129,7 +131,15 @@ export function createWeisWave(
     const move = getMove(candle);
     const newDir: "up" | "down" = move >= 0 ? "up" : "down";
 
-    if (newDir !== direction && Math.abs(move) > threshold) {
+    if (count === 2) {
+      // Second bar: the first observed move defines the initial wave
+      // direction — the batch seeds bar-0 direction from this same move
+      // with no threshold applied — so it can never be a reversal.
+      // Adopt it and keep accumulating on top of bar 0's volume;
+      // resetting here dropped bar 0 from the entire first wave.
+      direction = newDir;
+      waveVolume += candle.volume;
+    } else if (newDir !== direction && Math.abs(move) > threshold) {
       // Direction reversal - start new wave
       direction = newDir;
       waveVolume = candle.volume;
@@ -150,28 +160,20 @@ export function createWeisWave(
     },
 
     peek(candle: NormalizedCandle) {
-      if (prevCandle === null) {
-        return {
-          time: candle.time,
-          value: { waveVolume: candle.volume, direction: "up" as const },
-        };
-      }
-
-      const move = getMove(candle);
-      const newDir: "up" | "down" = move >= 0 ? "up" : "down";
-
-      let peekVolume: number;
-      let peekDir: "up" | "down";
-
-      if (newDir !== direction && Math.abs(move) > threshold) {
-        peekDir = newDir;
-        peekVolume = candle.volume;
-      } else {
-        peekDir = direction;
-        peekVolume = waveVolume + candle.volume;
-      }
-
-      return { time: candle.time, value: { waveVolume: peekVolume, direction: peekDir } };
+      // Run the real `next()` and put the saved state back, instead of
+      // hand-maintaining a mirror of `processCandle` — a mirror has to
+      // restate every rule (first bar, second-bar adoption, reversal)
+      // and silently drifts when one changes. Restoring after is safe
+      // here: `next()` replaces `prevCandle` with a fresh object and
+      // the other fields are primitives, so nothing the caller ever
+      // received is mutated.
+      const saved = { waveVolume, direction, prevCandle, count };
+      const result = indicator.next(candle);
+      waveVolume = saved.waveVolume;
+      direction = saved.direction;
+      prevCandle = saved.prevCandle;
+      count = saved.count;
+      return result;
     },
 
     getState(): IndicatorSnapshot<WeisWaveState> {


### PR DESCRIPTION
## Problem

The incremental `createWeisWave` provisionally labels bar 0 `"up"` — a streaming consumer cannot see the bar0→bar1 move that the batch `weisWave` uses to seed bar-0 direction. Two consequences when a stream's first move is downward:

**1. Bar 0's volume dropped out of the entire first wave.**
The second bar looked like a direction reversal (`down` vs the provisional `up`), so the wave was reset and `waveVolume` was understated by exactly bar 0's volume on every bar of the first wave — unbounded duration in a down-trending start:

```
falling market, volume=1000/bar
i=0  batch={down,1000}   inc={up,1000}
i=1  batch={down,2000}   inc={down,1000}   <-- short by bar-0's volume
i=2  batch={down,3000}   inc={down,2000}   <-- ...on every bar of the wave
...
i=9  batch={down,10000}  inc={down,9000}
```

**2. With a `threshold`, direction could stay wrong forever.**
The batch seeds the initial direction from the first move with **no threshold applied**; the incremental could only correct its provisional `"up"` through the reversal path, which the threshold gates. A stream opening with sub-threshold down moves stayed labeled `"up"` on every bar:

```
threshold=0.5, moves of -0.1/bar
i=1..3  batch={down,...}  inc={up,...}   <-- never corrects
```

## Fix

On the second bar, the first observed move now defines the initial wave direction — no threshold applied, no reset, volume keeps accumulating on top of bar 0's — which is exactly the batch seeding rule. After this, `waveVolume` matches batch on every bar and `direction` matches from bar 1 on. Bar 0's direction is the one value streaming cannot reproduce (the move that determines it has not happened yet when bar 0 must be emitted), so it stays provisionally `"up"`; this is now documented in the code and CHANGELOG.

The second-bar case is derived from the already-persisted `count`, so the state shape and schema version (v1) are unchanged and existing snapshots resume as before. One caveat documented in the CHANGELOG: a snapshot written by an earlier version *during the first wave* of a down-starting stream carries the understated total until the first reversal; re-warm from history to get corrected values.

`peek()` is now implemented by running the real `next()` and restoring the saved state, replacing a hand-maintained mirror that would otherwise have to restate the new seeding rule (and could drift from it). Restore-after is safe here because `next()` replaces `prevCandle` rather than mutating it and every other state field is a primitive.

## Test plan

New/strengthened regression tests in `volume-indicators.test.ts` (4 tests; all fail without the fix):

- **Batch parity**: 200-bar seeded random walk × {close, highlow, threshold 0.5} — every bar asserts `peek == next`, `waveVolume` equal to batch, and `direction` equal from bar 1 on. (Replaces a weaker test that only compared `waveVolume` from bar 2 and asserted a >50% match rate.)
- **Down-first stream**: 10-bar falling market — full batch parity plus explicit `{waveVolume: 2000, direction: "down"}` at bar 1 and `{10000, down}` at bar 9. Failed before with 1000/9000.
- **Sub-threshold adoption**: `threshold: 0.5` with −0.1 moves — direction `"down"` from bar 1. Failed before with `"up"` on all bars.
- **Persistence boundary**: snapshot after bar 0 through a real `JSON.stringify`/`parse` round trip, resumed and fed the falling stream — bars 1–9 deep-equal batch. Failed before on every bar.

Additional probe (not committed): 300-bar down-first random walk — 0/300 bars diverge on `waveVolume` after the fix (was: whole first wave), direction diverges only at bar 0 as documented.

Verification: core 6,689/6,689 tests (375 files), chart 934/934, mcp 83/83, `tsc --noEmit` clean, `pnpm build` pass, Biome clean on touched files.