### PR TITLE
fix(chart): scrollbar far-right lands on the End position, not flush

### DIFF
--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -23,6 +23,13 @@ layers:
 - A touch gesture cancelled by the system (`touchcancel` — incoming call,
   browser gesture takeover) now ends the drag like `touchend` instead of
   leaving a stuck drag state.
+- Dragging the scrollbar thumb to the far right now lands on the same
+  position as the End key — last bar plus the configured
+  `timeScale.rightOffset` margin. The scrollbar derived its own right
+  boundary as `total − visible`, so it always landed flush against the
+  last bar, silently destroying a configured margin. (The scroll-to-end
+  start index is exposed on the headless `TimeScale` as
+  `scrollToEndTarget`.)
 - An animated range transition lands on the exact target span even below
   one bar per screen (the interpolation floored the bar count to 1).
 - A beyond-left viewport no longer blanks number-line series (a negative

--- a/packages/chart/llms-full.txt
+++ b/packages/chart/llms-full.txt
@@ -213,6 +213,13 @@ layers:
 - A touch gesture cancelled by the system (`touchcancel` — incoming call,
   browser gesture takeover) now ends the drag like `touchend` instead of
   leaving a stuck drag state.
+- Dragging the scrollbar thumb to the far right now lands on the same
+  position as the End key — last bar plus the configured
+  `timeScale.rightOffset` margin. The scrollbar derived its own right
+  boundary as `total − visible`, so it always landed flush against the
+  last bar, silently destroying a configured margin. (The scroll-to-end
+  start index is exposed on the headless `TimeScale` as
+  `scrollToEndTarget`.)
 - An animated range transition lands on the exact target span even below
   one bar per screen (the interpolation floored the bar count to 1).
 - A beyond-left viewport no longer blanks number-line series (a negative

--- a/packages/chart/src/__tests__/viewport-attach.test.ts
+++ b/packages/chart/src/__tests__/viewport-attach.test.ts
@@ -204,6 +204,29 @@ describe("Viewport.attach() — scrollbar drag", () => {
     fireMouse(s.el, "mouseup", 250, 585);
     s.detach();
   });
+
+  it("thumb dragged to the far right keeps the configured rightOffset margin", () => {
+    const s = setup();
+    s.ts.setRightOffset(7);
+    // Thumb spans x=160..320 (visible 100..200 of 500 over an 800px track).
+    fireMouse(s.el, "mousedown", 200, 585); // grab inside the thumb
+    fireMouse(s.el, "mousemove", 800, 585); // drag to the far right
+    fireMouse(s.el, "mouseup", 800, 585);
+    // 500 bars, 100 visible, offset 7 → start 407 (End-key position), not
+    // the flush 400 that a local `total - visible` boundary would give.
+    expect(s.ts.startIndex).toBe(407);
+    expect(s.ts.startIndex).toBe(s.ts.scrollToEndTarget);
+    s.detach();
+  });
+
+  it("thumb dragged to the far right without rightOffset lands flush (legacy)", () => {
+    const s = setup();
+    fireMouse(s.el, "mousedown", 200, 585);
+    fireMouse(s.el, "mousemove", 800, 585);
+    fireMouse(s.el, "mouseup", 800, 585);
+    expect(s.ts.startIndex).toBe(400); // total 500 − visible 100
+    s.detach();
+  });
 });
 
 describe("Viewport.attach() — pane resize via gap", () => {

--- a/packages/chart/src/core/scale.ts
+++ b/packages/chart/src/core/scale.ts
@@ -385,16 +385,25 @@ export class TimeScale {
     this.clamp();
   }
 
+  /** Start index {@link scrollToEnd} lands on: last candles pinned to the
+   *  right edge plus the configured right offset, resolved through virtual
+   *  units so session-gap layouts map correctly. Single owner of the "end"
+   *  position for every jump-to-end consumer (End key, live snap, scrollbar
+   *  far-right) — never re-derive it as `total - visible`. */
+  get scrollToEndTarget(): number {
+    const targetVirt = Math.max(
+      0,
+      this.virtualTotal + this.effectiveRightOffset() - this._visibleCount,
+    );
+    return Math.max(0, this.realAtVirt(targetVirt));
+  }
+
   /** Scroll to show the last candles plus the configured right offset.
    *  virtualTotal already accounts for the last bar's own slot (see getter);
    *  when everything fits the target is clamped to 0 by the Math.max. */
   scrollToEnd(): void {
     this._granted = null; // explicit navigation releases any viewport grant
-    const targetVirt = Math.max(
-      0,
-      this.virtualTotal + this.effectiveRightOffset() - this._visibleCount,
-    );
-    this._startIndex = Math.max(0, this.realAtVirt(targetVirt));
+    this._startIndex = this.scrollToEndTarget;
   }
 
   /**

--- a/packages/chart/src/core/viewport.ts
+++ b/packages/chart/src/core/viewport.ts
@@ -98,7 +98,10 @@ export class Viewport {
     const total = timeScale.totalCount;
     if (total <= 0) return;
     const visible = timeScale.visibleCount;
-    const maxStart = Math.max(0, total - visible);
+    // Far right lands where scrollToEnd/End lands — honors rightOffset and
+    // session-gap layouts. `total - visible` here would strand the thumb's
+    // rightmost position flush against the last bar, eating the margin.
+    const maxStart = timeScale.scrollToEndTarget;
     const pointerFrac = (mouseX - sb.x) / sb.width;
 
     let newStart: number;


### PR DESCRIPTION
## Summary

Manual verification of the upcoming 0.5.0 features surfaced an interaction gap: with `timeScale.rightOffset` configured, dragging the scrollbar thumb to the far right landed the viewport flush against the last bar — silently destroying the margin and disagreeing with every other jump-to-end path (End key, live-edge follow, `fitContent`).

Root cause: `_applyScrollbarDrag` re-derived its right boundary locally as `total − visible` instead of using the scale-owned boundary, so it ignored both `rightOffset` and session-gap virtual units.

Fix (single-owner): `TimeScale` now exposes `scrollToEndTarget` — the start index `scrollToEnd()` lands on (virtual-unit aware, `rightOffset` included) — and both `scrollToEnd()` and the scrollbar clamp consume it. The semantic is: **thumb at far right = same place the End key takes you.** Without a configured `rightOffset` the landing is identical to the previous behavior.

Out of scope (tracked separately): scrollbar fractional-position quantization and thumb rendering issues at extreme spacing.

## Test plan

- [x] 2 new regression tests in `viewport-attach.test.ts`: far-right drag with `rightOffset: 7` lands at the End-key position (start 407 with 500 bars / 100 visible, not the flush 400); without `rightOffset` it lands flush at 400 (legacy behavior preserved)
- [x] `pnpm test` (chart): 1029/1029 pass
- [x] `pnpm build`, `npx tsc --noEmit --ignoreDeprecations 6.0` clean
- [x] `pnpm size-check` within limits (Main 42.36 / 42.5 kB)
- [x] Real-browser check: with `rightOffset: 7` and 500 bars, scrollbar far-right now settles at logical `to = 507.0` (was `to = 500.0` flush before the fix); wheel-zoom and pan behavior unchanged
- [x] Full real-browser viewport interaction scenario suite (rubber-band / ratchet / animation-survival / inertia / wheel-session, 9 scenarios) re-run against this change: all PASS