### PR TITLE
fix(core): incremental VSA 'test' rule scans the full 10-bar window (schema v2)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+### Breaking — incremental VSA scans the full 10-bar window for 'test' (schema v2)
+
+The incremental VSA's 'test' rule ("low volume near the lowest low of the last
+10 bars") saw only 9 previous bars: the internal candle buffer held 10 entries,
+and pushing the current bar before classification evicted the bar exactly 10
+back. When that bar held the decisive lowest low, `createVsa` reported a
+spurious `'test'` where the batch `vsa` says `'normal'` (`peek` mirrored the
+same window, so peek and next agreed — both wrong). In randomized 300-bar
+streams this fired on roughly 2-4 bars per stream; all other rules and the
+numeric fields were unaffected.
+
+The buffer now holds 11 entries (the current bar plus the 10 the rule scans),
+making the incremental classification identical to batch on every bar. Because
+a v1 snapshot's buffer cannot supply the 11th bar — resuming one would
+silently keep the 9-bar window — **VSA snapshot schema moves to v2 and v1
+snapshots are refused with a re-warm error**.
+
 ### Fixed — incremental ADXR no longer crashes at `period: 1`
 
 `createAdxr({ period: 1 })` threw `RangeError: Index N out of bounds` on the

--- a/packages/core/src/indicators/incremental/__tests__/price-wyckoff-indicators.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/price-wyckoff-indicators.test.ts
@@ -402,19 +402,88 @@ describe("FVG incremental", () => {
 
 // ---- VSA ----
 describe("VSA incremental", () => {
-  it("matches batch output (barType)", () => {
+  it("matches batch output exactly on every bar", () => {
+    // Exact equality, not a match-rate threshold: the old 80% tolerance
+    // hid a buffer off-by-one that made the 'test' rule scan 9 previous
+    // bars instead of batch's 10.
     const batch = vsa(candles, { volumeMaPeriod: 20, atrPeriod: 14 });
     const incremental = processAll(createVsa({ volumeMaPeriod: 20, atrPeriod: 14 }), candles);
     expect(incremental.length).toBe(batch.length);
-    // Match barType for bars where both are warmed up
-    let matchCount = 0;
-    for (let i = 30; i < batch.length; i++) {
-      if (batch[i].value.barType === incremental[i].value.barType) {
-        matchCount++;
+    for (let i = 0; i < batch.length; i++) {
+      const bv = batch[i].value;
+      const iv = incremental[i].value;
+      expect(iv.barType).toBe(bv.barType);
+      expect(iv.isEffortDivergence).toBe(bv.isEffortDivergence);
+      expect(Math.abs(iv.spreadRelative - bv.spreadRelative)).toBeLessThan(1e-10);
+      expect(Math.abs(iv.closePosition - bv.closePosition)).toBeLessThan(1e-10);
+      expect(Math.abs(iv.volumeRelative - bv.volumeRelative)).toBeLessThan(1e-10);
+    }
+  });
+
+  it("sees the decisive low exactly 10 bars back in the 'test' rule", () => {
+    // The 'test' rule scans the 10 bars before the current one. Build a
+    // stream whose lowest low sits exactly 10 bars back: a window one
+    // bar short misses it and reports a spurious 'test' where batch
+    // says 'normal'.
+    const fixture: NormalizedCandle[] = [];
+    const mk = (
+      i: number,
+      o: { open?: number; high?: number; low?: number; close?: number; volume?: number } = {},
+    ): NormalizedCandle => ({
+      time: 1700000000000 + i * 60000,
+      open: o.open ?? 100,
+      high: o.high ?? 100.6,
+      low: o.low ?? 99.4,
+      close: o.close ?? 100.2,
+      volume: o.volume ?? 1000,
+    });
+    for (let i = 0; i < 20; i++) fixture.push(mk(i));
+    fixture.push(mk(20, { low: 90, open: 100.2, close: 100 })); // decisive low
+    for (let i = 21; i < 30; i++) fixture.push(mk(i));
+    // Bar 30: low volume, low near the recent shallow lows; the decisive
+    // low (90) is exactly 10 back and far outside ATR tolerance.
+    fixture.push(mk(30, { volume: 500, low: 99.3, open: 100.1, close: 100 }));
+
+    const batch = vsa(fixture, { volumeMaPeriod: 20, atrPeriod: 14 });
+    const ind = createVsa({ volumeMaPeriod: 20, atrPeriod: 14 });
+    const inc = fixture.map((c) => {
+      const peeked = ind.peek(c).value;
+      const advanced = ind.next(c).value;
+      expect(peeked.barType).toBe(advanced.barType);
+      return advanced;
+    });
+    expect(batch[30].value.barType).toBe("normal");
+    expect(inc[30].barType).toBe("normal");
+  });
+
+  it("matches batch barType per bar across randomized streams (peek == next)", () => {
+    for (const seed0 of [12648430, 1, 987654321, 42424242]) {
+      let seed = seed0;
+      const rnd = () => {
+        seed = (seed * 16807) % 2147483647;
+        return seed / 2147483647;
+      };
+      const stream: NormalizedCandle[] = [];
+      let price = 100;
+      for (let i = 0; i < 300; i++) {
+        const drift = (rnd() - 0.5) * 3;
+        const open = price;
+        const close = price * (1 + drift / 100);
+        const high = Math.max(open, close) * (1 + rnd() * 0.008);
+        const low = Math.min(open, close) * (1 - rnd() * 0.008);
+        const volume = Math.floor(500 + rnd() * 2000);
+        stream.push({ time: 1700000000000 + i * 60000, open, high, low, close, volume });
+        price = close;
+      }
+      const batch = vsa(stream, { volumeMaPeriod: 20, atrPeriod: 14 });
+      const ind = createVsa({ volumeMaPeriod: 20, atrPeriod: 14 });
+      for (let i = 0; i < stream.length; i++) {
+        const peeked = ind.peek(stream[i]).value;
+        const advanced = ind.next(stream[i]).value;
+        expect(peeked.barType).toBe(advanced.barType);
+        expect(advanced.barType).toBe(batch[i].value.barType);
       }
     }
-    // Most should match (some edge cases in lookback may differ)
-    expect(matchCount).toBeGreaterThan((batch.length - 30) * 0.8);
   });
 
   it("peek does not mutate state", () => {

--- a/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
+++ b/packages/core/src/indicators/incremental/__tests__/state-contract-integration.test.ts
@@ -100,6 +100,7 @@ import { volumeAnomaly } from "../../volume/volume-anomaly";
 import { volumeTrend } from "../../volume/volume-trend";
 import { vwap } from "../../volume/vwap";
 import { weisWave } from "../../volume/weis-wave";
+import { vsa } from "../../wyckoff/vsa";
 import { createRoofingFilter, type RoofingFilterState } from "../filter/roofing-filter";
 import { createSuperSmoother, type SuperSmootherState } from "../filter/super-smoother";
 import { type AdxrState, createAdxr } from "../momentum/adxr";
@@ -2645,14 +2646,12 @@ describeContract<LiquiditySweepValue, LiquiditySweepState>({
     (typeof v === "object" && (v as { isSweep: boolean }).isSweep === false),
 });
 
-// VSA — Mixed (inner recursive ATR + windowed SMA + own 10-bar candle
-// buffer). The four threshold params are resume-invariant — they only
-// classify already-computed spread / volume ratios. batchCompute
-// omitted: the batch `vsa` and the incremental factory have a
-// pre-existing classification drift on a handful of bars (the legacy
-// parity test compared only `spreadRelative` / `volumeRelative`
-// within tolerance, never the `barType` enum); the migration left
-// `next` / `peek` untouched, so this is not a regression. The
+// VSA — Mixed (inner recursive ATR + windowed SMA + own 11-bar candle
+// buffer: current bar + the 10 previous bars the 'test' rule scans).
+// The four threshold params are resume-invariant — they only classify
+// already-computed spread / volume ratios. Batch parity is exact,
+// including the `barType` enum, since the buffer off-by-one that made
+// the 'test' rule scan 9 previous bars was fixed (schema v2). The
 // incremental never emits null (VSA classifies every bar from bar 0).
 describeContract<VsaValue, VsaState>({
   name: "vsa",
@@ -2669,7 +2668,7 @@ describeContract<VsaValue, VsaState>({
       warmUp,
     ),
   category: "mixed",
-  version: 1,
+  version: 2,
   defaultParams: {
     volumeMaPeriod: 20,
     atrPeriod: 14,
@@ -2682,6 +2681,18 @@ describeContract<VsaValue, VsaState>({
   resumeInvariantReconfig: [{ highVolumeThreshold: 2.0 }, { narrowSpreadThreshold: 0.5 }],
   makeCandles,
   streamLength: 120,
+  batchCompute: (opts, candles) =>
+    vsa(
+      candles,
+      opts as {
+        volumeMaPeriod?: number;
+        atrPeriod?: number;
+        highVolumeThreshold?: number;
+        lowVolumeThreshold?: number;
+        wideSpreadThreshold?: number;
+        narrowSpreadThreshold?: number;
+      },
+    ).map((s) => s.value),
   // VSA never emits a bare-null value. Until the inner volume SMA is
   // warmed, `volumeRelative` is exactly 1 (the `volMaVal == null`
   // fallback). The SMA is the slowest-warming inner indicator, so

--- a/packages/core/src/indicators/incremental/wyckoff/vsa.ts
+++ b/packages/core/src/indicators/incremental/wyckoff/vsa.ts
@@ -9,8 +9,9 @@
  * volume and price action.
  *
  * State category: **Mixed** (an inner recursive ATR snapshot and an
- * inner windowed SMA snapshot composed with an own 10-bar candle
- * buffer). `volumeMaPeriod` / `atrPeriod` shape the inner indicators
+ * inner windowed SMA snapshot composed with an own 11-bar candle
+ * buffer — the current bar plus the 10 previous bars the 'test' rule
+ * scans). `volumeMaPeriod` / `atrPeriod` shape the inner indicators
  * and are refused on resume. The four threshold params
  * (`highVolumeThreshold`, `lowVolumeThreshold`, `wideSpreadThreshold`,
  * `narrowSpreadThreshold`) are **resume-invariant** — they only
@@ -76,8 +77,15 @@ export type VsaState = {
   count: number;
 };
 
-/** Per-indicator schema version. Bumped on any breaking state change. */
-export const VSA_VERSION = 1;
+/**
+ * Per-indicator schema version. Bumped on any breaking state change.
+ *
+ * v2: candle buffer capacity grew from 10 to 11 (current bar + the 10
+ * previous bars the 'test' rule scans). A v1 snapshot's buffer holds
+ * only 10 bars, which perpetuates the 9-previous-bar window the fix
+ * removed, so v1 snapshots are refused with a re-warm error.
+ */
+export const VSA_VERSION = 2;
 
 type VsaParams = {
   volumeMaPeriod: number;
@@ -259,8 +267,11 @@ export function createVsa(
   const wideSpreadThreshold = params.wideSpreadThreshold;
   const narrowSpreadThreshold = params.narrowSpreadThreshold;
 
-  // 10-bar candle buffer for test detection (needs lookback of 10)
-  const candleBufferSize = 10;
+  // The 'test' rule scans the 10 bars BEFORE the current one, and the
+  // current bar is pushed before classification, so the buffer must
+  // hold 11 entries. At 10, the push evicted the bar exactly 10 back
+  // and the rule saw only 9 previous bars (batch scans i-10..i-1).
+  const candleBufferSize = 11;
 
   let atrIndicator: ReturnType<typeof createAtr>;
   let volumeSma: ReturnType<typeof createSma>;


### PR DESCRIPTION
## Problem

The incremental VSA's `'test'` rule — "low volume near the lowest low of the last 10 bars" — saw only **9** previous bars. The internal candle buffer held 10 entries, and the current bar is pushed *before* classification, so the push evicted the bar exactly 10 back. Whenever that evicted bar held the decisive lowest low, `createVsa` reported a spurious `'test'` where the batch `vsa` says `'normal'`. `peek()` mirrored the same window, so peek and next agreed — both wrong vs batch.

Deterministic repro (defaults `volumeMaPeriod: 20, atrPeriod: 14`; a deep low spike at bar 20, then a low-volume bar at bar 30 — the spike sits exactly 10 back):

```
bar 30:  batch = normal   incremental = test   <-- spurious
```

In 4 seeded 300-bar random walks, 8/1,200 bars diverged — every one a spurious `'test'`. The 5-bar rules (stoppingVolume / upthrust / spring) and all numeric fields (`spreadRelative`, `closePosition`, `volumeRelative`, `isEffortDivergence`) were unaffected and already matched batch exactly.

## Fix

- The candle buffer now holds **11** entries — the current bar plus the 10 previous bars the rule scans — making incremental classification identical to batch on every bar. `peek()` sizes its preview buffer from the same constant, so it follows automatically.
- **Snapshot schema moves to v2; v1 snapshots are refused with a re-warm error.** A v1 snapshot's buffer physically cannot supply the 11th bar, so resuming one would silently keep the 9-bar window the fix removes.
- The state-contract harness now runs full batch parity for VSA across its trending / flat-price / gap-candle streams. The "pre-existing classification drift" that had justified omitting VSA from that net was this bug.

## Test plan

- **Deterministic window regression**: stream whose decisive lowest low sits exactly 10 bars back; asserts both batch and incremental classify bar 30 as `'normal'`, with `peek == next` on every bar. Failed before (`test` vs `normal`).
- **Randomized parity**: 4 seeded 300-bar random walks; every bar asserts `peek == next == batch` on `barType`. Failed before on 8/1,200 bars.
- **Strengthened legacy test**: the previous parity test accepted an 80% `barType` match rate from bar 30 on — which is what hid this bug. It now requires exact equality of all five value fields on every bar of the 200-candle fixture.
- **Schema guard**: the existing state-contract version-guard invariant covers v1-snapshot refusal (it fails if the version is not bumped alongside the buffer change — verified during the negative check).
- Negative check: with the source fix parked, exactly the three new/strengthened tests plus the version-guard invariant fail (847/851 pass); restored, all pass.

Verification: core 6,696/6,696 tests (375 files), chart 934/934, mcp 83/83, `tsc --noEmit` clean, `pnpm build` pass, Biome clean on touched files.