### PR TITLE
feat(chart): timeScale.rightOffset + distance-preserving live-edge follow

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to `@trendcraft/chart` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added — `timeScale.rightOffset`: empty space after the last candle
+
+```ts
+createChart(el, { timeScale: { rightOffset: 5 } });
+```
+
+Reserves the given number of bar-slots (fractional allowed) between the last
+candle and the price axis, so the forming candle isn't drawn flush against
+the right edge. The margin is maintained while following the live edge and
+honored by `scrollToEnd`-style navigation (keyboard End included),
+`fitContent`, and `setVisibleRangeByDuration`. It can be changed at runtime
+via `applyOptions({ timeScale: { rightOffset } })` — when the chart is at the
+live edge the new margin applies immediately. Values that would leave fewer
+than 2 bars visible are capped; negative or non-finite values are rejected
+with a warning. Default: 0 (flush, as before).
+
+### Changed — live-edge following shifts instead of snapping
+
+When a new bar arrives while the last bar is visible, the chart used to
+scroll back to the end position outright. It now preserves the viewer's
+distance from the live edge instead. For a viewer pinned at the live edge
+the result is identical, but two long-standing annoyances are gone:
+
+- A custom viewport (a margin different from `rightOffset`, or any
+  position set through the public API while the last bar is visible) is no
+  longer overridden on the next update — the window drifts with the market
+  instead of snapping.
+- Panning a few bars into history no longer risks being yanked back to the
+  live edge by the next tick; the view preserves its distance from the live
+  edge.
+
+`setCandles` still lands at the live edge, and viewers who scrolled fully
+away from the last bar are still left alone, as before.
+
+### Fixed — clamping is consistent in session-gap layouts
+
+The scroll clamp compared the viewport size against the raw candle count,
+while the scroll boundary used gap-expanded units. With session gaps enabled
+and a viewport wider than the candle count but narrower than the expanded
+layout, the chart forced the view to the far left even though the last bars
+did not fit. Both now use the same units.
+
 ## [0.4.0] - 2026-07-26
 
 ### Fixed — `resize`, `paneResize`, and `seriesRemoved` events now fire

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -129,12 +129,12 @@
     {
       "name": "Main (createChart + all exports)",
       "path": "dist/index.js",
-      "limit": "41 kB"
+      "limit": "41.5 kB"
     },
     {
       "name": "Headless API",
       "path": "dist/headless.js",
-      "limit": "11 kB"
+      "limit": "11.25 kB"
     },
     {
       "name": "Sparkline (vanilla)",

--- a/packages/chart/src/__tests__/batch-updates.test.ts
+++ b/packages/chart/src/__tests__/batch-updates.test.ts
@@ -33,7 +33,7 @@ function createBatchableChart() {
   const warnings: Array<{ message: string; detail: unknown }> = [];
   const events = new Map<string, Set<(data: unknown) => void>>();
   let batching = false;
-  let batchScrollToEnd = false;
+  let batchFollowFromEndDistance: number | null = null;
   let renderCount = 0;
   let needsRender = false;
 
@@ -97,6 +97,7 @@ function createBatchableChart() {
       rebuildTimeIndex();
       timeScale.setTotalCount(data.candleCount);
       timeScale.scrollToEnd();
+      batchFollowFromEndDistance = null;
       scheduleRender();
       if (removed > 0) {
         emit("dataFiltered", { total: candles.length, valid: valid.length, removed });
@@ -113,8 +114,9 @@ function createBatchableChart() {
         warn("updateCandle: invalid candle data ignored", candle);
         return;
       }
-      const wasAtEnd = timeScale.endIndex >= data.candleCount - 1;
+      const wasAtEnd = data.candleCount - timeScale.endIndex <= 1;
       const prevCount = data.candleCount;
+      const prevEndDistance = timeScale.endDistanceVirtual;
       data.updateCandle(candle);
 
       if (data.candleCount > prevCount) {
@@ -124,9 +126,9 @@ function createBatchableChart() {
 
       if (wasAtEnd) {
         if (batching) {
-          batchScrollToEnd = true;
+          batchFollowFromEndDistance ??= prevEndDistance;
         } else {
-          timeScale.scrollToEnd();
+          timeScale.followLiveEdge(prevEndDistance);
         }
       }
       scheduleRender();
@@ -134,13 +136,14 @@ function createBatchableChart() {
 
     batchUpdates(fn: () => void) {
       batching = true;
-      batchScrollToEnd = false;
+      batchFollowFromEndDistance = null;
       try {
         fn();
       } finally {
         batching = false;
-        if (batchScrollToEnd) {
-          timeScale.scrollToEnd();
+        if (batchFollowFromEndDistance !== null) {
+          timeScale.followLiveEdge(batchFollowFromEndDistance);
+          batchFollowFromEndDistance = null;
         }
         scheduleRender();
       }
@@ -168,12 +171,12 @@ function createBatchableChart() {
 }
 
 describe("batchUpdates", () => {
-  it("batches multiple updateCandle calls into deferred scrollToEnd", () => {
+  it("batches multiple updateCandle calls into one deferred live-edge follow", () => {
     const chart = createBatchableChart();
     chart.setCandles(makeCandles(50));
     chart.flushRender(); // flush initial
 
-    const scrollSpy = vi.spyOn(chart.timeScale, "scrollToEnd");
+    const followSpy = vi.spyOn(chart.timeScale, "followLiveEdge");
 
     chart.batchUpdates(() => {
       for (let i = 0; i < 10; i++) {
@@ -188,21 +191,22 @@ describe("batchUpdates", () => {
       }
     });
 
-    // scrollToEnd should be called once at end of batch, not 10 times
-    // (Once per batch completion, not per updateCandle)
-    expect(scrollSpy).toHaveBeenCalledTimes(1);
+    // followLiveEdge should be called once at end of batch, not 10 times,
+    // covering the full appended span in one shift
+    expect(followSpy).toHaveBeenCalledTimes(1);
+    expect(followSpy).toHaveBeenCalledWith(50);
   });
 
-  it("does not call scrollToEnd during batch", () => {
+  it("does not follow the live edge during batch", () => {
     const chart = createBatchableChart();
     chart.setCandles(makeCandles(50));
     chart.flushRender();
 
-    let scrollCalled = false;
-    const origScrollToEnd = chart.timeScale.scrollToEnd.bind(chart.timeScale);
-    vi.spyOn(chart.timeScale, "scrollToEnd").mockImplementation(() => {
-      scrollCalled = true;
-      origScrollToEnd();
+    let followCalled = false;
+    const origFollow = chart.timeScale.followLiveEdge.bind(chart.timeScale);
+    vi.spyOn(chart.timeScale, "followLiveEdge").mockImplementation((prev: number) => {
+      followCalled = true;
+      origFollow(prev);
     });
 
     chart.batchUpdates(() => {
@@ -214,12 +218,12 @@ describe("batchUpdates", () => {
         close: 205,
         volume: 3000,
       });
-      // During batch, scrollToEnd should not have been called yet
-      expect(scrollCalled).toBe(false);
+      // During batch, followLiveEdge should not have been called yet
+      expect(followCalled).toBe(false);
     });
 
     // After batch, it should be called
-    expect(scrollCalled).toBe(true);
+    expect(followCalled).toBe(true);
   });
 
   it("recovers from errors inside batch callback", () => {

--- a/packages/chart/src/__tests__/right-offset.test.ts
+++ b/packages/chart/src/__tests__/right-offset.test.ts
@@ -1,0 +1,366 @@
+// @vitest-environment happy-dom
+/**
+ * timeScale.rightOffset + live-edge follow behavior.
+ *
+ * Two features under test:
+ * - `timeScale.rightOffset`: bar-slots of empty space reserved after the
+ *   last candle (scrollToEnd / fitContent / clamp / duration presets).
+ * - Shift-based live-edge following: appending a bar translates the window
+ *   by the appended span instead of snapping to the end position, so a
+ *   custom viewport (different margin, partial pan-back) is never
+ *   overridden by streaming updates.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { TimeScale } from "../core/scale";
+import type { CandleData } from "../core/types";
+import { createChart } from "../index";
+
+beforeAll(() => {
+  const noop = () => {};
+  const context2d = new Proxy(
+    {},
+    {
+      get: (_t, prop) => {
+        if (prop === "canvas") return null;
+        if (prop === "measureText") return () => ({ width: 0 }) as TextMetrics;
+        return noop;
+      },
+      set: () => true,
+    },
+  ) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as { getContext: () => unknown }).getContext = () =>
+    context2d;
+});
+
+function makeContainer(): HTMLElement {
+  const el = document.createElement("div");
+  el.style.width = "800px";
+  el.style.height = "400px";
+  document.body.appendChild(el);
+  return el;
+}
+
+function makeCandles(count: number, startTime = 1_700_000_000_000): CandleData[] {
+  return Array.from({ length: count }, (_, i) => ({
+    time: startTime + i * 60_000,
+    open: 100 + Math.sin(i / 5),
+    high: 101 + Math.sin(i / 5),
+    low: 99 + Math.sin(i / 5),
+    close: 100.5 + Math.sin(i / 5),
+    volume: 1000,
+  }));
+}
+
+function nextBar(candles: CandleData[], offset = 1): CandleData {
+  const last = candles[candles.length - 1];
+  return { ...last, time: last.time + offset * 60_000 };
+}
+
+// ---- TimeScale unit behavior ----
+
+describe("TimeScale rightOffset", () => {
+  function makeScale(total = 300, width = 800): TimeScale {
+    const ts = new TimeScale();
+    ts.setWidth(width);
+    ts.setTotalCount(total);
+    return ts;
+  }
+
+  it("scrollToEnd reserves the offset (index mode); default 0 is unchanged", () => {
+    const ts = makeScale();
+    ts.scrollToEnd();
+    const flush = ts.rawStartIndex;
+    expect(flush).toBe(300 - ts.visibleCount);
+
+    ts.setRightOffset(5);
+    ts.scrollToEnd();
+    expect(ts.rawStartIndex).toBe(flush + 5);
+
+    ts.setRightOffset(2.5); // fractional allowed
+    ts.scrollToEnd();
+    expect(ts.rawStartIndex).toBe(flush + 2.5);
+  });
+
+  it("scrollToEnd reserves the offset in virtual (gap) mode", () => {
+    const ts = makeScale(100);
+    ts.setGapsBefore([
+      { index: 30, size: 1.5 },
+      { index: 60, size: 1.5 },
+    ]);
+    ts.scrollToEnd();
+    const flush = ts.rawStartIndex;
+    ts.setRightOffset(5);
+    ts.scrollToEnd();
+    // 5 extra virtual slots on the right push the window 5 bar-slots right
+    // (no gaps sit inside the shifted span here, so real == virtual delta).
+    expect(ts.rawStartIndex).toBeCloseTo(flush + 5, 10);
+  });
+
+  it("caps an oversized offset so at least 2 bars stay visible", () => {
+    const ts = makeScale(300);
+    ts.setRightOffset(10_000);
+    ts.scrollToEnd();
+    // effective offset = visibleCount - 2 → exactly 2 bars remain in view
+    expect(ts.rawStartIndex).toBe(300 - 2);
+    expect(ts.endIndex).toBe(300);
+  });
+
+  it("rejects negative and non-finite offsets as 0", () => {
+    const ts = makeScale();
+    ts.setRightOffset(-3);
+    expect(ts.rightOffset).toBe(0);
+    ts.setRightOffset(Number.NaN);
+    expect(ts.rightOffset).toBe(0);
+  });
+
+  it("clamp allows scrolling to the offset position (composes with the 20% pad)", () => {
+    const ts = makeScale(300);
+    const pad = Math.ceil(ts.visibleCount * 0.2);
+
+    // Offset below the pad: boundary unchanged from today
+    ts.setRightOffset(Math.max(0, pad - 5));
+    ts.scrollTo(10_000); // clamped to maxStart
+    expect(ts.rawStartIndex).toBe(300 + pad - ts.visibleCount);
+
+    // Offset above the pad: boundary extends so scrollToEnd's target is
+    // reachable and never fights clamp
+    const bigOffset = pad + 15;
+    ts.setRightOffset(bigOffset);
+    ts.scrollToEnd();
+    const pinned = ts.rawStartIndex;
+    ts.scrollBy(0); // triggers a clamp round-trip
+    expect(ts.rawStartIndex).toBe(pinned);
+  });
+
+  it("fitContent includes the offset slots", () => {
+    const ts = makeScale(100, 800);
+    ts.fitContent();
+    const flushSpacing = ts.barSpacing;
+    ts.setRightOffset(100);
+    ts.fitContent();
+    expect(ts.barSpacing).toBeCloseTo(flushSpacing / 2, 10);
+    expect(ts.startIndex).toBe(0);
+  });
+
+  it("fitContent fits the gap-expanded layout plus the offset", () => {
+    const ts = makeScale(100, 800);
+    ts.setGapsBefore([{ index: 50, size: 30 }]); // virtualTotal = 130
+    ts.setRightOffset(10);
+    ts.fitContent();
+    // 140 virtual slots must share the 800px width — sizing from the raw
+    // bar count would leave the last bars past the right edge.
+    expect(ts.barSpacing).toBeCloseTo(800 / 140, 10);
+    expect(ts.startIndex).toBe(0);
+    expect(ts.visibleCount).toBeGreaterThanOrEqual(140);
+  });
+
+  it("setVisibleRangeToEnd keeps the start bar visible across session gaps", () => {
+    const ts = makeScale(2000, 800);
+    ts.setGapsBefore([{ index: 1900, size: 50 }]); // gap inside the window
+    ts.setVisibleRangeToEnd(1700);
+    // The gap consumes 50 window slots; sizing the window in real units
+    // would make scrollToEnd push the start bar 50 slots out of view.
+    expect(ts.startIndex).toBe(1700);
+  });
+
+  it("setVisibleRangeToEnd sizes the window to include the margin", () => {
+    // 300 bars in 800px stays above the 2px minimum bar spacing.
+    const ts = makeScale(2000, 800);
+    ts.setVisibleRangeToEnd(1700);
+    const flushSpacing = ts.barSpacing;
+    expect(ts.startIndex).toBe(1700);
+
+    ts.setRightOffset(5);
+    ts.setVisibleRangeToEnd(1700);
+    // Same start bar; 5 extra slots squeezed into the same width
+    expect(ts.startIndex).toBe(1700);
+    expect(ts.barSpacing).toBeCloseTo(flushSpacing * (300 / 305), 10);
+    // The window truly ends offset slots past the data
+    expect(ts.rawStartIndex + ts.visibleCount).toBeGreaterThanOrEqual(2005);
+  });
+
+  it("followLiveEdge re-establishes the end distance (shift on append, no-op otherwise)", () => {
+    const ts = makeScale(300);
+    ts.scrollTo(100);
+    const before = ts.rawStartIndex;
+
+    const dist = ts.endDistanceVirtual;
+    ts.setTotalCount(301);
+    ts.followLiveEdge(dist);
+    expect(ts.rawStartIndex).toBe(before + 1);
+
+    // No append → no movement
+    ts.followLiveEdge(ts.endDistanceVirtual);
+    expect(ts.rawStartIndex).toBe(before + 1);
+  });
+
+  it("followLiveEdge survives the transient index-mode clamp in gap layouts", () => {
+    // A session gap wider than the index-mode overscroll pad sits inside
+    // the pinned window. setTotalCount clears the virtual layout and clamps
+    // in index units before the layout is re-applied — a delta-based shift
+    // would inherit that clamped position and permanently lose margin.
+    const gaps = (n: number) => [{ index: Math.min(95, n - 1), size: 20 }];
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(100);
+    ts.setVisibleRange(0, 40); // ~40 visible bars
+    ts.setGapsBefore(gaps(100));
+    ts.scrollToEnd();
+    const dist = ts.endDistanceVirtual;
+
+    // The canvas-chart append sequence
+    ts.setTotalCount(101); // clears virt + transient index-mode clamp
+    ts.setGapsBefore(gaps(101)); // layout re-applied
+    ts.followLiveEdge(dist);
+    const followed = ts.rawStartIndex;
+
+    // A pinned viewer must land exactly where an explicit scrollToEnd lands
+    ts.scrollToEnd();
+    expect(followed).toBeCloseTo(ts.rawStartIndex, 10);
+  });
+});
+
+// ---- Chart-level behavior (real CanvasChart on happy-dom) ----
+
+describe("chart rightOffset and live-edge follow", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  function makeChart(rightOffset?: number) {
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 0,
+      ...(rightOffset !== undefined ? { timeScale: { rightOffset } } : {}),
+    });
+    return chart;
+  }
+
+  function startIndexOf(chart: ReturnType<typeof createChart>): number {
+    const range = chart.getVisibleRange();
+    if (!range) throw new Error("no visible range");
+    return range.startIndex;
+  }
+
+  it("reserves the configured margin at the live edge", () => {
+    const candles = makeCandles(300);
+    const flush = makeChart();
+    flush.setCandles(candles);
+    const offset = makeChart(5);
+    offset.setCandles(candles);
+    expect(startIndexOf(offset)).toBe(startIndexOf(flush) + 5);
+  });
+
+  it("keeps the margin while streaming (append advances the window by 1)", () => {
+    const candles = makeCandles(300);
+    const chart = makeChart(5);
+    chart.setCandles(candles);
+    const before = startIndexOf(chart);
+
+    chart.updateCandle(nextBar(candles));
+    expect(startIndexOf(chart)).toBe(before + 1);
+  });
+
+  it("does not override a custom viewport on the next tick (follow shifts, never snaps)", () => {
+    const candles = makeCandles(300);
+    const chart = makeChart(5);
+    chart.setCandles(candles);
+
+    // The user moves to a flush view (margin 0, last bar visible) — a
+    // different margin than the configured rightOffset.
+    chart.setVisibleRange(candles[200].time, candles[candles.length - 1].time);
+    const custom = startIndexOf(chart);
+
+    // A snap-to-end follow would jump by 1 + rightOffset here; the shift
+    // follow moves by exactly the appended bar.
+    chart.updateCandle(nextBar(candles));
+    expect(startIndexOf(chart)).toBe(custom + 1);
+  });
+
+  it("leaves a panned-away viewer alone", () => {
+    const candles = makeCandles(300);
+    const chart = makeChart(5);
+    chart.setCandles(candles);
+
+    chart.setVisibleRange(candles[0].time, candles[100].time); // last bar not visible
+    const before = startIndexOf(chart);
+
+    chart.updateCandle(nextBar(candles));
+    expect(startIndexOf(chart)).toBe(before);
+  });
+
+  it("batchUpdates follows once by the total appended span", () => {
+    const candles = makeCandles(300);
+    const chart = makeChart(5);
+    chart.setCandles(candles);
+    const before = startIndexOf(chart);
+
+    chart.batchUpdates(() => {
+      for (let i = 1; i <= 10; i++) {
+        chart.updateCandle(nextBar(candles, i));
+      }
+    });
+    expect(startIndexOf(chart)).toBe(before + 10);
+  });
+
+  it("setCandles inside a batch discards the earlier follow baseline", () => {
+    const candles = makeCandles(300);
+    const chart = makeChart();
+    chart.setCandles(candles);
+
+    // Append (captures a baseline), then replace with a much larger dataset
+    // inside the same batch. The stale baseline must not push the view past
+    // the fresh scrollToEnd position into the overscroll pad.
+    const bigger = makeCandles(3000);
+    chart.batchUpdates(() => {
+      chart.updateCandle(nextBar(candles));
+      chart.setCandles(bigger);
+    });
+    const after = startIndexOf(chart);
+
+    const reference = makeChart();
+    reference.setCandles(bigger);
+    expect(after).toBe(startIndexOf(reference));
+  });
+
+  it("applyOptions changes the margin immediately when pinned to the live edge", () => {
+    const candles = makeCandles(300);
+    const chart = makeChart(5);
+    chart.setCandles(candles);
+    const before = startIndexOf(chart);
+
+    chart.applyOptions({ timeScale: { rightOffset: 10 } });
+    expect(startIndexOf(chart)).toBe(before + 5);
+  });
+
+  it("warns and ignores an invalid rightOffset", () => {
+    const chart = makeChart();
+    const onError = vi.fn();
+    chart.on("error", onError);
+    chart.setCandles(makeCandles(300));
+    const before = startIndexOf(chart);
+
+    chart.applyOptions({ timeScale: { rightOffset: -3 } });
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("rightOffset") }),
+    );
+    expect(startIndexOf(chart)).toBe(before);
+  });
+
+  it("duration presets stay pinned to the live edge (margin follows on the next bar)", () => {
+    // 2000 one-minute candles span > 1 day, so "1D" is a strict subset.
+    const candles = makeCandles(2000);
+    const chart = makeChart(5);
+    chart.setCandles(candles);
+    chart.setVisibleRangeByDuration("1D");
+    const before = startIndexOf(chart);
+    expect(before).toBeGreaterThan(0);
+
+    // The preset lands at the live edge (margin included in the window), so
+    // streaming keeps following: the next bar advances the window by 1.
+    chart.updateCandle(nextBar(candles));
+    expect(startIndexOf(chart)).toBe(before + 1);
+  });
+});

--- a/packages/chart/src/core/scale.ts
+++ b/packages/chart/src/core/scale.ts
@@ -52,6 +52,8 @@ export class TimeScale {
   private readonly _minBarSpacing = 2;
   /** Maximum bar spacing */
   private readonly _maxBarSpacing = 50;
+  /** Bar-slots of empty space kept after the last bar (fractional allowed) */
+  private _rightOffset = 0;
 
   /**
    * Virtual position of each bar (length = totalCount when populated).
@@ -97,6 +99,43 @@ export class TimeScale {
 
   get width(): number {
     return this._width;
+  }
+
+  /** Configured right offset in bar-slots (see {@link setRightOffset}) */
+  get rightOffset(): number {
+    return this._rightOffset;
+  }
+
+  /**
+   * Total content span in virtual bar-slots (= totalCount in index mode).
+   * `_virt[last]` is the last bar's virtual position; `+1` converts that
+   * position into a slot count — the last bar occupies the slot
+   * `[virt[last], virt[last] + 1)` — it is NOT extra padding.
+   */
+  get virtualTotal(): number {
+    return this._virt.length > 0 ? this._virt[this._virt.length - 1] + 1 : this._totalCount;
+  }
+
+  /**
+   * Reserve empty space (in bar-slots, fractional allowed) after the last
+   * bar. Applied by {@link scrollToEnd}, {@link fitContent} and the clamp
+   * boundary. Negative and non-finite values coerce to 0 (this is the
+   * headless-layer fallback; the DOM chart layer validates first and warns).
+   * On the scrolling paths, values that would leave fewer than
+   * 2 bars visible are capped at
+   * application time (re-evaluated on zoom, since visibleCount changes);
+   * fitContent uses the raw value — every bar is on screen there.
+   */
+  setRightOffset(offset: number): void {
+    this._rightOffset = Number.isFinite(offset) ? Math.max(0, offset) : 0;
+    this.clamp();
+  }
+
+  /** The offset actually applied: capped so at least 2 bars stay visible
+   *  and the viewport can't go blank (self-locking at the live edge). */
+  private effectiveRightOffset(): number {
+    if (this._rightOffset <= 0) return 0;
+    return Math.min(this._rightOffset, Math.max(0, this._visibleCount - 2));
   }
 
   setTotalCount(count: number): void {
@@ -346,15 +385,42 @@ export class TimeScale {
     this.clamp();
   }
 
-  /** Scroll to show last candles */
+  /** Scroll to show the last candles plus the configured right offset.
+   *  virtualTotal already accounts for the last bar's own slot (see getter);
+   *  when everything fits the target is clamped to 0 by the Math.max. */
   scrollToEnd(): void {
-    if (this._virt.length === 0) {
-      this._startIndex = Math.max(0, this._totalCount - this._visibleCount);
-      return;
-    }
-    const virtEnd = this._virt[this._virt.length - 1] + 1; // last bar + 1 slot for padding
-    const targetVirt = Math.max(0, virtEnd - this._visibleCount);
+    const targetVirt = Math.max(
+      0,
+      this.virtualTotal + this.effectiveRightOffset() - this._visibleCount,
+    );
     this._startIndex = Math.max(0, this.realAtVirt(targetVirt));
+  }
+
+  /**
+   * Distance (in virtual bar-slots) from the window start to the end of the
+   * content. This is the follow invariant: capture it before a data/layout
+   * mutation and hand it to {@link followLiveEdge} afterwards.
+   */
+  get endDistanceVirtual(): number {
+    return this.virtualTotal - this.virtAt(this._startIndex);
+  }
+
+  /**
+   * Follow the live edge: re-establish the viewer's distance from the end
+   * of the content as captured before bars were appended. For a pinned
+   * viewer this equals the old scrollToEnd snap; for any other viewport it
+   * preserves the custom margin / pan position instead of overriding it.
+   *
+   * Re-establishing the distance (rather than shifting by a delta) also
+   * survives the transient index-mode clamp inside setTotalCount (the
+   * virtual layout is cleared and only re-applied afterwards) and layout
+   * rescales from a drifting median bar interval.
+   *
+   * @param prevEndDistance - {@link endDistanceVirtual} captured BEFORE the mutation
+   */
+  followLiveEdge(prevEndDistance: number): void {
+    this._startIndex = this.realAtVirt(this.virtualTotal - prevEndDistance);
+    this.clamp();
   }
 
   /** Zoom around a pixel position (Google Maps style — anchor stays under cursor) */
@@ -393,15 +459,34 @@ export class TimeScale {
     this.clamp();
   }
 
-  /** Fit all candles in view.
+  /** Fit all candles (plus the configured right offset) in view.
    *  barSpacing may go below 1px; the render pipeline remaps decimated
    *  candles to fill the canvas correctly in that case. */
   fitContent(): void {
     if (this._totalCount <= 0 || this._width <= 0) return;
-    this._barSpacing = Math.min(this._maxBarSpacing, this._width / this._totalCount);
+    // virtualTotal, not totalCount: in a gap-expanded layout the content
+    // spans more slots than there are bars, and each slot costs width.
+    const slots = this.virtualTotal + this._rightOffset;
+    this._barSpacing = Math.min(this._maxBarSpacing, this._width / slots);
     this._barSpacing = Math.max(0.1, this._barSpacing);
     this.recalcVisibleCount();
     this._startIndex = 0;
+  }
+
+  /** Show from `startIndex` through the live edge, including the right offset. */
+  setVisibleRangeToEnd(startIndex: number): void {
+    if (this._totalCount - startIndex <= 0) return;
+    // Count in virtual units: gaps between `startIndex` and the live edge
+    // consume window slots too, or scrollToEnd would push the start bar
+    // out of view by exactly the gap span. Use the raw offset: the
+    // effective cap depends on visibleCount, which this call is about to
+    // change — the destination window contains the full requested span,
+    // so the blank-viewport cap cannot bind there.
+    const count = this.virtualTotal + this._rightOffset - this.virtAt(startIndex);
+    this.setVisibleRange(startIndex, startIndex + count);
+    // setVisibleRange derives spacing from the count; scrollToEnd then
+    // aligns the window exactly (and handles virtual-mode layouts).
+    this.scrollToEnd();
   }
 
   /** Set startIndex and barSpacing directly (used by animation frames) */
@@ -460,13 +545,16 @@ export class TimeScale {
     return Math.max(0, Math.min(maxStart, this._startIndex));
   }
 
-  /** Maximum allowed startIndex, or null if all data fits in view */
+  /** Maximum allowed startIndex, or null if all content fits in view */
   private get maxStartIndex(): number | null {
     if (this._totalCount <= 0) return null;
-    const virtTotal =
-      this._virt.length > 0 ? this._virt[this._virt.length - 1] + 1 : this._totalCount;
-    if (this._visibleCount >= virtTotal) return null;
-    const rightPad = Math.ceil(this._visibleCount * 0.2);
+    const virtTotal = this.virtualTotal;
+    const offset = this.effectiveRightOffset();
+    if (this._visibleCount >= virtTotal + offset) return null;
+    // The scrollable empty space on the right is whichever is larger: the
+    // 20% overscroll pad or the configured right offset — so the pinned
+    // (scrollToEnd) position is always reachable without fighting clamp.
+    const rightPad = Math.max(Math.ceil(this._visibleCount * 0.2), offset);
     const maxStartVirt = Math.max(0, virtTotal + rightPad - this._visibleCount);
     if (this._virt.length === 0) return maxStartVirt;
     return this.realAtVirt(maxStartVirt);
@@ -538,11 +626,14 @@ export class TimeScale {
       this._startIndex = 0;
       return;
     }
-    if (this._visibleCount >= this._totalCount) {
+    // Single owner for the "everything fits" decision: maxStartIndex is
+    // null exactly when content + margin fit the viewport (it compares in
+    // virtual units, so gap-expanded layouts clamp consistently too).
+    const maxStart = this.maxStartIndex;
+    if (maxStart === null) {
       this._startIndex = 0;
       return;
     }
-    const maxStart = this.maxStartIndex ?? 0;
     this._startIndex = Math.max(0, Math.min(maxStart, this._startIndex));
   }
 }

--- a/packages/chart/src/core/types/config.ts
+++ b/packages/chart/src/core/types/config.ts
@@ -88,6 +88,18 @@ export type TimeScaleOptions = {
    * - object form: fine-grained control.
    */
   sessionGaps?: boolean | SessionGapsOptions;
+  /**
+   * Bars of empty space kept between the last candle and the right edge of
+   * the chart, so the forming candle isn't drawn flush against the price
+   * axis. Maintained while following the live edge, and honored by
+   * `scrollToEnd`-style navigation, `fitContent`, and duration presets.
+   *
+   * Units are bar-slots (fractional values allowed), so the margin scales
+   * with zoom — zooming out shrinks it visually, like the bars themselves.
+   * Values that would leave fewer than 2 bars visible are capped. Negative
+   * or non-finite values are rejected with a warning. Default: 0 (flush).
+   */
+  rightOffset?: number;
 };
 
 export type SessionGapsOptions = {

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -148,7 +148,8 @@ export class CanvasChart implements ChartInstance {
   private _needsRender = true;
   private _destroyed = false;
   private _batching = false;
-  private _batchScrollToEnd = false;
+  /** endDistanceVirtual captured when a batched update first requests live-follow */
+  private _batchFollowFromEndDistance: number | null = null;
   private _detachViewport: (() => void) | null = null;
   private _resizeObserver: ResizeObserver | null = null;
   private _aria: ChartAria | null = null;
@@ -317,6 +318,9 @@ export class CanvasChart implements ChartInstance {
       lockOnLongPress: options?.crosshair?.lockOnLongPress ?? true,
     };
     this._sessionGapsOpts = resolveSessionGapsOptions(options?.timeScale?.sessionGaps);
+    if (options?.timeScale?.rightOffset !== undefined) {
+      this._setRightOffsetOption(options.timeScale.rightOffset);
+    }
     this._locale = mergeLocale(options?.locale);
     setMonthNames(this._locale.months);
     this._pixelRatioPinned = options?.pixelRatio !== undefined;
@@ -597,6 +601,10 @@ export class CanvasChart implements ChartInstance {
     this._timeScale.setTotalCount(this._data.candleCount);
     this._applySessionGaps();
     this._timeScale.scrollToEnd();
+    // A full data replacement invalidates any follow baseline captured by
+    // earlier updates in the same batch — scrollToEnd above is the fresh
+    // authoritative position; later appends re-capture a valid baseline.
+    this._batchFollowFromEndDistance = null;
     this._needsRender = true;
     if (removed > 0) {
       this._emit("dataFiltered", { total: candles.length, valid: valid.length, removed });
@@ -617,9 +625,15 @@ export class CanvasChart implements ChartInstance {
       this._warn("updateCandle: invalid candle data ignored", candle, "BAD_CANDLE");
       return;
     }
-    // Auto-follow: if last candle is visible before update, keep following
-    const wasAtEnd = this._timeScale.endIndex >= this._data.candleCount - 1;
+    // Auto-follow: if the window reached (or nearly reached) the last bar
+    // before the update, keep following by re-establishing the viewer's
+    // distance from the live edge after the append. A scrollToEnd snap here
+    // would override any custom viewport (a wider margin set via the public
+    // API, or a viewer panned partway back) on every tick; preserving the
+    // end distance moves a pinned viewer exactly as the snap did.
+    const wasAtEnd = this._barsOffLiveEdge() <= 1;
     const prevCount = this._data.candleCount;
+    const prevEndDistance = this._timeScale.endDistanceVirtual;
 
     this._data.updateCandle(candle);
     const newCount = this._data.candleCount;
@@ -634,23 +648,33 @@ export class CanvasChart implements ChartInstance {
 
     if (wasAtEnd) {
       if (this._batching) {
-        this._batchScrollToEnd = true;
+        this._batchFollowFromEndDistance ??= prevEndDistance;
       } else {
-        this._timeScale.scrollToEnd();
+        this._timeScale.followLiveEdge(prevEndDistance);
       }
     }
     this._needsRender = true;
   }
 
+  /**
+   * How many bars the window end sits short of the last bar (0 = the last
+   * bar is inside the window; endIndex is exclusive and clamped to the
+   * candle count, so this never goes negative at the live edge).
+   */
+  private _barsOffLiveEdge(): number {
+    return this._data.candleCount - this._timeScale.endIndex;
+  }
+
   batchUpdates(fn: () => void): void {
     this._batching = true;
-    this._batchScrollToEnd = false;
+    this._batchFollowFromEndDistance = null;
     try {
       fn();
     } finally {
       this._batching = false;
-      if (this._batchScrollToEnd) {
-        this._timeScale.scrollToEnd();
+      if (this._batchFollowFromEndDistance !== null) {
+        this._timeScale.followLiveEdge(this._batchFollowFromEndDistance);
+        this._batchFollowFromEndDistance = null;
       }
       this._needsRender = true;
     }
@@ -899,11 +923,30 @@ export class CanvasChart implements ChartInstance {
       this.fitContent();
       return;
     }
-    this.setVisibleRange(startTime, lastTime);
+    // End at the live edge including the configured right offset — routing
+    // through the time-based setVisibleRange would saturate at the last bar
+    // and silently drop the margin.
+    const startIdx = this._data.indexAtTime(startTime);
+    this._animateToRange(() => this._timeScale.setVisibleRangeToEnd(startIdx));
   }
 
   fitContent(): void {
     this._animateToRange(() => this._timeScale.fitContent());
+  }
+
+  /** Validate and apply the `timeScale.rightOffset` option.
+   *  Returns false when the value was rejected (warn + keep previous). */
+  private _setRightOffsetOption(offset: number): boolean {
+    if (typeof offset !== "number" || !Number.isFinite(offset) || offset < 0) {
+      this._warn(
+        "timeScale.rightOffset: expected a finite number >= 0, ignoring",
+        offset,
+        "INVALID_INPUT",
+      );
+      return false;
+    }
+    this._timeScale.setRightOffset(offset);
+    return true;
   }
 
   setCrosshair(time: TimeValue | null): void {
@@ -1014,7 +1057,8 @@ export class CanvasChart implements ChartInstance {
    *
    * Runtime-capable fields: theme, chartType, volume, fontSize, watermark,
    * animationDuration, maxCandles, legend, priceFormatter, timeFormatter,
-   * width, height, priceAxisWidth, timeAxisHeight.
+   * width, height, priceAxisWidth, timeAxisHeight, timeScale.sessionGaps,
+   * timeScale.rightOffset.
    *
    * Fields that require re-creating the chart emit a warning and are ignored:
    * pixelRatio, fontFamily, scrollSensitivity, locale, formatInfoOverlay.
@@ -1064,10 +1108,22 @@ export class CanvasChart implements ChartInstance {
       this._needsRender = true;
     }
 
-    if (opts.timeScale !== undefined && opts.timeScale.sessionGaps !== undefined) {
-      this._sessionGapsOpts = resolveSessionGapsOptions(opts.timeScale.sessionGaps);
-      this._applySessionGaps();
-      this._needsRender = true;
+    if (opts.timeScale !== undefined) {
+      if (opts.timeScale.sessionGaps !== undefined) {
+        this._sessionGapsOpts = resolveSessionGapsOptions(opts.timeScale.sessionGaps);
+        this._applySessionGaps();
+        this._needsRender = true;
+      }
+      if (opts.timeScale.rightOffset !== undefined) {
+        // Re-scroll immediately when the last bar is visible so the new
+        // margin shows right away, not only on the next new bar. A rejected
+        // value must not move the viewport (it was "ignored").
+        const atEnd = this._barsOffLiveEdge() <= 0;
+        if (this._setRightOffsetOption(opts.timeScale.rightOffset)) {
+          if (atEnd) this._timeScale.scrollToEnd();
+          this._needsRender = true;
+        }
+      }
     }
 
     // Legend overlay — create/destroy


### PR DESCRIPTION
Addresses #340.

## What

**1. `timeScale.rightOffset`** — bars of empty space kept between the last candle and the price axis:

```ts
createChart(el, { timeScale: { rightOffset: 5 } });
```

- Units are bar-slots (fractional allowed), so the margin scales with zoom. Default 0 (flush, exactly as before).
- Honored by `scrollToEnd`-style navigation (keyboard End included), `fitContent`, `setVisibleRangeByDuration`, and the scroll clamp — the pinned position is always reachable without fighting the clamp (the margin composes with the existing 20% overscroll pad via `max`).
- Runtime-changeable via `applyOptions({ timeScale: { rightOffset } })`; when the last bar is visible the new margin applies immediately. Values that would leave fewer than 2 bars visible are capped (re-evaluated on zoom); negative or non-finite values warn and are ignored without moving the viewport.

**2. Live-edge following preserves the viewer's distance from the end instead of snapping.** Previously every `updateCandle` while the last bar was visible scrolled the chart back to the end position outright, which made it impossible to hold any custom right-edge margin from the outside — the library re-asserted its own position on every tick (the "fighting the library" problem from #340). Now the chart captures the viewer's distance from the live edge before the update and re-establishes it after. A pinned viewer moves exactly as before; everyone else keeps their position relative to the market.

The distance-capture formulation (rather than shifting by a bar delta) is deliberate: it survives the transient index-mode clamp that occurs while a session-gap layout is being re-applied mid-update, and layout rescales caused by a drifting median bar interval. `setCandles` inside `batchUpdates` discards any follow baseline captured earlier in the batch.

**3. Viewport sizing is consistently in gap-expanded (virtual) units.** The scroll clamp compared the viewport against the raw candle count while the scroll boundary used gap-expanded units; `fitContent` and duration presets sized windows in raw bar counts. In session-gap layouts this meant `fitContent` couldn't actually fit all content and duration presets pushed the requested start bar out of view by the gap span. All sizing now uses the same units.

Not included here (follow-up): a public index-space visible-range API (fractional indices, values beyond the last bar) so consumers can build custom right-edge behavior, plus an unclamped logical range in the `visibleRangeChange` payload.

## Test plan

- 20 tests in the new `right-offset.test.ts`: TimeScale unit behavior (offset in index and gap modes, oversized-offset cap, clamp composition, `fitContent`/`setVisibleRangeToEnd` in gap layouts, the transient-clamp follow regression) and real-chart behavior on happy-dom (margin at the live edge, streaming preserves the margin bar-for-bar, a custom viewport is not overridden on the next tick, panned-away viewers untouched, batch follow spans, `applyOptions` immediate re-scroll, invalid-value warning without viewport movement).
- `batch-updates.test.ts` mock updated to mirror the new follow logic (including the in-batch `setCandles` baseline reset).
- Negative checks: with the source change parked, 19 of the touched tests fail; with only the virtual-units fix parked, exactly the 2 gap-layout tests fail.
- Visual verification in a real browser (screenshot-measured): flush at default (2–5px gap), ~5 bar-widths (~40px) with `rightOffset: 5`, margin stable within ±2px while streaming one bar per 400ms, `fitContent` margin ~20 fitted slots with `rightOffset: 20`. A left-edge time-label overlap observed during verification reproduces identically with the feature disabled at the same scroll position (pre-existing axis labeling issue, tracked separately).
- Full suite: 952 passing (85 files); the only failures observed were unrelated timeout-based perf/doc-snippet tests that rotate run-to-run under machine load and pass in isolation.
- `tsc --noEmit` clean, `pnpm build` pass, Biome clean.

## Note: size limits raised (separate commit)

On CI's toolchain this feature pushes the Main bundle from just under its 41 kB budget to 41.2 kB (+202 B over) and Headless just over 11 kB, so the budgets were raised to 41.5 kB / 11.25 kB in a dedicated commit. (A local brotli measurement suggested the overage predated this branch, but CI's measurement is authoritative: `main` passes there and this diff adds the deciding bytes.) The other six bundle limits are unchanged and passing.
