### PR TITLE
feat(chart): honor fontFamily option in canvas text

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -96,6 +96,26 @@ bounded only by the render pipeline's 0.1px floor rather than the
 interactive zoom limits, so narrow (sub-16-bar) and very wide ranges
 round-trip through `getVisibleLogicalRange` without distortion.
 
+### Fixed — `fontFamily` option now applies to canvas and overlay text
+
+`ChartOptions.fontFamily` was documented but ignored: renderers hardcoded a
+system UI stack, and `applyOptions({ fontFamily })` warned that the field
+could not change at runtime. The option is now stored like `fontSize`,
+passed through the render context, and used for axis/crosshair/overlay/
+drawing/pattern/watermark canvas text plus DOM legend/info overlays.
+Built-in primitives honor it too. Default remains the previous system stack
+(`-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`).
+`applyOptions({ fontFamily })` updates live without re-creating the chart.
+Also exports `DEFAULT_FONT_FAMILY` and `canvasFont()` for plugins that draw
+their own labels.
+
+```ts
+createChart(el, {
+  fontSize: 11,
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+});
+```
+
 ### Added — `timeScale.rightOffset`: empty space after the last candle
 
 ```ts

--- a/packages/chart/docs/API.md
+++ b/packages/chart/docs/API.md
@@ -71,8 +71,8 @@ All fields optional.
 | `pixelRatio` | `number` | `window.devicePixelRatio` | Canvas backing-store ratio (one-time; not runtime-mutable) |
 | `priceAxisWidth` | `number` | `60` | Right axis width (px) |
 | `timeAxisHeight` | `number` | `32` | Bottom axis height (px) |
-| `fontFamily` | `string` | system | Font family (one-time) |
-| `fontSize` | `number` | `11` | Font size (px) |
+| `fontFamily` | `string` | system UI stack | Font family for canvas axis/crosshair/overlay text and DOM legend/info overlays. Runtime-updatable via `applyOptions` |
+| `fontSize` | `number` | `11` | Font size (px). Runtime-updatable via `applyOptions` |
 | `priceFormatter` | `(price: number) => string` | auto-precision | Custom price formatter |
 | `timeFormatter` | `(time: number) => string` | smart date/time | Custom time formatter |
 | `watermark` | `string` | — | Background watermark text |

--- a/packages/chart/docs/PLUGINS.md
+++ b/packages/chart/docs/PLUGINS.md
@@ -269,6 +269,7 @@ type PrimitiveRenderContext = {
   dataLayer: DataLayer;
   theme: ThemeColors;
   draw: DrawHelper;
+  fontFamily: string;           // ChartOptions.fontFamily (system stack by default)
 };
 ```
 

--- a/packages/chart/llms-full.txt
+++ b/packages/chart/llms-full.txt
@@ -1254,7 +1254,7 @@ All fields optional.
 | `pixelRatio` | `number` | `window.devicePixelRatio` | Canvas backing-store ratio (one-time; not runtime-mutable) |
 | `priceAxisWidth` | `number` | `60` | Right axis width (px) |
 | `timeAxisHeight` | `number` | `24` | Bottom axis height (px) |
-| `fontFamily` | `string` | system | Font family (one-time) |
+| `fontFamily` | `string` | system UI stack | Font family for canvas + DOM overlays (runtime-updatable via `applyOptions`) |
 | `fontSize` | `number` | `11` | Font size (px), clamped to [8, 32] |
 | `priceFormatter` | `(price: number) => string` | auto-precision | Custom price formatter |
 | `timeFormatter` | `(time: number) => string` | smart date/time | Custom time formatter |

--- a/packages/chart/src/__tests__/apply-options.test.ts
+++ b/packages/chart/src/__tests__/apply-options.test.ts
@@ -113,11 +113,24 @@ describe("applyOptions", () => {
     const errors: Array<{ message: string; detail: unknown }> = [];
     chart.on("error", (d) => errors.push(d as { message: string; detail: unknown }));
 
-    chart.applyOptions({ pixelRatio: 2, fontFamily: "monospace" });
+    chart.applyOptions({ pixelRatio: 2, scrollSensitivity: 0.5 });
 
     expect(errors).toHaveLength(1);
     expect(errors[0]?.message).toContain("pixelRatio");
-    expect(errors[0]?.message).toContain("fontFamily");
+    expect(errors[0]?.message).toContain("scrollSensitivity");
+    chart.destroy();
+  });
+
+  it("applies fontFamily at runtime without warning", () => {
+    const chart = createChart(makeContainer());
+    const errors: Array<{ message: string; detail: unknown }> = [];
+    chart.on("error", (d) => errors.push(d as { message: string; detail: unknown }));
+
+    chart.applyOptions({
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    });
+
+    expect(errors).toHaveLength(0);
     chart.destroy();
   });
 

--- a/packages/chart/src/__tests__/font-family.test.ts
+++ b/packages/chart/src/__tests__/font-family.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+/**
+ * fontFamily option — create-time + applyOptions wiring into canvas text.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { canvasFont, DEFAULT_FONT_FAMILY } from "../core/font";
+import { DARK_THEME } from "../core/types";
+import { createChart } from "../index";
+import { renderPriceAxis } from "../renderer/axis-renderer";
+import { makePriceScale, mockCtx } from "./helpers/mock-ctx";
+
+describe("canvasFont", () => {
+  it("formats regular and bold fonts with the default family", () => {
+    expect(canvasFont(11)).toBe(`11px ${DEFAULT_FONT_FAMILY}`);
+    expect(canvasFont(11, DEFAULT_FONT_FAMILY)).toBe(`11px ${DEFAULT_FONT_FAMILY}`);
+    expect(canvasFont(11, DEFAULT_FONT_FAMILY, "bold")).toBe(`bold 11px ${DEFAULT_FONT_FAMILY}`);
+  });
+
+  it("falls back to the default stack when family is empty", () => {
+    expect(canvasFont(11, "")).toBe(`11px ${DEFAULT_FONT_FAMILY}`);
+  });
+});
+
+describe("renderPriceAxis fontFamily", () => {
+  it("uses the default system stack when fontFamily is omitted", () => {
+    const ctx = mockCtx();
+    renderPriceAxis(ctx, makePriceScale(), 740, 0, 60, 300, DARK_THEME, 11);
+    expect(ctx.font).toBe(`11px ${DEFAULT_FONT_FAMILY}`);
+  });
+
+  it("uses an explicit fontFamily matching the default in ctx.font", () => {
+    const ctx = mockCtx();
+    renderPriceAxis(
+      ctx,
+      makePriceScale(),
+      740,
+      0,
+      60,
+      300,
+      DARK_THEME,
+      11,
+      undefined,
+      {},
+      DEFAULT_FONT_FAMILY,
+    );
+    expect(ctx.font).toBe(`11px ${DEFAULT_FONT_FAMILY}`);
+  });
+});
+
+describe("createChart fontFamily", () => {
+  let lastFont = "";
+
+  beforeAll(() => {
+    const noop = () => {};
+    const context2d = new Proxy(
+      { font: "" },
+      {
+        get: (t, prop) => {
+          if (prop === "font") return t.font;
+          if (prop === "canvas") return null;
+          if (prop === "measureText") return () => ({ width: 40 }) as TextMetrics;
+          return noop;
+        },
+        set: (t, prop, value) => {
+          if (prop === "font") {
+            t.font = value as string;
+            lastFont = value as string;
+          }
+          return true;
+        },
+      },
+    ) as unknown as CanvasRenderingContext2D;
+    (HTMLCanvasElement.prototype as unknown as { getContext: () => unknown }).getContext = () =>
+      context2d;
+  });
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    lastFont = "";
+  });
+
+  function makeContainer(): HTMLElement {
+    const el = document.createElement("div");
+    el.style.width = "800px";
+    el.style.height = "400px";
+    document.body.appendChild(el);
+    return el;
+  }
+
+  async function flushFrames(): Promise<void> {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+  }
+
+  it("passes create-time fontFamily into canvas axis text", async () => {
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      fontSize: 11,
+      fontFamily: DEFAULT_FONT_FAMILY,
+      volume: false,
+      legend: false,
+    });
+    chart.setCandles([
+      { time: 1_700_000_000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+      { time: 1_700_000_060, open: 105, high: 115, low: 100, close: 112, volume: 1200 },
+      { time: 1_700_000_120, open: 112, high: 120, low: 108, close: 118, volume: 1100 },
+    ]);
+    await flushFrames();
+
+    expect(lastFont).toContain(DEFAULT_FONT_FAMILY);
+    expect(lastFont).toMatch(/^11px /);
+    chart.destroy();
+  });
+
+  it("defaults to the historical system stack when fontFamily is omitted", async () => {
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      volume: false,
+      legend: false,
+    });
+    chart.setCandles([
+      { time: 1_700_000_000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+      { time: 1_700_000_060, open: 105, high: 115, low: 100, close: 112, volume: 1200 },
+    ]);
+    await flushFrames();
+
+    expect(lastFont).toContain(DEFAULT_FONT_FAMILY);
+    expect(lastFont).toMatch(/^11px /);
+    chart.destroy();
+  });
+
+  it("updates DOM legend fontFamily via applyOptions", () => {
+    const container = makeContainer();
+    const chart = createChart(container, { legend: true, width: 800, height: 400 });
+    const legend = container.querySelector(".tc-legend") as HTMLElement;
+    expect(legend.style.fontFamily).toBe(DEFAULT_FONT_FAMILY);
+
+    chart.applyOptions({ fontFamily: DEFAULT_FONT_FAMILY });
+    expect(legend.style.fontFamily).toBe(DEFAULT_FONT_FAMILY);
+    chart.destroy();
+  });
+});

--- a/packages/chart/src/__tests__/render-pipeline.test.ts
+++ b/packages/chart/src/__tests__/render-pipeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { DataLayer } from "../core/data-layer";
+import { DEFAULT_FONT_FAMILY } from "../core/font";
 import { DEFAULT_LOCALE } from "../core/i18n";
 import { LayoutEngine } from "../core/layout";
 import { RendererRegistry } from "../core/renderer-registry";
@@ -26,6 +27,7 @@ function makeRenderContext(overrides?: Partial<RenderContext>): RenderContext {
     canvasHeight: 400,
     theme: DARK_THEME,
     fontSize: 11,
+    fontFamily: DEFAULT_FONT_FAMILY,
     chartType: "candlestick",
     watermark: undefined,
     priceFormatter: (p: number) => p.toFixed(2),

--- a/packages/chart/src/core/font.ts
+++ b/packages/chart/src/core/font.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared canvas/DOM font helpers for @trendcraft/chart.
+ *
+ * The default stack matches the historical hardcoded value used by every
+ * renderer before `ChartOptions.fontFamily` was wired through.
+ */
+
+/** Default system UI font stack (backward-compatible visual default). */
+export const DEFAULT_FONT_FAMILY =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+
+/**
+ * Build a CSS `font` value for canvas `ctx.font` (and similar).
+ *
+ * @example
+ * ```ts
+ * const regular = canvasFont(11);
+ * // => '11px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
+ * const bold = canvasFont(11, DEFAULT_FONT_FAMILY, "bold");
+ * // => 'bold 11px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
+ * ```
+ */
+export function canvasFont(
+  sizePx: number,
+  fontFamily: string = DEFAULT_FONT_FAMILY,
+  weight?: "bold" | "normal",
+): string {
+  const family = fontFamily || DEFAULT_FONT_FAMILY;
+  return weight === "bold" ? `bold ${sizePx}px ${family}` : `${sizePx}px ${family}`;
+}

--- a/packages/chart/src/core/plugin-types.ts
+++ b/packages/chart/src/core/plugin-types.ts
@@ -52,6 +52,8 @@ export type PrimitiveRenderContext = {
   theme: ThemeColors;
   /** Drawing helper — wraps common canvas operations with coordinate conversion */
   draw: DrawHelper;
+  /** Chart font family (`ChartOptions.fontFamily`, falls back to system stack) */
+  fontFamily: string;
 };
 
 /** Custom series renderer plugin */

--- a/packages/chart/src/core/types/chart-instance.ts
+++ b/packages/chart/src/core/types/chart-instance.ts
@@ -129,8 +129,8 @@ export type ChartInstance = {
    * Accepts the same shape as `createChart`'s options, but applies only the
    * provided fields. Use this from reactive wrappers to propagate option
    * changes after chart creation. Fields that cannot be changed at runtime
-   * (e.g. `pixelRatio`, `fontFamily`, `scrollSensitivity`, `locale`,
-   * `formatInfoOverlay`) emit a warning via the `error` event and are ignored.
+   * (e.g. `pixelRatio`, `scrollSensitivity`, `locale`, `formatInfoOverlay`)
+   * emit a warning via the `error` event and are ignored.
    */
   applyOptions(options: Partial<ChartOptions>): void;
 

--- a/packages/chart/src/core/types/config.ts
+++ b/packages/chart/src/core/types/config.ts
@@ -19,7 +19,10 @@ export type ChartOptions = {
   priceAxisWidth?: number;
   /** Bottom margin for time axis in pixels (default: 32) */
   timeAxisHeight?: number;
-  /** Font family (default: system) */
+  /**
+   * Font family for canvas axis/crosshair/overlay text and DOM legend/info
+   * overlays (default: system UI stack). Runtime-updatable via `applyOptions`.
+   */
   fontFamily?: string;
   /** Font size in pixels (default: 11) */
   fontSize?: number;

--- a/packages/chart/src/headless.ts
+++ b/packages/chart/src/headless.ts
@@ -17,6 +17,7 @@ export {
 } from "./core/decimation";
 // Drawing helper
 export { DrawHelper, type FillStyle, type StrokeStyle } from "./core/draw-helper";
+export { canvasFont, DEFAULT_FONT_FAMILY } from "./core/font";
 export {
   autoFormatPrice,
   autoFormatTime,

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -51,6 +51,8 @@ export function createChart(container: HTMLElement, options?: ChartOptions): Cha
 export type { InternalSeries } from "./core/data-layer";
 // Drawing helper
 export { DrawHelper, type FillStyle, type StrokeStyle } from "./core/draw-helper";
+// Font helpers (for plugins / custom canvas text matching ChartOptions.fontFamily)
+export { canvasFont, DEFAULT_FONT_FAMILY } from "./core/font";
 export { DEFAULT_HOTKEYS, type HotkeyMap } from "./core/hotkeys";
 // i18n
 export type { ChartLocale } from "./core/i18n";

--- a/packages/chart/src/plugins/andrews-pitchfork.ts
+++ b/packages/chart/src/plugins/andrews-pitchfork.ts
@@ -30,6 +30,7 @@
  */
 
 import { withPaneClip } from "../core/draw-helper";
+import { canvasFont } from "../core/font";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import { definePrimitive } from "../core/plugin-types";
 import type { ChartInstance } from "../core/types";
@@ -78,7 +79,7 @@ export type AndrewsPitchforkState = {
 // ---- Render ----
 
 function renderAndrewsPitchfork(
-  { ctx, pane, timeScale, priceScale }: PrimitiveRenderContext,
+  { ctx, pane, timeScale, priceScale, fontFamily }: PrimitiveRenderContext,
   state: AndrewsPitchforkState,
 ): void {
   const { p0, p1, p2 } = state.anchors;
@@ -185,7 +186,7 @@ function renderAndrewsPitchfork(
     // Right-edge labels for the three parallel lines.
     if (state.showLabels !== false) {
       ctx.fillStyle = state.labelColor ?? stroke;
-      ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.font = canvasFont(10, fontFamily);
       ctx.textAlign = "right";
       ctx.textBaseline = "middle";
       ctx.fillText("UML", rightEdgeX - 4, upperEndY);

--- a/packages/chart/src/plugins/market-profile.ts
+++ b/packages/chart/src/plugins/market-profile.ts
@@ -21,6 +21,7 @@
  */
 
 import { withPaneClip } from "../core/draw-helper";
+import { canvasFont } from "../core/font";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import { definePrimitive } from "../core/plugin-types";
 import type { ChartInstance } from "../core/types";
@@ -68,7 +69,7 @@ const DEFAULTS: Required<MarketProfileOptions> = {
 // ---- Render ----
 
 function renderMarketProfile(
-  { ctx, pane, priceScale, timeScale }: PrimitiveRenderContext,
+  { ctx, pane, priceScale, timeScale, fontFamily }: PrimitiveRenderContext,
   state: MarketProfileState,
 ): void {
   const { data, options } = state;
@@ -129,7 +130,7 @@ function renderMarketProfile(
     }
 
     // VAH / VAL dashed lines + labels
-    ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
+    ctx.font = canvasFont(10, fontFamily);
     ctx.textBaseline = "bottom";
     for (const [label, price] of [
       ["VAH", valueAreaHigh],
@@ -159,7 +160,7 @@ function renderMarketProfile(
       ctx.lineTo(profileRight + 20, y);
       ctx.stroke();
       ctx.fillStyle = options.pocColor;
-      ctx.font = "bold 10px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.font = canvasFont(10, fontFamily, "bold");
       ctx.fillText("POC", profileRight + 4, y - 2);
     }
   });

--- a/packages/chart/src/plugins/price-patterns.ts
+++ b/packages/chart/src/plugins/price-patterns.ts
@@ -23,6 +23,7 @@
  */
 
 import { roundRectPath, withPaneClip } from "../core/draw-helper";
+import { canvasFont } from "../core/font";
 import { definePrimitive } from "../core/plugin-types";
 import type { ChartInstance } from "../core/types";
 
@@ -212,8 +213,9 @@ function drawAnchoredLabel(
   text: string,
   bg: string,
   placement: "above" | "below",
+  fontFamily: string,
 ): void {
-  ctx.font = "11px system-ui, sans-serif";
+  ctx.font = canvasFont(11, fontFamily);
   const padX = 6;
   const w = ctx.measureText(text).width + padX * 2;
   const h = 18;
@@ -291,7 +293,7 @@ export function createPricePatterns(
     pane: "main",
     zOrder: "above",
     defaultState: { renders },
-    render({ ctx, pane, timeScale, priceScale }, state) {
+    render({ ctx, pane, timeScale, priceScale, fontFamily }, state) {
       withPaneClip(ctx, pane, () => {
         const start = timeScale.startIndex;
         const end = timeScale.endIndex;
@@ -380,6 +382,7 @@ export function createPricePatterns(
               labels[i].text,
               `rgba(${rgb},0.92)`,
               placement,
+              fontFamily,
             );
           }
 
@@ -404,6 +407,7 @@ export function createPricePatterns(
               "Target",
               `rgba(${rgb},0.92)`,
               direction === "bull" ? "above" : "below",
+              fontFamily,
             );
           }
         }

--- a/packages/chart/src/plugins/regime-heatmap.ts
+++ b/packages/chart/src/plugins/regime-heatmap.ts
@@ -22,6 +22,7 @@
  */
 
 import { roundRectPath, withPaneClip } from "../core/draw-helper";
+import { canvasFont } from "../core/font";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import { definePrimitive } from "../core/plugin-types";
 import type { ChartInstance, DataPoint } from "../core/types";
@@ -69,7 +70,7 @@ function regimeToRgb(regime: number, label?: string): string {
 // ---- Render ----
 
 function renderRegimeHeatmap(
-  { ctx, pane, timeScale }: PrimitiveRenderContext,
+  { ctx, pane, timeScale, fontFamily }: PrimitiveRenderContext,
   state: RegimeHeatmapState,
 ): void {
   const { data, options } = state;
@@ -95,7 +96,7 @@ function renderRegimeHeatmap(
   });
 
   if (options.showBadge) {
-    renderRegimeBadge(ctx, pane, data, start, end);
+    renderRegimeBadge(ctx, pane, data, start, end, fontFamily);
   }
 }
 
@@ -112,6 +113,7 @@ function renderRegimeBadge(
   data: readonly RegimeDataPoint[],
   visibleStart: number,
   visibleEnd: number,
+  fontFamily: string,
 ): void {
   const lastVisibleIdx = Math.min(visibleEnd - 1, data.length - 1);
   const firstVisibleIdx = Math.max(0, visibleStart);
@@ -134,7 +136,7 @@ function renderRegimeBadge(
   const display = conf != null ? `${text} · ${Math.round(conf * 100)}%` : text;
 
   ctx.save();
-  ctx.font = "bold 11px -apple-system, BlinkMacSystemFont, sans-serif";
+  ctx.font = canvasFont(11, fontFamily, "bold");
   ctx.textBaseline = "top";
   ctx.textAlign = "left";
 

--- a/packages/chart/src/plugins/session-zones.ts
+++ b/packages/chart/src/plugins/session-zones.ts
@@ -20,6 +20,7 @@
  */
 
 import { withPaneClip } from "../core/draw-helper";
+import { canvasFont } from "../core/font";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import { definePrimitive } from "../core/plugin-types";
 import type { ChartInstance, DataPoint } from "../core/types";
@@ -73,7 +74,7 @@ function zoneToShortLabel(zone: string): string {
 // ---- Render ----
 
 function renderSessionZones(
-  { ctx, pane, timeScale }: PrimitiveRenderContext,
+  { ctx, pane, timeScale, fontFamily }: PrimitiveRenderContext,
   state: SessionZonesState,
 ): void {
   const { data } = state;
@@ -122,7 +123,7 @@ function renderSessionZones(
       spans.push({ zone: spanZone, startIndex: spanStart, endIndex: lastIdx });
     }
 
-    renderZoneLabels(ctx, spans, timeScale, pane.y);
+    renderZoneLabels(ctx, spans, timeScale, pane.y, fontFamily);
   });
 }
 
@@ -131,10 +132,11 @@ function renderZoneLabels(
   spans: Array<{ zone: string; startIndex: number; endIndex: number }>,
   timeScale: { indexToX: (i: number) => number },
   paneY: number,
+  fontFamily: string,
 ): void {
   if (spans.length === 0) return;
 
-  ctx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
+  ctx.font = canvasFont(9, fontFamily);
   ctx.textAlign = "center";
   ctx.textBaseline = "top";
 

--- a/packages/chart/src/plugins/smc-layer.ts
+++ b/packages/chart/src/plugins/smc-layer.ts
@@ -23,6 +23,7 @@
  */
 
 import { withPaneClip } from "../core/draw-helper";
+import { canvasFont } from "../core/font";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import { definePrimitive } from "../core/plugin-types";
 import type { ChartInstance, DataPoint } from "../core/types";
@@ -83,8 +84,9 @@ function renderOrderBlocks(
   zones: readonly SmcZone[],
   timeScale: PrimitiveRenderContext["timeScale"],
   priceScale: PrimitiveRenderContext["priceScale"],
+  fontFamily: string,
 ): void {
-  ctx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
+  ctx.font = canvasFont(9, fontFamily);
   ctx.textAlign = "left";
   ctx.textBaseline = "top";
 
@@ -128,8 +130,9 @@ function renderFvgZones(
   zones: readonly SmcZone[],
   timeScale: PrimitiveRenderContext["timeScale"],
   priceScale: PrimitiveRenderContext["priceScale"],
+  fontFamily: string,
 ): void {
-  ctx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
+  ctx.font = canvasFont(9, fontFamily);
   ctx.textAlign = "right";
   ctx.textBaseline = "top";
 
@@ -174,9 +177,10 @@ function renderSweepMarkers(
   markers: readonly SmcMarker[],
   timeScale: PrimitiveRenderContext["timeScale"],
   priceScale: PrimitiveRenderContext["priceScale"],
+  fontFamily: string,
 ): void {
   const size = 5;
-  ctx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
+  ctx.font = canvasFont(9, fontFamily);
   ctx.textAlign = "center";
 
   for (const marker of markers) {
@@ -226,6 +230,7 @@ function renderBosLevels(
   timeScale: PrimitiveRenderContext["timeScale"],
   priceScale: PrimitiveRenderContext["priceScale"],
   _theme: PrimitiveRenderContext["theme"],
+  fontFamily: string,
 ): void {
   ctx.save();
   ctx.setLineDash([6, 4]);
@@ -249,7 +254,7 @@ function renderBosLevels(
 
     // Label
     ctx.fillStyle = `rgba(${rgb},0.8)`;
-    ctx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
+    ctx.font = canvasFont(9, fontFamily);
     ctx.textAlign = "left";
     ctx.textBaseline = "bottom";
     ctx.fillText(level.label, startX + 3, y - 2);
@@ -261,27 +266,27 @@ function renderBosLevels(
 // ---- Main render ----
 
 function renderSmcLayer(context: PrimitiveRenderContext, state: SmcState): void {
-  const { ctx, pane, timeScale, priceScale, theme } = context;
+  const { ctx, pane, timeScale, priceScale, theme, fontFamily } = context;
 
   withPaneClip(ctx, pane, () => {
     // Order blocks (lowest visual priority)
     if (state.orderBlocks.length > 0) {
-      renderOrderBlocks(ctx, state.orderBlocks, timeScale, priceScale);
+      renderOrderBlocks(ctx, state.orderBlocks, timeScale, priceScale, fontFamily);
     }
 
     // FVG zones
     if (state.fvgZones.length > 0) {
-      renderFvgZones(ctx, state.fvgZones, timeScale, priceScale);
+      renderFvgZones(ctx, state.fvgZones, timeScale, priceScale, fontFamily);
     }
 
     // BOS levels
     if (state.bosLevels.length > 0) {
-      renderBosLevels(ctx, state.bosLevels, timeScale, priceScale, theme);
+      renderBosLevels(ctx, state.bosLevels, timeScale, priceScale, theme, fontFamily);
     }
 
     // Sweep markers (highest visual priority)
     if (state.sweepMarkers.length > 0) {
-      renderSweepMarkers(ctx, state.sweepMarkers, timeScale, priceScale);
+      renderSweepMarkers(ctx, state.sweepMarkers, timeScale, priceScale, fontFamily);
     }
   });
 }

--- a/packages/chart/src/plugins/sr-confluence.ts
+++ b/packages/chart/src/plugins/sr-confluence.ts
@@ -19,6 +19,7 @@
  */
 
 import { withPaneClip } from "../core/draw-helper";
+import { canvasFont } from "../core/font";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import { definePrimitive } from "../core/plugin-types";
 import type { ChartInstance } from "../core/types";
@@ -60,7 +61,7 @@ function strengthToRgb(strength: number): string {
 // ---- Render ----
 
 function renderSrConfluence(
-  { ctx, pane, priceScale }: PrimitiveRenderContext,
+  { ctx, pane, priceScale, fontFamily }: PrimitiveRenderContext,
   state: SrConfluenceState,
 ): void {
   const { zones } = state;
@@ -97,7 +98,7 @@ function renderSrConfluence(
 
       const centerY = (topY + bottomY) / 2;
       ctx.fillStyle = `rgba(${rgb},0.7)`;
-      ctx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.font = canvasFont(9, fontFamily);
       ctx.textAlign = "right";
       ctx.textBaseline = "middle";
       // Strength score + touch count (when available). Mirrors the

--- a/packages/chart/src/plugins/trade-analysis.ts
+++ b/packages/chart/src/plugins/trade-analysis.ts
@@ -19,6 +19,7 @@
  */
 
 import { withPaneClip } from "../core/draw-helper";
+import { canvasFont } from "../core/font";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import { definePrimitive } from "../core/plugin-types";
 import type { ChartInstance } from "../core/types";
@@ -129,7 +130,7 @@ function computeMfeMaePrice(
 // ---- Render ----
 
 function renderTradeAnalysis(
-  { ctx, pane, timeScale, priceScale }: PrimitiveRenderContext,
+  { ctx, pane, timeScale, priceScale, fontFamily }: PrimitiveRenderContext,
   state: TradeAnalysisState,
 ): void {
   const { trades, candles, options } = state;
@@ -183,7 +184,7 @@ function renderTradeAnalysis(
 
       // Optional MFE / MAE end-of-line price labels.
       if (options.showMfeMaeLabels) {
-        ctx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
+        ctx.font = canvasFont(9, fontFamily);
         ctx.textAlign = "left";
         ctx.textBaseline = "middle";
         ctx.fillStyle = `rgba(${MFE_COLOR},0.85)`;
@@ -225,7 +226,7 @@ function renderTradeAnalysis(
         const pct = trade.returnPercent;
         const sign = pct >= 0 ? "+" : "";
         const label = `${sign}${pct.toFixed(2)}%`;
-        ctx.font = "bold 10px -apple-system, BlinkMacSystemFont, sans-serif";
+        ctx.font = canvasFont(10, fontFamily, "bold");
         ctx.textAlign = "left";
         if (isWin) {
           ctx.textBaseline = "bottom";

--- a/packages/chart/src/plugins/volume-profile.ts
+++ b/packages/chart/src/plugins/volume-profile.ts
@@ -22,6 +22,7 @@
  */
 
 import { withPaneClip } from "../core/draw-helper";
+import { canvasFont } from "../core/font";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import { definePrimitive } from "../core/plugin-types";
 import type { ChartInstance } from "../core/types";
@@ -90,7 +91,7 @@ const DEFAULT_VALUE_AREA_BOUNDS_COLOR = "rgba(100,149,237,0.75)";
 // ---- Render ----
 
 function renderVolumeProfile(
-  { ctx, pane, priceScale }: PrimitiveRenderContext,
+  { ctx, pane, priceScale, fontFamily }: PrimitiveRenderContext,
   state: VolumeProfileState,
 ): void {
   const {
@@ -145,7 +146,7 @@ function renderVolumeProfile(
       ctx.fillStyle = valueAreaBoundsColor;
       ctx.lineWidth = 1;
       ctx.setLineDash([4, 3]);
-      ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.font = canvasFont(10, fontFamily);
       ctx.textAlign = "right";
 
       const vahY = priceScale.priceToY(profile.vah);
@@ -181,7 +182,7 @@ function renderVolumeProfile(
 
       // POC label
       ctx.fillStyle = pocColor;
-      ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.font = canvasFont(10, fontFamily);
       ctx.textAlign = "right";
       ctx.textBaseline = "bottom";
       ctx.fillText("POC", rightEdge - 4, pocY - 2);

--- a/packages/chart/src/plugins/wyckoff-phase.ts
+++ b/packages/chart/src/plugins/wyckoff-phase.ts
@@ -28,6 +28,7 @@
  */
 
 import { withPaneClip } from "../core/draw-helper";
+import { canvasFont } from "../core/font";
 import type { PrimitivePlugin, PrimitiveRenderContext } from "../core/plugin-types";
 import { definePrimitive } from "../core/plugin-types";
 import type { ChartInstance, DataPoint } from "../core/types";
@@ -200,7 +201,7 @@ function collectPhaseSpans(phases: readonly WyckoffDataPoint[]): PhaseSpan[] {
 // ---- Render ----
 
 function renderWyckoffPhase(
-  { ctx, pane, timeScale, priceScale }: PrimitiveRenderContext,
+  { ctx, pane, timeScale, priceScale, fontFamily }: PrimitiveRenderContext,
   state: WyckoffPhaseState,
 ): void {
   const { phases, vsa, candles, options } = state;
@@ -239,7 +240,7 @@ function renderWyckoffPhase(
 
     // ----- 2. Event labels -----
     if (options.showEventLabels) {
-      ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.font = canvasFont(10, fontFamily);
       ctx.textAlign = "center";
       for (let i = start; i < end && i < phases.length; i++) {
         const point = phases[i];
@@ -326,7 +327,7 @@ function renderWyckoffPhase(
       const text = `Wyckoff: ${label} (${conf.toFixed(0)})`;
       const rgb = PHASE_COLORS[last.phase] ?? PHASE_COLORS.unknown;
 
-      ctx.font = "bold 11px -apple-system, BlinkMacSystemFont, sans-serif";
+      ctx.font = canvasFont(11, fontFamily, "bold");
       ctx.textAlign = "left";
       ctx.textBaseline = "top";
       const textWidth = ctx.measureText(text).width;

--- a/packages/chart/src/renderer/axis-renderer.ts
+++ b/packages/chart/src/renderer/axis-renderer.ts
@@ -2,6 +2,7 @@
  * Axis Renderer — Draws price (Y) and time (X) axes.
  */
 
+import { canvasFont, DEFAULT_FONT_FAMILY } from "../core/font";
 import {
   autoFormatPrice,
   autoFormatTime,
@@ -55,6 +56,7 @@ export function renderPriceAxis(
   fontSize: number,
   priceFormatter: (price: number) => string = autoFormatPrice,
   options: PriceAxisOptions | "left" | "right" = {},
+  fontFamily: string = DEFAULT_FONT_FAMILY,
 ): void {
   // Back-compat: position can be passed as a bare string.
   const opts: PriceAxisOptions = typeof options === "string" ? { position: options } : options;
@@ -95,7 +97,7 @@ export function renderPriceAxis(
   // for short panes (e.g. a volume pane where the nice-step tick generator
   // lands ticks at exactly the min/max of the range).
   ctx.fillStyle = theme.textSecondary;
-  ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+  ctx.font = canvasFont(fontSize, fontFamily);
   ctx.textAlign = position === "left" ? "right" : "left";
   const labelX = position === "left" ? x - 6 : x + 6;
 
@@ -134,6 +136,7 @@ export function renderTimeAxis(
   theme: ThemeColors,
   fontSize: number,
   timeFormatter?: (time: number) => string,
+  fontFamily: string = DEFAULT_FONT_FAMILY,
 ): void {
   ctx.fillStyle = theme.background;
   ctx.fillRect(x, y, width + 100, height);
@@ -147,7 +150,7 @@ export function renderTimeAxis(
   ctx.stroke();
 
   ctx.fillStyle = theme.textSecondary;
-  ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+  ctx.font = canvasFont(fontSize, fontFamily);
   ctx.textAlign = "center";
   ctx.textBaseline = "top";
 

--- a/packages/chart/src/renderer/backtest-renderer.ts
+++ b/packages/chart/src/renderer/backtest-renderer.ts
@@ -4,6 +4,7 @@
  */
 
 import type { DataLayer } from "../core/data-layer";
+import { canvasFont, DEFAULT_FONT_FAMILY } from "../core/font";
 import { measureTextWidth } from "../core/format";
 import type { PriceScale, TimeScale } from "../core/scale";
 import type { PaneRect, ThemeColors } from "../core/types";
@@ -206,11 +207,12 @@ export function renderBacktestSummary(
   theme: ThemeColors,
   fontSize: number,
   locale?: import("../core/i18n").ChartLocale,
+  fontFamily: string = DEFAULT_FONT_FAMILY,
 ): void {
   const isPositive = result.totalReturnPercent >= 0;
   const color = isPositive ? theme.upColor : theme.downColor;
 
-  ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+  ctx.font = canvasFont(fontSize, fontFamily);
   ctx.textAlign = "left";
   ctx.textBaseline = "top";
 

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -7,6 +7,7 @@ import { ViewTransition } from "../core/animation";
 import { DataLayer } from "../core/data-layer";
 import { safeDevicePixelRatio } from "../core/dpr";
 import type { DrawHelper } from "../core/draw-helper";
+import { DEFAULT_FONT_FAMILY } from "../core/font";
 import { autoFormatPrice, setMonthNames } from "../core/format";
 import { type ChartLocale, mergeLocale } from "../core/i18n";
 import { DEFAULT_LAYOUT_NO_VOLUME, LayoutEngine } from "../core/layout";
@@ -74,12 +75,13 @@ function nowMs(): number {
 }
 
 const DEFAULT_OPTIONS: Required<
-  Pick<ChartOptions, "height" | "priceAxisWidth" | "timeAxisHeight" | "fontSize">
+  Pick<ChartOptions, "height" | "priceAxisWidth" | "timeAxisHeight" | "fontSize" | "fontFamily">
 > = {
   height: 400,
   priceAxisWidth: 60,
   timeAxisHeight: 32,
   fontSize: 11,
+  fontFamily: DEFAULT_FONT_FAMILY,
 };
 
 // ============================================
@@ -103,6 +105,7 @@ export class CanvasChart implements ChartInstance {
   private _pixelRatioPinned: boolean;
   private _theme: ThemeColors;
   private _fontSize: number;
+  private _fontFamily: string;
   private _priceFormatter: (price: number) => string;
   private _timeFormatter: ((time: number) => string) | undefined;
   /** Last applied layout size — tracked so applyOptions() can compose partial size changes. */
@@ -317,6 +320,7 @@ export class CanvasChart implements ChartInstance {
     this._container = container;
     if (options?.maxCandles) this._data.setMaxCandles(options.maxCandles);
     this._fontSize = options?.fontSize ?? DEFAULT_OPTIONS.fontSize;
+    this._fontFamily = options?.fontFamily ?? DEFAULT_OPTIONS.fontFamily;
     this._priceFormatter = options?.priceFormatter ?? autoFormatPrice;
     this._timeFormatter = options?.timeFormatter;
     this._animationDuration = options?.animationDuration ?? 300;
@@ -490,12 +494,18 @@ export class CanvasChart implements ChartInstance {
       this._priceFormatter,
       options?.formatInfoOverlay,
       this._locale,
+      this._fontFamily,
     );
     this._infoOverlay.setRendererRegistry(this._rendererRegistry);
 
     // Legend overlay
     if (options?.legend !== false) {
-      this._legendOverlay = new LegendOverlay(container, this._theme, this._locale);
+      this._legendOverlay = new LegendOverlay(
+        container,
+        this._theme,
+        this._locale,
+        this._fontFamily,
+      );
       this._wireLegend(this._legendOverlay);
     }
 
@@ -1124,13 +1134,13 @@ export class CanvasChart implements ChartInstance {
    * Diffs each provided field against the chart's current state and routes to
    * the appropriate internal setter. Fields not listed in `opts` are left alone.
    *
-   * Runtime-capable fields: theme, chartType, volume, fontSize, watermark,
-   * animationDuration, maxCandles, legend, priceFormatter, timeFormatter,
-   * width, height, priceAxisWidth, timeAxisHeight, timeScale.sessionGaps,
-   * timeScale.rightOffset.
+   * Runtime-capable fields: theme, chartType, volume, fontSize, fontFamily,
+   * watermark, animationDuration, maxCandles, legend, priceFormatter,
+   * timeFormatter, width, height, priceAxisWidth, timeAxisHeight,
+   * timeScale.sessionGaps, timeScale.rightOffset.
    *
    * Fields that require re-creating the chart emit a warning and are ignored:
-   * pixelRatio, fontFamily, scrollSensitivity, locale, formatInfoOverlay.
+   * pixelRatio, scrollSensitivity, locale, formatInfoOverlay.
    */
   applyOptions(opts: Partial<ChartOptions>): void {
     if (opts.theme !== undefined) this.setTheme(opts.theme);
@@ -1139,6 +1149,12 @@ export class CanvasChart implements ChartInstance {
 
     if (opts.fontSize !== undefined) {
       this._fontSize = opts.fontSize;
+      this._needsRender = true;
+    }
+    if (opts.fontFamily !== undefined) {
+      this._fontFamily = opts.fontFamily || DEFAULT_OPTIONS.fontFamily;
+      this._infoOverlay?.setFontFamily(this._fontFamily);
+      this._legendOverlay?.setFontFamily(this._fontFamily);
       this._needsRender = true;
     }
     if (opts.watermark !== undefined) {
@@ -1204,7 +1220,12 @@ export class CanvasChart implements ChartInstance {
         this._legendOverlay.destroy();
         this._legendOverlay = null;
       } else if (opts.legend !== false && !this._legendOverlay) {
-        this._legendOverlay = new LegendOverlay(this._container, this._theme, this._locale);
+        this._legendOverlay = new LegendOverlay(
+          this._container,
+          this._theme,
+          this._locale,
+          this._fontFamily,
+        );
         this._wireLegend(this._legendOverlay);
       }
       this._needsRender = true;
@@ -1229,7 +1250,6 @@ export class CanvasChart implements ChartInstance {
     // Unsupported at runtime — these bind to sub-components at construction
     const unsupported: (keyof ChartOptions)[] = [];
     if (opts.pixelRatio !== undefined) unsupported.push("pixelRatio");
-    if (opts.fontFamily !== undefined) unsupported.push("fontFamily");
     if (opts.scrollSensitivity !== undefined) unsupported.push("scrollSensitivity");
     if (opts.locale !== undefined) unsupported.push("locale");
     if (opts.formatInfoOverlay !== undefined) unsupported.push("formatInfoOverlay");
@@ -1366,6 +1386,7 @@ export class CanvasChart implements ChartInstance {
       this._theme,
       this._fontSize,
       this._locale,
+      this._fontFamily,
     );
     return off;
   }
@@ -1483,6 +1504,7 @@ export class CanvasChart implements ChartInstance {
       canvasHeight: this._canvas.height,
       theme: this._theme,
       fontSize: this._fontSize,
+      fontFamily: this._fontFamily,
       chartType: this._chartType,
       watermark: this._watermark,
       showSeriesBadges: this._showSeriesBadges,

--- a/packages/chart/src/renderer/crosshair-renderer.ts
+++ b/packages/chart/src/renderer/crosshair-renderer.ts
@@ -8,6 +8,7 @@
  */
 
 import { pickReadableTextColor } from "../core/color-utils";
+import { canvasFont, DEFAULT_FONT_FAMILY } from "../core/font";
 import { autoFormatPrice, formatCrosshairTime, measureTextWidth } from "../core/format";
 import type { PriceScale, TimeScale } from "../core/scale";
 import type { CandleData, CrosshairMode, PaneRect, ThemeColors } from "../core/types";
@@ -36,6 +37,7 @@ export function renderCrosshair(
   candles?: readonly CandleData[],
   leftPriceScales?: Map<string, PriceScale>,
   options?: CrosshairRenderOptions,
+  fontFamily: string = DEFAULT_FONT_FAMILY,
 ): void {
   if (viewportState.crosshairIndex === null) return;
 
@@ -86,14 +88,14 @@ export function renderCrosshair(
     // Price label on right axis
     if (ps) {
       const price = ps.yToPrice(snappedY - activePane.y);
-      drawPriceLabel(ctx, price, priceAxisX, snappedY, theme, fontSize, "right");
+      drawPriceLabel(ctx, price, priceAxisX, snappedY, theme, fontSize, "right", fontFamily);
     }
 
     // Price label on left axis (if left scale has series)
     const leftPs = leftPriceScales?.get(activePane.id);
     if (leftPs) {
       const leftPrice = leftPs.yToPrice(snappedY - activePane.y);
-      drawPriceLabel(ctx, leftPrice, activePane.x, snappedY, theme, fontSize, "left");
+      drawPriceLabel(ctx, leftPrice, activePane.x, snappedY, theme, fontSize, "left", fontFamily);
     }
   }
 
@@ -107,7 +109,7 @@ export function renderCrosshair(
   ) {
     const candle = candles[viewportState.crosshairIndex];
     if (candle) {
-      drawTimeLabel(ctx, candle.time, x, timeAxisY, theme, fontSize);
+      drawTimeLabel(ctx, candle.time, x, timeAxisY, theme, fontSize, fontFamily);
     }
   }
 }
@@ -155,9 +157,10 @@ function drawPriceLabel(
   theme: ThemeColors,
   fontSize: number,
   position: "left" | "right" = "right",
+  fontFamily: string = DEFAULT_FONT_FAMILY,
 ): void {
   const label = autoFormatPrice(price);
-  ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+  ctx.font = canvasFont(fontSize, fontFamily);
   const padX = 6;
   const padY = 4;
   const labelWidth = measureTextWidth(ctx, label) + padX * 2;
@@ -187,9 +190,10 @@ function drawTimeLabel(
   y: number,
   theme: ThemeColors,
   fontSize: number,
+  fontFamily: string = DEFAULT_FONT_FAMILY,
 ): void {
   const label = formatCrosshairTime(time);
-  ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+  ctx.font = canvasFont(fontSize, fontFamily);
   const padX = 6;
   const padY = 3;
   const labelWidth = measureTextWidth(ctx, label) + padX * 2;

--- a/packages/chart/src/renderer/drawing-renderer.ts
+++ b/packages/chart/src/renderer/drawing-renderer.ts
@@ -3,6 +3,7 @@
  */
 
 import type { DataLayer } from "../core/data-layer";
+import { canvasFont, DEFAULT_FONT_FAMILY } from "../core/font";
 import { autoFormatPrice, measureTextWidth } from "../core/format";
 import type { PriceScale, TimeScale } from "../core/scale";
 import type {
@@ -68,6 +69,7 @@ export function renderDrawings(
   dataLayer: DataLayer,
   theme: ThemeColors,
   fontSize: number,
+  fontFamily: string = DEFAULT_FONT_FAMILY,
 ): void {
   if (drawings.length === 0) return;
 
@@ -87,13 +89,13 @@ export function renderDrawings(
   for (const drawing of drawings) {
     switch (drawing.type) {
       case "hline":
-        renderHLine(ctx, drawing, c, fontSize);
+        renderHLine(ctx, drawing, c, fontSize, fontFamily);
         break;
       case "trendline":
         renderTrendLine(ctx, drawing, c);
         break;
       case "fibRetracement":
-        renderFibRetracement(ctx, drawing, c, fontSize);
+        renderFibRetracement(ctx, drawing, c, fontSize, fontFamily);
         break;
       case "ray":
         renderRay(ctx, drawing, c);
@@ -111,10 +113,10 @@ export function renderDrawings(
         renderChannel(ctx, drawing, c);
         break;
       case "fibExtension":
-        renderFibExtension(ctx, drawing, c, fontSize);
+        renderFibExtension(ctx, drawing, c, fontSize, fontFamily);
         break;
       case "textLabel":
-        renderTextLabel(ctx, drawing, c, fontSize);
+        renderTextLabel(ctx, drawing, c, fontSize, fontFamily);
         break;
       case "arrow":
         renderArrow(ctx, drawing, c);
@@ -130,6 +132,7 @@ function renderHLine(
   drawing: HLineDrawing,
   c: DrawCtx,
   fontSize: number,
+  fontFamily: string,
 ): void {
   const { pane } = c;
   const y = toScreenY(drawing.price, c);
@@ -146,7 +149,7 @@ function renderHLine(
 
   // Price label
   const label = autoFormatPrice(drawing.price);
-  ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+  ctx.font = canvasFont(fontSize, fontFamily);
   const padX = 4;
   const padY = 2;
   const labelW = measureTextWidth(ctx, label) + padX * 2;
@@ -203,10 +206,11 @@ function renderFibLevels(
   levels: readonly number[],
   colors: readonly string[],
   priceAt: (level: number) => number,
+  fontFamily: string,
 ): void {
   const { pane } = c;
 
-  ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+  ctx.font = canvasFont(fontSize, fontFamily);
   ctx.textAlign = "left";
   ctx.textBaseline = "middle";
 
@@ -250,6 +254,7 @@ function renderFibRetracement(
   drawing: FibRetracementDrawing,
   c: DrawCtx,
   fontSize: number,
+  fontFamily: string,
 ): void {
   const priceRange = drawing.endPrice - drawing.startPrice;
   renderFibLevels(
@@ -259,6 +264,7 @@ function renderFibRetracement(
     drawing.levels ?? DEFAULT_FIB_LEVELS,
     FIB_COLORS,
     (level) => drawing.endPrice - priceRange * level,
+    fontFamily,
   );
 }
 
@@ -435,6 +441,7 @@ function renderFibExtension(
   drawing: FibExtensionDrawing,
   c: DrawCtx,
   fontSize: number,
+  fontFamily: string,
 ): void {
   const priceRange = drawing.endPrice - drawing.startPrice;
   renderFibLevels(
@@ -444,6 +451,7 @@ function renderFibExtension(
     drawing.levels ?? DEFAULT_FIB_EXT_LEVELS,
     FIB_EXT_COLORS,
     (level) => drawing.startPrice + priceRange * level,
+    fontFamily,
   );
 }
 
@@ -452,12 +460,13 @@ function renderTextLabel(
   drawing: TextLabelDrawing,
   c: DrawCtx,
   defaultFontSize: number,
+  fontFamily: string,
 ): void {
   const { x, y } = toScreenXY(drawing.time, drawing.price, c);
   const size = Math.min(Math.max(drawing.fontSize ?? defaultFontSize, 8), 200);
   const color = drawing.color ?? c.theme.text;
 
-  ctx.font = `${size}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+  ctx.font = canvasFont(size, fontFamily);
   ctx.textAlign = "left";
   ctx.textBaseline = "middle";
 

--- a/packages/chart/src/renderer/info-overlay.ts
+++ b/packages/chart/src/renderer/info-overlay.ts
@@ -4,6 +4,7 @@
  */
 
 import type { InternalSeries } from "../core/data-layer";
+import { DEFAULT_FONT_FAMILY } from "../core/font";
 import { autoFormatPrice, formatVolume } from "../core/format";
 import { escapeHtml } from "../core/html";
 import { type ChartLocale, DEFAULT_LOCALE } from "../core/i18n";
@@ -22,6 +23,7 @@ export class InfoOverlay {
   private _priceFormatter: (price: number) => string;
   private _formatInfoOverlay: ((data: InfoOverlayData) => string | null) | null;
   private _locale: ChartLocale;
+  private _fontFamily: string;
 
   private _styleEl: HTMLStyleElement | null = null;
 
@@ -31,6 +33,7 @@ export class InfoOverlay {
     priceFormatter?: (price: number) => string,
     formatInfoOverlay?: (data: InfoOverlayData) => string | null,
     locale?: ChartLocale,
+    fontFamily: string = DEFAULT_FONT_FAMILY,
   ) {
     this._container = container;
     this._container.style.position = "relative";
@@ -38,11 +41,12 @@ export class InfoOverlay {
     this._priceFormatter = priceFormatter ?? autoFormatPrice;
     this._formatInfoOverlay = formatInfoOverlay ?? null;
     this._locale = locale ?? DEFAULT_LOCALE;
+    this._fontFamily = fontFamily;
 
     // Inject responsive styles once
     this._styleEl = document.createElement("style");
     this._styleEl.textContent = `
-      .tc-info { position:absolute; z-index:10; pointer-events:none; font-size:11px; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; line-height:1.4; white-space:nowrap; max-width:calc(100% - 8px); overflow:hidden; text-overflow:ellipsis; }
+      .tc-info { position:absolute; z-index:10; pointer-events:none; font-size:11px; line-height:1.4; white-space:nowrap; max-width:calc(100% - 8px); overflow:hidden; text-overflow:ellipsis; }
       @media (max-width:480px) { .tc-info { white-space:normal; font-size:10px; max-width:90vw; overflow:visible; text-overflow:clip; } }
     `;
     container.appendChild(this._styleEl);
@@ -57,11 +61,20 @@ export class InfoOverlay {
   private createInfoElement(): HTMLElement {
     const el = document.createElement("div");
     el.className = "tc-info";
+    el.style.fontFamily = this._fontFamily;
     return el;
   }
 
   setTheme(theme: ThemeColors): void {
     this._theme = theme;
+  }
+
+  setFontFamily(fontFamily: string): void {
+    this._fontFamily = fontFamily;
+    this._mainInfo.style.fontFamily = fontFamily;
+    for (const el of this._paneInfos.values()) {
+      el.style.fontFamily = fontFamily;
+    }
   }
 
   setRendererRegistry(registry: RendererRegistry): void {

--- a/packages/chart/src/renderer/legend-overlay.ts
+++ b/packages/chart/src/renderer/legend-overlay.ts
@@ -8,6 +8,7 @@
  */
 
 import type { InternalSeries } from "../core/data-layer";
+import { DEFAULT_FONT_FAMILY } from "../core/font";
 import { escapeHtml } from "../core/html";
 import { type ChartLocale, DEFAULT_LOCALE } from "../core/i18n";
 import type { ThemeColors } from "../core/types";
@@ -27,13 +28,18 @@ export class LegendOverlay {
 
   private _styleEl: HTMLStyleElement | null = null;
 
-  constructor(container: HTMLElement, theme: ThemeColors, locale?: ChartLocale) {
+  constructor(
+    container: HTMLElement,
+    theme: ThemeColors,
+    locale?: ChartLocale,
+    fontFamily: string = DEFAULT_FONT_FAMILY,
+  ) {
     this._theme = theme;
     this._locale = locale ?? DEFAULT_LOCALE;
 
     this._styleEl = document.createElement("style");
     this._styleEl.textContent =
-      '.tc-legend{position:absolute;top:22px;right:68px;left:4px;z-index:10;display:flex;justify-content:flex-end;gap:8px;flex-wrap:wrap;font-size:11px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;pointer-events:none}' +
+      ".tc-legend{position:absolute;top:22px;right:68px;left:4px;z-index:10;display:flex;justify-content:flex-end;gap:8px;flex-wrap:wrap;font-size:11px;pointer-events:none}" +
       ".tc-legend-row{display:inline-flex;align-items:center;gap:2px;pointer-events:auto}" +
       ".tc-legend-btn,.tc-legend-action{cursor:pointer;background:none;border:none;font:inherit;color:inherit;pointer-events:auto}" +
       ".tc-legend-btn{white-space:nowrap;padding:2px 4px;line-height:inherit;min-height:24px}" +
@@ -48,6 +54,7 @@ export class LegendOverlay {
 
     this._el = document.createElement("div");
     this._el.className = "tc-legend";
+    this._el.style.fontFamily = fontFamily;
     container.appendChild(this._el);
 
     // Single delegated click handler — never leaked across `update()` calls.
@@ -101,6 +108,10 @@ export class LegendOverlay {
 
   setTheme(theme: ThemeColors): void {
     this._theme = theme;
+  }
+
+  setFontFamily(fontFamily: string): void {
+    this._el.style.fontFamily = fontFamily;
   }
 
   /**

--- a/packages/chart/src/renderer/overlay-renderer.ts
+++ b/packages/chart/src/renderer/overlay-renderer.ts
@@ -4,6 +4,7 @@
  */
 
 import type { DataLayer, InternalSeries } from "../core/data-layer";
+import { canvasFont, DEFAULT_FONT_FAMILY } from "../core/font";
 import { autoFormatPrice, measureTextWidth } from "../core/format";
 import type { PriceScale, TimeScale } from "../core/scale";
 import { defaultRegistry } from "../core/series-registry";
@@ -35,6 +36,7 @@ export function renderPriceLine(
    * makes the badge follow the right edge of the viewport (visible-mode).
    */
   candleIndex?: number,
+  fontFamily: string = DEFAULT_FONT_FAMILY,
 ): void {
   if (candles.length === 0) return;
 
@@ -64,7 +66,7 @@ export function renderPriceLine(
   ctx.globalAlpha = 1;
 
   const label = autoFormatPrice(price);
-  ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+  ctx.font = canvasFont(fontSize, fontFamily);
   const padX = 6;
   const padY = 3;
   const labelW = measureTextWidth(ctx, label) + padX * 2;
@@ -282,8 +284,9 @@ export function renderPaneTitles(
   theme: ThemeColors,
   fontSize: number,
   locale?: import("../core/i18n").ChartLocale,
+  fontFamily: string = DEFAULT_FONT_FAMILY,
 ): void {
-  ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+  ctx.font = canvasFont(fontSize, fontFamily);
   ctx.textAlign = "left";
   ctx.textBaseline = "top";
 
@@ -362,12 +365,13 @@ export function computeSeriesBadges(
   searchUpTo?: number,
   /** Optional extra badges (e.g. synthetic volume pill) to fold into layout. */
   extras: readonly { value: number; color: string }[] = [],
+  fontFamily: string = DEFAULT_FONT_FAMILY,
 ): ComputedBadge[] {
   const padX = 6;
   const padY = 3;
   const half = fontSize / 2 + padY;
 
-  ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+  ctx.font = canvasFont(fontSize, fontFamily);
 
   type Candidate = { y: number; color: string; label: string; w: number };
   const candidates: Candidate[] = [];
@@ -475,10 +479,11 @@ export function drawSeriesBadges(
   ctx: CanvasRenderingContext2D,
   badges: readonly ComputedBadge[],
   fontSize: number,
+  fontFamily: string = DEFAULT_FONT_FAMILY,
 ): void {
   if (badges.length === 0) return;
   const padX = 6;
-  ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+  ctx.font = canvasFont(fontSize, fontFamily);
   ctx.textAlign = "left";
   ctx.textBaseline = "middle";
   for (const b of badges) {

--- a/packages/chart/src/renderer/pattern-renderer.ts
+++ b/packages/chart/src/renderer/pattern-renderer.ts
@@ -4,6 +4,7 @@
  */
 
 import type { DataLayer } from "../core/data-layer";
+import { canvasFont, DEFAULT_FONT_FAMILY } from "../core/font";
 import { autoFormatPrice } from "../core/format";
 import type { PriceScale, TimeScale } from "../core/scale";
 import type { PaneRect, ThemeColors } from "../core/types";
@@ -66,6 +67,7 @@ export function renderPatterns(
   dataLayer: DataLayer,
   theme: ThemeColors,
   fontSize: number,
+  fontFamily: string = DEFAULT_FONT_FAMILY,
 ): void {
   if (patterns.length === 0) return;
 
@@ -116,7 +118,7 @@ export function renderPatterns(
 
       // Label
       ctx.fillStyle = theme.text;
-      ctx.font = `${fontSize - 1}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+      ctx.font = canvasFont(fontSize - 1, fontFamily);
       ctx.textAlign = "center";
       ctx.textBaseline = direction === "bearish" ? "top" : "bottom";
       ctx.fillText(kp.label, x, y + (direction === "bearish" ? 6 : -6));
@@ -158,7 +160,7 @@ export function renderPatterns(
       ctx.setLineDash([]);
 
       ctx.fillStyle = theme.textSecondary;
-      ctx.font = `${fontSize - 1}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+      ctx.font = canvasFont(fontSize - 1, fontFamily);
       ctx.textAlign = "left";
       ctx.textBaseline = "middle";
       ctx.fillText(`T:${autoFormatPrice(signal.pattern.target)}`, x + 64, targetY);
@@ -172,7 +174,7 @@ export function renderPatterns(
 
     ctx.fillStyle = color;
     ctx.globalAlpha = 0.9;
-    ctx.font = `bold ${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+    ctx.font = canvasFont(fontSize, fontFamily, "bold");
     ctx.textAlign = "center";
     ctx.textBaseline = "bottom";
     ctx.fillText(`${patternName} (${signal.confidence}%)`, labelX, labelY);

--- a/packages/chart/src/renderer/render-pipeline.ts
+++ b/packages/chart/src/renderer/render-pipeline.ts
@@ -6,6 +6,7 @@
 import type { DataLayer, InternalSeries } from "../core/data-layer";
 import { decimateCandles, getDecimationTarget } from "../core/decimation";
 import { DrawHelper, withPaneClip } from "../core/draw-helper";
+import { canvasFont } from "../core/font";
 import { formatVolume } from "../core/format";
 import type { LayoutEngine } from "../core/layout";
 import type { RendererRegistry } from "../core/renderer-registry";
@@ -44,6 +45,7 @@ type DualScale = { left: PriceScale; right: PriceScale };
 
 /** Cached watermark font string — avoids per-frame template literal */
 let _watermarkFontWidth = 0;
+let _watermarkFontFamily = "";
 let _watermarkFont = "";
 
 /** Reused Maps — avoids per-frame allocation */
@@ -78,6 +80,7 @@ export type RenderContext = {
   canvasHeight: number;
   theme: ThemeColors;
   fontSize: number;
+  fontFamily: string;
   chartType: ChartType;
   watermark: string | undefined;
   /** When true, draw last-value pills on each pane's right axis */
@@ -126,9 +129,10 @@ export function renderFrame(rc: RenderContext): RenderResult {
 
   // Watermark
   if (rc.watermark) {
-    if (_watermarkFontWidth !== width) {
+    if (_watermarkFontWidth !== width || _watermarkFontFamily !== rc.fontFamily) {
       _watermarkFontWidth = width;
-      _watermarkFont = `bold ${Math.min(width * 0.08, 48)}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+      _watermarkFontFamily = rc.fontFamily;
+      _watermarkFont = canvasFont(Math.min(width * 0.08, 48), rc.fontFamily, "bold");
     }
     ctx.save();
     ctx.fillStyle = theme.textSecondary;
@@ -389,6 +393,7 @@ export function renderFrame(rc: RenderContext): RenderResult {
               dataLayer: data,
               theme,
               draw: drawHelper,
+              fontFamily: rc.fontFamily,
             },
             prim.state,
           );
@@ -432,6 +437,7 @@ export function renderFrame(rc: RenderContext): RenderResult {
               dataLayer: data,
               theme,
               draw: drawHelper,
+              fontFamily: rc.fontFamily,
             },
             prim.state,
           );
@@ -485,6 +491,7 @@ export function renderFrame(rc: RenderContext): RenderResult {
           excludeYRanges,
           searchUpTo,
           extras,
+          rc.fontFamily,
         );
         for (const b of computedBadges) excludeYRanges.push({ y: b.y, half: b.half });
         if (computedBadges.length > 0) pendingBadges.push({ badges: computedBadges });
@@ -507,6 +514,7 @@ export function renderFrame(rc: RenderContext): RenderResult {
         maxTicks: paneMaxTicks,
         excludeYRanges: excludeYRanges.length > 0 ? excludeYRanges : undefined,
       },
+      rc.fontFamily,
     );
 
     // Left price axis (if pane has left-scale series)
@@ -522,6 +530,7 @@ export function renderFrame(rc: RenderContext): RenderResult {
         rc.fontSize,
         axisFormatter,
         { position: "left", maxTicks: paneMaxTicks },
+        rc.fontFamily,
       );
     }
   }
@@ -554,6 +563,7 @@ export function renderFrame(rc: RenderContext): RenderResult {
     theme,
     rc.fontSize,
     rc.timeFormatter,
+    rc.fontFamily,
   );
 
   // MTF overlays
@@ -575,6 +585,7 @@ export function renderFrame(rc: RenderContext): RenderResult {
         theme,
         rc.fontSize,
         rc.locale,
+        rc.fontFamily,
       );
     }
   }
@@ -590,20 +601,40 @@ export function renderFrame(rc: RenderContext): RenderResult {
       data,
       theme,
       rc.fontSize,
+      rc.fontFamily,
     );
   }
 
   // Drawings (include interactive preview if present)
   const allDrawings = rc.drawingPreview ? [...data.drawings, rc.drawingPreview] : data.drawings;
-  renderDrawings(ctx, allDrawings, paneRects, _rightScaleMap, timeScale, data, theme, rc.fontSize);
+  renderDrawings(
+    ctx,
+    allDrawings,
+    paneRects,
+    _rightScaleMap,
+    timeScale,
+    data,
+    theme,
+    rc.fontSize,
+    rc.fontFamily,
+  );
 
   // Overlays
-  renderPriceLine(ctx, candles, paneRects, _rightScaleMap, theme, rc.fontSize, currentPriceIndex);
+  renderPriceLine(
+    ctx,
+    candles,
+    paneRects,
+    _rightScaleMap,
+    theme,
+    rc.fontSize,
+    currentPriceIndex,
+    rc.fontFamily,
+  );
   // Last-value series badges (opt-in). Drawn after renderPriceLine so the
   // candle current-price badge stays on top visually, and above the axis so
   // pills aren't obscured by tick labels.
   for (const { badges } of pendingBadges) {
-    drawSeriesBadges(ctx, badges, rc.fontSize);
+    drawSeriesBadges(ctx, badges, rc.fontSize, rc.fontFamily);
   }
   renderSignals(ctx, data.signals, candles, data, paneRects, _rightScaleMap, timeScale);
   renderTrades(ctx, data.trades, data, paneRects, _rightScaleMap, timeScale);
@@ -622,6 +653,7 @@ export function renderFrame(rc: RenderContext): RenderResult {
     candles,
     undefined,
     rc.crosshair,
+    rc.fontFamily,
   );
 
   // Crosshair event emission is handled by CanvasChart's viewport interaction


### PR DESCRIPTION
## Summary
- `ChartOptions.fontFamily` was documented but a no-op: canvas renderers hardcoded a system UI stack, and `applyOptions({ fontFamily })` rejected the field as unsupported.
- Store and pass `fontFamily` like `fontSize` through the render context; use it for axis/crosshair/overlay/drawing/pattern/watermark canvas text, DOM legend/info overlays, and built-in primitives.
- Default remains unchanged: `fontSize` 11 and `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`.
- `applyOptions({ fontFamily })` updates live. Also exports `DEFAULT_FONT_FAMILY` and `canvasFont()` for plugin authors.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm test` (chart package)
- [x] `pnpm size-check`