### PR TITLE
fix(chart): viewport interaction hardening for logical-range viewports

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -47,6 +47,22 @@ layers:
   viewport center for a non-finite anchor, so an unexpected NaN in
   event-derived coordinates can no longer poison the viewport position
   permanently.
+- The scroll clamp respects positions granted by `setVisibleLogicalRange`
+  as a first-class envelope. Previously the interaction layer treated a
+  granted beyond-boundary position as ordinary overscroll: the first
+  wheel notch or drag pixel could fling the view most of the margin back
+  toward the ordinary boundary, a streaming tick destroyed a margin
+  before the first bar, and in the everything-fits regime a single arrow
+  key snapped a both-sides margin to the left edge. Granted margins now
+  behave predictably: user gestures consume them bar-by-bar (rubber-band
+  resistance and bounce apply only beyond the granted position), they
+  stream with the live-edge follow, and they are released by explicit
+  navigation (`fitContent`, scroll-to-end, time-based ranges,
+  `setCandles`). Consumed margin is not re-enterable by gestures — set a
+  new logical range to widen it again. A container resize no longer
+  auto-refits away a wide logical-range viewport, and a
+  `timeScale.rightOffset` update leaves an active logical-range viewport
+  in place (the new offset applies once the range is released).
 
 ### Added — logical-range viewport API: `setVisibleLogicalRange` / `getVisibleLogicalRange`
 

--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — interaction and event hardening for logical-range viewports
+
+The states the logical-range API makes reachable (fractional resting
+positions, viewports beyond the data, bar spacing outside the interactive
+zoom range) are now handled consistently by the interaction and event
+layers:
+
+- Interactive zoom moves continuously toward its `[1, 50]` px/bar range
+  when the current spacing sits outside it, instead of teleporting to the
+  boundary — which inverted the gesture (zooming in at 800px/bar snapped
+  out 16×; also reachable before via `fitContent` on very large datasets).
+- Dragging from a fractional resting position no longer snaps the viewport
+  by the fractional part on the first pixel of movement.
+- An animated range transition lands on the exact target span even below
+  one bar per screen (the interpolation floored the bar count to 1).
+- A beyond-left viewport no longer blanks number-line series (a negative
+  index reached `Array.slice`, which reads it as an offset from the end).
+- `getVisibleRange()`'s time/index fields are clamped to the data as
+  documented — a beyond-data viewport used to report epoch-0 times, which
+  sent time-based viewport sync to the first bar.
+- `visibleRangeChange` has a single emission owner: movement is detected
+  on the fractional logical range with a ~0.25px threshold (sub-bar pans
+  and zooms now emit; integer-floored comparison swallowed them), and a
+  programmatic range change with animation enabled emits its final state
+  exactly once on completion (previously it could emit nothing at all).
+  Listeners may observe more frequent events during interaction.
+- The internal viewport sync tags forwarded range changes with an
+  origin/generation token, so the completion event of a forwarded change
+  is consumed exactly once instead of echoing between charts — including
+  multi-timeframe time-based sync, where the follower's quantized range
+  differs from the sender's and value comparison cannot work.
+- Only actual viewport gestures (pan, zoom, scrollbar, viewport keys,
+  inertia) cancel a running programmatic range animation. Hovering the
+  crosshair, resizing a pane, or previewing a drawing used to kill the
+  animation mid-flight — freezing the view at an intermediate range and
+  swallowing the completion event.
+- Interactive zoom ignores a non-finite factor and falls back to the
+  viewport center for a non-finite anchor, so an unexpected NaN in
+  event-derived coordinates can no longer poison the viewport position
+  permanently.
+
 ### Added — logical-range viewport API: `setVisibleLogicalRange` / `getVisibleLogicalRange`
 
 ```ts

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -129,12 +129,12 @@
     {
       "name": "Main (createChart + all exports)",
       "path": "dist/index.js",
-      "limit": "41.5 kB"
+      "limit": "42.5 kB"
     },
     {
       "name": "Headless API",
       "path": "dist/headless.js",
-      "limit": "11.25 kB"
+      "limit": "11.75 kB"
     },
     {
       "name": "Sparkline (vanilla)",
@@ -159,12 +159,12 @@
     {
       "name": "React wrapper",
       "path": "dist/react/TrendChart.js",
-      "limit": "33 kB"
+      "limit": "34 kB"
     },
     {
       "name": "Vue wrapper",
       "path": "dist/vue/TrendChart.js",
-      "limit": "33 kB"
+      "limit": "34 kB"
     }
   ],
   "devDependencies": {

--- a/packages/chart/src/__tests__/viewport-hardening.test.ts
+++ b/packages/chart/src/__tests__/viewport-hardening.test.ts
@@ -1,0 +1,502 @@
+// @vitest-environment happy-dom
+/**
+ * Viewport hardening regressions — interaction / emission / consumer fixes
+ * for the states made reachable by the logical-range API:
+ *
+ * - M2: interactive zoom moves continuously TOWARD [1, 50] from an
+ *   out-of-range bar spacing instead of teleporting to the boundary
+ *   (which inverted the gesture direction).
+ * - M5: visibleRangeChange emission is a single owner with a ~0.25px
+ *   fractional change threshold, force-emits once on animation completion,
+ *   and syncCharts identifies forwarded completions by an origin/generation
+ *   token instead of range values (async echo prevention, incl. time-mode
+ *   MTF where the target's quantized range is unknowable to the sender).
+ * - M6: a beyond-left viewport must not blank number-line series (negative
+ *   Array.slice start read from the END of the data).
+ * - M7: getVisibleRange()'s four legacy fields are clamped to the data
+ *   (beyond-data viewports used to report epoch-0 times).
+ * - M8: drag origin uses the raw fractional startIndex (the floored getter
+ *   snapped the viewport on the first pixel of drag).
+ * - M9: an animated range transition lands on the exact target spacing
+ *   even for sub-1-bar spans (the count was floored to 1).
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, type vi } from "vitest";
+import type { InternalSeries } from "../core/data-layer";
+import { TimeScale } from "../core/scale";
+import type { CandleData, ChartInstance, VisibleRangeChangeData } from "../core/types";
+import { createChart } from "../index";
+import { syncCharts } from "../integration/sync";
+import { dispatchSeries } from "../renderer/series-dispatcher";
+import { makePriceScale, mockCtx } from "./helpers/mock-ctx";
+
+beforeAll(() => {
+  const noop = () => {};
+  const context2d = new Proxy(
+    {},
+    {
+      get: (_t, prop) => {
+        if (prop === "canvas") return null;
+        if (prop === "measureText") return () => ({ width: 0 }) as TextMetrics;
+        return noop;
+      },
+      set: () => true,
+    },
+  ) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as { getContext: () => unknown }).getContext = () =>
+    context2d;
+});
+
+function makeContainer(): HTMLElement {
+  const el = document.createElement("div");
+  el.style.width = "800px";
+  el.style.height = "400px";
+  document.body.appendChild(el);
+  return el;
+}
+
+function makeCandles(
+  count: number,
+  intervalMs = 60_000,
+  startTime = 1_700_000_000_000,
+): CandleData[] {
+  return Array.from({ length: count }, (_, i) => ({
+    time: startTime + i * intervalMs,
+    open: 100,
+    high: 101,
+    low: 99,
+    close: 100.5,
+    volume: 1000,
+  }));
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// ---- M2: zoom continuity from out-of-range spacing ----
+
+describe("M2 zoom continuity", () => {
+  function scaleWithSpacing(spanFrom: number, spanTo: number): TimeScale {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(300);
+    ts.setVisibleLogicalRange(spanFrom, spanTo);
+    return ts;
+  }
+
+  it("zooming in at 800px/bar does not teleport out to 50px/bar", () => {
+    const ts = scaleWithSpacing(10, 11); // spacing 800
+    expect(ts.barSpacing).toBeCloseTo(800, 6);
+    ts.zoom(1.1); // zoom in: away from range — must not move
+    expect(ts.barSpacing).toBeCloseTo(800, 6);
+    ts.zoom(0.9); // zoom out: toward range — continuous
+    expect(ts.barSpacing).toBeCloseTo(720, 6);
+  });
+
+  it("zooming out at 0.32px/bar does not teleport in to 1px/bar", () => {
+    const ts = scaleWithSpacing(0, 2500); // spacing 0.32
+    expect(ts.barSpacing).toBeCloseTo(0.32, 6);
+    ts.zoom(0.9); // zoom out: away from range — must not move
+    expect(ts.barSpacing).toBeCloseTo(0.32, 6);
+    ts.zoom(1.1); // zoom in: toward range — continuous
+    expect(ts.barSpacing).toBeCloseTo(0.352, 6);
+  });
+
+  it("ignores non-finite factor and falls back to center for a non-finite anchor", () => {
+    // Wheel/pinch anchors derive from browser event coordinates; a NaN
+    // reaching _startIndex would poison the viewport permanently.
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(300);
+    ts.setVisibleRange(0, 100);
+    const spacing = ts.barSpacing;
+    const start = ts.rawStartIndex;
+
+    ts.zoom(Number.NaN);
+    expect(ts.barSpacing).toBe(spacing);
+    expect(ts.rawStartIndex).toBe(start);
+
+    ts.zoom(1.1, Number.NaN); // anchor falls back to the viewport center
+    expect(Number.isFinite(ts.rawStartIndex)).toBe(true);
+    expect(ts.barSpacing).toBeCloseTo(spacing * 1.1, 6);
+  });
+
+  it("keeps the ordinary [1, 50] behavior inside the range", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(300);
+    ts.setVisibleRange(0, 100); // spacing 8
+    ts.zoom(1.1);
+    expect(ts.barSpacing).toBeCloseTo(8.8, 6);
+    ts.zoom(1000); // cap at max
+    expect(ts.barSpacing).toBe(50);
+    ts.zoom(0.0001); // floor at interactive min
+    expect(ts.barSpacing).toBe(1);
+  });
+});
+
+// ---- M6: LTTB slice with a beyond-left viewport ----
+
+describe("M6 number-line series at beyond-left viewports", () => {
+  it("renders the line instead of blanking it (negative slice start)", () => {
+    const n = 5000;
+    const data = Array.from({ length: n }, (_, i) => ({
+      time: 1 + i,
+      value: 100 + Math.sin(i / 50) * 10,
+    }));
+    const series: InternalSeries = {
+      id: "s",
+      paneId: "main",
+      scaleId: "right",
+      type: "line",
+      config: {},
+      data: data as InternalSeries["data"],
+      visible: true,
+    };
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(n);
+    ts.setVisibleLogicalRange(-1000, 4000); // left margin + LTTB-dense span
+    const ctx = mockCtx();
+    dispatchSeries(ctx, series, ts, makePriceScale(400, 80, 120));
+    const drawn =
+      (ctx.lineTo as ReturnType<typeof vi.fn>).mock.calls.length +
+      (ctx.moveTo as ReturnType<typeof vi.fn>).mock.calls.length;
+    // Pre-fix: slice(-1000, 4000) → slice(4000, 4000) → empty → ~0 calls.
+    expect(drawn).toBeGreaterThan(100);
+  });
+});
+
+// ---- Chart-level fixtures ----
+
+describe("chart-level hardening", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  function makeChart(opts: { duration?: number } = {}) {
+    return createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: opts.duration ?? 0,
+    });
+  }
+
+  it("M7: beyond-data viewports report clamped times, never epoch 0", () => {
+    const candles = makeCandles(300);
+    const chart = makeChart();
+    chart.setCandles(candles);
+
+    chart.setVisibleLogicalRange(310, 340); // fully beyond right
+    let range = chart.getVisibleRange();
+    expect(range?.startTime).toBe(candles[299].time);
+    expect(range?.endTime).toBe(candles[299].time);
+    expect(range?.startIndex).toBe(299);
+    expect(range?.endIndex).toBe(299);
+
+    chart.setVisibleLogicalRange(-40, -10); // fully before left
+    range = chart.getVisibleRange();
+    expect(range?.startTime).toBe(candles[0].time);
+    expect(range?.endTime).toBe(candles[0].time);
+    expect(range?.startIndex).toBe(0);
+    expect(range?.endIndex).toBe(0);
+  });
+
+  it("M9: an animated transition lands on the exact sub-1-bar span", async () => {
+    const chart = makeChart({ duration: 60 });
+    chart.setCandles(makeCandles(300));
+
+    chart.setVisibleLogicalRange(10, 10.25);
+    await sleep(250); // settle
+    const r = chart.getVisibleLogicalRange();
+    expect(r).not.toBeNull();
+    // Pre-fix the count was floored to 1 → span landed at 1, not 0.25.
+    expect((r?.to ?? 0) - (r?.from ?? 0)).toBeCloseTo(0.25, 6);
+  });
+
+  it("M5: sub-bar movement emits (fractional threshold, not floored indices)", () => {
+    const chart = makeChart();
+    chart.setCandles(makeCandles(300));
+    chart.setVisibleLogicalRange(10, 11);
+
+    const events: VisibleRangeChangeData[] = [];
+    chart.on("visibleRangeChange", (d) => events.push(d as VisibleRangeChangeData));
+    chart.setVisibleLogicalRange(10.3, 11.3); // floored indices unchanged
+    expect(events.length).toBeGreaterThan(0);
+    const last = events[events.length - 1];
+    expect(last.logicalRange?.from).toBeCloseTo(10.3, 6);
+  });
+
+  it("M5: a default-animated programmatic set emits its final state exactly once", async () => {
+    const chart = makeChart({ duration: 300 });
+    chart.setCandles(makeCandles(300));
+    await sleep(50);
+
+    const events: VisibleRangeChangeData[] = [];
+    chart.on("visibleRangeChange", (d) => events.push(d as VisibleRangeChangeData));
+    chart.setVisibleLogicalRange(100, 200);
+    await sleep(600); // settle
+    // Pre-fix: tween frames update the floored compare while suppressed,
+    // and the final sub-bar frame changes nothing → zero events ever.
+    expect(events.length).toBe(1);
+    expect(events[0].logicalRange?.from).toBeCloseTo(100, 6);
+    expect(events[0].logicalRange?.to).toBeCloseTo(200, 6);
+  });
+
+  it("M8: dragging from a fractional resting position does not snap to the floor", () => {
+    const chart = makeChart();
+    chart.setCandles(makeCandles(300));
+    chart.setVisibleLogicalRange(100.6, 180.6);
+    const canvas = document.querySelector("canvas");
+    expect(canvas).not.toBeNull();
+    if (!canvas) return;
+
+    canvas.dispatchEvent(new MouseEvent("mousedown", { clientX: 400, clientY: 200 }));
+    canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 399, clientY: 200 }));
+    canvas.dispatchEvent(new MouseEvent("mouseup", { clientX: 399, clientY: 200 }));
+
+    const from = chart.getVisibleLogicalRange()?.from ?? 0;
+    // A 1px drag moves ~1/spacing ≈ 0.11 bars. Pre-fix the origin was
+    // floored to 100, snapping the view by the 0.6 fractional part.
+    expect(Math.abs(from - 100.6)).toBeGreaterThan(0.001); // it did move
+    expect(Math.abs(from - 100.6)).toBeLessThan(0.2); // ...but never snapped
+  });
+});
+
+// ---- P1: only viewport gestures cancel a running range animation ----
+// Hover / pane-resize / drawing previews go through the plain onUpdate
+// channel (the hover test covers the whole channel); pan / wheel / pinch /
+// viewport keys / inertia go through onViewportMutation.
+
+describe("animation vs interaction channels", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  function makeAnimatedChart() {
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 300,
+    });
+    chart.setCandles(makeCandles(600));
+    return chart;
+  }
+
+  function canvasOf(): HTMLCanvasElement {
+    const canvas = document.body.querySelector("canvas");
+    if (!canvas) throw new Error("no canvas");
+    return canvas as HTMLCanvasElement;
+  }
+
+  it("hovering during an animation does not cancel it (final range + one emit)", async () => {
+    const chart = makeAnimatedChart();
+    await sleep(50);
+    const events: VisibleRangeChangeData[] = [];
+    chart.on("visibleRangeChange", (d) => events.push(d as VisibleRangeChangeData));
+
+    chart.setVisibleLogicalRange(200, 300);
+    await sleep(100); // mid-animation
+    const canvas = canvasOf();
+    for (let i = 0; i < 5; i++) {
+      canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 300 + i * 10, clientY: 150 }));
+    }
+    await sleep(500); // settle
+
+    // Pre-fix: the hover killed the animation → the view froze mid-flight,
+    // no completion emit, and the abandoned range leaked as fresh input.
+    expect(chart.getVisibleLogicalRange()?.from).toBeCloseTo(200, 4);
+    expect(chart.getVisibleLogicalRange()?.to).toBeCloseTo(300, 4);
+    expect(events.length).toBe(1);
+  });
+
+  it("a wheel gesture during an animation cancels it", async () => {
+    const chart = makeAnimatedChart();
+    await sleep(50);
+    chart.setVisibleLogicalRange(200, 300);
+    await sleep(100); // mid-animation
+    canvasOf().dispatchEvent(
+      new WheelEvent("wheel", { deltaY: 120, clientX: 400, clientY: 150, cancelable: true }),
+    );
+    await sleep(500);
+
+    // The animation never reached its target; the user gesture won.
+    const afterWheel = chart.getVisibleLogicalRange()?.from ?? Number.NaN;
+    expect(Number.isFinite(afterWheel)).toBe(true); // NaN would vacuously pass .not
+    expect(afterWheel).not.toBeCloseTo(200, 2);
+  });
+
+  it("a viewport key during an animation cancels it; drag does too", async () => {
+    const chart = makeAnimatedChart();
+    await sleep(50);
+    chart.setVisibleLogicalRange(200, 300);
+    await sleep(100);
+    canvasOf().dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft" }));
+    await sleep(500);
+    const afterKey = chart.getVisibleLogicalRange()?.from ?? Number.NaN;
+    expect(Number.isFinite(afterKey)).toBe(true);
+    expect(afterKey).not.toBeCloseTo(200, 2);
+
+    chart.setVisibleLogicalRange(400, 500);
+    await sleep(100);
+    const canvas = canvasOf();
+    canvas.dispatchEvent(new MouseEvent("mousedown", { clientX: 400, clientY: 150 }));
+    canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 350, clientY: 150 }));
+    canvas.dispatchEvent(new MouseEvent("mouseup", { clientX: 350, clientY: 150 }));
+    await sleep(500);
+    const afterDrag = chart.getVisibleLogicalRange()?.from ?? Number.NaN;
+    expect(Number.isFinite(afterDrag)).toBe(true);
+    expect(afterDrag).not.toBeCloseTo(400, 2);
+  });
+
+  it("sync survives a hover on the follower and recovers after a gesture-cancel", async () => {
+    const candles = makeCandles(600);
+    const a = createChart(makeContainer(), { width: 800, height: 400, animationDuration: 300 });
+    a.setCandles(candles);
+    const b = createChart(makeContainer(), { width: 800, height: 400, animationDuration: 300 });
+    b.setCandles(candles);
+    await sleep(50);
+    syncCharts([a, b], { viewport: "logical" });
+
+    // Hover on B mid-follow: its animation must still complete and be
+    // consumed (a stuck pending expectation would break the NEXT sync).
+    a.setVisibleLogicalRange(400, 500);
+    await sleep(400); // B mid-animation
+    const canvases = document.body.querySelectorAll("canvas");
+    canvases[1]?.dispatchEvent(new MouseEvent("mousemove", { clientX: 300, clientY: 150 }));
+    await sleep(700);
+    expect(b.getVisibleLogicalRange()?.from).toBeCloseTo(400, 4);
+
+    // A user gesture cancels B's next follow mid-flight; the resulting
+    // token-less movement is fresh input and must propagate to A, and the
+    // group must keep functioning afterwards.
+    a.setVisibleLogicalRange(100, 200);
+    await sleep(400);
+    canvases[1]?.dispatchEvent(
+      new WheelEvent("wheel", { deltaY: 120, clientX: 400, clientY: 150, cancelable: true }),
+    );
+    await sleep(900);
+    const aRange = a.getVisibleLogicalRange();
+    const bRange = b.getVisibleLogicalRange();
+    // Converged on B's post-gesture state (not wedged, no echo storm).
+    expect(aRange?.from).toBeCloseTo(bRange?.from ?? Number.NaN, 2);
+
+    // Subsequent syncs still work.
+    a.setVisibleLogicalRange(250, 350);
+    await sleep(900);
+    expect(b.getVisibleLogicalRange()?.from).toBeCloseTo(250, 4);
+  });
+});
+
+// ---- M5 sync echo prevention (real charts, animated) ----
+
+describe("syncCharts async echo prevention", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  function makeChartWith(candles: CandleData[], duration = 300): ChartInstance {
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: duration,
+    });
+    chart.setCandles(candles);
+    return chart;
+  }
+
+  it("logical mode: one change → one follow, no echo loop, ranges converge", async () => {
+    const candles = makeCandles(600);
+    const a = makeChartWith(candles);
+    const b = makeChartWith(candles);
+    await sleep(50);
+    syncCharts([a, b], { viewport: "logical" });
+
+    const aEvents: unknown[] = [];
+    const bEvents: unknown[] = [];
+    a.on("visibleRangeChange", (d) => aEvents.push(d));
+    b.on("visibleRangeChange", (d) => bEvents.push(d));
+
+    a.setVisibleLogicalRange(400, 500);
+    await sleep(900); // both animations settle
+
+    const aCount = aEvents.length;
+    const bCount = bEvents.length;
+    await sleep(400);
+    // No further events after settle — an echo loop would keep counting.
+    expect(aEvents.length).toBe(aCount);
+    expect(bEvents.length).toBe(bCount);
+    expect(aCount).toBe(1); // A's own completion only — never re-set by B's echo
+    expect(bCount).toBe(1); // B's forwarded completion only
+
+    expect(a.getVisibleLogicalRange()?.from).toBeCloseTo(400, 4);
+    expect(b.getVisibleLogicalRange()?.from).toBeCloseTo(400, 4);
+    expect(b.getVisibleLogicalRange()?.to).toBeCloseTo(500, 4);
+  });
+
+  it("time mode MTF: follower quantizes, still consumed, no echo", async () => {
+    // Different timeframes: 1-minute vs 5-minute over the same span.
+    const oneMin = makeCandles(600, 60_000);
+    const fiveMin = makeCandles(120, 300_000);
+    const a = makeChartWith(oneMin);
+    const b = makeChartWith(fiveMin);
+    await sleep(50);
+    syncCharts([a, b], { viewport: true });
+
+    const aEvents: unknown[] = [];
+    const bEvents: unknown[] = [];
+    a.on("visibleRangeChange", (d) => aEvents.push(d));
+    b.on("visibleRangeChange", (d) => bEvents.push(d));
+
+    a.setVisibleRange(oneMin[300].time, oneMin[420].time);
+    await sleep(900);
+
+    const aCount = aEvents.length;
+    const bCount = bEvents.length;
+    await sleep(400);
+    expect(aEvents.length).toBe(aCount); // no async ping-pong
+    expect(bEvents.length).toBe(bCount);
+    expect(aCount).toBe(1);
+    expect(bCount).toBe(1);
+
+    // B quantized the times to its own (5-min) bars: logical range differs
+    // from A's, yet the completion was recognized by token, not by value.
+    const bRange = b.getVisibleRange();
+    expect(bRange?.startTime).toBe(fiveMin[60].time); // same wall-clock start
+    expect(b.getVisibleLogicalRange()?.from).toBeCloseTo(60, 1);
+  });
+
+  it("a user action during the follower's animation is not swallowed", async () => {
+    const candles = makeCandles(600);
+    const a = makeChartWith(candles);
+    const b = makeChartWith(candles);
+    await sleep(50);
+    syncCharts([a, b], { viewport: "logical" });
+
+    a.setVisibleLogicalRange(400, 500);
+    await sleep(400); // A settled + forward issued; B still animating
+    // "User" acts on B mid-animation (no token → fresh input for the group).
+    b.setVisibleLogicalRange(100, 200);
+    await sleep(900);
+
+    // The user action won: both charts converge on B's range, not A's.
+    expect(b.getVisibleLogicalRange()?.from).toBeCloseTo(100, 4);
+    expect(a.getVisibleLogicalRange()?.from).toBeCloseTo(100, 4);
+  });
+
+  it("rapid successive changes supersede cleanly (stale generation never wins)", async () => {
+    const candles = makeCandles(600);
+    const a = makeChartWith(candles);
+    const b = makeChartWith(candles);
+    await sleep(50);
+    syncCharts([a, b], { viewport: "logical" });
+
+    a.setVisibleLogicalRange(400, 500);
+    await sleep(350); // first forward in flight on B
+    a.setVisibleLogicalRange(200, 300); // supersedes
+    await sleep(1000);
+
+    expect(b.getVisibleLogicalRange()?.from).toBeCloseTo(200, 4);
+    expect(b.getVisibleLogicalRange()?.to).toBeCloseTo(300, 4);
+    expect(a.getVisibleLogicalRange()?.from).toBeCloseTo(200, 4);
+  });
+});

--- a/packages/chart/src/__tests__/viewport-hardening.test.ts
+++ b/packages/chart/src/__tests__/viewport-hardening.test.ts
@@ -262,6 +262,709 @@ describe("chart-level hardening", () => {
   });
 });
 
+// ---- Clamp envelope: granted logical-range positions vs interaction ----
+// The envelope is [min(0, granted), max(normalMax, granted)] where
+// `granted` is the resting position ratified by setVisibleLogicalRange /
+// gesture settles. Margins are consumable by interaction, re-creatable
+// only via the API (one-way ratchet); fitContent / scrollToEnd /
+// setVisibleRange release the grant; the live-edge follow re-bases it.
+
+describe("clamp envelope for granted viewports", () => {
+  it("rubber-band dampens only movement beyond the granted position (M1)", () => {
+    // 500 bars, spacing 8: normalMax = 500 + 20 - 100 = 420. The granted
+    // margin position 450 sits 30 bars past it — pre-envelope, the first
+    // 1-bar wheel pan snapped to 420 + 31*0.4 = 432.4 (an 18-bar jump).
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(500);
+    ts.setVisibleLogicalRange(450, 550);
+    expect(ts.overscroll).toBe(0); // granted position is not "overscroll"
+
+    ts.scrollByUnclamped(1); // one wheel notch further right
+    expect(ts.rawStartIndex).toBeCloseTo(450.4, 6); // gentle, from 450
+    // Bounce returns to the granted position, not the ordinary boundary
+    expect(ts.clampedStartIndex).toBeCloseTo(450, 6);
+  });
+
+  it("a beyond-left viewport survives a data append (M3)", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(500);
+    ts.setVisibleLogicalRange(-50, 50);
+    ts.setTotalCount(501); // streaming append clamps — must not yank to 0
+    expect(ts.rawStartIndex).toBe(-50);
+  });
+
+  it("an all-fits margin viewport moves bar-by-bar, never snapping to 0 (M4)", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(100);
+    ts.setVisibleLogicalRange(-20, 120); // both-sides margin, all fits
+    ts.scrollBy(1);
+    expect(ts.rawStartIndex).toBe(-19); // one bar, not a 20-bar snap
+    for (let i = 0; i < 30; i++) ts.scrollBy(1);
+    expect(ts.rawStartIndex).toBe(0); // converges to the ordinary bound
+    ts.ratifySettledPosition();
+    expect(ts.hasViewportGrant).toBe(false); // grant dissolved inside bounds
+  });
+
+  it("margins are consumable by gestures but not re-expandable (ratchet)", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(500);
+    ts.setVisibleLogicalRange(450, 550);
+
+    ts.scrollTo(430); // user pans partway back toward the data
+    ts.ratifySettledPosition(); // gesture settles
+    expect(ts.rawStartIndex).toBe(430);
+
+    ts.scrollTo(460); // trying to re-enter the consumed margin
+    expect(ts.rawStartIndex).toBe(430); // clamped at the ratified position
+  });
+
+  it("explicit navigation releases the grant", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(500);
+
+    ts.setVisibleLogicalRange(450, 550);
+    expect(ts.hasViewportGrant).toBe(true);
+    ts.scrollToEnd();
+    expect(ts.hasViewportGrant).toBe(false);
+
+    ts.setVisibleLogicalRange(-50, 50);
+    ts.fitContent();
+    expect(ts.hasViewportGrant).toBe(false);
+
+    ts.setVisibleLogicalRange(450, 550);
+    ts.setVisibleRange(100, 200);
+    expect(ts.hasViewportGrant).toBe(false);
+  });
+
+  it("the live-edge follow re-bases the grant with the margin intact", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(500);
+    ts.setVisibleLogicalRange(450, 550);
+
+    const dist = ts.endDistanceVirtual;
+    ts.setTotalCount(501);
+    ts.followLiveEdge(dist);
+    expect(ts.rawStartIndex).toBeCloseTo(451, 6);
+    expect(ts.hasViewportGrant).toBe(true);
+    ts.setTotalCount(502); // next tick's clamp must respect the re-based grant
+    expect(ts.rawStartIndex).toBeCloseTo(451, 6);
+  });
+});
+
+describe("grant = explicit logical viewport, not merely beyond-bounds", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("a wide range starting at 0 still blocks the resize auto-refit", () => {
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 0,
+    });
+    chart.setCandles(makeCandles(300));
+    chart.setVisibleLogicalRange(0, 1000); // start inside ordinary bounds
+    chart.resize(900, 400);
+    const r = chart.getVisibleLogicalRange();
+    // fitContent would collapse the span to ~300 slots; the explicit range
+    // keeps its spacing, so the span stays in the requested order.
+    expect((r?.to ?? 0) - (r?.from ?? 0)).toBeGreaterThan(900);
+    expect(r?.from).toBeCloseTo(0, 6);
+  });
+
+  it("an in-bounds range including the live edge is not repositioned by rightOffset", () => {
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 0,
+      timeScale: { rightOffset: 5 },
+    });
+    chart.setCandles(makeCandles(300));
+    // Start inside the ordinary overscroll pad; margin only on the right.
+    chart.setVisibleLogicalRange(215, 310);
+    expect(chart.getVisibleLogicalRange()?.from).toBeCloseTo(215, 6);
+
+    chart.applyOptions({ timeScale: { rightOffset: 8 } });
+    expect(chart.getVisibleLogicalRange()?.from).toBeCloseTo(215, 6); // untouched
+  });
+
+  it("the first in-bounds gesture settle dissolves the grant", () => {
+    const ts = new TimeScale();
+    ts.setWidth(800);
+    ts.setTotalCount(300);
+    ts.setVisibleLogicalRange(50, 150); // fully ordinary position
+    expect(ts.hasViewportGrant).toBe(true); // active until a settle
+    ts.ratifySettledPosition(); // first gesture settles in-bounds
+    expect(ts.hasViewportGrant).toBe(false);
+  });
+});
+
+describe("non-mutating gestures never dissolve a grant", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  function chartWith(range: [number, number], rightOffset?: number) {
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 0,
+      ...(rightOffset !== undefined ? { timeScale: { rightOffset } } : {}),
+    });
+    chart.setCandles(makeCandles(300));
+    chart.setVisibleLogicalRange(range[0], range[1]);
+    const scale = (chart as unknown as { _timeScale: TimeScale })._timeScale;
+    const canvas = document.body.querySelector("canvas") as HTMLCanvasElement;
+    return { chart, scale, canvas };
+  }
+
+  it("a plain click keeps an in-bounds live-edge grant (rightOffset stays put)", () => {
+    const { chart, canvas } = chartWith([215, 310], 5);
+    canvas.dispatchEvent(new MouseEvent("mousedown", { clientX: 400, clientY: 150 }));
+    canvas.dispatchEvent(new MouseEvent("mouseup", { clientX: 400, clientY: 150 }));
+
+    chart.applyOptions({ timeScale: { rightOffset: 8 } });
+    expect(chart.getVisibleLogicalRange()?.from).toBeCloseTo(215, 6);
+  });
+
+  it("a tap-only interaction keeps a wide grant across resize (no auto-fit)", () => {
+    const { chart, canvas } = chartWith([0, 1000]);
+    canvas.dispatchEvent(new MouseEvent("mousedown", { clientX: 400, clientY: 150 }));
+    canvas.dispatchEvent(new MouseEvent("mouseup", { clientX: 400, clientY: 150 }));
+
+    chart.resize(900, 400);
+    const r = chart.getVisibleLogicalRange();
+    expect((r?.to ?? 0) - (r?.from ?? 0)).toBeGreaterThan(900); // not fit to ~300
+  });
+
+  it("a long-press crosshair keeps the grant", async () => {
+    const { scale, canvas } = chartWith([215, 310]);
+    // touchstart is required for the long-press timer; happy-dom lacks a
+    // Touch constructor, so drive the timer path via a synthesized event.
+    const finger = { clientX: 400, clientY: 150 };
+    const touchStart = new Event("touchstart", { cancelable: true }) as TouchEvent;
+    Object.defineProperty(touchStart, "touches", { value: [finger] });
+    Object.defineProperty(touchStart, "changedTouches", { value: [finger] });
+    canvas.dispatchEvent(touchStart);
+    await sleep(600); // long-press fires at 500ms
+    const touchEnd = new Event("touchend") as TouchEvent;
+    Object.defineProperty(touchEnd, "touches", { value: [] });
+    Object.defineProperty(touchEnd, "changedTouches", { value: [finger] });
+    canvas.dispatchEvent(touchEnd);
+
+    expect(scale.hasViewportGrant).toBe(true);
+  });
+
+  it("a real drag settle shrinks or dissolves the grant", () => {
+    const { scale, canvas } = chartWith([215, 310]);
+    canvas.dispatchEvent(new MouseEvent("mousedown", { clientX: 400, clientY: 150 }));
+    canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 460, clientY: 150 }));
+    canvas.dispatchEvent(new MouseEvent("mouseup", { clientX: 460, clientY: 150 }));
+    // In-bounds resting position after a genuine move: grant dissolves.
+    expect(scale.hasViewportGrant).toBe(false);
+  });
+
+  it("grabbing and releasing the scrollbar thumb keeps position and grant", () => {
+    const { chart, scale, canvas } = chartWith([215, 310]);
+    // Compute the thumb's actual location from the same math the renderer
+    // and hit-test use: startFrac = startIndex/total over the scrollbar
+    // strip at layout.scrollbarY — pressing INSIDE the thumb is a grab
+    // (offset captured, nothing moves); only a track press would jump.
+    const layout = (chart as unknown as { _layout: { scrollbarY: number; dataAreaWidth: number } })
+      ._layout;
+    const total = scale.totalCount;
+    const thumbStartX = (Math.max(0, scale.startIndex / total) * layout.dataAreaWidth) | 0;
+    const thumbEndX = (Math.min(1, scale.endIndex / total) * layout.dataAreaWidth) | 0;
+    const insideThumbX = (thumbStartX + thumbEndX) / 2;
+    const scrollbarMidY = layout.scrollbarY + 2;
+
+    const beforeStart = scale.rawStartIndex;
+    canvas.dispatchEvent(
+      new MouseEvent("mousedown", { clientX: insideThumbX, clientY: scrollbarMidY }),
+    );
+    // Sanity: a grab must not have moved the viewport (else the press
+    // missed the thumb and the test setup is wrong — fail loudly).
+    expect(scale.rawStartIndex).toBe(beforeStart);
+    canvas.dispatchEvent(
+      new MouseEvent("mouseup", { clientX: insideThumbX, clientY: scrollbarMidY }),
+    );
+
+    expect(scale.rawStartIndex).toBe(beforeStart); // startIndex unchanged
+    expect(scale.hasViewportGrant).toBe(true); // grant intact
+  });
+
+  it("a thumb grab during an animation lets it complete with one emit", async () => {
+    document.body.innerHTML = "";
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 300,
+    });
+    chart.setCandles(makeCandles(500));
+    chart.setVisibleLogicalRange(100, 200);
+    await sleep(500); // settle the initial move
+    const scale = (chart as unknown as { _timeScale: TimeScale })._timeScale;
+    const layout = (chart as unknown as { _layout: { scrollbarY: number; dataAreaWidth: number } })
+      ._layout;
+    const canvas = document.body.querySelector("canvas") as HTMLCanvasElement;
+
+    const events: unknown[] = [];
+    chart.on("visibleRangeChange", (d) => events.push(d));
+    chart.setVisibleLogicalRange(150, 250); // pure pan (same span → same spacing)
+    await sleep(100); // mid-animation
+    const thumbX =
+      ((Math.max(0, scale.startIndex / scale.totalCount) +
+        Math.min(1, scale.endIndex / scale.totalCount)) /
+        2) *
+      layout.dataAreaWidth;
+    const y = layout.scrollbarY + 2;
+    canvas.dispatchEvent(new MouseEvent("mousedown", { clientX: thumbX, clientY: y }));
+    canvas.dispatchEvent(new MouseEvent("mouseup", { clientX: thumbX, clientY: y }));
+    await sleep(500);
+
+    expect(chart.getVisibleLogicalRange()?.from).toBeCloseTo(150, 4); // completed
+    expect(events.length).toBe(1); // exactly the completion emit
+  });
+
+  it("an absorbed zoom key during a pure-pan animation does not cancel it", async () => {
+    document.body.innerHTML = "";
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 300,
+    });
+    chart.setCandles(makeCandles(500));
+    const scale = (chart as unknown as { _timeScale: TimeScale })._timeScale;
+    // Pin bar spacing at the interactive max (50px): span = dataWidth / 50.
+    const span = scale.width / 50;
+    chart.setVisibleLogicalRange(100, 100 + span);
+    await sleep(500);
+    expect(scale.barSpacing).toBeCloseTo(50, 6);
+
+    const events: unknown[] = [];
+    chart.on("visibleRangeChange", (d) => events.push(d));
+    chart.setVisibleLogicalRange(150, 150 + span); // pure pan at max spacing
+    await sleep(100); // mid-animation
+    const canvas = document.body.querySelector("canvas") as HTMLCanvasElement;
+    canvas.dispatchEvent(new KeyboardEvent("keydown", { key: "+" })); // absorbed at 50px
+    await sleep(500);
+
+    expect(chart.getVisibleLogicalRange()?.from).toBeCloseTo(150, 4); // completed
+    expect(events.length).toBe(1);
+  });
+
+  it("an absorbed wheel zoom during a pure-pan animation does not cancel it", async () => {
+    document.body.innerHTML = "";
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 300,
+    });
+    chart.setCandles(makeCandles(500));
+    const scale = (chart as unknown as { _timeScale: TimeScale })._timeScale;
+    const span = scale.width / 50;
+    chart.setVisibleLogicalRange(100, 100 + span);
+    await sleep(500);
+
+    const events: unknown[] = [];
+    chart.on("visibleRangeChange", (d) => events.push(d));
+    chart.setVisibleLogicalRange(150, 150 + span);
+    await sleep(100);
+    const canvas = document.body.querySelector("canvas") as HTMLCanvasElement;
+    // Zoom-in at the 50px cap: fully absorbed.
+    canvas.dispatchEvent(
+      new WheelEvent("wheel", { deltaY: -120, clientX: 400, clientY: 150, cancelable: true }),
+    );
+    await sleep(500);
+
+    expect(chart.getVisibleLogicalRange()?.from).toBeCloseTo(150, 4);
+    expect(events.length).toBe(1);
+  });
+
+  it("an absorbed wheel leaves no idling inertia to ambush the next animation", async () => {
+    // NOTE: happy-dom's rAF cadence does not reproduce the original ambush
+    // (found by real-browser verification: an absorbed wheel armed a
+    // silently idling zoom-inertia loop whose stale velocity cancelled the
+    // next programmatic animation once it moved the spacing off the cap).
+    // This test pins the end-to-end property — animation lands exactly
+    // despite a preceding absorbed wheel — as a guard; the authoritative
+    // regression check for the timing-dependent path is the real-browser
+    // scenario suite used at verification time.
+    document.body.innerHTML = "";
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 300,
+    });
+    chart.setCandles(makeCandles(500));
+    const scale = (chart as unknown as { _timeScale: TimeScale })._timeScale;
+    const span = scale.width / 50;
+    chart.setVisibleLogicalRange(100, 100 + span); // pin spacing at the 50px cap
+    await sleep(500);
+
+    const canvas = document.body.querySelector("canvas") as HTMLCanvasElement;
+    // Absorbed at the cap — but it used to ARM zoom inertia with residual
+    // velocity that idled silently (~650ms of no-op frames)...
+    canvas.dispatchEvent(
+      new WheelEvent("wheel", { deltaY: -120, clientX: 400, clientY: 150, cancelable: true }),
+    );
+    await sleep(50);
+    // ...until this animation moved the spacing off the cap, at which point
+    // the stale velocity sprang back to life and cancelled it mid-flight.
+    chart.setVisibleLogicalRange(300, 400);
+    await sleep(600);
+    expect(chart.getVisibleLogicalRange()?.from).toBeCloseTo(300, 3);
+    expect(
+      (chart.getVisibleLogicalRange()?.to ?? 0) - (chart.getVisibleLogicalRange()?.from ?? 0),
+    ).toBeCloseTo(100, 3);
+  });
+
+  it("a wheel-session timer does not corrupt a concurrent drag's settle", async () => {
+    const { scale, canvas } = chartWith([215, 310]);
+    // Wheel pan mutates and arms the 150ms session timer...
+    canvas.dispatchEvent(
+      new WheelEvent("wheel", { deltaX: 40, deltaY: 0, clientX: 400, clientY: 150 }),
+    );
+    // ...then a mouse drag starts and moves before the timer fires.
+    canvas.dispatchEvent(new MouseEvent("mousedown", { clientX: 400, clientY: 150 }));
+    canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 460, clientY: 150 }));
+    await sleep(250); // wheel timer fires mid-drag
+    canvas.dispatchEvent(new MouseEvent("mouseup", { clientX: 460, clientY: 150 }));
+
+    // The drag's settle must still run: with a shared flag the wheel timer
+    // reset it and the in-bounds grant survived incorrectly.
+    expect(scale.hasViewportGrant).toBe(false);
+  });
+
+  it("a mid-session direction flip keeps the pre-flip pan's ratification", async () => {
+    // A pan → zoom flip inside the 150ms window is the SAME compound
+    // gesture. Treating the flip as a new session reset viewportMutated,
+    // so a flip into a fully-absorbed zoom ended the session without
+    // ratifying the pan — leaving a stale grant whose consumed margin
+    // could be re-entered without resistance.
+    document.body.innerHTML = "";
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 0,
+    });
+    chart.setCandles(makeCandles(300));
+    const scale = (chart as unknown as { _timeScale: TimeScale })._timeScale;
+    const span = scale.width / 50; // pin spacing at the 50px interactive cap
+    chart.setVisibleLogicalRange(-50, -50 + span); // beyond-left grant
+    expect(scale.hasViewportGrant).toBe(true);
+
+    const canvas = document.body.querySelector("canvas") as HTMLCanvasElement;
+    // Two horizontal pan notches consume left margin; the ~10ms gap makes
+    // the second sample land in the velocity window, building a real
+    // panVelocity for the stale-flick half of the regression.
+    canvas.dispatchEvent(
+      new WheelEvent("wheel", { deltaX: 100, deltaY: 0, clientX: 400, clientY: 150 }),
+    );
+    await sleep(10);
+    canvas.dispatchEvent(
+      new WheelEvent("wheel", { deltaX: 100, deltaY: 0, clientX: 400, clientY: 150 }),
+    );
+    const panned = scale.rawStartIndex;
+    expect(panned).toBeGreaterThan(-50);
+
+    // Flip to a zoom-in within the window — fully absorbed at the cap.
+    canvas.dispatchEvent(
+      new WheelEvent("wheel", { deltaY: -120, clientX: 400, clientY: 150, cancelable: true }),
+    );
+    await sleep(400); // session timer fires; any inertia would settle here
+
+    // The flipped axis must not inherit the pan's velocity: without the
+    // flip-time reset the timer hands it to pan inertia as a "flick".
+    expect(scale.rawStartIndex).toBeCloseTo(panned, 6);
+    // The pan that preceded the flip WAS ratified: the consumed margin is
+    // gone, so scrolling hard left stops at the panned position, not -50.
+    expect(scale.hasViewportGrant).toBe(true);
+    scale.scrollTo(-1e9);
+    expect(scale.rawStartIndex).toBeCloseTo(panned, 6);
+  });
+
+  it("a real zoom followed by an absorbed-pan flip still ratifies the zoom's position", async () => {
+    // Symmetric to the pan→absorbed-zoom case: absorbed PAN events must not
+    // build panVelocity. Before the fix the timer's flick check ran
+    // unconditionally, so a phantom flick started pan inertia whose
+    // absorbed no-op run terminated without ratifying — losing the
+    // ratification the real zoom movement was owed and leaving the stale
+    // pre-zoom grant re-enterable.
+    //
+    // Absorbed pans are synthesized via float resolution: at a granted
+    // position of 1e16 the ulp is 2, so a sub-1-bar delta rounds away to
+    // nothing while its deltaX still feeds the velocity sampler.
+    document.body.innerHTML = "";
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 0,
+    });
+    chart.setCandles(makeCandles(300));
+    const scale = (chart as unknown as { _timeScale: TimeScale })._timeScale;
+    const start = 1e16;
+    chart.setVisibleLogicalRange(start, start + scale.width / 40); // spacing 40
+    expect(scale.hasViewportGrant).toBe(true);
+
+    const canvas = document.body.querySelector("canvas") as HTMLCanvasElement;
+    // Ten real zoom-outs (synchronous — no inertia frame runs in between):
+    // spacing 40 → ~13.9, and the center anchor walks startIndex measurably
+    // below the granted 1e16.
+    for (let i = 0; i < 10; i++) {
+      canvas.dispatchEvent(
+        new WheelEvent("wheel", { deltaY: 120, clientX: 400, clientY: 150, cancelable: true }),
+      );
+    }
+    const zoomed = scale.rawStartIndex;
+    expect(zoomed).toBeLessThanOrEqual(start - 2); // the zoom really moved
+
+    // Flip to pan within the session; deltaX 12 < spacing (~13.9) is under
+    // the 2-ulp resolution at ~1e16 — fully absorbed, but it used to sample
+    // panVelocity from deltaX anyway.
+    canvas.dispatchEvent(
+      new WheelEvent("wheel", { deltaX: 12, deltaY: 0, clientX: 400, clientY: 150 }),
+    );
+    await sleep(10);
+    canvas.dispatchEvent(
+      new WheelEvent("wheel", { deltaX: 12, deltaY: 0, clientX: 400, clientY: 150 }),
+    );
+    expect(scale.rawStartIndex).toBe(zoomed); // premise: pans were absorbed
+
+    await sleep(400); // session timer + (formerly) the phantom inertia run
+
+    // The zoomed position was ratified: the envelope's right edge is now
+    // the zoomed resting position, not the stale pre-zoom grant at 1e16.
+    scale.scrollTo(1e18);
+    expect(scale.rawStartIndex).toBe(zoomed);
+  });
+
+  it("an animation after absorbed pans completes (no phantom pan flick)", async () => {
+    document.body.innerHTML = "";
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 300,
+    });
+    chart.setCandles(makeCandles(500));
+    const scale = (chart as unknown as { _timeScale: TimeScale })._timeScale;
+    const start = 1e16;
+    chart.setVisibleLogicalRange(start, start + scale.width / 50); // spacing 50
+    await sleep(500); // let the initial range animation settle
+    const canvas = document.body.querySelector("canvas") as HTMLCanvasElement;
+
+    // Three absorbed pans (deltaX 48 < 50 px = 0.96 bars, under the 2-ulp
+    // resolution at 1e16). They move nothing, but before the fix they blended
+    // a large panVelocity, and the timer (whose settle side effects were not
+    // yet gated on viewportMutated) handed it to pan inertia as a flick —
+    // cancelling the animation below the moment the inertia frame landed on
+    // movable coordinates.
+    for (let i = 0; i < 3; i++) {
+      canvas.dispatchEvent(
+        new WheelEvent("wheel", { deltaX: 48, deltaY: 0, clientX: 400, clientY: 150 }),
+      );
+      await sleep(10);
+    }
+    expect(scale.rawStartIndex).toBe(start); // premise: all absorbed
+
+    chart.setVisibleLogicalRange(300, 400);
+    await sleep(600);
+    const r = chart.getVisibleLogicalRange();
+    expect(r?.from).toBeCloseTo(300, 3);
+    expect((r?.to ?? 0) - (r?.from ?? 0)).toBeCloseTo(100, 3);
+  });
+
+  it("an animation after a pan→absorbed-zoom flip completes (no stale-velocity cancel)", async () => {
+    document.body.innerHTML = "";
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 300,
+    });
+    chart.setCandles(makeCandles(500));
+    const scale = (chart as unknown as { _timeScale: TimeScale })._timeScale;
+    const span = scale.width / 50;
+    chart.setVisibleLogicalRange(100, 100 + span); // pin spacing at the cap
+    await sleep(500);
+
+    const canvas = document.body.querySelector("canvas") as HTMLCanvasElement;
+    canvas.dispatchEvent(
+      new WheelEvent("wheel", { deltaX: 100, deltaY: 0, clientX: 400, clientY: 150 }),
+    );
+    await sleep(10);
+    canvas.dispatchEvent(
+      new WheelEvent("wheel", { deltaX: 100, deltaY: 0, clientX: 400, clientY: 150 }),
+    );
+    // Flip to an absorbed zoom-in. The flip must drop the pan velocity, or
+    // the session timer (firing ~100ms into the animation below) hands the
+    // stale horizontal velocity to pan inertia as a flick that mutates the
+    // viewport and cancels the animation mid-flight.
+    canvas.dispatchEvent(
+      new WheelEvent("wheel", { deltaY: -120, clientX: 400, clientY: 150, cancelable: true }),
+    );
+    await sleep(50);
+    chart.setVisibleLogicalRange(300, 400);
+    await sleep(600);
+    const r = chart.getVisibleLogicalRange();
+    expect(r?.from).toBeCloseTo(300, 3);
+    expect((r?.to ?? 0) - (r?.from ?? 0)).toBeCloseTo(100, 3);
+  });
+
+  it("an absorbed arrow at the boundary keeps an in-bounds grant", () => {
+    document.body.innerHTML = "";
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 0,
+    });
+    chart.setCandles(makeCandles(300));
+    const scale = (chart as unknown as { _timeScale: TimeScale })._timeScale;
+    // Find the ordinary boundary, then grant exactly there with the same
+    // spacing (same span → normalMaxStart unchanged).
+    scale.scrollTo(1e9);
+    const edge = scale.rawStartIndex;
+    const span = scale.width / scale.barSpacing;
+    chart.setVisibleLogicalRange(edge, edge + span);
+    expect(scale.hasViewportGrant).toBe(true);
+
+    const canvas = document.body.querySelector("canvas") as HTMLCanvasElement;
+    canvas.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" })); // absorbed
+    expect(scale.rawStartIndex).toBeCloseTo(edge, 9);
+    expect(scale.hasViewportGrant).toBe(true); // not dissolved by a no-op key
+  });
+
+  it("End releases a grant even when the position is already pinned", () => {
+    document.body.innerHTML = "";
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 0,
+    });
+    chart.setCandles(makeCandles(300));
+    const scale = (chart as unknown as { _timeScale: TimeScale })._timeScale;
+    const pinned = scale.rawStartIndex; // setCandles lands at scrollToEnd
+    const span = scale.width / scale.barSpacing;
+    chart.setVisibleLogicalRange(pinned, pinned + span); // grant at the pinned spot
+    expect(scale.hasViewportGrant).toBe(true);
+
+    const canvas = document.body.querySelector("canvas") as HTMLCanvasElement;
+    canvas.dispatchEvent(new KeyboardEvent("keydown", { key: "End" }));
+    expect(scale.rawStartIndex).toBeCloseTo(pinned, 9); // position identical
+    expect(scale.hasViewportGrant).toBe(false); // grant release counted as the change
+  });
+});
+
+describe("gesture-end coverage: mouseleave and touchcancel", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  function grantChart() {
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 0,
+    });
+    chart.setCandles(makeCandles(500));
+    chart.setVisibleLogicalRange(450, 550); // granted margin past the pad
+    const scale = (chart as unknown as { _timeScale: TimeScale })._timeScale;
+    const canvas = document.body.querySelector("canvas");
+    if (!canvas) throw new Error("no canvas");
+    return { chart, scale, canvas };
+  }
+
+  it("releasing a drag outside the canvas (mouseleave) still settles the gesture", () => {
+    const { scale, canvas } = grantChart();
+    // Drag left, consuming part of the margin, then leave the canvas with
+    // the button down — mouseup never arrives.
+    canvas.dispatchEvent(new MouseEvent("mousedown", { clientX: 400, clientY: 150 }));
+    canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 480, clientY: 150 }));
+    const midDrag = scale.rawStartIndex;
+    expect(midDrag).toBeLessThan(450); // moved toward the data
+    canvas.dispatchEvent(new MouseEvent("mouseleave", { clientX: 900, clientY: 150 }));
+
+    // The gesture settled: the envelope shrank to the resting position, so
+    // the consumed margin is not re-enterable without a new API grant.
+    scale.scrollTo(450);
+    expect(scale.rawStartIndex).toBeCloseTo(midDrag, 6);
+  });
+
+  it("touchcancel runs the same settle path as touchend", () => {
+    const { scale, canvas } = grantChart();
+    // Enter a drag state (viewState is shared across handlers), then have
+    // the browser cancel the gesture instead of ending it.
+    canvas.dispatchEvent(new MouseEvent("mousedown", { clientX: 400, clientY: 150 }));
+    canvas.dispatchEvent(new MouseEvent("mousemove", { clientX: 480, clientY: 150 }));
+    const midDrag = scale.rawStartIndex;
+    canvas.dispatchEvent(new Event("touchcancel"));
+
+    scale.scrollTo(450);
+    expect(scale.rawStartIndex).toBeCloseTo(midDrag, 6);
+  });
+});
+
+describe("chart-level envelope integration (D2/D3)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("D2: a container resize does not auto-refit away a wide logical range", () => {
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 0,
+    });
+    chart.setCandles(makeCandles(300));
+    chart.setVisibleLogicalRange(-20, 380); // wide: visibleCount >= total
+    chart.resize(900, 400);
+    expect(chart.getVisibleLogicalRange()?.from).toBeCloseTo(-20, 6);
+  });
+
+  it("D3: a rightOffset update leaves an active logical-range viewport alone", () => {
+    const chart = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 0,
+      timeScale: { rightOffset: 5 },
+    });
+    chart.setCandles(makeCandles(300));
+    chart.setVisibleLogicalRange(250, 330);
+
+    chart.applyOptions({ timeScale: { rightOffset: 8 } });
+    expect(chart.getVisibleLogicalRange()?.from).toBe(250); // not repositioned
+
+    // The stored option DID update: after an explicit navigation releases
+    // the grant, streaming at the live edge maintains the NEW margin.
+    const candles = makeCandles(300);
+    chart.setVisibleRange(candles[200].time, candles[299].time); // releases grant
+    const flush = createChart(makeContainer(), {
+      width: 800,
+      height: 400,
+      animationDuration: 0,
+      timeScale: { rightOffset: 8 },
+    });
+    flush.setCandles(candles);
+    const before = chart.getVisibleLogicalRange();
+    const beforeFlush = flush.getVisibleLogicalRange();
+    const next = { ...candles[299], time: candles[299].time + 60_000 };
+    chart.updateCandle(next);
+    flush.updateCandle(next);
+    // Both advance by exactly one bar — the updated offset is in effect
+    // (a follow with the old offset would differ from the reference chart).
+    expect((chart.getVisibleLogicalRange()?.from ?? 0) - (before?.from ?? 0)).toBeCloseTo(1, 6);
+    expect((flush.getVisibleLogicalRange()?.from ?? 0) - (beforeFlush?.from ?? 0)).toBeCloseTo(
+      1,
+      6,
+    );
+  });
+});
+
 // ---- P1: only viewport gestures cancel a running range animation ----
 // Hover / pane-resize / drawing previews go through the plain onUpdate
 // channel (the hover test covers the whole channel); pan / wheel / pinch /

--- a/packages/chart/src/__tests__/viewport-invariants.fuzz.test.ts
+++ b/packages/chart/src/__tests__/viewport-invariants.fuzz.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Randomized viewport invariant fuzz — fixed seeds, CI-resident.
+ *
+ * Drives TimeScale through long random sequences of every mutating
+ * operation and asserts structural invariants after each. Complements the
+ * example-based tests: any state the operations can reach must be finite,
+ * renderable, and recoverable, and the clamp envelope must always contain
+ * the resting position after a settle.
+ *
+ * On failure the seed and a trailing window of the op log are printed —
+ * paste the seed into `SEEDS` to reproduce deterministically.
+ */
+
+import { describe, expect, it } from "vitest";
+import { TimeScale } from "../core/scale";
+
+const SEEDS = [0x9e3779b9, 0x85ebca6b, 0xc2b2ae35];
+const OPS_PER_SEED = 4000;
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a += 0x6d2b79f5;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+type Op = { name: string; run: (ts: TimeScale, rnd: () => number) => void };
+
+const OPS: Op[] = [
+  { name: "setWidth", run: (ts, r) => ts.setWidth([0, 1, 333.7, 800, 1600][(r() * 5) | 0]) },
+  {
+    name: "setTotalCount",
+    run: (ts, r) => ts.setTotalCount([0, 1, 50, 300, 5000][(r() * 5) | 0]),
+  },
+  {
+    name: "gaps",
+    run: (ts, r) => {
+      const n = ts.totalCount;
+      if (n < 3) return;
+      ts.setGapsBefore([
+        { index: (r() * n) | 0, size: r() * 25 },
+        { index: (r() * n) | 0, size: r() * 2 },
+      ]);
+    },
+  },
+  { name: "clearGaps", run: (ts) => ts.clearGaps() },
+  { name: "scrollBy", run: (ts, r) => ts.scrollBy((r() - 0.5) * 200) },
+  { name: "scrollTo", run: (ts, r) => ts.scrollTo((r() - 0.3) * ts.totalCount * 1.5) },
+  { name: "scrollByUnclamped", run: (ts, r) => ts.scrollByUnclamped((r() - 0.5) * 100) },
+  { name: "zoom", run: (ts, r) => ts.zoom(0.1 + r() * 4, r() * 1000 - 100) },
+  { name: "zoomNaN", run: (ts) => ts.zoom(Number.NaN, Number.NaN) },
+  { name: "scrollToEnd", run: (ts) => ts.scrollToEnd() },
+  { name: "fitContent", run: (ts) => ts.fitContent() },
+  {
+    name: "rightOffset",
+    run: (ts, r) => ts.setRightOffset([0, 2.5, 30, 1e5, Number.NaN, -5][(r() * 6) | 0]),
+  },
+  {
+    name: "setVisibleRange",
+    run: (ts, r) => {
+      const a = (r() - 0.2) * ts.totalCount;
+      ts.setVisibleRange(a, a + r() * ts.totalCount);
+    },
+  },
+  {
+    name: "setVisibleLogicalRange",
+    run: (ts, r) => {
+      const from = (r() - 0.5) * ts.totalCount * 2;
+      ts.setVisibleLogicalRange(from, from + r() * r() * 3000 + 0.01);
+    },
+  },
+  {
+    name: "followAfterAppend",
+    run: (ts) => {
+      const dist = ts.endDistanceVirtual;
+      ts.setTotalCount(ts.totalCount + 1);
+      ts.followLiveEdge(dist);
+    },
+  },
+  { name: "ratify", run: (ts) => ts.ratifySettledPosition() },
+  {
+    name: "setImmediate",
+    run: (ts, r) => ts.setImmediate((r() - 0.5) * ts.totalCount * 2, 0.05 + r() * 900),
+  },
+];
+
+function checkInvariants(ts: TimeScale, log: string[], seed: number): void {
+  const fail = (what: string): never => {
+    throw new Error(
+      `invariant violated: ${what} (seed=0x${seed.toString(16)})\nlast ops: ${log.slice(-12).join(" → ")}\nstate: start=${ts.rawStartIndex} spacing=${ts.barSpacing} visible=${ts.visibleCount} total=${ts.totalCount} width=${ts.width}`,
+    );
+  };
+  if (!Number.isFinite(ts.rawStartIndex)) fail("rawStartIndex not finite");
+  if (!Number.isFinite(ts.barSpacing) || ts.barSpacing < 0.05) fail("barSpacing bad");
+  if (!Number.isInteger(ts.visibleCount) || ts.visibleCount < 0) fail("visibleCount bad");
+  if (!Number.isFinite(ts.endIndex) || ts.endIndex > ts.totalCount) fail("endIndex bad");
+  const lr = ts.getVisibleLogicalRange();
+  if (ts.width > 0 && !(Number.isFinite(lr.from) && Number.isFinite(lr.to) && lr.to > lr.from)) {
+    fail("logical range bad");
+  }
+  if (!Number.isFinite(ts.indexToX(0)) || !Number.isFinite(ts.xToIndex(0))) {
+    fail("coordinate transform not finite");
+  }
+}
+
+describe("viewport invariant fuzz (fixed seeds)", () => {
+  for (const seed of SEEDS) {
+    it(`seed 0x${seed.toString(16)}: ${OPS_PER_SEED} ops hold all invariants`, () => {
+      const rnd = mulberry32(seed);
+      const ts = new TimeScale();
+      ts.setWidth(800);
+      ts.setTotalCount(300);
+      const log: string[] = [];
+
+      for (let i = 0; i < OPS_PER_SEED; i++) {
+        const op = OPS[(rnd() * OPS.length) | 0];
+        log.push(op.name);
+        op.run(ts, rnd);
+        checkInvariants(ts, log, seed);
+      }
+
+      // Envelope invariants at settle: after ratify the resting position is
+      // inside the envelope, and clamped ops can no longer move away from it
+      // unexpectedly (recoverability).
+      ts.ratifySettledPosition();
+      const rest = ts.rawStartIndex;
+      ts.scrollBy(0); // clamp round-trip
+      expect(ts.rawStartIndex).toBeCloseTo(rest, 9);
+
+      // Recoverability: explicit navigation always lands in ordinary bounds
+      // and releases any grant.
+      ts.scrollToEnd();
+      expect(ts.hasViewportGrant).toBe(false);
+      expect(Number.isFinite(ts.rawStartIndex)).toBe(true);
+      ts.scrollBy(1);
+      ts.scrollBy(-1);
+      expect(Number.isFinite(ts.rawStartIndex)).toBe(true);
+    });
+  }
+});

--- a/packages/chart/src/core/animation.ts
+++ b/packages/chart/src/core/animation.ts
@@ -89,10 +89,13 @@ export class ViewTransition {
     const progress = Math.min(1, elapsed / this._duration);
     const eased = easeOutCubic(progress);
 
-    // Interpolate center and count, then derive startIndex and barSpacing
+    // Interpolate center and count, then derive startIndex and barSpacing.
+    // Floor the derived SPACING (render floor 0.1px), never the count: a
+    // sub-1-bar target span (spacing > width) must land on its exact value,
+    // and count only shrinks below 1 when that is precisely the intent.
     const center = lerp(this._fromCenter, this._toCenter, eased);
     const count = lerp(this._fromCount, this._toCount, eased);
-    const barSpacing = this._width / Math.max(1, count);
+    const barSpacing = Math.max(0.1, this._width / count);
     const startIndex = center - count / 2;
 
     this._onFrame?.(startIndex, barSpacing);

--- a/packages/chart/src/core/interaction/inertia.ts
+++ b/packages/chart/src/core/interaction/inertia.ts
@@ -22,6 +22,13 @@ import type { TimeScale } from "../scale";
 import type { PanInertiaState, ZoomInertiaState } from "./types";
 
 export class InertiaController {
+  /** True once the current pan/zoom inertia RUN actually moved the scale.
+   *  Unchanged (absorbed) frames neither notify the mutation channel nor,
+   *  at termination, ratify — an inertia run fully absorbed by the zoom
+   *  cap or clamp envelope is a no-op gesture. */
+  private panMoved = false;
+  private zoomMoved = false;
+
   constructor(
     private readonly timeScale: TimeScale,
     private readonly pan: PanInertiaState,
@@ -32,6 +39,7 @@ export class InertiaController {
   /** Begin pan inertia / bounce-back. Caller sets `pan.velocity` first. */
   startPan(): void {
     this.cancelPanFrame();
+    this.panMoved = false;
     this.pan.raf = requestAnimationFrame(this.runPan);
   }
 
@@ -48,6 +56,7 @@ export class InertiaController {
    */
   startZoom(): void {
     this.cancelZoomFrame();
+    this.zoomMoved = false;
     this.zoom.raf = requestAnimationFrame(this.runZoom);
   }
 
@@ -84,16 +93,19 @@ export class InertiaController {
     const over = ts.overscroll;
 
     if (Math.abs(over) > 0.1) {
-      // Bounce-back: spring toward clamped position
+      // Bounce-back: spring toward clamped position (always a real move —
+      // the overscroll guard guarantees a nonzero spring)
       const target = ts.clampedStartIndex;
       const raw = ts.rawStartIndex;
       const springForce = (target - raw) * 0.2;
       ts.setStartIndexUnclamped(raw + springForce);
       this.pan.velocity = 0;
+      this.panMoved = true;
 
       if (Math.abs(ts.overscroll) < 0.5) {
         ts.setStartIndexUnclamped(ts.clampedStartIndex);
         this.pan.raf = null;
+        ts.ratifySettledPosition(); // bounce settled — envelope tracks the rest
         this.onUpdate();
         return;
       }
@@ -104,25 +116,52 @@ export class InertiaController {
 
     if (Math.abs(this.pan.velocity) < 0.5) {
       this.pan.raf = null;
+      // Only a run that actually moved settles the envelope.
+      if (this.panMoved) ts.ratifySettledPosition();
       return;
     }
+    const before = ts.rawStartIndex;
     const deltaBars = -this.pan.velocity / ts.barSpacing;
     ts.scrollByUnclamped(deltaBars);
     this.pan.velocity *= 0.92;
-    this.onUpdate();
-    this.pan.raf = requestAnimationFrame(this.runPan);
+    if (ts.rawStartIndex !== before) {
+      this.panMoved = true;
+      this.onUpdate();
+      this.pan.raf = requestAnimationFrame(this.runPan);
+      return;
+    }
+    // Fully absorbed frame: TERMINATE instead of decaying silently. A loop
+    // idling with residual velocity is a trap — the moment anything moves
+    // the scale off the absorbing limit (e.g. a programmatic animation
+    // starts), the stale velocity would spring back to life and cancel it.
+    this.pan.raf = null;
+    if (this.panMoved) ts.ratifySettledPosition();
   };
 
   private runZoom = (): void => {
     if (Math.abs(this.zoom.velocity) < 0.0005) {
       this.zoom.raf = null;
       this.zoom.anchorX = null;
+      // Only a run that actually zoomed settles the envelope: a run fully
+      // absorbed at the zoom cap is a no-op gesture.
+      if (this.zoomMoved) this.timeScale.ratifySettledPosition();
       return;
     }
+    const before = this.timeScale.barSpacing;
     const factor = 1 - this.zoom.velocity;
     this.timeScale.zoom(factor, this.zoom.anchorX ?? undefined);
     this.zoom.velocity *= 0.9;
-    this.onUpdate();
-    this.zoom.raf = requestAnimationFrame(this.runZoom);
+    if (this.timeScale.barSpacing !== before) {
+      this.zoomMoved = true;
+      this.onUpdate();
+      this.zoom.raf = requestAnimationFrame(this.runZoom);
+      return;
+    }
+    // Fully absorbed frame (zoom cap): terminate — see runPan for why a
+    // silently idling loop with residual velocity is dangerous.
+    this.zoom.raf = null;
+    this.zoom.anchorX = null;
+    this.zoom.velocity = 0;
+    if (this.zoomMoved) this.timeScale.ratifySettledPosition();
   };
 }

--- a/packages/chart/src/core/interaction/keyboard-handler.ts
+++ b/packages/chart/src/core/interaction/keyboard-handler.ts
@@ -78,7 +78,7 @@ export function attachKeyboardHandlers(
         return; // Don't prevent default for unhandled keys
     }
     e.preventDefault();
-    ctx.onUpdate();
+    ctx.onViewportMutation();
   };
 
   el.addEventListener("keydown", onKeyDown);

--- a/packages/chart/src/core/interaction/keyboard-handler.ts
+++ b/packages/chart/src/core/interaction/keyboard-handler.ts
@@ -51,6 +51,9 @@ export function attachKeyboardHandlers(
       return;
     }
 
+    const beforeStart = timeScale.rawStartIndex;
+    const beforeSpacing = timeScale.barSpacing;
+    const beforeGrant = timeScale.hasViewportGrant;
     switch (e.key) {
       case "ArrowLeft":
         timeScale.scrollBy(e.shiftKey ? -10 : -1);
@@ -78,7 +81,23 @@ export function attachKeyboardHandlers(
         return; // Don't prevent default for unhandled keys
     }
     e.preventDefault();
-    ctx.onViewportMutation();
+    // Each key press is a discrete gesture; ratify AND notify as a viewport
+    // mutation only when it actually changed something. Position and
+    // spacing cover arrows / zoom keys; the grant flag covers Home/End/fit
+    // releasing a grant while the visible position happens to be identical
+    // — that release is a real mutation. An arrow absorbed at a clamp edge
+    // or +/- at the zoom limit changes nothing: it must neither dissolve
+    // an in-bounds grant nor cancel a running range animation.
+    const changed =
+      timeScale.rawStartIndex !== beforeStart ||
+      timeScale.barSpacing !== beforeSpacing ||
+      timeScale.hasViewportGrant !== beforeGrant;
+    if (changed) {
+      timeScale.ratifySettledPosition();
+      ctx.onViewportMutation();
+    } else {
+      ctx.onUpdate();
+    }
   };
 
   el.addEventListener("keydown", onKeyDown);

--- a/packages/chart/src/core/interaction/mouse-handler.ts
+++ b/packages/chart/src/core/interaction/mouse-handler.ts
@@ -33,13 +33,16 @@ export function attachMouseHandlers(
     const sb = scrollbar();
     if (sb && my >= sb.y && my <= sb.y + sb.height) {
       ctx.beginScrollbarDrag(mx, sb);
-      ctx.onUpdate();
+      ctx.onViewportMutation();
       return;
     }
 
     ctx.viewState.isDragging = true;
     ctx.drag.startX = e.clientX;
-    ctx.drag.startIndex = timeScale.startIndex;
+    // Raw (fractional) start: the floored getter would snap the viewport by
+    // the fractional part on the first pixel of drag — a resting fractional
+    // position is the norm after setVisibleLogicalRange.
+    ctx.drag.startIndex = timeScale.rawStartIndex;
   };
 
   const onMouseMove = (e: MouseEvent) => {
@@ -63,7 +66,7 @@ export function attachMouseHandlers(
     if (ctx.drag.scrollbarDragging) {
       const sb = scrollbar();
       if (sb) ctx.applyScrollbarDrag(ctx.viewState.mouseX, sb);
-      ctx.onUpdate();
+      ctx.onViewportMutation();
       return;
     }
 
@@ -84,8 +87,11 @@ export function attachMouseHandlers(
       const rawStart = ctx.drag.startIndex + deltaBars;
       timeScale.setStartIndexUnclamped(rawStart);
       rubberBandDampen(timeScale);
+      ctx.onViewportMutation();
+      return;
     }
 
+    // Plain hover (crosshair only) — must not cancel a running range animation
     ctx.onUpdate();
   };
 

--- a/packages/chart/src/core/interaction/mouse-handler.ts
+++ b/packages/chart/src/core/interaction/mouse-handler.ts
@@ -32,12 +32,22 @@ export function attachMouseHandlers(
 
     const sb = scrollbar();
     if (sb && my >= sb.y && my <= sb.y + sb.height) {
+      // A track press jumps the viewport; a thumb grab does not. Track the
+      // actual change so releasing an untouched thumb doesn't ratify.
+      ctx.drag.viewportMutated = false;
+      const before = timeScale.rawStartIndex;
       ctx.beginScrollbarDrag(mx, sb);
-      ctx.onViewportMutation();
+      if (timeScale.rawStartIndex !== before) {
+        ctx.drag.viewportMutated = true;
+        ctx.onViewportMutation(); // track press jumped the viewport
+      } else {
+        ctx.onUpdate(); // thumb grab: nothing moved yet
+      }
       return;
     }
 
     ctx.viewState.isDragging = true;
+    ctx.drag.viewportMutated = false; // becomes true only if the drag moves
     ctx.drag.startX = e.clientX;
     // Raw (fractional) start: the floored getter would snap the viewport by
     // the fractional part on the first pixel of drag — a resting fractional
@@ -65,8 +75,14 @@ export function attachMouseHandlers(
 
     if (ctx.drag.scrollbarDragging) {
       const sb = scrollbar();
+      const before = timeScale.rawStartIndex;
       if (sb) ctx.applyScrollbarDrag(ctx.viewState.mouseX, sb);
-      ctx.onViewportMutation();
+      if (timeScale.rawStartIndex !== before) {
+        ctx.drag.viewportMutated = true;
+        ctx.onViewportMutation();
+      } else {
+        ctx.onUpdate();
+      }
       return;
     }
 
@@ -82,12 +98,18 @@ export function attachMouseHandlers(
     ctx.viewState.crosshairIndex = timeScale.xToIndex(ctx.viewState.mouseX);
 
     if (ctx.viewState.isDragging) {
+      const before = timeScale.rawStartIndex;
       const dx = e.clientX - ctx.drag.startX;
       const deltaBars = -(dx / timeScale.barSpacing);
       const rawStart = ctx.drag.startIndex + deltaBars;
       timeScale.setStartIndexUnclamped(rawStart);
       rubberBandDampen(timeScale);
-      ctx.onViewportMutation();
+      if (timeScale.rawStartIndex !== before) {
+        ctx.drag.viewportMutated = true;
+        ctx.onViewportMutation();
+      } else {
+        ctx.onUpdate(); // zero-delta move event: repaint only
+      }
       return;
     }
 
@@ -95,25 +117,44 @@ export function attachMouseHandlers(
     ctx.onUpdate();
   };
 
-  const onMouseUp = () => {
-    // Bounce-back if overscrolled via mouse drag. The inertia loop handles
-    // both spring-back-from-overscroll and velocity-driven flick; here we
-    // explicitly zero velocity because mouse drag doesn't track flick speed.
-    if (ctx.viewState.isDragging && Math.abs(timeScale.overscroll) > 0.1) {
-      inertia.stopPan();
-      ctx.pan.velocity = 0;
-      inertia.startPan();
+  // Shared gesture-end: mouseup AND a mouseleave that interrupts a drag.
+  // Releasing the button outside the canvas never delivers mouseup here, so
+  // without this the drag's grant/overscroll would go unresolved — leaving
+  // a stale envelope (a consumed margin re-enterable without resistance)
+  // and, when overscrolled, no bounce-back.
+  const endDragGesture = () => {
+    // Only a gesture that actually MOVED the viewport settles the clamp
+    // envelope: a plain click (mousedown+up without movement) or an
+    // untouched scrollbar thumb must not dissolve an in-bounds grant.
+    if (ctx.drag.viewportMutated) {
+      // Bounce-back if overscrolled via mouse drag. The inertia loop
+      // handles both spring-back and velocity flick; velocity is zeroed
+      // because mouse drag doesn't track flick speed.
+      if (ctx.viewState.isDragging && Math.abs(timeScale.overscroll) > 0.1) {
+        inertia.stopPan();
+        ctx.pan.velocity = 0;
+        inertia.startPan();
+      } else {
+        // Gesture settles right here (no bounce/inertia will follow):
+        // ratify the resting position into the clamp envelope.
+        timeScale.ratifySettledPosition();
+      }
     }
+    ctx.drag.viewportMutated = false;
     ctx.viewState.isDragging = false;
     ctx.drag.scrollbarDragging = false;
     ctx.drag.scrollbarGrabOffsetFrac = null;
     ctx.paneResize.gap = null;
   };
 
+  const onMouseUp = () => {
+    endDragGesture();
+  };
+
   const onMouseLeave = () => {
-    ctx.viewState.isDragging = false;
-    ctx.drag.scrollbarDragging = false;
-    ctx.drag.scrollbarGrabOffsetFrac = null;
+    endDragGesture();
+    // Plain hover exit: clear the crosshair and repaint (never a
+    // viewport mutation — must not cancel a running range animation).
     ctx.viewState.crosshairIndex = null;
     ctx.viewState.activePaneId = null;
     ctx.onUpdate();

--- a/packages/chart/src/core/interaction/touch-handler.ts
+++ b/packages/chart/src/core/interaction/touch-handler.ts
@@ -26,7 +26,7 @@ export function attachTouchHandlers(
       const sb = scrollbar();
       if (sb && touchLocalY >= sb.y && touchLocalY <= sb.y + sb.height) {
         ctx.beginScrollbarDrag(touchLocalX, sb);
-        ctx.onUpdate();
+        ctx.onViewportMutation();
         return;
       }
 
@@ -39,7 +39,7 @@ export function attachTouchHandlers(
       // Double-tap detection
       if (!drawingActive && now - ctx.touch.lastTapTime < 300) {
         timeScale.fitContent();
-        ctx.onUpdate();
+        ctx.onViewportMutation();
         ctx.touch.lastTapTime = 0;
         return;
       }
@@ -60,7 +60,9 @@ export function attachTouchHandlers(
       ctx.pan.lastTouchMoveTime = now;
       ctx.pan.velocity = 0;
       ctx.drag.startX = ctx.pan.lastTouchX;
-      ctx.drag.startIndex = timeScale.startIndex;
+      // Raw (fractional) start — same reason as the mouse handler: the
+      // floored getter snaps a fractional resting position on first move.
+      ctx.drag.startIndex = timeScale.rawStartIndex;
     } else if (e.touches.length === 2) {
       // Switch from pan to pinch: cancel drag state
       if (ctx.touch.longPressTimer) {
@@ -89,7 +91,7 @@ export function attachTouchHandlers(
       const localX = sbTouch.clientX - rect.left;
       const sb = scrollbar();
       if (sb) ctx.applyScrollbarDrag(localX, sb);
-      ctx.onUpdate();
+      ctx.onViewportMutation();
       return;
     }
 
@@ -116,7 +118,7 @@ export function attachTouchHandlers(
       const rawStart = ctx.drag.startIndex + deltaBars;
       timeScale.setStartIndexUnclamped(rawStart);
       rubberBandDampen(timeScale);
-      ctx.onUpdate();
+      ctx.onViewportMutation();
     } else if (e.touches.length === 2) {
       const tdx = e.touches[0].clientX - e.touches[1].clientX;
       const tdy = e.touches[0].clientY - e.touches[1].clientY;
@@ -128,7 +130,7 @@ export function attachTouchHandlers(
         const midX = (e.touches[0].clientX + e.touches[1].clientX) / 2;
         const rect = el.getBoundingClientRect();
         timeScale.zoom(amplified, midX - rect.left);
-        ctx.onUpdate();
+        ctx.onViewportMutation();
       }
       ctx.touch.lastDist = dist;
     }

--- a/packages/chart/src/core/interaction/touch-handler.ts
+++ b/packages/chart/src/core/interaction/touch-handler.ts
@@ -25,8 +25,15 @@ export function attachTouchHandlers(
       const touchLocalY = touch.clientY - rect.top;
       const sb = scrollbar();
       if (sb && touchLocalY >= sb.y && touchLocalY <= sb.y + sb.height) {
+        ctx.drag.viewportMutated = false;
+        const before = timeScale.rawStartIndex;
         ctx.beginScrollbarDrag(touchLocalX, sb);
-        ctx.onViewportMutation();
+        if (timeScale.rawStartIndex !== before) {
+          ctx.drag.viewportMutated = true;
+          ctx.onViewportMutation();
+        } else {
+          ctx.onUpdate();
+        }
         return;
       }
 
@@ -56,6 +63,7 @@ export function attachTouchHandlers(
       }
 
       ctx.viewState.isDragging = true;
+      ctx.drag.viewportMutated = false; // becomes true only if the pan moves
       ctx.pan.lastTouchX = touch.clientX;
       ctx.pan.lastTouchMoveTime = now;
       ctx.pan.velocity = 0;
@@ -90,8 +98,14 @@ export function attachTouchHandlers(
       const rect = el.getBoundingClientRect();
       const localX = sbTouch.clientX - rect.left;
       const sb = scrollbar();
+      const before = timeScale.rawStartIndex;
       if (sb) ctx.applyScrollbarDrag(localX, sb);
-      ctx.onViewportMutation();
+      if (timeScale.rawStartIndex !== before) {
+        ctx.drag.viewportMutated = true;
+        ctx.onViewportMutation();
+      } else {
+        ctx.onUpdate();
+      }
       return;
     }
 
@@ -113,12 +127,18 @@ export function attachTouchHandlers(
         return;
       }
 
+      const before = timeScale.rawStartIndex;
       const dx = currentX - ctx.drag.startX;
       const deltaBars = -(dx / timeScale.barSpacing);
       const rawStart = ctx.drag.startIndex + deltaBars;
       timeScale.setStartIndexUnclamped(rawStart);
       rubberBandDampen(timeScale);
-      ctx.onViewportMutation();
+      if (timeScale.rawStartIndex !== before) {
+        ctx.drag.viewportMutated = true;
+        ctx.onViewportMutation();
+      } else {
+        ctx.onUpdate();
+      }
     } else if (e.touches.length === 2) {
       const tdx = e.touches[0].clientX - e.touches[1].clientX;
       const tdy = e.touches[0].clientY - e.touches[1].clientY;
@@ -129,8 +149,14 @@ export function attachTouchHandlers(
         const amplified = 1 + (rawFactor - 1) * 2.5;
         const midX = (e.touches[0].clientX + e.touches[1].clientX) / 2;
         const rect = el.getBoundingClientRect();
+        const before = timeScale.barSpacing;
         timeScale.zoom(amplified, midX - rect.left);
-        ctx.onViewportMutation();
+        if (timeScale.barSpacing !== before) {
+          ctx.drag.viewportMutated = true;
+          ctx.onViewportMutation();
+        } else {
+          ctx.onUpdate(); // pinch absorbed at the zoom limit
+        }
       }
       ctx.touch.lastDist = dist;
     }
@@ -142,13 +168,21 @@ export function attachTouchHandlers(
       ctx.touch.longPressTimer = null;
     }
 
-    // Start inertia if swiped fast enough, or bounce-back if overscrolled
-    if (ctx.viewState.isDragging && !ctx.touch.longPressCrosshairLocked) {
-      if (Math.abs(ctx.pan.velocity) > 3 || Math.abs(timeScale.overscroll) > 0.1) {
-        inertia.startPan();
+    // Only a gesture that actually moved the viewport settles the clamp
+    // envelope — a tap or long-press crosshair must not dissolve a grant.
+    if (ctx.drag.viewportMutated) {
+      let settled = true;
+      if (ctx.viewState.isDragging && !ctx.touch.longPressCrosshairLocked) {
+        if (Math.abs(ctx.pan.velocity) > 3 || Math.abs(timeScale.overscroll) > 0.1) {
+          inertia.startPan();
+          settled = false; // the inertia loop ratifies when it terminates
+        }
+      }
+      if (settled) {
+        timeScale.ratifySettledPosition();
       }
     }
-
+    ctx.drag.viewportMutated = false;
     ctx.viewState.isDragging = false;
     ctx.touch.longPressCrosshairLocked = false;
     ctx.touch.lastDist = 0;
@@ -157,6 +191,10 @@ export function attachTouchHandlers(
   el.addEventListener("touchstart", onTouchStart, { passive: false });
   el.addEventListener("touchmove", onTouchMove, { passive: false });
   el.addEventListener("touchend", onTouchEnd);
+  // The browser can end a gesture with touchcancel (system gesture,
+  // element removal, palm rejection). Same settle path as touchend, or the
+  // drag's grant/overscroll would go unresolved.
+  el.addEventListener("touchcancel", onTouchEnd);
 
   return () => {
     if (ctx.touch.longPressTimer) {
@@ -166,5 +204,6 @@ export function attachTouchHandlers(
     el.removeEventListener("touchstart", onTouchStart);
     el.removeEventListener("touchmove", onTouchMove);
     el.removeEventListener("touchend", onTouchEnd);
+    el.removeEventListener("touchcancel", onTouchEnd);
   };
 }

--- a/packages/chart/src/core/interaction/types.ts
+++ b/packages/chart/src/core/interaction/types.ts
@@ -33,6 +33,14 @@ export type ViewportState = {
 export type DragState = {
   startX: number;
   startIndex: number;
+  /**
+   * True once the CURRENT gesture has actually changed the TimeScale
+   * (pan moved, pinch zoomed, scrollbar jumped/moved). Grant
+   * ratification and bounce run only for mutating gestures — a plain
+   * click, tap, or long-press must not dissolve an in-bounds viewport
+   * grant. Reset at gesture start and after gesture end.
+   */
+  viewportMutated: boolean;
   scrollbarDragging: boolean;
   /** See Viewport._scrollbarGrabOffsetFrac for semantics. */
   scrollbarGrabOffsetFrac: number | null;
@@ -64,9 +72,22 @@ export type ZoomInertiaState = {
 export type WheelGestureState = {
   /** "pan" | "zoom" | null — locks the active gesture for ~150ms */
   dir: "pan" | "zoom" | null;
+  /**
+   * Settle timer. Its null-ness is the SESSION boundary: a direction flip
+   * while the timer is pending belongs to the same compound gesture (so
+   * per-session state like viewportMutated survives the flip); the timer
+   * callback nulls it to mark the session's end.
+   */
   timer: ReturnType<typeof setTimeout> | null;
   panVelocity: number;
   lastPanTime: number;
+  /**
+   * True once THIS wheel session actually changed the TimeScale. Owned by
+   * the wheel session exclusively — pointer/touch gestures overlap wheel's
+   * 150ms expiry timer, so sharing DragState.viewportMutated would let the
+   * timer destroy a concurrent drag's state (and vice versa).
+   */
+  viewportMutated: boolean;
 };
 
 /** Touch-specific shared state (pinch baseline + double-tap + long-press). */

--- a/packages/chart/src/core/interaction/types.ts
+++ b/packages/chart/src/core/interaction/types.ts
@@ -96,7 +96,16 @@ export type InteractionContext = {
   hotkeyMap: HotkeyMap | undefined;
   hotkeyDisabled: boolean;
   dispatch?: (action: HotkeyAction) => void;
+  /** Something needs a repaint (crosshair, pane resize, drawing preview…). */
   onUpdate: () => void;
+  /**
+   * The USER moved the viewport (pan / zoom / scrollbar / viewport keys /
+   * inertia frames). Implies {@link onUpdate}. Kept separate so that a
+   * running programmatic range animation is cancelled only by actual
+   * viewport gestures — a mere hover must not kill it (and with it the
+   * exactly-once completion emit that viewport sync relies on).
+   */
+  onViewportMutation: () => void;
 
   // Mutable shared state (owned by Viewport; handed by reference)
   viewState: ViewportState;

--- a/packages/chart/src/core/interaction/wheel-handler.ts
+++ b/packages/chart/src/core/interaction/wheel-handler.ts
@@ -101,7 +101,7 @@ export function attachWheelHandlers(
         inertia.startZoom();
       }
     }
-    ctx.onUpdate();
+    ctx.onViewportMutation();
   };
 
   el.addEventListener("wheel", onWheel, { passive: false });

--- a/packages/chart/src/core/interaction/wheel-handler.ts
+++ b/packages/chart/src/core/interaction/wheel-handler.ts
@@ -28,41 +28,93 @@ export function attachWheelHandlers(
         ? "pan"
         : "zoom";
 
-    // Reset lock immediately if direction flipped
+    // A new wheel SESSION starts only when no settle timer is pending. A
+    // direction flip inside the 150ms window is the same compound gesture —
+    // resetting viewportMutated there would drop movement that preceded the
+    // flip and skip its ratification (leaving a stale grant behind when the
+    // flipped-to axis is fully absorbed by the zoom/scroll limits).
+    if (ctx.wheel.timer === null) {
+      ctx.wheel.viewportMutated = false;
+      ctx.wheel.panVelocity = 0;
+    }
+
+    // Reset the direction lock immediately if the dominant axis flipped —
+    // same session, new axis. The old axis's residual velocity must not
+    // cross the flip: a stale horizontal panVelocity would otherwise be
+    // handed to pan inertia as a "flick" when the timer fires after a
+    // pan→zoom reversal.
     if (ctx.wheel.dir !== null && ctx.wheel.dir !== eventDir) {
       ctx.wheel.dir = null;
       ctx.zoom.anchorX = null;
       inertia.stopZoom();
+      ctx.wheel.panVelocity = 0;
     }
 
-    if (ctx.wheel.dir === null) ctx.wheel.dir = eventDir;
+    if (ctx.wheel.dir === null) {
+      ctx.wheel.dir = eventDir;
+    }
 
     if (ctx.wheel.timer) clearTimeout(ctx.wheel.timer);
     ctx.wheel.timer = setTimeout(() => {
       ctx.wheel.dir = null;
-      // Hand residual wheel velocity to the pan-inertia loop. Falls back to
-      // bounce-back when overscrolled but not actively flicking.
-      const flick = wheelInertiaEnabled && Math.abs(ctx.wheel.panVelocity) > 3;
-      if (flick || Math.abs(timeScale.overscroll) > 0.1) {
-        inertia.stopPan();
-        ctx.pan.velocity = flick ? ctx.wheel.panVelocity : 0;
-        inertia.startPan();
+      // Settle side effects belong ONLY to a session that actually moved
+      // the viewport (gated on the session's OWN flag, never DragState's —
+      // a concurrent pointer drag owns that). A fully-absorbed session must
+      // neither ratify NOR bounce: the overscroll it observes can be a
+      // running range animation's transient interpolation state (the grant
+      // already points at the animation's target), and bouncing that
+      // hijacks the animation to the envelope edge.
+      if (ctx.wheel.viewportMutated) {
+        // Hand residual wheel velocity to the pan-inertia loop. Falls back
+        // to bounce-back when overscrolled but not actively flicking.
+        const flick = wheelInertiaEnabled && Math.abs(ctx.wheel.panVelocity) > 3;
+        if (flick || Math.abs(timeScale.overscroll) > 0.1) {
+          inertia.stopPan();
+          ctx.pan.velocity = flick ? ctx.wheel.panVelocity : 0;
+          inertia.startPan();
+        } else if (ctx.zoom.raf === null) {
+          // Session over with no inertia running: the gesture settles here —
+          // the inertia loops ratify their own termination otherwise.
+          timeScale.ratifySettledPosition();
+        }
       }
+      ctx.wheel.viewportMutated = false;
       ctx.wheel.panVelocity = 0;
+      // Session boundary marker: the null timer is what lets the next wheel
+      // event know it starts a NEW session (a mid-session direction flip
+      // keeps the pending timer and therefore the session state above).
+      ctx.wheel.timer = null;
     }, 150);
 
+    let eventChanged = false;
     if (ctx.wheel.dir === "pan") {
+      const beforePan = timeScale.rawStartIndex;
       const deltaBars = e.deltaX / timeScale.barSpacing;
       timeScale.scrollByUnclamped(deltaBars);
+      eventChanged = timeScale.rawStartIndex !== beforePan;
       const now = performance.now();
-      const dt = now - ctx.wheel.lastPanTime;
-      // pan.velocity convention: positive = reveal past (content moves right),
-      // so invert deltaX which is positive when scrolling forward in time.
-      const sample = dt > 0 && dt < 100 ? (-e.deltaX / dt) * 16 * sens : 0;
-      if (dt > 0 && dt < 100) {
-        ctx.wheel.panVelocity = ctx.wheel.panVelocity * 0.5 + sample * 0.5;
+      if (eventChanged) {
+        const dt = now - ctx.wheel.lastPanTime;
+        // pan.velocity convention: positive = reveal past (content moves right),
+        // so invert deltaX which is positive when scrolling forward in time.
+        const sample = dt > 0 && dt < 100 ? (-e.deltaX / dt) * 16 * sens : 0;
+        if (dt > 0 && dt < 100) {
+          ctx.wheel.panVelocity = ctx.wheel.panVelocity * 0.5 + sample * 0.5;
+        } else {
+          ctx.wheel.panVelocity = sample;
+        }
       } else {
-        ctx.wheel.panVelocity = sample;
+        // Mirror the zoom branch: a pan fully absorbed by the envelope
+        // contributes no velocity — and wipes what's left. This is one of
+        // two layers (the other: the timer gates its settle side effects
+        // on viewportMutated): before them, residual velocity from
+        // absorbed events started pan inertia at session end, whose
+        // absorbed no-op run skipped the ratification a preceding real
+        // movement (e.g. a zoom before a direction flip) still owed — or,
+        // with an animation running, sprang to life the moment the
+        // animation moved the viewport off the absorbing boundary and
+        // cancelled it.
+        ctx.wheel.panVelocity = 0;
       }
       ctx.wheel.lastPanTime = now;
     } else {
@@ -85,7 +137,9 @@ export function attachWheelHandlers(
         ctx.zoom.raf = null;
       }
 
+      const beforeZoom = timeScale.barSpacing;
       timeScale.zoom(factor, ctx.zoom.anchorX);
+      eventChanged = timeScale.barSpacing !== beforeZoom;
 
       const dt = now - ctx.zoom.lastTime;
       if (dt < 50) {
@@ -95,13 +149,23 @@ export function attachWheelHandlers(
       }
       ctx.zoom.lastTime = now;
 
-      // Skipped entirely when wheelInertia is off so the zoom stops the moment
-      // the user lifts their fingers.
-      if (wheelInertiaEnabled) {
+      // Skipped entirely when wheelInertia is off so the zoom stops the
+      // moment the user lifts their fingers — and for a fully-absorbed
+      // event (zoom cap): arming inertia with velocity that cannot act now
+      // would leave a loop idling until something ELSE moves the spacing
+      // off the cap, then fire the stale velocity into it.
+      if (wheelInertiaEnabled && eventChanged) {
         inertia.startZoom();
       }
     }
-    ctx.onViewportMutation();
+    if (eventChanged) {
+      ctx.wheel.viewportMutated = true;
+      ctx.onViewportMutation();
+    } else {
+      // Fully absorbed by the zoom/scroll limits: nothing moved, so a
+      // running range animation must survive this event.
+      ctx.onUpdate();
+    }
   };
 
   el.addEventListener("wheel", onWheel, { passive: false });

--- a/packages/chart/src/core/scale.ts
+++ b/packages/chart/src/core/scale.ts
@@ -389,6 +389,7 @@ export class TimeScale {
    *  virtualTotal already accounts for the last bar's own slot (see getter);
    *  when everything fits the target is clamped to 0 by the Math.max. */
   scrollToEnd(): void {
+    this._granted = null; // explicit navigation releases any viewport grant
     const targetVirt = Math.max(
       0,
       this.virtualTotal + this.effectiveRightOffset() - this._visibleCount,
@@ -426,6 +427,9 @@ export class TimeScale {
    */
   followLiveEdge(prevEndDistance: number): void {
     this._startIndex = this.realAtVirt(this.virtualTotal - prevEndDistance);
+    // Re-base an active grant onto the new resting position so a granted
+    // margin keeps streaming with the market instead of eroding per tick.
+    if (this._granted !== null) this._granted = this._startIndex;
   }
 
   /** Zoom around a pixel position (Google Maps style — anchor stays under cursor) */
@@ -467,6 +471,7 @@ export class TimeScale {
   setVisibleRange(start: number, end: number): void {
     const count = end - start;
     if (count <= 0) return;
+    this._granted = null; // ordinary (data-bounded) range: release any grant
     this._barSpacing = Math.max(
       this._minBarSpacing,
       Math.min(this._maxBarSpacing, this._width / count),
@@ -481,6 +486,7 @@ export class TimeScale {
    *  candles to fill the canvas correctly in that case. */
   fitContent(): void {
     if (this._totalCount <= 0 || this._width <= 0) return;
+    this._granted = null; // fitting to content releases any viewport grant
     // virtualTotal, not totalCount: in a gap-expanded layout the content
     // spans more slots than there are bars, and each slot costs width.
     const slots = this.virtualTotal + this._rightOffset;
@@ -548,6 +554,14 @@ export class TimeScale {
     this._barSpacing = spacing;
     this.recalcVisibleCount();
     this._startIndex = from;
+    // Grant the requested resting position UNCONDITIONALLY — the grant is
+    // the owner of "an explicit logical viewport is active", not merely
+    // "the position is beyond ordinary bounds". A wide range starting at 0
+    // or a viewport inside the overscroll pad must still block auto-refit
+    // and rightOffset repositioning (D2/D3); within ordinary bounds the
+    // envelope arithmetic is unchanged, and the FIRST gesture settle
+    // dissolves an in-bounds grant via ratifySettledPosition().
+    this._granted = from;
   }
 
   /** Set startIndex and barSpacing directly (used by animation frames).
@@ -576,45 +590,43 @@ export class TimeScale {
   }
 
   /** Returns how far past the edge the viewport is (0 = within bounds).
-   *  Negative = past left edge, positive = past right edge. */
+   *  Negative = past left edge, positive = past right edge.
+   *  Measured against the clamp envelope, so a granted logical-range
+   *  position reads as 0 — the rubber band resists only movement BEYOND
+   *  what the viewer legitimately holds. */
   get overscroll(): number {
-    const maxStart = this.maxStartIndex;
-    if (maxStart === null) return 0;
-    if (this._startIndex < 0) return this._startIndex;
-    if (this._startIndex > maxStart) return this._startIndex - maxStart;
+    if (this._startIndex < this.allowedMin) return this._startIndex - this.allowedMin;
+    if (this._startIndex > this.allowedMax) return this._startIndex - this.allowedMax;
     return 0;
   }
 
   /** Scroll without clamping (allows overscroll for bounce effect) */
   scrollByUnclamped(deltaBars: number): void {
     this._startIndex += deltaBars;
-    // Soft clamp: allow overscroll but with increasing resistance
-    const maxStart = this.maxStartIndex;
-    if (maxStart === null) {
-      this.clamp();
-      return;
-    }
-    if (this._startIndex < 0) {
-      this._startIndex *= 0.4; // Rubber-band resistance
-    } else if (this._startIndex > maxStart) {
-      const over = this._startIndex - maxStart;
-      this._startIndex = maxStart + over * 0.4;
+    // Soft clamp: allow overscroll beyond the envelope, with resistance
+    const min = this.allowedMin;
+    const max = this.allowedMax;
+    if (this._startIndex < min) {
+      this._startIndex = min + (this._startIndex - min) * 0.4; // Rubber-band resistance
+    } else if (this._startIndex > max) {
+      this._startIndex = max + (this._startIndex - max) * 0.4;
     }
   }
 
-  /** Snap back to the nearest edge (for bounce-back after overscroll) */
+  /** Snap back to the nearest envelope edge (bounce-back after overscroll) */
   get clampedStartIndex(): number {
-    const maxStart = this.maxStartIndex;
-    if (maxStart === null) return 0;
-    return Math.max(0, Math.min(maxStart, this._startIndex));
+    return Math.max(this.allowedMin, Math.min(this.allowedMax, this._startIndex));
   }
 
-  /** Maximum allowed startIndex, or null if all content fits in view */
-  private get maxStartIndex(): number | null {
-    if (this._totalCount <= 0) return null;
+  /**
+   * Maximum ordinary startIndex. Total (never null): when all content
+   * (plus margin) fits the viewport this is 0 — the left-aligned layout.
+   */
+  private get normalMaxStart(): number {
+    if (this._totalCount <= 0) return 0;
     const virtTotal = this.virtualTotal;
     const offset = this.effectiveRightOffset();
-    if (this._visibleCount >= virtTotal + offset) return null;
+    if (this._visibleCount >= virtTotal + offset) return 0;
     // The scrollable empty space on the right is whichever is larger: the
     // 20% overscroll pad or the configured right offset — so the pinned
     // (scrollToEnd) position is always reachable without fighting clamp.
@@ -622,6 +634,53 @@ export class TimeScale {
     const maxStartVirt = Math.max(0, virtTotal + rightPad - this._visibleCount);
     if (this._virt.length === 0) return maxStartVirt;
     return this.realAtVirt(maxStartVirt);
+  }
+
+  // ---- Clamp envelope --------------------------------------------------
+  //
+  // The ordinary scroll bounds are [0, normalMaxStart]. A position set
+  // through setVisibleLogicalRange may legitimately sit OUTSIDE them (a
+  // margin wider than the overscroll pad, or space before the first bar);
+  // `_granted` records that resting position, and the effective bounds
+  // become [min(0, granted), max(normalMaxStart, granted)]. The grant is
+  // a ratification of where the viewer rests, not a persistent region:
+  // it shrinks to the new resting position when a user gesture settles
+  // (margins are consumable by interaction, re-creatable only via the
+  // API — a one-way ratchet), is released entirely by fitContent /
+  // scrollToEnd / setVisibleRange / setCandles, and is re-based by the
+  // live-edge follow so streaming keeps a granted margin.
+
+  /** Resting position granted by setVisibleLogicalRange (null = none).
+   *  Non-null also for in-bounds positions: it doubles as the marker that
+   *  an explicit logical viewport is active (D2/D3 protection). */
+  private _granted: number | null = null;
+
+  private get allowedMin(): number {
+    return this._granted !== null ? Math.min(0, this._granted) : 0;
+  }
+
+  private get allowedMax(): number {
+    const normal = this.normalMaxStart;
+    return this._granted !== null ? Math.max(normal, this._granted) : normal;
+  }
+
+  /** True while an explicit logical-range viewport grant is active
+   *  (in-bounds included — the grant marks "an explicit viewport is set",
+   *  not "the position is beyond ordinary bounds"). */
+  get hasViewportGrant(): boolean {
+    return this._granted !== null;
+  }
+
+  /**
+   * Ratify the current resting position as the clamp envelope: called
+   * when a user gesture fully settles (pointer up without bounce, bounce
+   * / inertia termination, each discrete keyboard step, wheel-session
+   * expiry). Inside the ordinary bounds the grant dissolves; outside, it
+   * shrinks to exactly where the viewer now rests.
+   */
+  ratifySettledPosition(): void {
+    const s = this._startIndex;
+    this._granted = s < 0 || s > this.normalMaxStart ? s : null;
   }
 
   /**
@@ -690,15 +749,13 @@ export class TimeScale {
       this._startIndex = 0;
       return;
     }
-    // Single owner for the "everything fits" decision: maxStartIndex is
-    // null exactly when content + margin fit the viewport (it compares in
-    // virtual units, so gap-expanded layouts clamp consistently too).
-    const maxStart = this.maxStartIndex;
-    if (maxStart === null) {
-      this._startIndex = 0;
-      return;
-    }
-    this._startIndex = Math.max(0, Math.min(maxStart, this._startIndex));
+    // Clamp into the envelope, not the ordinary bounds: a granted
+    // logical-range position (including one preserved across the
+    // transient relayout inside setTotalCount) must survive clamping.
+    // normalMaxStart compares in virtual units, so gap-expanded layouts
+    // clamp consistently, and the all-fits regime yields [min(0,g), max(0,g)]
+    // — a granted both-sides margin moves bar-by-bar instead of snapping.
+    this._startIndex = Math.max(this.allowedMin, Math.min(this.allowedMax, this._startIndex));
   }
 }
 

--- a/packages/chart/src/core/scale.ts
+++ b/packages/chart/src/core/scale.ts
@@ -430,15 +430,27 @@ export class TimeScale {
 
   /** Zoom around a pixel position (Google Maps style — anchor stays under cursor) */
   zoom(factor: number, anchorX?: number): void {
+    // Event-fed inputs (wheel/pinch anchors are derived from browser
+    // coordinates) must not poison the scale: a NaN reaching _startIndex
+    // is permanent and unrecoverable from the UI. Ignore a non-finite
+    // factor; fall back to the viewport center for a non-finite anchor.
+    if (!Number.isFinite(factor)) return;
     // Compute anchor as a fractional index before zoom
     // indexToX: x = (index - startIndex + 0.5) * barSpacing
     // → index = x / barSpacing - 0.5 + startIndex
-    const ax = anchorX ?? this._width / 2;
+    const ax = anchorX !== undefined && Number.isFinite(anchorX) ? anchorX : this._width / 2;
     const anchorIndex = ax / this._barSpacing - 0.5 + this._startIndex;
 
     // Zoom-out minimum: 1px per bar. This ensures decimated candles render correctly.
     // fitContent() can go below 1px internally but interactive zoom stops here.
-    const newSpacing = Math.max(1, Math.min(this._maxBarSpacing, this._barSpacing * factor));
+    // When the current spacing sits OUTSIDE [1, maxBarSpacing] (reachable via
+    // setVisibleLogicalRange's exact-span policy), the bounds fold the current
+    // value in so the first gesture moves continuously TOWARD the range —
+    // a hard clamp would teleport to the boundary, inverting the gesture
+    // direction (e.g. zoom-in at 800px/bar snapping out to 50px/bar).
+    const lo = Math.min(1, this._barSpacing);
+    const hi = Math.max(this._maxBarSpacing, this._barSpacing);
+    const newSpacing = Math.max(lo, Math.min(hi, this._barSpacing * factor));
     if (Math.abs(newSpacing - this._barSpacing) < 0.01) return;
 
     this._barSpacing = newSpacing;

--- a/packages/chart/src/core/viewport-origin.ts
+++ b/packages/chart/src/core/viewport-origin.ts
@@ -1,0 +1,50 @@
+/**
+ * Viewport mutation provenance — internal to the package.
+ *
+ * `syncCharts` must tell "the completion event of a range I forwarded"
+ * apart from "a user moved this chart". Comparing range VALUES cannot do
+ * that: a time-based multi-timeframe target quantizes the forwarded times
+ * to its own bars, so the resulting logical range is not knowable by the
+ * sender. Instead, the internal viewport setters carry an opaque
+ * origin/generation token through to the completion event, attached to the
+ * payload under a non-exported Symbol — invisible to `JSON.stringify`,
+ * enumeration, and the public `VisibleRangeChangeData` type.
+ *
+ * The token never outlives its own mutation: it is captured into the
+ * animation's completion closure (a cancelled animation drops its `onDone`
+ * without firing, taking the token with it) and the staging slot on the
+ * chart is cleared synchronously around the setter call.
+ */
+
+/** Provenance of a programmatic viewport mutation. */
+export type ViewportOrigin = {
+  /** Unique id of the initiator (e.g. one syncCharts group). */
+  origin: string;
+  /** Monotonic per-target counter, so stale completions are identifiable. */
+  generation: number;
+};
+
+const VIEWPORT_ORIGIN = Symbol("tc.vo");
+
+/** Internal chart surface for initiating a mutation with provenance. */
+export const APPLY_WITH_ORIGIN = Symbol("tc.awo");
+
+export type ViewportOriginCarrier = {
+  [APPLY_WITH_ORIGIN](origin: ViewportOrigin, apply: () => void): void;
+};
+
+/** Attach a token to an event payload (non-enumerable — never serialized). */
+export function attachViewportOrigin(payload: object, token: ViewportOrigin): void {
+  Object.defineProperty(payload, VIEWPORT_ORIGIN, {
+    value: token,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
+/** Read a token off an event payload, if one was attached. */
+export function readViewportOrigin(payload: unknown): ViewportOrigin | null {
+  if (payload === null || typeof payload !== "object") return null;
+  const token = (payload as Record<symbol, unknown>)[VIEWPORT_ORIGIN];
+  return (token as ViewportOrigin | undefined) ?? null;
+}

--- a/packages/chart/src/core/viewport.ts
+++ b/packages/chart/src/core/viewport.ts
@@ -69,6 +69,7 @@ export class Viewport {
      * (outside the thumb); in that case we page-jump to center on the cursor.
      */
     scrollbarGrabOffsetFrac: null,
+    viewportMutated: false,
   };
 
   private _onUpdate: (() => void) | null = null;
@@ -190,7 +191,7 @@ export class Viewport {
       paneResize: { gap: null, startY: 0 },
       pan: { velocity: 0, raf: null, lastTouchX: 0, lastTouchMoveTime: 0 },
       zoom: { velocity: 0, raf: null, lastTime: 0, anchorX: null },
-      wheel: { dir: null, timer: null, panVelocity: 0, lastPanTime: 0 },
+      wheel: { dir: null, timer: null, panVelocity: 0, lastPanTime: 0, viewportMutated: false },
       touch: {
         lastDist: 0,
         lastTapTime: 0,

--- a/packages/chart/src/core/viewport.ts
+++ b/packages/chart/src/core/viewport.ts
@@ -72,6 +72,7 @@ export class Viewport {
   };
 
   private _onUpdate: (() => void) | null = null;
+  private _onViewportMutation: (() => void) | null = null;
 
   get state(): Readonly<ViewportState> {
     return this._state;
@@ -79,6 +80,11 @@ export class Viewport {
 
   setOnUpdate(cb: () => void): void {
     this._onUpdate = cb;
+  }
+
+  /** Called only for user viewport gestures (see InteractionContext). */
+  setOnViewportMutation(cb: () => void): void {
+    this._onViewportMutation = cb;
   }
 
   /**
@@ -175,6 +181,10 @@ export class Viewport {
       hotkeyDisabled: hotkeyMap === false,
       dispatch: opts?.onAction,
       onUpdate: () => this._onUpdate?.(),
+      onViewportMutation: () => {
+        this._onViewportMutation?.();
+        this._onUpdate?.();
+      },
       viewState: this._state,
       drag: this._drag,
       paneResize: { gap: null, startY: 0 },
@@ -192,7 +202,10 @@ export class Viewport {
       isDrawingActive: opts?.isDrawingActive,
     };
 
-    const inertia = new InertiaController(timeScale, ctx.pan, ctx.zoom, ctx.onUpdate);
+    // Inertia frames move the viewport, so they go through the mutation
+    // channel (a fling arriving during a programmatic animation cancels it,
+    // exactly like the gesture that spawned the fling).
+    const inertia = new InertiaController(timeScale, ctx.pan, ctx.zoom, ctx.onViewportMutation);
 
     const detachers = [
       attachMouseHandlers(ctx, inertia),

--- a/packages/chart/src/integration/sync.ts
+++ b/packages/chart/src/integration/sync.ts
@@ -14,6 +14,16 @@
  */
 
 import type { ChartInstance, CrosshairMoveData, VisibleRangeChangeData } from "../core/types";
+import {
+  APPLY_WITH_ORIGIN,
+  readViewportOrigin,
+  type ViewportOrigin,
+  type ViewportOriginCarrier,
+} from "../core/viewport-origin";
+
+/** Distinct id per syncCharts group, so overlapping groups never consume
+ *  each other's completion events. */
+let nextSyncGroupId = 0;
 
 export type SyncOptions = {
   /** Mirror crosshair hover across charts (default: true) */
@@ -52,8 +62,35 @@ export function syncCharts(charts: ChartInstance[], opts: SyncOptions = {}): () 
 
   // Set at the start of each forward cycle; sync events observed while set
   // are ignored, so we never feed our own changes back into the network.
+  // This guards the SYNCHRONOUS part only (charts with animation disabled
+  // emit inside the setter call); asynchronous completion events — the
+  // default, with a ~300ms range animation — are identified by the
+  // origin/generation token below instead. Matching completions are
+  // consumed exactly once; a stale generation (superseded forward) is
+  // dropped without touching the newer expectation; anything without our
+  // token (user gestures, other groups, programmatic calls) is treated as
+  // fresh input. Range VALUES are never used to infer sync provenance —
+  // a time-mode multi-timeframe target quantizes forwarded times to its
+  // own bars, so the sender cannot predict the resulting range.
   let forwarding = false;
+  const groupId = `sync#${nextSyncGroupId++}`;
+  const generations = new Map<ChartInstance, number>();
+  const pending = new Map<ChartInstance, ViewportOrigin>();
   const handlers: Array<() => void> = [];
+
+  /** Forward a viewport mutation to `target` with provenance when supported. */
+  function forwardViewport(target: ChartInstance, apply: () => void): void {
+    const carrier = target as Partial<ViewportOriginCarrier>;
+    if (typeof carrier[APPLY_WITH_ORIGIN] !== "function") {
+      apply();
+      return;
+    }
+    const generation = (generations.get(target) ?? 0) + 1;
+    generations.set(target, generation);
+    const token: ViewportOrigin = { origin: groupId, generation };
+    pending.set(target, token);
+    carrier[APPLY_WITH_ORIGIN]?.(token, apply);
+  }
 
   for (const source of charts) {
     if (syncCrosshair) {
@@ -80,6 +117,17 @@ export function syncCharts(charts: ChartInstance[], opts: SyncOptions = {}): () 
         if (forwarding) return;
         const range = data as VisibleRangeChangeData;
         if (!range) return;
+        // Async completion of a range we forwarded to this chart?
+        const token = readViewportOrigin(range);
+        if (token && token.origin === groupId) {
+          const expected = pending.get(source);
+          if (expected && expected.generation === token.generation) {
+            pending.delete(source); // consume exactly once
+          }
+          // Stale generation (superseded forward): drop silently — it must
+          // neither propagate old state nor clear the newer expectation.
+          return;
+        }
         // "logical" mode mirrors the unclamped bar-index range (preserves
         // margins past the last bar, same-data charts only, see SyncOptions);
         // the default mirrors times so MTF charts translate per their own data.
@@ -100,9 +148,11 @@ export function syncCharts(charts: ChartInstance[], opts: SyncOptions = {}): () 
           for (const target of charts) {
             if (target === source) continue;
             if (useLogical) {
-              target.setVisibleLogicalRange(logical.from, logical.to);
+              forwardViewport(target, () =>
+                target.setVisibleLogicalRange(logical.from, logical.to),
+              );
             } else {
-              target.setVisibleRange(range.startTime, range.endTime);
+              forwardViewport(target, () => target.setVisibleRange(range.startTime, range.endTime));
             }
           }
         } finally {

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -1186,8 +1186,11 @@ export class CanvasChart implements ChartInstance {
       if (opts.timeScale.rightOffset !== undefined) {
         // Re-scroll immediately when the last bar is visible so the new
         // margin shows right away, not only on the next new bar. A rejected
-        // value must not move the viewport (it was "ignored").
-        const atEnd = this._barsOffLiveEdge() <= 0;
+        // value must not move the viewport (it was "ignored"), and neither
+        // must an option update while an explicit logical-range viewport is
+        // active — the grant owns the position; the new offset applies once
+        // the grant is released (scrollToEnd / fitContent / time range).
+        const atEnd = this._barsOffLiveEdge() <= 0 && !this._timeScale.hasViewportGrant;
         if (this._setRightOffsetOption(opts.timeScale.rightOffset)) {
           if (atEnd) this._timeScale.scrollToEnd();
           this._needsRender = true;
@@ -1443,7 +1446,12 @@ export class CanvasChart implements ChartInstance {
       timeAxisHeight:
         timeAxisHeight ?? this._sizeState?.timeAxisHeight ?? DEFAULT_OPTIONS.timeAxisHeight,
     };
-    const wasFit = this._timeScale.visibleCount >= this._timeScale.totalCount;
+    // "All data visible" also matches a deliberately wide logical-range
+    // viewport; auto-refitting would silently destroy the granted range
+    // (fitContent releases the grant), so only refit when none is active.
+    const wasFit =
+      this._timeScale.visibleCount >= this._timeScale.totalCount &&
+      !this._timeScale.hasViewportGrant;
     this._timeScale.setWidth(this._layout.dataAreaWidth);
     // Re-fit if all data was visible before resize
     if (wasFit && this._timeScale.totalCount > 0) {

--- a/packages/chart/src/renderer/canvas-chart.ts
+++ b/packages/chart/src/renderer/canvas-chart.ts
@@ -42,6 +42,7 @@ import { DARK_THEME, LIGHT_THEME } from "../core/types";
 import type { ShapeCheck } from "../core/validation";
 import { checkBacktest, checkSignals, checkTrades, summarizeIssues } from "../core/validation";
 import { Viewport } from "../core/viewport";
+import { APPLY_WITH_ORIGIN, attachViewportOrigin } from "../core/viewport-origin";
 import { INDICATOR_PRESETS, type IndicatorPreset } from "../integration/indicator-presets";
 import { introspect } from "../integration/series-introspector";
 import { ChartAria } from "./chart-aria";
@@ -160,10 +161,17 @@ export class CanvasChart implements ChartInstance {
   private _sessionGapsOpts: ResolvedSessionGapsOptions;
   private _overlaysHidden = false;
   private _overlaySavedVisibility: Map<string, boolean> | null = null;
-  // Cached visible range for change-detection in the render loop — the public
-  // `visibleRangeChange` event fires only when the indices actually move.
-  private _lastVisibleStart = -1;
-  private _lastVisibleEnd = -1;
+  // Last emitted logical range for change-detection — the public
+  // `visibleRangeChange` event fires when either window edge moves by more
+  // than ~0.25px (in bars: 0.25 / barSpacing). Fractional resting positions
+  // are the norm since the logical-range API, so an integer-floored compare
+  // would silently swallow sub-bar movement (up to a full screen at narrow
+  // logical ranges).
+  private _lastEmittedLogical: { from: number; to: number } | null = null;
+  // Provenance staged for the next _animateToRange call (see viewport-origin).
+  // Cleared synchronously around the setter — it must never leak into a
+  // later, unrelated mutation.
+  private _nextRangeOrigin: import("../core/viewport-origin").ViewportOrigin | null = null;
   // Last crosshair index that was emitted via crosshairMove, kept so user
   // interaction only fires the event on real changes. Only user-driven
   // transitions go through _maybeEmitCrosshair(); programmatic setCrosshair()
@@ -397,15 +405,24 @@ export class CanvasChart implements ChartInstance {
       }
     });
 
-    // Viewport interaction
-    this._viewport.setOnUpdate(() => {
-      // User interaction cancels any running range transition. Clear the
-      // `_animatingRange` flag too: ViewTransition.cancel() nulls the onDone
-      // callback, so without this reset the flag would stay true forever and
-      // silently swallow every subsequent visibleRangeChange emit — which
-      // showed up as "sync stops following after you scroll mid-animation".
+    // Viewport interaction — two channels:
+    // - onViewportMutation fires only for USER viewport gestures (pan /
+    //   zoom / scrollbar / viewport keys / inertia frames) and cancels any
+    //   running range transition. Clear the `_animatingRange` flag too:
+    //   ViewTransition.cancel() nulls the onDone callback, so without this
+    //   reset the flag would stay true forever and silently swallow every
+    //   subsequent visibleRangeChange emit.
+    // - onUpdate fires for anything needing a repaint (crosshair hover,
+    //   pane resize, drawing preview…). It must NOT cancel the transition:
+    //   a mere hover during a programmatic range animation would otherwise
+    //   kill the animation and its exactly-once completion emit — leaving
+    //   sync peers with a stuck pending expectation, and re-emitting the
+    //   abandoned mid-flight range as token-less fresh input.
+    this._viewport.setOnViewportMutation(() => {
       this._transition.cancel();
       this._animatingRange = false;
+    });
+    this._viewport.setOnUpdate(() => {
       this._needsRender = true;
       // Emit crosshairMove synchronously from the interaction event rather
       // than from the render that comes on the next rAF. Letting sync fan
@@ -983,9 +1000,32 @@ export class CanvasChart implements ChartInstance {
     this._needsRender = true;
   }
 
+  /**
+   * Run a programmatic viewport mutation with provenance: the token is
+   * staged for the `_animateToRange` inside `apply()` and cleared
+   * synchronously, so it cannot leak into a later, unrelated mutation.
+   * Internal surface (non-exported Symbol) used by syncCharts.
+   */
+  [APPLY_WITH_ORIGIN](
+    origin: import("../core/viewport-origin").ViewportOrigin,
+    apply: () => void,
+  ): void {
+    this._nextRangeOrigin = origin;
+    try {
+      apply();
+    } finally {
+      this._nextRangeOrigin = null;
+    }
+  }
+
   /** Animate from current viewport state to the state produced by `applyTarget()` */
   private _animateToRange(applyTarget: () => void): void {
     this._transition.cancel();
+    // Consume any staged provenance into this animation's completion
+    // closure. A cancelled animation drops its onDone without firing, so
+    // the token dies with it — it can never stamp a later mutation.
+    const origin = this._nextRangeOrigin;
+    this._nextRangeOrigin = null;
 
     // Raw (fractional) start indices: flooring here would truncate a
     // fractional logical-range target to the previous whole bar.
@@ -1014,6 +1054,10 @@ export class CanvasChart implements ChartInstance {
       },
       () => {
         this._animatingRange = false;
+        this._needsRender = true;
+        // Exactly-once completion emit with the final state (and the
+        // provenance token, when this mutation was sync-forwarded).
+        this._maybeEmitVisibleRange({ force: true, origin });
       },
     );
   }
@@ -1208,11 +1252,16 @@ export class CanvasChart implements ChartInstance {
   getVisibleRange(): import("../core/types").VisibleRangeChangeData | null {
     const candles = this._data.candles;
     if (candles.length === 0) return null;
-    const startIdx = this._timeScale.startIndex;
-    const endIdx = Math.min(this._timeScale.endIndex, candles.length - 1);
+    // The four legacy fields are documented as clamped to the data range —
+    // for a beyond-data viewport an unclamped index would read a missing
+    // candle and report epoch-0 times (sending time-based sync targets to
+    // bar 0). The unclamped truth lives in logicalRange.
+    const lastIdx = candles.length - 1;
+    const startIdx = Math.max(0, Math.min(this._timeScale.startIndex, lastIdx));
+    const endIdx = Math.max(startIdx, Math.min(this._timeScale.endIndex, lastIdx));
     return {
-      startTime: candles[Math.max(0, startIdx)]?.time ?? 0,
-      endTime: candles[endIdx]?.time ?? 0,
+      startTime: candles[startIdx].time,
+      endTime: candles[endIdx].time,
       startIndex: startIdx,
       endIndex: endIdx,
       logicalRange: this._timeScale.getVisibleLogicalRange(),
@@ -1464,19 +1513,49 @@ export class CanvasChart implements ChartInstance {
     // here, so mirrored charts pick up the change inside the same rAF tick
     // and repaint without a one-frame lag. See _maybeEmitCrosshair().
 
-    // Emit visibleRangeChange on actual index movement. Suppressed while
-    // `_animatingRange` is true so programmatic setVisibleRange / fitContent
-    // tweens don't flood listeners on every frame of the transition.
-    const startIdx = this._timeScale.startIndex;
-    const endIdx = this._timeScale.endIndex;
-    if (startIdx !== this._lastVisibleStart || endIdx !== this._lastVisibleEnd) {
-      this._lastVisibleStart = startIdx;
-      this._lastVisibleEnd = endIdx;
-      if (!this._animatingRange) {
-        const range = this.getVisibleRange();
-        if (range) this._emit("visibleRangeChange", range);
-      }
+    // Emit visibleRangeChange on actual movement (single emission owner).
+    // Suppressed while `_animatingRange` is true so programmatic tweens
+    // don't flood listeners per frame; the animation's onDone force-emits
+    // the final state exactly once instead.
+    this._maybeEmitVisibleRange();
+  }
+
+  /**
+   * Single owner of `visibleRangeChange` emission.
+   *
+   * - Change detection compares the logical range with a ~0.25px-per-edge
+   *   threshold (converted to bars at the current spacing), so fractional
+   *   movement emits and float noise doesn't.
+   * - `force` bypasses both the animation gate and the change check —
+   *   used by the animation's completion so a programmatic range set emits
+   *   its final state exactly once even when it short-circuits (same-value
+   *   target), which sync provenance consumers rely on.
+   * - `origin` provenance is attached to the payload under a non-exported
+   *   Symbol (see core/viewport-origin.ts); the public payload is unchanged.
+   */
+  private _maybeEmitVisibleRange(
+    opts: {
+      force?: boolean;
+      origin?: import("../core/viewport-origin").ViewportOrigin | null;
+    } = {},
+  ): void {
+    if (this._animatingRange && !opts.force) return;
+    if (this._data.candleCount === 0) return;
+    const logical = this._timeScale.getVisibleLogicalRange();
+    if (!opts.force) {
+      const last = this._lastEmittedLogical;
+      const thresholdBars = 0.25 / Math.max(0.1, this._timeScale.barSpacing);
+      const changed =
+        !last ||
+        Math.abs(logical.from - last.from) > thresholdBars ||
+        Math.abs(logical.to - last.to) > thresholdBars;
+      if (!changed) return;
     }
+    const range = this.getVisibleRange();
+    if (!range) return;
+    this._lastEmittedLogical = { from: logical.from, to: logical.to };
+    if (opts.origin) attachViewportOrigin(range, opts.origin);
+    this._emit("visibleRangeChange", range);
   }
 
   private _updateAriaLabel(): void {

--- a/packages/chart/src/renderer/series-dispatcher.ts
+++ b/packages/chart/src/renderer/series-dispatcher.ts
@@ -133,6 +133,13 @@ export function dispatchSeries(
 
     const data = s.data as DataPoint<number | null>[];
     const target = getDecimationTarget(timeScale.endIndex - timeScale.startIndex, timeScale.width);
+    // Clamp the slice window to the data: a beyond-left viewport yields a
+    // negative startIndex, which Array.slice would interpret as an offset
+    // from the END (length + start) — silently blanking the whole series.
+    // The clamped value must feed the slice, the LTTB index offset, and the
+    // cache key identically, or the three drift apart.
+    const sliceStart = Math.max(0, timeScale.startIndex);
+    const sliceEnd = Math.max(sliceStart, timeScale.endIndex);
     let points: readonly DataPoint<number | null>[] = data;
     let origIndices: Int32Array | undefined;
     if (target > 0) {
@@ -140,24 +147,20 @@ export function dispatchSeries(
       const cached = _lttbCache.get(data);
       if (
         cached &&
-        cached.start === timeScale.startIndex &&
-        cached.end === timeScale.endIndex &&
+        cached.start === sliceStart &&
+        cached.end === sliceEnd &&
         cached.target === target &&
         cached.version === ver
       ) {
         points = cached.points;
         origIndices = cached.originalIndices;
       } else {
-        const decimated = lttb(
-          data.slice(timeScale.startIndex, timeScale.endIndex),
-          target,
-          timeScale.startIndex,
-        );
+        const decimated = lttb(data.slice(sliceStart, sliceEnd), target, sliceStart);
         points = decimated.points;
         origIndices = decimated.originalIndices;
         _lttbCache.set(data, {
-          start: timeScale.startIndex,
-          end: timeScale.endIndex,
+          start: sliceStart,
+          end: sliceEnd,
           target,
           version: ver,
           points,


### PR DESCRIPTION
## Summary

The logical-range viewport API (`setVisibleLogicalRange` / `getVisibleLogicalRange`, #352) and `timeScale.rightOffset` (#351) let a chart legitimately rest at positions the interaction layer previously treated as out of bounds: margins beyond the last bar, space before the first bar, fractional positions, and extreme bar spacings. Follow-up verification showed the interaction layer and several consumers were not prepared for these states — the first user gesture (or even a plain hover or streaming tick) could destroy a deliberately configured viewport. This PR hardens them, in three commits.

### Commit 1 — independent interaction/consumer fixes

- **Zoom continuity at extreme spacing**: zooming in at e.g. 800 px/bar no longer teleports out to the interactive cap (a 16x zoom-out from a zoom-in gesture); the bounds fold the current spacing in so gestures move continuously toward the ordinary range. Non-finite guards keep event-derived NaN coordinates from permanently poisoning the viewport.
- **Event emission**: `visibleRangeChange` gating now compares fractional logical ranges with a 0.25-px-per-edge threshold (sub-bar movements emit; noise doesn't), and a default-animated programmatic set emits its final state exactly once on completion (previously it never emitted with the default 300 ms animation).
- **`syncCharts`**: async echo prevention via per-group origin/generation tokens instead of value matching — required for time-mode sync between charts of different timeframes, where the follower's quantized result can't be predicted. Stale generations never win; a user action during the follower's animation is not swallowed.
- **Two interaction channels**: user viewport mutations cancel a running range animation; crosshair hover, pane resize, and fully-absorbed events never do.
- **Renderer/consumer contract fixes**: LTTB decimation no longer blanks number-line series at beyond-left viewports (negative slice start); `getVisibleRange()`'s legacy index/time fields are clamped to `[0, len-1]` (no more epoch-0 `startTime` at beyond-data viewports; the unclamped truth lives in `logicalRange`); dragging from a fractional resting position no longer snaps by the fractional part on the first pixel; sub-1-bar animated spans land on the exact span.

### Commit 2 — clamp envelope for granted viewports

A viewport granted through `setVisibleLogicalRange` was destroyed by the first interaction: rubber-band dampening consumed most of a granted margin on the first wheel notch or drag pixel, a single arrow key snapped an all-fits margin to the left edge, and a beyond-left viewport vanished on the next streaming append.

`TimeScale` now owns a clamp envelope: effective scroll bounds are `[min(0, granted), max(normalMaxStart, granted)]`, where `granted` records the resting position of an explicit logical-range viewport. Margins are consumable by interaction and re-creatable only via the API (a one-way ratchet): a gesture that actually moved the viewport ratifies its settled position into the envelope; `fitContent` / scroll-to-end / time-based ranges / `setCandles` release it; the live-edge follow re-bases it so a granted margin keeps streaming.

Gesture plumbing this required:
- **Per-gesture `viewportMutated` flags** (pointer/touch drag and wheel session tracked separately — the wheel 150 ms settle timer overlaps pointer gestures). Only a gesture that actually changed the viewport ratifies, notifies the mutation channel, or (for wheel) runs flick/bounce at settle. Plain clicks, taps, long-presses, hovers, an untouched scrollbar thumb, and fully-absorbed events are side-effect-free.
- **Wheel session semantics**: the session boundary is the settle timer, not the direction lock — a pan-to-zoom flip inside the 150 ms window is one compound gesture that keeps the session's `viewportMutated` and drops the flipped-out axis's residual velocity. Absorbed pan events contribute no velocity (symmetric with absorbed zooms not arming inertia), so a phantom flick can neither skip a ratification the session still owed nor hijack a later animation.
- **Inertia loops terminate on absorbed frames** instead of idling with residual velocity that would spring back to life against the next programmatic animation (a timing-dependent cancel reproducible only with real rAF cadence).
- **`mouseleave` / `touchcancel`** end a drag gesture exactly like `mouseup` / `touchend`, so releasing outside the canvas can't leave a stale envelope or skip bounce-back.
- **Resize / options**: a container resize no longer auto-refits away an active logical-range viewport, and `applyOptions` `rightOffset` updates leave one in place (the new offset applies once the range is released).

### Commit 3 — size limits

Local brotli measurements after the change: Main 42.07 kB (limit 41.5 → 42.5), Headless 11.63 kB (11.25 → 11.75), React wrapper 33.31 kB / Vue wrapper 33.59 kB (33 → 34 each — the wrappers bundle the main chart code, so the growth carries over). CI's measurement is authoritative; the wrapper bumps will be reverted if CI stays within the old limits.

## Test plan

- **`viewport-hardening.test.ts` — 47 tests**, driven by real DOM events (mouse drags, wheel sessions incl. direction flips and absorbed events, keyboard, synthesized touch incl. `touchcancel`, scrollbar-thumb geometry computed from the actual layout). Covers the envelope (numeric pins, ratchet, release, follow re-base), grant semantics (resize, `rightOffset`, first in-bounds settle), non-mutating gestures, animation-vs-interaction channels, emission exactness, and `syncCharts` echo/generation behavior with two live charts.
- **`viewport-invariants.fuzz.test.ts`** — 3 fixed seeds x 4,000 mutating ops each (including NaN injections), asserting scale invariants and envelope recoverability; failures print the seed and the last 12 ops.
- **Negative checks**: each fix was parked and its regression tests confirmed to fail, then restored (27/45 and 2/2 and 2/2 across the rounds).
- **Full chart suite**: 1,019 tests / 88 files green. `tsc --noEmit` clean, biome clean, build green, size-check green.
- **Real-browser verification**: a 9-scenario probe (real events, real rAF timing, on-page PASS/FAIL log) passed 9/9. Two of the bugs fixed here (the absorbed-inertia ambush and the no-op wheel session bouncing an animation's transient overscroll) reproduce only under real browser timing and are invisible to happy-dom; the probe transcript verified them before/after.