### PR TITLE
feat(chart): logical-range viewport API

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — logical-range viewport API: `setVisibleLogicalRange` / `getVisibleLogicalRange`
+
+```ts
+chart.setVisibleLogicalRange(250, 330); // bars 250..300 + 30 empty slots
+const r = chart.getVisibleLogicalRange(); // { from, to } — fractional, unclamped
+```
+
+The time-based `setVisibleRange` cannot express empty space past the last
+candle: times after the last bar all resolve to it. The logical-range API
+works in bar-index units, accepts fractional values, and may extend beyond
+the data on either side — so custom right-edge margins (wider than
+`timeScale.rightOffset`, conditional, animated, whatever) can be built on
+top of the public API. It composes with live-edge following: while the last
+bar is visible, streaming updates preserve the window's distance from the
+live edge, custom margin included.
+
+Logical indices address the current candle array — they are shifted by
+`maxCandles` trimming and invalidated by `setCandles`. Read-modify-set
+synchronously; never persist them.
+
+`VisibleRangeChangeData` (the `visibleRangeChange` payload and
+`getVisibleRange()` result) gains an optional `logicalRange: { from, to }`
+field carrying the unclamped window edges — the existing time/index fields
+saturate at the last bar, so a right-edge margin was previously invisible
+to listeners. The chart always populates it; it is typed optional so
+existing code constructing this type (test mocks) keeps compiling.
+
+The requested span is exact: bar spacing follows `width / span` directly,
+bounded only by the render pipeline's 0.1px floor rather than the
+interactive zoom limits, so narrow (sub-16-bar) and very wide ranges
+round-trip through `getVisibleLogicalRange` without distortion.
+
 ### Added — `timeScale.rightOffset`: empty space after the last candle
 
 ```ts

--- a/packages/chart/docs/API.md
+++ b/packages/chart/docs/API.md
@@ -199,12 +199,26 @@ setDrawingTool(tool: DrawingType | null): void
 ```typescript
 setVisibleRange(start: TimeValue, end: TimeValue): void
 setVisibleRangeByDuration(duration: RangeDuration): void
+setVisibleLogicalRange(from: number, to: number): void
+getVisibleLogicalRange(): LogicalRange | null
 fitContent(): void
 getVisibleRange(): VisibleRangeChangeData | null
 setLayout(config: LayoutConfig): void
 ```
 
 `RangeDuration = '1D' | '1W' | '1M' | '3M' | '6M' | 'YTD' | '1Y' | 'ALL'`
+
+`setVisibleLogicalRange(from, to)` sets the viewport in logical (bar-index)
+units — `LogicalRange = { from, to }`. Values are fractional and may extend
+beyond the data on either side, which is the one way to express empty space
+past the last candle (times after the last bar all resolve to it, so
+`setVisibleRange` cannot). While the last bar is visible, live updates
+preserve the window's distance from the live edge — custom margins included.
+The requested span is exact down to the render floor (0.1px per bar).
+
+Logical indices address the *current* candle array: they are shifted by
+`maxCandles` trimming and invalidated by `setCandles`. Read-modify-set
+synchronously (pair with `getVisibleLogicalRange()`); never persist them.
 
 ```typescript
 setCrosshair(time: number | null): void

--- a/packages/chart/docs/GUIDE.md
+++ b/packages/chart/docs/GUIDE.md
@@ -310,7 +310,7 @@ Subscribe via `chart.on(event, handler)`. Unsubscribe via `chart.off`. Events ar
 | Event | Payload |
 |---|---|
 | `crosshairMove` | `CrosshairMoveData` — time, index, ohlcv, paneId |
-| `visibleRangeChange` | `VisibleRangeChangeData` — startTime, endTime, startIndex, endIndex |
+| `visibleRangeChange` | `VisibleRangeChangeData` — startTime, endTime, startIndex, endIndex (clamped to the data), plus `logicalRange: { from, to }` with the unclamped fractional window edges (a right-edge margin is only visible here) |
 | `click` | `ChartClickData` — x, y, index, time, shiftKey, altKey, metaKey, ctrlKey; fires on pointer up |
 | `resize` | `{ width, height }` |
 | `paneResize` | `{ paneId, height }` — fires when the user drags a pane divider |

--- a/packages/chart/src/__tests__/logical-range.test.ts
+++ b/packages/chart/src/__tests__/logical-range.test.ts
@@ -1,0 +1,233 @@
+// @vitest-environment happy-dom
+/**
+ * setVisibleLogicalRange / getVisibleLogicalRange — the index-space viewport
+ * API. Unlike the time-based setVisibleRange (whose time→index conversion
+ * saturates at the last bar), logical ranges are fractional and may extend
+ * beyond the data, so empty space past the last bar is expressible; the
+ * unclamped range also rides on getVisibleRange()/visibleRangeChange.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { TimeScale } from "../core/scale";
+import type { CandleData, VisibleRangeChangeData } from "../core/types";
+import { createChart } from "../index";
+
+beforeAll(() => {
+  const noop = () => {};
+  const context2d = new Proxy(
+    {},
+    {
+      get: (_t, prop) => {
+        if (prop === "canvas") return null;
+        if (prop === "measureText") return () => ({ width: 0 }) as TextMetrics;
+        return noop;
+      },
+      set: () => true,
+    },
+  ) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as { getContext: () => unknown }).getContext = () =>
+    context2d;
+});
+
+function makeContainer(): HTMLElement {
+  const el = document.createElement("div");
+  el.style.width = "800px";
+  el.style.height = "400px";
+  document.body.appendChild(el);
+  return el;
+}
+
+function makeCandles(count: number, startTime = 1_700_000_000_000): CandleData[] {
+  return Array.from({ length: count }, (_, i) => ({
+    time: startTime + i * 60_000,
+    open: 100,
+    high: 101,
+    low: 99,
+    close: 100.5,
+    volume: 1000,
+  }));
+}
+
+// ---- TimeScale unit behavior ----
+
+describe("TimeScale logical range", () => {
+  function makeScale(total = 300, width = 800): TimeScale {
+    const ts = new TimeScale();
+    ts.setWidth(width);
+    ts.setTotalCount(total);
+    return ts;
+  }
+
+  it("round-trips a range beyond the data without clamping", () => {
+    const ts = makeScale(300);
+    ts.setVisibleLogicalRange(250, 330); // 30 slots past the last bar
+    const r = ts.getVisibleLogicalRange();
+    expect(r.from).toBe(250);
+    expect(r.to).toBeCloseTo(330, 6);
+    // The window genuinely sits past the ordinary scroll boundary
+    expect(ts.rawStartIndex).toBe(250);
+  });
+
+  it("preserves fractional indices", () => {
+    const ts = makeScale(300);
+    ts.setVisibleLogicalRange(10.5, 90.5);
+    const r = ts.getVisibleLogicalRange();
+    expect(r.from).toBe(10.5);
+    expect(r.to).toBeCloseTo(90.5, 6);
+  });
+
+  it("measures the span in virtual units under session gaps", () => {
+    const ts = makeScale(300);
+    ts.setGapsBefore([{ index: 150, size: 20 }]);
+    ts.setVisibleLogicalRange(100, 200); // spans the gap: 120 virtual slots
+    expect(ts.barSpacing).toBeCloseTo(800 / 120, 6);
+    const r = ts.getVisibleLogicalRange();
+    expect(r.from).toBe(100);
+    expect(r.to).toBeCloseTo(200, 6);
+  });
+
+  it("round-trips a narrow span exactly (spacing exceeds the interactive zoom cap)", () => {
+    const ts = makeScale(300);
+    ts.setVisibleLogicalRange(250, 251); // 1 slot in 800px → 800px/bar
+    const r = ts.getVisibleLogicalRange();
+    expect(r.from).toBe(250);
+    expect(r.to).toBeCloseTo(251, 6);
+    expect(ts.barSpacing).toBeCloseTo(800, 6);
+  });
+
+  it("round-trips a very wide span exactly (spacing below the interactive minimum)", () => {
+    const ts = makeScale(300);
+    ts.setVisibleLogicalRange(0, 1000); // 0.8px/bar — decimated rendering
+    const r = ts.getVisibleLogicalRange();
+    expect(r.from).toBe(0);
+    expect(r.to).toBeCloseTo(1000, 6);
+  });
+
+  it("caps only at the render floor (0.1px/bar)", () => {
+    const ts = makeScale(300);
+    ts.setVisibleLogicalRange(0, 100_000); // would need 0.008px/bar
+    const r = ts.getVisibleLogicalRange();
+    expect(ts.barSpacing).toBeCloseTo(0.1, 6);
+    expect(r.to).toBeCloseTo(800 / 0.1, 6); // documented cap: width / 0.1 slots
+  });
+
+  it("ignores an empty, inverted, or denormal-small span", () => {
+    const ts = makeScale(300);
+    ts.setVisibleLogicalRange(200, 280);
+    const before = ts.getVisibleLogicalRange();
+    ts.setVisibleLogicalRange(50, 50);
+    ts.setVisibleLogicalRange(60, 40);
+    // Positive but denormal-small: width / span overflows to Infinity
+    ts.setVisibleLogicalRange(0, Number.MIN_VALUE);
+    const after = ts.getVisibleLogicalRange();
+    expect(after).toEqual(before);
+    expect(Number.isFinite(ts.barSpacing)).toBe(true);
+  });
+});
+
+// ---- Chart-level behavior ----
+
+describe("chart logical range API", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  function makeChart(rightOffset?: number) {
+    return createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 0,
+      ...(rightOffset !== undefined ? { timeScale: { rightOffset } } : {}),
+    });
+  }
+
+  it("expresses a custom margin past the last bar and follows the live edge with it", () => {
+    const candles = makeCandles(300);
+    const chart = makeChart();
+    chart.setCandles(candles);
+
+    chart.setVisibleLogicalRange(250, 330);
+    const r1 = chart.getVisibleLogicalRange();
+    expect(r1).not.toBeNull();
+    expect(r1?.from).toBe(250);
+    expect(r1?.to).toBeCloseTo(330, 6);
+
+    // Last bar is visible, so streaming preserves the 30-slot margin: the
+    // whole window advances by the appended bar.
+    const last = candles[candles.length - 1];
+    chart.updateCandle({ ...last, time: last.time + 60_000 });
+    const r2 = chart.getVisibleLogicalRange();
+    expect(r2?.from).toBeCloseTo(251, 6);
+    expect(r2?.to).toBeCloseTo(331, 6);
+  });
+
+  it("round-trips get → set (restores the same view)", () => {
+    const candles = makeCandles(300);
+    const chart = makeChart(5);
+    chart.setCandles(candles);
+    const saved = chart.getVisibleLogicalRange();
+    expect(saved).not.toBeNull();
+    if (!saved) throw new Error("unreachable");
+
+    chart.fitContent(); // move somewhere else
+    chart.setVisibleLogicalRange(saved.from, saved.to);
+    const restored = chart.getVisibleLogicalRange();
+    expect(restored?.from).toBeCloseTo(saved.from, 6);
+    expect(restored?.to).toBeCloseTo(saved.to, 6);
+  });
+
+  it("getVisibleRange().logicalRange carries the unclamped margin", () => {
+    const candles = makeCandles(300);
+    const chart = makeChart(5);
+    chart.setCandles(candles);
+
+    const range = chart.getVisibleRange();
+    expect(range).not.toBeNull();
+    // Clamped fields saturate at the last bar...
+    expect(range?.endIndex).toBe(299);
+    // ...while the logical range sees the margin past it. `to` is the true
+    // fractional right edge: scrollToEnd positions in whole ceiled window
+    // slots, so up to one fractional slot of the configured margin sits
+    // off-screen — the visible margin is within (offset-1, offset].
+    const margin = (range?.logicalRange?.to ?? 0) - 300;
+    expect(margin).toBeGreaterThan(4);
+    expect(margin).toBeLessThanOrEqual(5);
+  });
+
+  it("emits the logical range on visibleRangeChange", async () => {
+    const candles = makeCandles(300);
+    const chart = makeChart();
+    chart.setCandles(candles);
+    // Let the render loop emit (and swallow) the initial range first.
+    await new Promise((r) => setTimeout(r, 60));
+
+    const events: VisibleRangeChangeData[] = [];
+    chart.on("visibleRangeChange", (d) => events.push(d as VisibleRangeChangeData));
+    chart.setVisibleLogicalRange(250, 330);
+    // Emission happens from the render loop (rAF-driven); flush a few frames.
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(events.length).toBeGreaterThan(0);
+    const last = events[events.length - 1];
+    expect(last.logicalRange?.from).toBe(250);
+    expect(last.logicalRange?.to).toBeCloseTo(330, 6);
+  });
+
+  it("warns and ignores invalid ranges without moving the viewport", () => {
+    const chart = makeChart();
+    const onError = vi.fn();
+    chart.on("error", onError);
+    chart.setCandles(makeCandles(300));
+    const before = chart.getVisibleLogicalRange();
+
+    chart.setVisibleLogicalRange(50, 50);
+    chart.setVisibleLogicalRange(Number.NaN, 100);
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(chart.getVisibleLogicalRange()).toEqual(before);
+  });
+
+  it("returns null with no data", () => {
+    const chart = makeChart();
+    expect(chart.getVisibleLogicalRange()).toBeNull();
+  });
+});

--- a/packages/chart/src/__tests__/sync-charts.test.ts
+++ b/packages/chart/src/__tests__/sync-charts.test.ts
@@ -4,7 +4,10 @@ import type { ChartInstance, CrosshairMoveData, VisibleRangeChangeData } from ".
 import { syncCharts } from "../integration/sync";
 
 // Tiny fake ChartInstance exposing just the surface that syncCharts uses.
-type FakeChart = Pick<ChartInstance, "on" | "off" | "setCrosshair" | "setVisibleRange"> & {
+type FakeChart = Pick<
+  ChartInstance,
+  "on" | "off" | "setCrosshair" | "setVisibleRange" | "setVisibleLogicalRange"
+> & {
   emit: (event: string, data: unknown) => void;
 };
 
@@ -24,6 +27,7 @@ function makeFakeChart(): FakeChart {
     }) as FakeChart["off"],
     setCrosshair: vi.fn(),
     setVisibleRange: vi.fn(),
+    setVisibleLogicalRange: vi.fn(),
     emit: (event, data) => {
       listeners.get(event)?.forEach((h) => h(data));
     },
@@ -87,9 +91,42 @@ describe("syncCharts", () => {
       endTime: 100,
       startIndex: 0,
       endIndex: 99,
+      logicalRange: { from: 0, to: 104.5 },
     };
     a.emit("visibleRangeChange", range);
+    // `viewport: true` mirrors TIMES, even when a logical range is present:
+    // multi-timeframe charts must translate times through their own data —
+    // bar index 100 on a 1h chart and a 4h chart are different moments.
     expect(b.setVisibleRange).toHaveBeenCalledWith(1, 100);
+    expect(b.setVisibleLogicalRange).not.toHaveBeenCalled();
+  });
+
+  it('viewport: "logical" mirrors the unclamped bar-index range', () => {
+    const a = makeFakeChart();
+    const b = makeFakeChart();
+    syncCharts([a, b] as unknown as ChartInstance[], { viewport: "logical" });
+
+    a.emit("visibleRangeChange", {
+      startTime: 1,
+      endTime: 100,
+      startIndex: 0,
+      endIndex: 99,
+      logicalRange: { from: 0, to: 104.5 },
+    });
+    // Same-data charts only: the logical mirror round-trips the empty space
+    // past the last bar that the saturated time fields cannot express.
+    expect(b.setVisibleLogicalRange).toHaveBeenCalledWith(0, 104.5);
+    expect(b.setVisibleRange).not.toHaveBeenCalled();
+  });
+
+  it('viewport: "logical" falls back to times when a payload has no logical range', () => {
+    const a = makeFakeChart();
+    const b = makeFakeChart();
+    syncCharts([a, b] as unknown as ChartInstance[], { viewport: "logical" });
+
+    a.emit("visibleRangeChange", { startTime: 1, endTime: 100, startIndex: 0, endIndex: 99 });
+    expect(b.setVisibleRange).toHaveBeenCalledWith(1, 100);
+    expect(b.setVisibleLogicalRange).not.toHaveBeenCalled();
   });
 
   it("does not mirror viewport by default", () => {

--- a/packages/chart/src/core/scale.ts
+++ b/packages/chart/src/core/scale.ts
@@ -416,11 +416,16 @@ export class TimeScale {
    * virtual layout is cleared and only re-applied afterwards) and layout
    * rescales from a drifting median bar interval.
    *
+   * Deliberately unclamped: a position that was legal before the append
+   * stays legal after it (the boundary moves by the same span), and a
+   * deliberately beyond-boundary viewport (setVisibleLogicalRange margin
+   * wider than the overscroll pad) must keep its margin — clamping here
+   * would erode it on the first tick.
+   *
    * @param prevEndDistance - {@link endDistanceVirtual} captured BEFORE the mutation
    */
   followLiveEdge(prevEndDistance: number): void {
     this._startIndex = this.realAtVirt(this.virtualTotal - prevEndDistance);
-    this.clamp();
   }
 
   /** Zoom around a pixel position (Google Maps style — anchor stays under cursor) */
@@ -489,12 +494,59 @@ export class TimeScale {
     this.scrollToEnd();
   }
 
-  /** Set startIndex and barSpacing directly (used by animation frames) */
+  /**
+   * Visible range in logical (bar-index) units: `from` is the fractional
+   * bar index at the left window edge, `to` the one at the right edge.
+   * Unlike the time-based range, the values are NOT clamped to the data —
+   * `to` past the last bar measures the empty space after it (a right
+   * margin), and fractional parts measure partial bar visibility. The span
+   * is the window's true fractional width (`width / barSpacing`), not the
+   * integer-ceiled `visibleCount`, so a range set through
+   * {@link setVisibleLogicalRange} reads back exactly.
+   */
+  getVisibleLogicalRange(): { from: number; to: number } {
+    const from = this._startIndex;
+    const span = this._width > 0 ? this._width / this._barSpacing : this._visibleCount;
+    return { from, to: this.realAtVirt(this.virtAt(from) + span) };
+  }
+
+  /**
+   * Set the visible range in logical (bar-index) units. Fractional values
+   * and values beyond the data range are allowed — this is the one way to
+   * express empty space past the last bar (or before the first) that the
+   * time-based `setVisibleRange` cannot reach. The position is applied
+   * without clamping; the next user scroll/zoom clamps as usual.
+   *
+   * The exact span wins over the interactive zoom limits: bar spacing is
+   * derived directly from `width / span`, bounded only by the render
+   * pipeline's 0.1px floor (the same floor `fitContent` uses — spans
+   * wider than `width / 0.1` slots are capped there).
+   *
+   * Logical indices address the CURRENT candle array: they are shifted by
+   * `maxCandles` trimming and invalidated by `setCandles`. Read-modify-set
+   * synchronously; never persist them.
+   */
+  setVisibleLogicalRange(from: number, to: number): void {
+    const span = this.virtAt(to) - this.virtAt(from);
+    if (!(span > 0) || this._width <= 0) return;
+    // A denormal-small span passes the > 0 check but overflows the
+    // division to Infinity — refuse rather than poison the spacing.
+    const spacing = Math.max(0.1, this._width / span);
+    if (!Number.isFinite(spacing)) return;
+    this._barSpacing = spacing;
+    this.recalcVisibleCount();
+    this._startIndex = from;
+  }
+
+  /** Set startIndex and barSpacing directly (used by animation frames).
+   *  Deliberately unclamped: animations interpolate between positions their
+   *  callers already validated, and range targets may sit intentionally
+   *  beyond the scroll boundary (setVisibleLogicalRange) — clamping here
+   *  would silently pull them back. Clamping is the entry points' job. */
   setImmediate(startIndex: number, barSpacing: number): void {
     this._barSpacing = Math.max(0.1, barSpacing);
     this.recalcVisibleCount();
     this._startIndex = startIndex;
-    this.clamp();
   }
 
   /** Set startIndex without clamping (used for rubber-band overscroll) */

--- a/packages/chart/src/core/types/chart-instance.ts
+++ b/packages/chart/src/core/types/chart-instance.ts
@@ -5,7 +5,7 @@
 
 import type { ChartOptions, ChartType, RangeDuration } from "./config";
 import type { Drawing, DrawingType } from "./drawing";
-import type { ChartEvent, VisibleRangeChangeData } from "./event";
+import type { ChartEvent, LogicalRange, VisibleRangeChangeData } from "./event";
 import type { CandleData, DataPoint, TimeValue } from "./fundamental";
 import type {
   BacktestResultData,
@@ -87,6 +87,21 @@ export type ChartInstance = {
   // Viewport
   setVisibleRange(start: TimeValue, end: TimeValue): void;
   setVisibleRangeByDuration(duration: RangeDuration): void;
+  /**
+   * Set the visible range in logical (bar-index) units. Fractional values
+   * and values beyond the data range are allowed — this is the way to
+   * express empty space past the last bar that the time-based
+   * `setVisibleRange` cannot (times after the last bar all resolve to it).
+   * Composes with live-edge following: if the last bar is visible, streaming
+   * updates preserve the window's distance from the live edge.
+   *
+   * Logical indices address the current candle array — they are shifted by
+   * `maxCandles` trimming and invalidated by `setCandles`. Read-modify-set
+   * synchronously (pair with `getVisibleLogicalRange`); never persist them.
+   */
+  setVisibleLogicalRange(from: number, to: number): void;
+  /** Current visible range in logical units (unclamped), or null with no data. */
+  getVisibleLogicalRange(): LogicalRange | null;
   fitContent(): void;
 
   /**

--- a/packages/chart/src/core/types/event.ts
+++ b/packages/chart/src/core/types/event.ts
@@ -75,11 +75,37 @@ export type ChartClickData = {
   ctrlKey: boolean;
 };
 
+/**
+ * Visible range in logical (bar-index) units. `from` is the fractional bar
+ * index at the left window edge, `to` the one at the right edge. Unlike the
+ * time/index fields of {@link VisibleRangeChangeData}, the values are NOT
+ * clamped to the data: `to` past the last bar measures the empty space after
+ * it (e.g. the `timeScale.rightOffset` margin), and fractional parts measure
+ * partial bar visibility.
+ *
+ * Logical indices address the current candle array — they are shifted by
+ * `maxCandles` trimming and invalidated by `setCandles`. Read-modify-set
+ * synchronously; never persist them.
+ */
+export type LogicalRange = {
+  from: number;
+  to: number;
+};
+
 export type VisibleRangeChangeData = {
+  /** Time of the first visible candle (clamped to the data range) */
   startTime: TimeValue;
+  /** Time of the last visible candle (clamped to the data range) */
   endTime: TimeValue;
+  /** Index of the first visible candle (clamped to the data range) */
   startIndex: number;
+  /** Index of the last visible candle (clamped to the data range) */
   endIndex: number;
+  /** Unclamped window edges — the only fields that can express empty space
+   *  past the last bar (see {@link LogicalRange}). Always populated by the
+   *  chart; optional so existing code constructing this type (test mocks)
+   *  keeps compiling. */
+  logicalRange?: LogicalRange;
 };
 
 /**

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -97,6 +97,7 @@ export type {
   InfoOverlayData,
   InteractionOptions,
   LayoutConfig,
+  LogicalRange,
   PaneConfig,
   RangeDuration,
   RayDrawing,

--- a/packages/chart/src/integration/sync.ts
+++ b/packages/chart/src/integration/sync.ts
@@ -18,8 +18,20 @@ import type { ChartInstance, CrosshairMoveData, VisibleRangeChangeData } from ".
 export type SyncOptions = {
   /** Mirror crosshair hover across charts (default: true) */
   crosshair?: boolean;
-  /** Mirror visible range (pan/zoom) across charts (default: false) */
-  viewport?: boolean;
+  /**
+   * Mirror visible range (pan/zoom) across charts (default: false).
+   *
+   * - `true`: mirror via the time-based range. Correct for multi-timeframe
+   *   layouts — each chart translates the times to its own bar indices —
+   *   but the time axis saturates at the last bar, so empty space after it
+   *   (a right-edge margin) is not mirrored.
+   * - `"logical"`: mirror via the unclamped logical (bar-index) range,
+   *   preserving margins past the last bar. Only valid when every chart
+   *   shows the SAME candle array (same symbol and timeframe) — bar index
+   *   100 on a 1h chart and on a 4h chart are different times. Falls back
+   *   to the time-based range for payloads without a logical range.
+   */
+  viewport?: boolean | "logical";
 };
 
 /**
@@ -32,7 +44,8 @@ export type SyncOptions = {
  */
 export function syncCharts(charts: ChartInstance[], opts: SyncOptions = {}): () => void {
   const syncCrosshair = opts.crosshair !== false;
-  const syncViewport = opts.viewport === true;
+  const syncViewport = opts.viewport === true || opts.viewport === "logical";
+  const logicalViewport = opts.viewport === "logical";
   if (charts.length < 2 || (!syncCrosshair && !syncViewport)) {
     return () => {};
   }
@@ -66,14 +79,31 @@ export function syncCharts(charts: ChartInstance[], opts: SyncOptions = {}): () 
       const onRange = (data: unknown): void => {
         if (forwarding) return;
         const range = data as VisibleRangeChangeData;
-        if (!range || typeof range.startTime !== "number" || typeof range.endTime !== "number") {
+        if (!range) return;
+        // "logical" mode mirrors the unclamped bar-index range (preserves
+        // margins past the last bar, same-data charts only, see SyncOptions);
+        // the default mirrors times so MTF charts translate per their own data.
+        const logical = range.logicalRange;
+        const useLogical =
+          logicalViewport &&
+          logical !== undefined &&
+          Number.isFinite(logical.from) &&
+          Number.isFinite(logical.to);
+        if (
+          !useLogical &&
+          (typeof range.startTime !== "number" || typeof range.endTime !== "number")
+        ) {
           return;
         }
         forwarding = true;
         try {
           for (const target of charts) {
             if (target === source) continue;
-            target.setVisibleRange(range.startTime, range.endTime);
+            if (useLogical) {
+              target.setVisibleLogicalRange(logical.from, logical.to);
+            } else {
+              target.setVisibleRange(range.startTime, range.endTime);
+            }
           }
         } finally {
           forwarding = false;

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -913,6 +913,29 @@ export class CanvasChart implements ChartInstance {
     this._animateToRange(() => this._timeScale.setVisibleRange(startIdx, endIdx));
   }
 
+  setVisibleLogicalRange(from: number, to: number): void {
+    if (
+      typeof from !== "number" ||
+      typeof to !== "number" ||
+      !Number.isFinite(from) ||
+      !Number.isFinite(to) ||
+      to <= from
+    ) {
+      this._warn(
+        "setVisibleLogicalRange: expected finite numbers with to > from, ignoring",
+        { from, to },
+        "INVALID_INPUT",
+      );
+      return;
+    }
+    this._animateToRange(() => this._timeScale.setVisibleLogicalRange(from, to));
+  }
+
+  getVisibleLogicalRange(): import("../core/types").LogicalRange | null {
+    if (this._data.candleCount === 0) return null;
+    return this._timeScale.getVisibleLogicalRange();
+  }
+
   setVisibleRangeByDuration(duration: import("../core/types").RangeDuration): void {
     const candles = this._data.candles;
     if (candles.length === 0) return;
@@ -964,12 +987,14 @@ export class CanvasChart implements ChartInstance {
   private _animateToRange(applyTarget: () => void): void {
     this._transition.cancel();
 
-    const fromStart = this._timeScale.startIndex;
+    // Raw (fractional) start indices: flooring here would truncate a
+    // fractional logical-range target to the previous whole bar.
+    const fromStart = this._timeScale.rawStartIndex;
     const fromSpacing = this._timeScale.barSpacing;
 
     // Apply target state to get the destination values
     applyTarget();
-    const toStart = this._timeScale.startIndex;
+    const toStart = this._timeScale.rawStartIndex;
     const toSpacing = this._timeScale.barSpacing;
 
     // Restore original state before animating
@@ -1190,6 +1215,7 @@ export class CanvasChart implements ChartInstance {
       endTime: candles[endIdx]?.time ?? 0,
       startIndex: startIdx,
       endIndex: endIdx,
+      logicalRange: this._timeScale.getVisibleLogicalRange(),
     };
   }
 


### PR DESCRIPTION
Addresses #340 — together with #351 this completes the three commitments made there (`rightOffset`, distance-preserving follow, and this index-space API).

## What

```ts
chart.setVisibleLogicalRange(250, 330); // bars 250..300 + 30 empty slots
const r = chart.getVisibleLogicalRange(); // { from, to } — fractional, unclamped
```

**`setVisibleLogicalRange(from, to)` / `getVisibleLogicalRange()`** — viewport control in logical (bar-index) units. Fractional values and values beyond the data range are allowed on either side, which is the one way to express empty space past the last candle: the time-based `setVisibleRange` saturates there, since times after the last bar all resolve to it. Custom right-edge behavior (margins wider than `timeScale.rightOffset`, conditional, animated) can now be built entirely on the public API, and it composes with live-edge following — while the last bar is visible, streaming updates preserve the window's distance from the live edge, custom margin included.

Contract details:

- **Exact spans.** Bar spacing derives from `width / span` directly, bounded only by the render pipeline's 0.1px floor (the same floor `fitContent` uses) rather than the interactive zoom limits — so a 1-bar range (800px/bar) and a 1000-bar range (0.8px/bar) both round-trip through the getter precisely. The getter reports the true fractional window width, not the integer-ceiled visible count. Denormal-small spans that would overflow the division are refused with a warning.
- **Index stability.** Logical indices address the *current* candle array: they are shifted by `maxCandles` trimming and invalidated by `setCandles`. Documented as read-modify-set synchronously; never persist.
- **Payload.** `VisibleRangeChangeData` gains an optional `logicalRange: { from, to }` with the unclamped window edges — the existing time/index fields are clamped to the data, so a right-edge margin was previously invisible to `visibleRangeChange` listeners and `getVisibleRange()` callers. The chart always populates it; it is typed optional so existing code constructing the type (test mocks) keeps compiling.

Two internal clamps are removed because they eroded deliberately beyond-boundary viewports: the animation-frame setter (which pulled logical-range targets back to the scroll boundary before they ever rendered) and the live-edge follow (which ate custom margins wider than the overscroll pad on every tick — a position that was legal before an append stays legal after it, so the clamp was only ever destructive there). The full suite confirms no interaction regressions.

## Test plan

- 14 tests in `logical-range.test.ts`: exact round-trips (narrow 1-bar span, wide 1000-bar span, fractional endpoints, session-gap layouts measured in virtual units), the documented 0.1px-floor cap position, margin expression + bar-for-bar preservation under streaming appends, get→set view restoration, `getVisibleRange().logicalRange` and the emitted `visibleRangeChange` payload carrying the unclamped edges, invalid-input warnings that leave the viewport unmoved, and null with no data.
- `sync-charts.test.ts`: the viewport mirror's default remains time-based even when a payload carries a logical range (multi-timeframe charts must translate times through their own data), plus the opt-in same-data logical mode and its time fallback.
- Negative check: with the source changes parked, 15 of the touched tests fail; restored, all pass.
- Visual verification in a real browser: `setVisibleLogicalRange(250, 330)` renders a ~264px empty region right of the last candle, and that margin held with 0px drift while ~60 bars streamed in at 400ms intervals.
- Full suite: 969/969 (86 files); `tsc --noEmit` clean; `pnpm build` pass; Biome clean; bundle sizes within limits (Main 41.39/41.5 kB, Headless 11.08/11.25 kB).

## Docs

`docs/API.md` (viewport methods) and `docs/GUIDE.md` (event payload table) updated; `LogicalRange` added to the package's public type exports (the docs type-check harness caught the omission).