### PR TITLE
chore(chart): scrollbar guardrails — single-owner geometry, jump-to-end contract, llms-full generator

### DIFF
--- a/packages/chart/RELEASE.md
+++ b/packages/chart/RELEASE.md
@@ -13,7 +13,8 @@ The full cross-package release workflow (including `trendcraft` coordination and
 - [ ] `pnpm --filter @trendcraft/chart test` green
 - [ ] `pnpm --filter @trendcraft/chart verify:publish` green — confirms every `package.json#exports` subpath resolves in both ESM and CJS and exposes its advertised symbols
 - [ ] `pnpm --filter @trendcraft/chart size-check` within limits. The authoritative budget lives in `package.json#size-limit` (currently main ≤ 42.5 kB, headless ≤ 11.75 kB, sparkline ≤ 5 kB vanilla / ≤ 7 kB React+Vue, replay ≤ 3 kB, React/Vue ≤ 34 kB, brotli). If a feature warrants a raise, bump it there and call it out in the CHANGELOG `Changed` section.
-- [ ] Docs sanity pass — `README.md`, `docs/*.md`, `llms.txt`, `llms-full.txt` reflect any new public API
+- [ ] Docs sanity pass — `README.md`, `docs/*.md`, `llms.txt` reflect any new public API. `llms-full.txt` is generated: run `pnpm --filter @trendcraft/chart gen:llms` after any doc change (CI fails on drift via `llms-full-parity.test.ts`)
+- [ ] New viewport/navigation option or semantic? Sweep EVERY navigation consumer — mouse drag, wheel pan/zoom, keyboard (arrows / Home / End), **scrollbar (drag + track click)**, live-edge follow, `fitContent`, duration presets, viewport sync — and verify each honors it. The scrollbar is the historically forgotten one
 - [ ] Examples still build: `cd packages/chart/examples/simple-chart && pnpm build` (repeat for `simple-react-chart`, `simple-vue-chart`)
 
 ## Publish

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -77,6 +77,7 @@
     "size-check": "size-limit",
     "format": "biome format --write .",
     "verify:publish": "node scripts/verify-publish.mjs",
+    "gen:llms": "node scripts/gen-llms-full.mjs",
     "prepublishOnly": "pnpm build && pnpm test && pnpm verify:publish"
   },
   "keywords": [

--- a/packages/chart/scripts/gen-llms-full.mjs
+++ b/packages/chart/scripts/gen-llms-full.mjs
@@ -1,0 +1,41 @@
+// Regenerates llms-full.txt from its declared sources (README, CHANGELOG,
+// docs/*.md). Run after any doc change: `pnpm gen:llms` from packages/chart.
+// The docs harness (llms-full-parity.test.ts) fails CI when the file drifts
+// from this concatenation, so the file can never silently go stale again.
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SECTIONS = [
+  ["README", "README.md"],
+  ["CHANGELOG", "CHANGELOG.md"],
+  ["GUIDE", "docs/GUIDE.md"],
+  ["API Reference", "docs/API.md"],
+  ["Live Data", "docs/LIVE.md"],
+  ["Plugins", "docs/PLUGINS.md"],
+  ["Cookbook", "docs/COOKBOOK.md"],
+];
+
+const HEADER = `# @trendcraft/chart — Full Documentation
+
+> Concatenated documentation for LLM ingestion. Generated from README.md, CHANGELOG.md, and docs/*.md (README, CHANGELOG, GUIDE, API, LIVE, PLUGINS, COOKBOOK).
+> Canonical sources: https://github.com/sawapi/trendcraft/tree/main/packages/chart
+
+---
+`;
+
+/** Build the llms-full.txt content from the sources under `rootDir`. */
+export function buildLlmsFull(rootDir) {
+  const body = SECTIONS.map(([title, file]) => {
+    const content = readFileSync(join(rootDir, file), "utf8").replace(/\s+$/, "");
+    return `\n# ${title}\n\n${content}\n`;
+  }).join("\n---\n");
+  return HEADER + body;
+}
+
+const isCli = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isCli) {
+  const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+  writeFileSync(join(root, "llms-full.txt"), buildLlmsFull(root));
+  console.log("llms-full.txt regenerated");
+}

--- a/packages/chart/src/__tests__/llms-full-parity.test.ts
+++ b/packages/chart/src/__tests__/llms-full-parity.test.ts
@@ -1,0 +1,26 @@
+/**
+ * llms-full.txt is a generated concatenation of README, CHANGELOG, and
+ * docs/*.md (see scripts/gen-llms-full.mjs). It has historically drifted —
+ * at one point it carried a CHANGELOG ending at 0.2.0 and event payload
+ * shapes from several revisions back — because nothing checked it.
+ *
+ * This test pins byte-exact parity with the generator. If it fails, run
+ * `pnpm gen:llms` from packages/chart and commit the result.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+// @ts-expect-error — plain .mjs module without type declarations
+import { buildLlmsFull } from "../../scripts/gen-llms-full.mjs";
+
+const root = join(fileURLToPath(import.meta.url), "..", "..", "..");
+
+describe("llms-full.txt parity", () => {
+  it("matches the generator output byte-for-byte", () => {
+    const expected: string = buildLlmsFull(root);
+    const actual = readFileSync(join(root, "llms-full.txt"), "utf8");
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/chart/src/__tests__/scroll-to-end-contract.test.ts
+++ b/packages/chart/src/__tests__/scroll-to-end-contract.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Contract: every jump-to-end path lands on `TimeScale.scrollToEndTarget`.
+ *
+ * The scrollbar once re-derived its right boundary locally as
+ * `total - visible` and silently destroyed a configured rightOffset margin.
+ * This suite pins the single-owner contract at the TimeScale level across
+ * rightOffset (integer / fractional / none) and session-gap layouts; the
+ * DOM-level consumers (End key, scrollbar far-right) are pinned to the same
+ * owner in viewport-attach.test.ts.
+ */
+
+import { describe, expect, it } from "vitest";
+import { TimeScale } from "../core/scale";
+
+type Config = { label: string; rightOffset: number; gaps: boolean };
+
+const CONFIGS: Config[] = [
+  { label: "no offset, no gaps", rightOffset: 0, gaps: false },
+  { label: "integer offset", rightOffset: 7, gaps: false },
+  { label: "fractional offset", rightOffset: 7.5, gaps: false },
+  { label: "no offset, session gaps", rightOffset: 0, gaps: true },
+  { label: "integer offset, session gaps", rightOffset: 7, gaps: true },
+];
+
+const GAPS = [
+  { index: 200, size: 3 },
+  { index: 400, size: 5 },
+];
+
+function makeScale({ rightOffset, gaps }: Config, total = 500): TimeScale {
+  const ts = new TimeScale();
+  ts.setWidth(800);
+  ts.setTotalCount(total);
+  if (gaps) ts.setGapsBefore(GAPS);
+  if (rightOffset > 0) ts.setRightOffset(rightOffset);
+  ts.setVisibleRange(100, 200);
+  return ts;
+}
+
+describe.each(CONFIGS)("jump-to-end contract — $label", (config) => {
+  it("scrollToEnd() lands on scrollToEndTarget", () => {
+    const ts = makeScale(config);
+    ts.scrollToEnd();
+    expect(ts.rawStartIndex).toBe(ts.scrollToEndTarget);
+  });
+
+  it("a pinned viewer follows appends onto scrollToEndTarget", () => {
+    const ts = makeScale(config);
+    ts.scrollToEnd();
+    const prevEndDistance = ts.endDistanceVirtual;
+    ts.setTotalCount(501);
+    if (config.gaps) ts.setGapsBefore(GAPS);
+    ts.followLiveEdge(prevEndDistance);
+    expect(ts.rawStartIndex).toBeCloseTo(ts.scrollToEndTarget, 9);
+  });
+
+  it.skipIf(config.gaps)("scrollToEndTarget leaves the offset visible past the data", () => {
+    // Gap-free layouts only: with session gaps the window spans virtual
+    // slots, so real-index arithmetic doesn't express the margin directly.
+    const ts = makeScale(config);
+    ts.scrollToEnd();
+    expect(ts.rawStartIndex + ts.visibleCount).toBeGreaterThanOrEqual(
+      500 + config.rightOffset - 1e-9,
+    );
+  });
+});

--- a/packages/chart/src/__tests__/viewport-attach.test.ts
+++ b/packages/chart/src/__tests__/viewport-attach.test.ts
@@ -229,6 +229,40 @@ describe("Viewport.attach() — scrollbar drag", () => {
   });
 });
 
+// Contract: the DOM-level jump-to-end consumers land where scrollToEnd()
+// lands (see scroll-to-end-contract.test.ts for the TimeScale-level paths).
+describe.each([
+  { label: "fractional rightOffset", rightOffset: 7.5, gaps: false },
+  { label: "rightOffset with session gaps", rightOffset: 7, gaps: true },
+])("Viewport.attach() — jump-to-end parity ($label)", ({ rightOffset, gaps }) => {
+  function setupWithConfig() {
+    const s = setup();
+    if (gaps)
+      s.ts.setGapsBefore([
+        { index: 200, size: 3 },
+        { index: 400, size: 5 },
+      ]);
+    s.ts.setRightOffset(rightOffset);
+    return s;
+  }
+
+  it("End key lands on scrollToEndTarget", () => {
+    const s = setupWithConfig();
+    fireKey(s.el, "End");
+    expect(s.ts.rawStartIndex).toBe(s.ts.scrollToEndTarget);
+    s.detach();
+  });
+
+  it("scrollbar far-right lands on scrollToEndTarget", () => {
+    const s = setupWithConfig();
+    fireMouse(s.el, "mousedown", 200, 585);
+    fireMouse(s.el, "mousemove", 800, 585);
+    fireMouse(s.el, "mouseup", 800, 585);
+    expect(s.ts.rawStartIndex).toBe(s.ts.scrollToEndTarget);
+    s.detach();
+  });
+});
+
 describe("Viewport.attach() — pane resize via gap", () => {
   it("calls resizePanes with delta when dragging gap", () => {
     const gapAtY = (y: number) => (y >= 398 && y <= 402 ? 0 : null);

--- a/packages/chart/src/__tests__/viewport-attach.test.ts
+++ b/packages/chart/src/__tests__/viewport-attach.test.ts
@@ -261,6 +261,16 @@ describe.each([
     expect(s.ts.rawStartIndex).toBe(s.ts.scrollToEndTarget);
     s.detach();
   });
+
+  it("scrollbar far-right track click lands on scrollToEndTarget", () => {
+    const s = setupWithConfig();
+    // Direct click outside the thumb: the page-jump path computes its own
+    // center-on-cursor start, so it must share the same boundary owner.
+    fireMouse(s.el, "mousedown", 800, 585);
+    fireMouse(s.el, "mouseup", 800, 585);
+    expect(s.ts.rawStartIndex).toBe(s.ts.scrollToEndTarget);
+    s.detach();
+  });
 });
 
 describe("Viewport.attach() — pane resize via gap", () => {

--- a/packages/chart/src/core/scrollbar-geometry.ts
+++ b/packages/chart/src/core/scrollbar-geometry.ts
@@ -1,0 +1,42 @@
+/**
+ * Scrollbar thumb geometry — single owner.
+ *
+ * The renderer draws this rect and the pointer hit-test grabs it. Both MUST
+ * go through {@link scrollbarThumbRect}: deriving the geometry twice is how
+ * the drawn thumb silently stops matching the grabbable one.
+ */
+
+import type { TimeScale } from "./scale";
+
+/** Minimum thumb width in px so it stays grabbable on huge datasets. */
+export const MIN_THUMB_WIDTH = 8;
+
+export type ScrollbarThumb = {
+  /** Left edge of the thumb in canvas px. */
+  x: number;
+  /** Thumb width in canvas px (already floored at {@link MIN_THUMB_WIDTH}). */
+  width: number;
+  /** Fraction of the track where the visible range starts — the quantity the
+   *  drag logic anchors its grab offset to. */
+  startFrac: number;
+};
+
+/**
+ * Thumb rectangle along the scrollbar track for the current viewport, or
+ * `null` when there is nothing to draw or grab (no data / zero-width track).
+ */
+export function scrollbarThumbRect(
+  timeScale: TimeScale,
+  trackX: number,
+  trackWidth: number,
+): ScrollbarThumb | null {
+  const total = timeScale.totalCount;
+  if (trackWidth <= 0 || total <= 0) return null;
+  const startFrac = Math.max(0, timeScale.startIndex / total);
+  const endFrac = Math.min(1, timeScale.endIndex / total);
+  return {
+    x: trackX + startFrac * trackWidth,
+    width: Math.max(MIN_THUMB_WIDTH, (endFrac - startFrac) * trackWidth),
+    startFrac,
+  };
+}

--- a/packages/chart/src/core/viewport.ts
+++ b/packages/chart/src/core/viewport.ts
@@ -26,6 +26,7 @@ import type {
 } from "./interaction/types";
 import { attachWheelHandlers } from "./interaction/wheel-handler";
 import type { TimeScale } from "./scale";
+import { scrollbarThumbRect } from "./scrollbar-geometry";
 import type { HotkeyAction, PaneRect } from "./types";
 
 export type { ScrollbarRect, ViewportState } from "./interaction/types";
@@ -124,17 +125,14 @@ export class Viewport {
    */
   private _beginScrollbarDrag(mouseX: number, sb: ScrollbarRect, timeScale: TimeScale): void {
     this._drag.scrollbarDragging = true;
-    const total = timeScale.totalCount;
-    if (sb.width <= 0 || total <= 0) {
+    // Geometry shared with the renderer — the grabbable thumb IS the drawn one.
+    const thumb = scrollbarThumbRect(timeScale, sb.x, sb.width);
+    if (!thumb) {
       this._drag.scrollbarGrabOffsetFrac = null;
       return;
     }
-    const startFrac = Math.max(0, timeScale.startIndex / total);
-    const endFrac = Math.min(1, timeScale.endIndex / total);
-    const thumbX = sb.x + startFrac * sb.width;
-    const thumbW = Math.max(8, (endFrac - startFrac) * sb.width);
-    if (mouseX >= thumbX && mouseX <= thumbX + thumbW) {
-      this._drag.scrollbarGrabOffsetFrac = (mouseX - sb.x) / sb.width - startFrac;
+    if (mouseX >= thumb.x && mouseX <= thumb.x + thumb.width) {
+      this._drag.scrollbarGrabOffsetFrac = (mouseX - sb.x) / sb.width - thumb.startFrac;
     } else {
       this._drag.scrollbarGrabOffsetFrac = null;
       this._applyScrollbarDrag(mouseX, sb, timeScale);

--- a/packages/chart/src/renderer/scrollbar-renderer.ts
+++ b/packages/chart/src/renderer/scrollbar-renderer.ts
@@ -3,6 +3,7 @@
  */
 
 import type { TimeScale } from "../core/scale";
+import { scrollbarThumbRect } from "../core/scrollbar-geometry";
 import type { ThemeColors } from "../core/types";
 
 /**
@@ -39,13 +40,11 @@ export function renderScrollbar(
   ctx.fillStyle = theme.grid;
   ctx.fillRect(x, trackY, width, trackH);
 
-  // Thumb (visible range)
-  const total = timeScale.totalCount;
-  const startFrac = Math.max(0, timeScale.startIndex / total);
-  const endFrac = Math.min(1, timeScale.endIndex / total);
-
-  const thumbX = x + startFrac * width;
-  const thumbW = Math.max(8, (endFrac - startFrac) * width);
+  // Thumb (visible range) — geometry shared with the pointer hit-test
+  const thumb = scrollbarThumbRect(timeScale, x, width);
+  if (!thumb) return;
+  const thumbX = thumb.x;
+  const thumbW = thumb.width;
 
   ctx.fillStyle = theme.textSecondary;
   ctx.globalAlpha = 0.4;


### PR DESCRIPTION
## Summary

Recurrence prevention for the class of bug fixed in #358 (a consumer re-deriving a scale-owned quantity and drifting), plus the docs-drift class fixed in #357. No public behavior changes — tests and tooling only.

1. **Single-owner scrollbar thumb geometry** — the thumb rect (start/end fractions, 8px min width) was computed twice, verbatim: once in the renderer for drawing, once in the pointer hit-test. One edit away from "the thumb you see isn't the thumb you can grab". Consolidated into `scrollbarThumbRect()` (`core/scrollbar-geometry.ts`), used by both.
2. **Jump-to-end contract suite** — every jump-to-end path must land on `TimeScale.scrollToEndTarget`: `scrollToEnd()` and the pinned live-edge follow at the TimeScale level, the End key and scrollbar far-right at the DOM level, across `rightOffset` {0, 7, 7.5} × session gaps on/off. A consumer that starts re-deriving the boundary fails CI immediately. (Writing this caught a subtlety already: fractional positions must be asserted via `rawStartIndex`, since `startIndex` floors.)
3. **`llms-full.txt` generator committed + parity test** — the file claims to be generated from README/CHANGELOG/docs but no generator was checked in, which is how it drifted badly before #357. `scripts/gen-llms-full.mjs` (runnable via `pnpm --filter @trendcraft/chart gen:llms`) is now the owner, and `llms-full-parity.test.ts` pins byte-exact parity in the normal test run.
4. **RELEASE.md checklist** — docs step now points at the generator; new line requires sweeping every navigation consumer (mouse drag, wheel pan/zoom, keyboard, scrollbar drag + track click, live follow, `fitContent`, duration presets, sync) whenever a viewport/navigation option is added — the scrollbar being the historically forgotten one.

## Test plan

- [x] `pnpm test` (chart): 91 files, 1047 passed, 2 intentionally skipped (real-index margin arithmetic doesn't apply to gap layouts)
- [x] New suites: `scroll-to-end-contract.test.ts` (13 pass / 2 skip) + 4 DOM parity tests in `viewport-attach.test.ts` + `llms-full-parity.test.ts`
- [x] `pnpm build`, `npx tsc --noEmit --ignoreDeprecations 6.0`, `pnpm lint` clean
- [x] `pnpm size-check` within limits (Main 42.36 / 42.5 kB — geometry consolidation adds no public API)
- [x] `pnpm --filter @trendcraft/chart gen:llms` verified from the repo root; current llms-full.txt already byte-identical