### PR TITLE
fix(core): incremental ADXR no longer crashes at period=1

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Fixed — incremental ADXR no longer crashes at `period: 1`
+
+`createAdxr({ period: 1 })` threw `RangeError: Index N out of bounds` on the
+first bar with a non-null ADX — from `next()`, `peek()`, and even the
+`isWarmedUp` getter, so it could not be guarded from outside. Both validators
+accept `period >= 1`, and the batch `adxr` handles it fine (at period 1 the
+pair `adx[i] + adx[i - (period - 1)]` is the current ADX twice, so ADXR
+degenerates to ADX). The incremental read for the paired value indexed one
+past the newest buffer element in that case; it now returns the current ADX
+directly, matching batch on every bar. Behavior at `period >= 2` is unchanged,
+and snapshots keep schema v1.
+
 ### Fixed — incremental Weis Wave: bar-0 volume no longer drops out of the first wave
 
 When a stream's first move was downward, `createWeisWave` treated the second

--- a/packages/core/src/indicators/incremental/__tests__/new-indicators.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/new-indicators.test.ts
@@ -191,6 +191,55 @@ describe("ADXR incremental", () => {
     expect(stateAfter).toBe(stateBefore);
   });
 
+  it("period=1 degenerates to ADX and matches batch on every bar", () => {
+    // At period=1 the lookback is 0, so the paired past value is the
+    // current ADX itself. The general buffer read for it steps one past
+    // the newest element (the current ADX is pushed after computing),
+    // which used to throw a RangeError on the first non-null ADX — from
+    // next(), peek(), and even the isWarmedUp getter. period=2 runs the
+    // same loop as the smallest period that exercises the buffer read.
+    for (const period of [1, 2]) {
+      const batch = adxr(candles, { period, dmiPeriod: 5, adxPeriod: 5 });
+      const ind = createAdxr({ period, dmiPeriod: 5, adxPeriod: 5 });
+      for (let i = 0; i < candles.length; i++) {
+        const peeked = ind.peek(candles[i]).value;
+        expect(typeof ind.isWarmedUp).toBe("boolean"); // getter must not throw
+        const advanced = ind.next(candles[i]).value;
+        const expected = batch[i].value;
+        if (expected === null) {
+          expect(peeked).toBeNull();
+          expect(advanced).toBeNull();
+        } else {
+          expect(advanced).not.toBeNull();
+          expect(Math.abs(advanced! - expected)).toBeLessThan(1e-10);
+          expect(peeked).not.toBeNull();
+          expect(Math.abs(peeked! - expected)).toBeLessThan(1e-10);
+        }
+      }
+      expect(ind.isWarmedUp).toBe(true);
+      expect(batch.some((s) => s.value !== null)).toBe(true);
+    }
+  });
+
+  it("period=1 resumes from a JSON round-tripped snapshot", () => {
+    const opts = { period: 1, dmiPeriod: 5, adxPeriod: 5 };
+    const batch = adxr(candles, opts);
+    const ind1 = createAdxr(opts);
+    for (let i = 0; i < 30; i++) ind1.next(candles[i]);
+    const snap = JSON.parse(JSON.stringify(ind1.getState()));
+    const ind2 = createAdxr(opts, { fromState: snap });
+    for (let i = 30; i < 80; i++) {
+      const v = ind2.next(candles[i]).value;
+      const expected = batch[i].value;
+      if (expected === null) {
+        expect(v).toBeNull();
+      } else {
+        expect(v).not.toBeNull();
+        expect(Math.abs(v! - expected)).toBeLessThan(1e-10);
+      }
+    }
+  });
+
   it("getState/fromState restores correctly", () => {
     const ind1 = createAdxr({ period: 14 });
     for (let i = 0; i < 80; i++) ind1.next(candles[i]);

--- a/packages/core/src/indicators/incremental/momentum/adxr.ts
+++ b/packages/core/src/indicators/incremental/momentum/adxr.ts
@@ -107,6 +107,13 @@ export function createAdxr(
 
   function computeAdxr(currentAdx: number | null): number | null {
     if (currentAdx === null) return null;
+
+    // At period = 1 the pair is adx[i] itself (ADXR degenerates to ADX,
+    // as in the batch indicator). The buffer holds only strictly-past
+    // values, so the general read below would step one past the newest
+    // element and throw.
+    if (lookback === 0) return currentAdx;
+
     if (adxBuffer.length < lookback) return null;
 
     // The oldest value in the buffer when full represents adx[i - lookback]
@@ -127,16 +134,11 @@ export function createAdxr(
     },
 
     peek(candle: NormalizedCandle) {
+      // Same value computation as next() (which reads the buffer before
+      // pushing), through the one shared computeAdxr — a restated copy
+      // here is where the two paths drift apart.
       const dmiResult = dmiInd.peek(candle);
-      const currentAdx = dmiResult.value.adx;
-
-      if (currentAdx === null) return { time: candle.time, value: null };
-      if (adxBuffer.length < lookback) return { time: candle.time, value: null };
-
-      const pastAdx = adxBuffer.get(adxBuffer.length - lookback);
-      if (pastAdx === null) return { time: candle.time, value: null };
-
-      return { time: candle.time, value: (currentAdx + pastAdx) / 2 };
+      return { time: candle.time, value: computeAdxr(dmiResult.value.adx) };
     },
 
     getState(): IndicatorSnapshot<AdxrState> {
@@ -157,6 +159,10 @@ export function createAdxr(
     },
 
     get isWarmedUp() {
+      // Mirrors the read the next computeAdxr will perform: at period=1
+      // that is the freshest pushed ADX (the general index would step
+      // one past the newest element and throw).
+      if (lookback === 0) return adxBuffer.length > 0 && adxBuffer.newest() !== null;
       return adxBuffer.length > lookback && adxBuffer.get(adxBuffer.length - lookback) !== null;
     },
   };


### PR DESCRIPTION
## Problem

`createAdxr({ period: 1 })` threw on the first bar with a non-null ADX:

```
40 bars, dmiPeriod=5, adxPeriod=5
batch adxr(period=1) non-null count: 31          <- works, equals DMI's ADX
incremental next() THREW at bar 10: RangeError: Index 1 out of bounds [0, 1)
isWarmedUp getter THREW: RangeError: Index 1 out of bounds [0, 1)
```

With `lookback = period − 1 = 0`, the warm-up guard `length < lookback` never fires, and the paired-value read `adxBuffer.get(adxBuffer.length − lookback)` becomes `get(length)` — one past the newest element, because the current ADX is pushed only after computing. The same read sat in `next()`, `peek()`, and the `isWarmedUp` getter, so a caller could not even probe warm-up state to avoid the crash. Both the batch and incremental validators explicitly accept `period >= 1`, and the batch `adxr(period: 1)` works: the pair `adx[i] + adx[i − (period − 1)]` is the current ADX twice, so ADXR degenerates to ADX.

## Fix

- `computeAdxr` returns the current ADX directly when `lookback === 0` — the paired past value *is* the current value; the buffer holds only strictly-past values so the general read cannot express this case.
- `peek()` now delegates to `computeAdxr` instead of restating the same buffer read inline, so the two paths cannot drift.
- `isWarmedUp` handles the lookback-0 case by checking the freshest pushed ADX (`length > 0 && newest() !== null`), mirroring the read the next computation will perform.

Behavior at `period >= 2` is unchanged, and snapshots keep schema v1.

## Test plan

New regression tests in `new-indicators.test.ts` (both fail without the fix, with the exact `RangeError` above):

- **Per-bar parity for period 1 and 2**: over the 200-candle seeded fixture (`dmiPeriod: 5, adxPeriod: 5`), every bar asserts `peek == next == batch` (nulls aligned, values within 1e-10) and touches the `isWarmedUp` getter so it must not throw; ends warmed up with non-null batch values present. Period 2 runs the same loop as the smallest period that exercises the buffer read.
- **Period-1 resume**: snapshot after 30 bars through a real `JSON.stringify`/`parse` round trip, resumed and compared against batch for bars 30–79.

Verification: core 6,691/6,691 tests (375 files), chart 934/934, mcp 83/83, `tsc --noEmit` clean, `pnpm build` pass, Biome clean on touched files.