### PR TITLE
fix(core): reject fractional and non-finite periods in 18 batch indicators

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ## [Unreleased]
 
+### Breaking — 18 batch indicators now reject fractional and non-finite periods
+
+A period is a bar count, but the batch indicators only checked a lower bound,
+so a value that is not a positive integer passed straight through and changed
+what the indicator computed — usually without any error:
+
+- `atr(candles, { period: 14.5 })` never reached its `i === period` seed
+  branch, so the missing seed was coerced to 0 by `prevAtr ?? 0` and the whole
+  series came out roughly 15x too small. `rsi` and `mfi` degraded the same way.
+- `cci`, `standardDeviation`, `ulcerIndex` and `historicalVolatility` indexed
+  fractional offsets and pushed `NaN` into a `Series<number | null>` — 16 of 30
+  values for `cci(candles, { period: 14.5 })`.
+- `period: NaN` made the `i < period - 1` warm-up guard false for every bar, so
+  `donchianChannel`, `williamsR`, `highestLowest` and `stochastics` emitted a
+  structurally valid but completely different indicator: an all-time expanding
+  channel starting at bar 0, with no warm-up nulls. `volumeMa(14.5)` summed 15
+  bars and divided by 14.5.
+- `bollingerBands`, `roc`, `aroon`, `choppinessIndex`, `dpo` and `cmo` crashed
+  with a raw `TypeError` from deep inside the window loop.
+
+These now throw a validation error, matching what the moving-average family and
+every incremental counterpart have always done. Affected: `atr`, `rsi`, `mfi`,
+`cci`, `standardDeviation`, `ulcerIndex`, `historicalVolatility`,
+`donchianChannel`, `williamsR`, `highestLowest`/`highest`/`lowest`,
+`stochastics` (`kPeriod`, `dPeriod`, `slowing`), `volumeMa`, `bollingerBands`,
+`roc`, `aroon`, `choppinessIndex`, `dpo`, `cmo`.
+
+Existing error messages and lower bounds are unchanged, and valid integer
+periods behave exactly as before. Rejected values are those that were already
+producing wrong numbers or a crash: fractional, `NaN`, `±Infinity`, and — for
+the few options with no default (`highestLowest`, `highest`, `lowest`,
+`volumeMa`) — omitting the option entirely. Callers that reach these indicators
+indirectly surface the error too, so a fractional period fed through a
+parameter sweep, a serialized strategy, or a wrapper such as `supertrend`,
+`keltnerChannel` or `vsa` now fails loudly instead of returning a plausible
+wrong series.
+
+### Fixed — Safe API reports a non-integer period as INVALID_PARAMETER
+
+`trendcraft/safe` classifies a thrown error into a typed code, but its
+classifier only recognised "must be at least", "positive" and similar wordings.
+"must be an integer" fell through to `INDICATOR_ERROR`, which is meant for a
+failure inside the computation rather than a bad argument. This already
+affected the moving-average family — `smaSafe(candles, { period: 14.5 })`
+returned `INDICATOR_ERROR` — and would have applied to every indicator covered
+by the period validation above. Such errors now classify as
+`INVALID_PARAMETER`. The message text is unchanged; only the code differs.
+
 ### Breaking — incremental VSA scans the full 10-bar window for 'test' (schema v2)
 
 The incremental VSA's 'test' rule ("low volume near the lowest low of the last

--- a/packages/core/src/indicators/__tests__/period-validation.test.ts
+++ b/packages/core/src/indicators/__tests__/period-validation.test.ts
@@ -1,0 +1,550 @@
+/**
+ * Period-option validation across the batch indicators.
+ *
+ * A period is a bar count used to index candle arrays. Before this suite the
+ * batch indicators only checked a lower bound, so a fractional or non-finite
+ * period slipped through and changed what the indicator computed without ever
+ * failing:
+ *
+ * - `atr(candles, { period: 14.5 })` never reached its `i === period` seed
+ *   branch, so `prevAtr ?? 0` seeded from 0 and the whole series came out
+ *   roughly 15x too small.
+ * - `cci(candles, { period: 14.5 })` indexed fractional offsets, pushing NaN
+ *   into a `Series<number | null>`.
+ * - `donchianChannel(candles, { period: NaN })` made the `i < period - 1`
+ *   warm-up guard false for every bar, emitting an all-time expanding channel
+ *   from bar 0 instead of nulls.
+ *
+ * The incremental twins already rejected these values, so the two surfaces
+ * disagreed on what a valid period was.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import type { NormalizedCandle, Result, TrendCraftError } from "../../types";
+import {
+  createAroon,
+  createAtr,
+  createBollingerBands,
+  createCci,
+  createChoppinessIndex,
+  createCmo,
+  createDonchianChannel,
+  createDpo,
+  createHighestLowest,
+  createHistoricalVolatility,
+  createMfi,
+  createRoc,
+  createRsi,
+  createStandardDeviation,
+  createStochastics,
+  createUlcerIndex,
+  createWilliamsR,
+} from "../incremental";
+import { aroon } from "../momentum/aroon";
+import { cci } from "../momentum/cci";
+import { cmo } from "../momentum/cmo";
+import { dpo } from "../momentum/dpo";
+import { roc } from "../momentum/roc";
+import { rsi } from "../momentum/rsi";
+import { stochastics } from "../momentum/stochastics";
+import { williamsR } from "../momentum/williams-r";
+import { highest, highestLowest, lowest } from "../price/highest-lowest";
+import {
+  aroonSafe,
+  atrSafe,
+  bollingerBandsSafe,
+  cciSafe,
+  donchianChannelSafe,
+  dpoSafe,
+  highestLowestSafe,
+  mfiSafe,
+  rocSafe,
+  rsiSafe,
+  smaSafe,
+  stochasticsSafe,
+  volumeMaSafe,
+  williamsRSafe,
+} from "../safe";
+import { atr } from "../volatility/atr";
+import { bollingerBands } from "../volatility/bollinger-bands";
+import { choppinessIndex } from "../volatility/choppiness-index";
+import { donchianChannel } from "../volatility/donchian-channel";
+import { historicalVolatility } from "../volatility/historical-volatility";
+import { standardDeviation } from "../volatility/standard-deviation";
+import { ulcerIndex } from "../volatility/ulcer-index";
+import { mfi } from "../volume/mfi";
+import { volumeMa } from "../volume/volume-ma";
+
+const candles: NormalizedCandle[] = Array.from({ length: 40 }, (_, i) => {
+  const close = 100 + Math.sin(i / 3) * 5 + i * 0.2;
+  return {
+    time: 1700000000000 + i * 86400000,
+    open: close - 0.4,
+    high: close + 1.1,
+    low: close - 1.2,
+    close,
+    volume: 1000 + i * 10,
+  };
+});
+
+interface Target {
+  /** Name used in test titles */
+  name: string;
+  /** Message prefix the indicator uses for this option */
+  label: string;
+  /** Smallest accepted value */
+  min: number;
+  /** Invoke the batch indicator with the given value for the option */
+  run: (period: number) => unknown;
+  /** Invoke the incremental twin, when one exists */
+  runIncremental?: (period: number) => unknown;
+  /**
+   * True when the option has no default, so omitting it reaches the guard as
+   * `undefined`. Everywhere else `undefined` legitimately selects the default.
+   */
+  optionIsRequired?: boolean;
+}
+
+const TARGETS: Target[] = [
+  {
+    name: "atr",
+    label: "ATR period",
+    min: 1,
+    run: (p) => atr(candles, { period: p }),
+    runIncremental: (p) => createAtr({ period: p }),
+  },
+  {
+    name: "rsi",
+    label: "RSI period",
+    min: 1,
+    run: (p) => rsi(candles, { period: p }),
+    runIncremental: (p) => createRsi({ period: p }),
+  },
+  {
+    name: "mfi",
+    label: "MFI period",
+    min: 1,
+    run: (p) => mfi(candles, { period: p }),
+    runIncremental: (p) => createMfi({ period: p }),
+  },
+  {
+    name: "cci",
+    label: "CCI period",
+    min: 1,
+    run: (p) => cci(candles, { period: p }),
+    runIncremental: (p) => createCci({ period: p }),
+  },
+  {
+    name: "standardDeviation",
+    label: "Standard Deviation period",
+    min: 1,
+    run: (p) => standardDeviation(candles, { period: p }),
+    runIncremental: (p) => createStandardDeviation({ period: p }),
+  },
+  {
+    name: "ulcerIndex",
+    label: "Ulcer Index period",
+    min: 1,
+    run: (p) => ulcerIndex(candles, { period: p }),
+    runIncremental: (p) => createUlcerIndex({ period: p }),
+  },
+  {
+    name: "historicalVolatility",
+    label: "Historical Volatility period",
+    min: 2,
+    run: (p) => historicalVolatility(candles, { period: p }),
+    runIncremental: (p) => createHistoricalVolatility({ period: p }),
+  },
+  {
+    name: "donchianChannel",
+    label: "Donchian Channel period",
+    min: 1,
+    run: (p) => donchianChannel(candles, { period: p }),
+    runIncremental: (p) => createDonchianChannel({ period: p }),
+  },
+  {
+    name: "williamsR",
+    label: "Williams %R period",
+    min: 1,
+    run: (p) => williamsR(candles, { period: p }),
+    runIncremental: (p) => createWilliamsR({ period: p }),
+  },
+  {
+    name: "highestLowest",
+    label: "Period",
+    min: 1,
+    run: (p) => highestLowest(candles, { period: p }),
+    runIncremental: (p) => createHighestLowest({ period: p }),
+    optionIsRequired: true,
+  },
+  {
+    name: "highest",
+    label: "Period",
+    min: 1,
+    run: (p) => highest(candles, p),
+    optionIsRequired: true,
+  },
+  {
+    name: "lowest",
+    label: "Period",
+    min: 1,
+    run: (p) => lowest(candles, p),
+    optionIsRequired: true,
+  },
+  {
+    name: "stochastics (kPeriod)",
+    label: "kPeriod",
+    min: 1,
+    run: (p) => stochastics(candles, { kPeriod: p }),
+    runIncremental: (p) => createStochastics({ kPeriod: p }),
+  },
+  {
+    name: "stochastics (dPeriod)",
+    label: "dPeriod",
+    min: 1,
+    run: (p) => stochastics(candles, { dPeriod: p }),
+    runIncremental: (p) => createStochastics({ dPeriod: p }),
+  },
+  {
+    name: "stochastics (slowing)",
+    label: "slowing",
+    min: 1,
+    run: (p) => stochastics(candles, { slowing: p }),
+    runIncremental: (p) => createStochastics({ slowing: p }),
+  },
+  {
+    // No incremental twin exists for volumeMa.
+    name: "volumeMa",
+    label: "Volume MA period",
+    min: 1,
+    run: (p) => volumeMa(candles, { period: p }),
+    optionIsRequired: true,
+  },
+  {
+    name: "bollingerBands",
+    label: "Bollinger Bands period",
+    min: 1,
+    run: (p) => bollingerBands(candles, { period: p }),
+    runIncremental: (p) => createBollingerBands({ period: p }),
+  },
+  {
+    name: "roc",
+    label: "ROC period",
+    min: 1,
+    run: (p) => roc(candles, { period: p }),
+    runIncremental: (p) => createRoc({ period: p }),
+  },
+  {
+    name: "aroon",
+    label: "Aroon period",
+    min: 1,
+    run: (p) => aroon(candles, { period: p }),
+    runIncremental: (p) => createAroon({ period: p }),
+  },
+  {
+    name: "choppinessIndex",
+    label: "Choppiness Index period",
+    min: 2,
+    run: (p) => choppinessIndex(candles, { period: p }),
+    runIncremental: (p) => createChoppinessIndex({ period: p }),
+  },
+  {
+    name: "dpo",
+    label: "DPO period",
+    min: 1,
+    run: (p) => dpo(candles, { period: p }),
+    runIncremental: (p) => createDpo({ period: p }),
+  },
+  {
+    name: "cmo",
+    label: "CMO period",
+    min: 1,
+    run: (p) => cmo(candles, { period: p }),
+    runIncremental: (p) => createCmo({ period: p }),
+  },
+];
+
+/**
+ * Values with no integer representation. `undefined` is deliberately absent:
+ * for every option that declares a default it means "use the default", so it
+ * is only invalid for the handful of required options covered separately.
+ */
+const nonIntegerValues = (min: number): Array<[string, number]> => [
+  ["NaN", Number.NaN],
+  ["Infinity", Number.POSITIVE_INFINITY],
+  [`fractional (${min + 0.5})`, min + 0.5],
+  [`fractional (${min + 1.5})`, min + 1.5],
+];
+
+/**
+ * Values that compare below the minimum. `null` is here because it is what
+ * `JSON.stringify` turns `NaN` and `Infinity` into, and it numerically
+ * coerces to 0.
+ */
+const belowMinValues = (min: number): Array<[string, number]> => [
+  ["-Infinity", Number.NEGATIVE_INFINITY],
+  [`min - 1 (${min - 1})`, min - 1],
+  ["0", 0],
+  ["-0", -0],
+  ["-1", -1],
+  ["Number.MIN_VALUE", Number.MIN_VALUE],
+  ["null", null as unknown as number],
+];
+
+describe("period option validation (batch indicators)", () => {
+  for (const target of TARGETS) {
+    describe(target.name, () => {
+      for (const [name, value] of nonIntegerValues(target.min)) {
+        it(`rejects ${name} as a non-integer`, () => {
+          expect(() => target.run(value)).toThrow(`${target.label} must be an integer`);
+        });
+      }
+
+      for (const [name, value] of belowMinValues(target.min)) {
+        it(`rejects ${name} as below the minimum`, () => {
+          expect(() => target.run(value)).toThrow(`${target.label} must be at least ${target.min}`);
+        });
+      }
+
+      it("accepts the minimum and the next integer", () => {
+        expect(() => target.run(target.min)).not.toThrow();
+        expect(() => target.run(target.min + 1)).not.toThrow();
+      });
+
+      if (target.optionIsRequired) {
+        it("rejects undefined, since this option has no default", () => {
+          expect(() => target.run(undefined as unknown as number)).toThrow(
+            `${target.label} must be an integer`,
+          );
+        });
+      } else {
+        it("treats undefined as a request for the default", () => {
+          expect(() => target.run(undefined as unknown as number)).not.toThrow();
+        });
+      }
+    });
+  }
+
+  it("accepts a huge integer period (only integrality is validated, not magnitude)", () => {
+    expect(() => rsi(candles, { period: Number.MAX_SAFE_INTEGER })).not.toThrow();
+    const series = rsi(candles, { period: Number.MAX_SAFE_INTEGER });
+    expect(series.every((point) => point.value === null)).toBe(true);
+  });
+});
+
+describe("period validation agrees with the incremental twin", () => {
+  const twins = TARGETS.filter((t) => t.runIncremental !== undefined);
+
+  it("covers every target that has an incremental counterpart", () => {
+    expect(twins.length).toBe(TARGETS.length - 3); // highest, lowest, volumeMa have none
+  });
+
+  for (const target of twins) {
+    // The two surfaces word their errors differently (the incremental engine
+    // routes through `requireParam`), so only the accept/reject decision is
+    // compared — not the message. Lower bounds are excluded because a few
+    // pairs legitimately disagree there for unrelated, pre-existing reasons.
+    for (const [name, value] of nonIntegerValues(target.min)) {
+      it(`${target.name}: both surfaces reject ${name}`, () => {
+        expect(() => target.run(value)).toThrow();
+        expect(() => target.runIncremental?.(value)).toThrow();
+      });
+    }
+
+    it(`${target.name}: both surfaces accept a valid period`, () => {
+      expect(() => target.run(target.min + 1)).not.toThrow();
+      expect(() => target.runIncremental?.(target.min + 1)).not.toThrow();
+    });
+  }
+});
+
+/**
+ * The Safe API turns a thrown error into a typed `Result`, so the error *code*
+ * is part of its contract. A rejected period is a bad parameter and must
+ * classify as INVALID_PARAMETER — not INDICATOR_ERROR, which is for a failure
+ * inside the computation. The classifier previously keyed on "must be at
+ * least" and friends only, so the "must be an integer" message fell through.
+ */
+describe("Safe API classifies a rejected period as INVALID_PARAMETER", () => {
+  type SafeCall = (period: number) => Result<unknown, TrendCraftError>;
+
+  const SAFE_TARGETS: Array<[string, SafeCall]> = [
+    // sma reaches the message through the moving-average family's own guard,
+    // which predates the shared validator — it was misclassified too.
+    ["smaSafe", (p) => smaSafe(candles, { period: p })],
+    ["rsiSafe", (p) => rsiSafe(candles, { period: p })],
+    ["atrSafe", (p) => atrSafe(candles, { period: p })],
+    ["mfiSafe", (p) => mfiSafe(candles, { period: p })],
+    ["cciSafe", (p) => cciSafe(candles, { period: p })],
+    ["rocSafe", (p) => rocSafe(candles, { period: p })],
+    ["dpoSafe", (p) => dpoSafe(candles, { period: p })],
+    ["aroonSafe", (p) => aroonSafe(candles, { period: p })],
+    ["williamsRSafe", (p) => williamsRSafe(candles, { period: p })],
+    ["donchianChannelSafe", (p) => donchianChannelSafe(candles, { period: p })],
+    ["bollingerBandsSafe", (p) => bollingerBandsSafe(candles, { period: p })],
+    ["highestLowestSafe", (p) => highestLowestSafe(candles, { period: p })],
+    ["stochasticsSafe", (p) => stochasticsSafe(candles, { kPeriod: p })],
+    ["volumeMaSafe", (p) => volumeMaSafe(candles, { period: p })],
+  ];
+
+  const codeOf = (result: Result<unknown, TrendCraftError>): string =>
+    result.ok ? "ok" : result.error.code;
+
+  for (const [name, call] of SAFE_TARGETS) {
+    it(`${name}: fractional and NaN periods are INVALID_PARAMETER`, () => {
+      expect(codeOf(call(14.5))).toBe("INVALID_PARAMETER");
+      expect(codeOf(call(Number.NaN))).toBe("INVALID_PARAMETER");
+      expect(codeOf(call(Number.POSITIVE_INFINITY))).toBe("INVALID_PARAMETER");
+    });
+
+    it(`${name}: a below-minimum period stays INVALID_PARAMETER`, () => {
+      expect(codeOf(call(0))).toBe("INVALID_PARAMETER");
+    });
+
+    it(`${name}: a valid period still succeeds`, () => {
+      expect(codeOf(call(3))).toBe("ok");
+    });
+  }
+});
+
+/**
+ * Structural inventory: which batch indicators bound a period-like option
+ * without ever checking that it is an integer.
+ *
+ * This is a stocktake, not the primary regression guard — the per-indicator
+ * behavioural tests above are. Its job is to keep the remaining population
+ * visible and to fail when a new indicator quietly joins it.
+ *
+ * Matching is per *option*, not per file: an indicator that validates one of
+ * its periods and leaves a second one bare is still reported, which a
+ * file-level "does this file mention assertPeriod anywhere" check would miss.
+ */
+describe("period guard inventory", () => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const indicatorsRoot = path.resolve(here, "..");
+
+  const NAME_PART =
+    "[A-Za-z0-9_]*(?:period|Period|lookback|Lookback|bars|Bars|slowing|Slowing)[A-Za-z0-9_]*";
+
+  /** Period-like identifiers this file compares against a numeric literal. */
+  const boundedOptions = (text: string): string[] => [
+    ...new Set(
+      [...text.matchAll(new RegExp(`(${NAME_PART})\\s*(?:<|<=)\\s*[0-9]`, "g"))].map((m) => m[1]),
+    ),
+  ];
+
+  /** Identifiers this file checks for integrality, by either route. */
+  const integerChecked = (text: string): Set<string> =>
+    new Set([
+      ...[...text.matchAll(/Number\.isInteger\(\s*([A-Za-z0-9_]+)\s*\)/g)].map((m) => m[1]),
+      ...[...text.matchAll(/assertPeriod\(\s*"[^"]*"\s*,\s*([A-Za-z0-9_]+)/g)].map((m) => m[1]),
+    ]);
+
+  /** Files whose period options this change routes through `assertPeriod`. */
+  const FIXED_HERE = [
+    "momentum/aroon.ts",
+    "momentum/cci.ts",
+    "momentum/cmo.ts",
+    "momentum/dpo.ts",
+    "momentum/roc.ts",
+    "momentum/rsi.ts",
+    "momentum/stochastics.ts",
+    "momentum/williams-r.ts",
+    "price/highest-lowest.ts",
+    "volatility/atr.ts",
+    "volatility/bollinger-bands.ts",
+    "volatility/choppiness-index.ts",
+    "volatility/donchian-channel.ts",
+    "volatility/historical-volatility.ts",
+    "volatility/standard-deviation.ts",
+    "volatility/ulcer-index.ts",
+    "volume/mfi.ts",
+    "volume/volume-ma.ts",
+  ];
+
+  /**
+   * Bounded-but-unchecked period options, as `file -> option names`.
+   * Shrinking this map is the remaining work; it must never grow.
+   */
+  const KNOWN_UNVALIDATED: Record<string, string[]> = {
+    "adaptive/adaptive-bollinger.ts": ["period"],
+    "adaptive/adaptive-ma.ts": ["erPeriod"],
+    "adaptive/adaptive-rsi.ts": ["minPeriod"],
+    "adaptive/adaptive-stochastics.ts": ["minPeriod"],
+    "filter/roofing-filter.ts": ["highPassPeriod", "lowPassPeriod"],
+    "filter/super-smoother.ts": ["period"],
+    "momentum/adxr.ts": ["period"],
+    "momentum/awesome-oscillator.ts": ["fastPeriod", "slowPeriod"],
+    "momentum/balance-of-power.ts": ["smoothPeriod"],
+    "momentum/coppock-curve.ts": ["longRocPeriod", "shortRocPeriod", "wmaPeriod"],
+    "momentum/dmi.ts": ["adxPeriod", "period"],
+    "momentum/imi.ts": ["period"],
+    "momentum/macd.ts": ["fastPeriod", "signalPeriod", "slowPeriod"],
+    "momentum/mass-index.ts": ["emaPeriod", "sumPeriod"],
+    "momentum/ppo.ts": ["fastPeriod", "signalPeriod", "slowPeriod"],
+    "momentum/qstick.ts": ["period"],
+    "momentum/stoch-rsi.ts": ["dPeriod", "kPeriod", "rsiPeriod", "stochPeriod"],
+    "momentum/trix.ts": ["period", "signalPeriod"],
+    "momentum/tsi.ts": ["longPeriod", "shortPeriod", "signalPeriod"],
+    "momentum/ultimate-oscillator.ts": ["period1", "period2", "period3"],
+    "price/break-of-structure.ts": ["swingPeriod"],
+    "price/fractals.ts": ["period"],
+    "price/returns.ts": ["period"],
+    "price/swing-points.ts": ["leftBars", "rightBars"],
+    "relative-strength/benchmark-rs.ts": ["period"],
+    "relative-strength/multi-rs.ts": ["period"],
+    "smc/liquidity-sweep.ts": ["maxRecoveryBars", "swingPeriod"],
+    "smc/order-block.ts": ["maxBarsActive", "swingPeriod", "volumePeriod"],
+    "trend/ichimoku.ts": ["kijunPeriod", "senkouBPeriod", "tenkanPeriod"],
+    "trend/linear-regression.ts": ["period"],
+    "trend/schaff-trend-cycle.ts": ["cyclePeriod", "fastPeriod", "slowPeriod"],
+    "trend/supertrend.ts": ["period"],
+    "trend/vortex.ts": ["period"],
+    "volatility/atr-stops.ts": ["period"],
+    "volatility/chandelier-exit.ts": ["hlLookback", "period"],
+    "volatility/garman-klass.ts": ["period"],
+    "volatility/keltner-channel.ts": ["atrPeriod", "emaPeriod"],
+    "volume/cmf.ts": ["period"],
+    "volume/ease-of-movement.ts": ["period"],
+    "volume/elder-force-index.ts": ["longPeriod", "shortPeriod"],
+    "volume/klinger.ts": ["longPeriod", "shortPeriod", "signalPeriod"],
+    "volume/volume-anomaly.ts": ["period"],
+  };
+
+  const collect = (dir: string, out: string[] = []): string[] => {
+    for (const entry of readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        // `incremental` validates through `requireParam`; `safe` wraps other
+        // indicators rather than declaring its own periods.
+        if (entry === "__tests__" || entry === "incremental" || entry === "safe") continue;
+        collect(full, out);
+      } else if (entry.endsWith(".ts")) {
+        out.push(full);
+      }
+    }
+    return out;
+  };
+
+  const unvalidated: Record<string, string[]> = {};
+  for (const file of collect(indicatorsRoot)) {
+    const text = readFileSync(file, "utf8");
+    const bounded = boundedOptions(text);
+    if (bounded.length === 0) continue;
+    const checked = integerChecked(text);
+    const bare = bounded.filter((name) => !checked.has(name)).sort();
+    if (bare.length > 0) unvalidated[path.relative(indicatorsRoot, file)] = bare;
+  }
+
+  it("reports exactly the pinned bounded-but-unchecked options", () => {
+    expect(unvalidated).toEqual(KNOWN_UNVALIDATED);
+  });
+
+  it("reports none of the options fixed here", () => {
+    const regressed = FIXED_HERE.filter((file) => unvalidated[file] !== undefined);
+    expect(regressed).toEqual([]);
+  });
+});

--- a/packages/core/src/indicators/momentum/aroon.ts
+++ b/packages/core/src/indicators/momentum/aroon.ts
@@ -12,6 +12,7 @@
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 import { AROON_META } from "../indicator-meta";
 
 /**
@@ -63,7 +64,7 @@ export function aroon(
 ): Series<AroonValue> {
   const { period = 25 } = options;
 
-  if (period < 1) throw new Error("Aroon period must be at least 1");
+  assertPeriod("Aroon period", period);
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
   const result: Series<AroonValue> = [];

--- a/packages/core/src/indicators/momentum/cci.ts
+++ b/packages/core/src/indicators/momentum/cci.ts
@@ -8,6 +8,7 @@
 import { getPriceSeries, isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, PriceSource, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 import { CCI_META } from "../indicator-meta";
 
 /**
@@ -53,9 +54,7 @@ export function cci(
 ): Series<number | null> {
   const { period = 20, constant = 0.015, source = "hlc3" } = options;
 
-  if (period < 1) {
-    throw new Error("CCI period must be at least 1");
-  }
+  assertPeriod("CCI period", period);
 
   // Normalize if needed
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);

--- a/packages/core/src/indicators/momentum/cmo.ts
+++ b/packages/core/src/indicators/momentum/cmo.ts
@@ -11,6 +11,7 @@
 import { getPrice, isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, PriceSource, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 import { CMO_META } from "../indicator-meta";
 
 /**
@@ -49,9 +50,7 @@ export function cmo(
 ): Series<number | null> {
   const { period = 14, source = "close" } = options;
 
-  if (period < 1) {
-    throw new Error("CMO period must be at least 1");
-  }
+  assertPeriod("CMO period", period);
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
   const result: Series<number | null> = [];

--- a/packages/core/src/indicators/momentum/dpo.ts
+++ b/packages/core/src/indicators/momentum/dpo.ts
@@ -9,6 +9,7 @@
 import { getPrice, isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, PriceSource, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 
 /**
  * DPO options
@@ -52,9 +53,7 @@ export function dpo(
 ): Series<number | null> {
   const { period = 20, source = "close" } = options;
 
-  if (period < 1) {
-    throw new Error("DPO period must be at least 1");
-  }
+  assertPeriod("DPO period", period);
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
   const result: Series<number | null> = [];

--- a/packages/core/src/indicators/momentum/roc.ts
+++ b/packages/core/src/indicators/momentum/roc.ts
@@ -8,6 +8,7 @@
 import { getPrice, isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, PriceSource, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 import { ROC_META } from "../indicator-meta";
 
 /**
@@ -50,9 +51,7 @@ export function roc(
 ): Series<number | null> {
   const { period = 12, source = "close" } = options;
 
-  if (period < 1) {
-    throw new Error("ROC period must be at least 1");
-  }
+  assertPeriod("ROC period", period);
 
   // Normalize if needed
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);

--- a/packages/core/src/indicators/momentum/rsi.ts
+++ b/packages/core/src/indicators/momentum/rsi.ts
@@ -6,6 +6,7 @@
 import { getPriceSeries, isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, RsiOptions, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 import { RSI_META } from "../indicator-meta";
 
 /**
@@ -34,9 +35,7 @@ export function rsi(
 ): Series<number | null> {
   const { period = 14, source = "close" } = options;
 
-  if (period < 1) {
-    throw new Error("RSI period must be at least 1");
-  }
+  assertPeriod("RSI period", period);
 
   // Normalize if needed
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);

--- a/packages/core/src/indicators/momentum/stochastics.ts
+++ b/packages/core/src/indicators/momentum/stochastics.ts
@@ -6,6 +6,7 @@
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 import { STOCHASTICS_META } from "../indicator-meta";
 
 /**
@@ -63,9 +64,9 @@ export function stochastics(
 ): Series<StochasticsValue> {
   const { kPeriod = 14, dPeriod = 3, slowing = 3 } = options;
 
-  if (kPeriod < 1) throw new Error("kPeriod must be at least 1");
-  if (dPeriod < 1) throw new Error("dPeriod must be at least 1");
-  if (slowing < 1) throw new Error("slowing must be at least 1");
+  assertPeriod("kPeriod", kPeriod);
+  assertPeriod("dPeriod", dPeriod);
+  assertPeriod("slowing", slowing);
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
 

--- a/packages/core/src/indicators/momentum/williams-r.ts
+++ b/packages/core/src/indicators/momentum/williams-r.ts
@@ -8,6 +8,7 @@
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 import { WILLIAMS_R_META } from "../indicator-meta";
 
 /**
@@ -47,9 +48,7 @@ export function williamsR(
 ): Series<number | null> {
   const { period = 14 } = options;
 
-  if (period < 1) {
-    throw new Error("Williams %R period must be at least 1");
-  }
+  assertPeriod("Williams %R period", period);
 
   // Normalize if needed
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);

--- a/packages/core/src/indicators/price/highest-lowest.ts
+++ b/packages/core/src/indicators/price/highest-lowest.ts
@@ -5,6 +5,7 @@
 import { getPriceSeries, isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries } from "../../core/tag-series";
 import type { Candle, HighestLowestOptions, NormalizedCandle, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 
 /**
  * Result type for highest/lowest
@@ -41,9 +42,7 @@ export function highestLowest(
 ): Series<HighestLowestValue> {
   const { period, source } = options;
 
-  if (period < 1) {
-    throw new Error("Period must be at least 1");
-  }
+  assertPeriod("Period", period);
 
   // Normalize if needed
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
@@ -119,9 +118,7 @@ export function highest(
   candles: Candle[] | NormalizedCandle[],
   period: number,
 ): Series<number | null> {
-  if (period < 1) {
-    throw new Error("Period must be at least 1");
-  }
+  assertPeriod("Period", period);
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
   const result: Series<number | null> = [];
@@ -164,9 +161,7 @@ export function lowest(
   candles: Candle[] | NormalizedCandle[],
   period: number,
 ): Series<number | null> {
-  if (period < 1) {
-    throw new Error("Period must be at least 1");
-  }
+  assertPeriod("Period", period);
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
   const result: Series<number | null> = [];

--- a/packages/core/src/indicators/safe.ts
+++ b/packages/core/src/indicators/safe.ts
@@ -95,7 +95,11 @@ type SafeVersion<F extends (...args: never[]) => unknown> = (
 ) => Result<ReturnType<F>, TrendCraftError>;
 
 function classifyErrorCode(message: string): TrendCraftErrorCode {
-  if (/must be (at least|positive|greater|less|non-negative)/i.test(message)) {
+  // "an? integer|integers" covers both the singular form used by the period
+  // validator and the plural one used by array-valued options such as
+  // emaRibbon's `periods`. A rejected period is a bad parameter, not an
+  // indicator failure, so it must not fall through to INDICATOR_ERROR.
+  if (/must be (at least|positive|greater|less|non-negative|an? integer|integers)/i.test(message)) {
     return "INVALID_PARAMETER";
   }
   if (/not enough|insufficient|need at least/i.test(message)) {

--- a/packages/core/src/indicators/volatility/atr.ts
+++ b/packages/core/src/indicators/volatility/atr.ts
@@ -6,6 +6,7 @@
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
 import type { AtrOptions, Candle, NormalizedCandle, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 import { ATR_META } from "../indicator-meta";
 
 /**
@@ -35,9 +36,7 @@ export function atr(
 ): Series<number | null> {
   const { period = 14 } = options;
 
-  if (period < 1) {
-    throw new Error("ATR period must be at least 1");
-  }
+  assertPeriod("ATR period", period);
 
   // Normalize if needed
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);

--- a/packages/core/src/indicators/volatility/bollinger-bands.ts
+++ b/packages/core/src/indicators/volatility/bollinger-bands.ts
@@ -12,6 +12,7 @@ import type {
   NormalizedCandle,
   Series,
 } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 import { BB_META } from "../indicator-meta";
 
 /**
@@ -39,9 +40,7 @@ export function bollingerBands(
 ): Series<BollingerBandsValue> {
   const { period = 20, stdDev = 2, source = "close" } = options;
 
-  if (period < 1) {
-    throw new Error("Bollinger Bands period must be at least 1");
-  }
+  assertPeriod("Bollinger Bands period", period);
 
   if (stdDev <= 0) {
     throw new Error("Standard deviation multiplier must be positive");

--- a/packages/core/src/indicators/volatility/choppiness-index.ts
+++ b/packages/core/src/indicators/volatility/choppiness-index.ts
@@ -9,6 +9,7 @@
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 import { CHOPPINESS_META } from "../indicator-meta";
 
 /**
@@ -51,9 +52,7 @@ export function choppinessIndex(
 ): Series<number | null> {
   const { period = 14 } = options;
 
-  if (period < 2) {
-    throw new Error("Choppiness Index period must be at least 2");
-  }
+  assertPeriod("Choppiness Index period", period, 2);
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
 

--- a/packages/core/src/indicators/volatility/donchian-channel.ts
+++ b/packages/core/src/indicators/volatility/donchian-channel.ts
@@ -7,6 +7,7 @@
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 import { DONCHIAN_META } from "../indicator-meta";
 
 /**
@@ -65,9 +66,7 @@ export function donchianChannel(
 ): Series<DonchianValue> {
   const { period = 20 } = options;
 
-  if (period < 1) {
-    throw new Error("Donchian Channel period must be at least 1");
-  }
+  assertPeriod("Donchian Channel period", period);
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
 

--- a/packages/core/src/indicators/volatility/historical-volatility.ts
+++ b/packages/core/src/indicators/volatility/historical-volatility.ts
@@ -8,6 +8,7 @@
 import { getPrice, isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, PriceSource, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 
 /**
  * Historical Volatility options
@@ -51,9 +52,7 @@ export function historicalVolatility(
 ): Series<number | null> {
   const { period = 20, annualFactor = 252, source = "close" } = options;
 
-  if (period < 2) {
-    throw new Error("Historical Volatility period must be at least 2");
-  }
+  assertPeriod("Historical Volatility period", period, 2);
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
   const result: Series<number | null> = [];

--- a/packages/core/src/indicators/volatility/standard-deviation.ts
+++ b/packages/core/src/indicators/volatility/standard-deviation.ts
@@ -7,6 +7,7 @@
 
 import { getPrice, isNormalized, normalizeCandles } from "../../core/normalize";
 import type { Candle, NormalizedCandle, PriceSource, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 
 /**
  * Standard Deviation options
@@ -47,9 +48,7 @@ export function standardDeviation(
 ): Series<number | null> {
   const { period = 20, source = "close" } = options;
 
-  if (period < 1) {
-    throw new Error("Standard Deviation period must be at least 1");
-  }
+  assertPeriod("Standard Deviation period", period);
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
   const result: Series<number | null> = [];

--- a/packages/core/src/indicators/volatility/ulcer-index.ts
+++ b/packages/core/src/indicators/volatility/ulcer-index.ts
@@ -8,6 +8,7 @@
 import { getPrice, isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, PriceSource, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 
 /**
  * Ulcer Index options
@@ -55,9 +56,7 @@ export function ulcerIndex(
 ): Series<number | null> {
   const { period = 14, source = "close" } = options;
 
-  if (period < 1) {
-    throw new Error("Ulcer Index period must be at least 1");
-  }
+  assertPeriod("Ulcer Index period", period);
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
   const result: Series<number | null> = [];

--- a/packages/core/src/indicators/volume/mfi.ts
+++ b/packages/core/src/indicators/volume/mfi.ts
@@ -6,6 +6,7 @@
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import { tagSeries, withLabelParams } from "../../core/tag-series";
 import type { Candle, NormalizedCandle, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 import { MFI_META } from "../indicator-meta";
 
 /**
@@ -53,9 +54,7 @@ export function mfi(
 ): Series<number | null> {
   const { period = 14 } = options;
 
-  if (period < 1) {
-    throw new Error("MFI period must be at least 1");
-  }
+  assertPeriod("MFI period", period);
 
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);
 

--- a/packages/core/src/indicators/volume/volume-ma.ts
+++ b/packages/core/src/indicators/volume/volume-ma.ts
@@ -4,6 +4,7 @@
 
 import { isNormalized, normalizeCandles } from "../../core/normalize";
 import type { Candle, NormalizedCandle, Series } from "../../types";
+import { assertPeriod } from "../../utils/validate-period";
 
 /**
  * Options for Volume MA calculation
@@ -32,9 +33,7 @@ export function volumeMa(
 ): Series<number | null> {
   const { period, type = "sma" } = options;
 
-  if (period < 1) {
-    throw new Error("Volume MA period must be at least 1");
-  }
+  assertPeriod("Volume MA period", period);
 
   // Normalize if needed
   const normalized = isNormalized(candles) ? candles : normalizeCandles(candles);

--- a/packages/core/src/utils/validate-period.ts
+++ b/packages/core/src/utils/validate-period.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared validation for integer-valued "period" style indicator options.
+ *
+ * Window lengths, lookbacks and smoothing counts are bar counts: they index
+ * candle arrays, so only positive integers are meaningful. Accepting a
+ * fractional or non-finite value does not merely produce a slightly different
+ * number — it silently changes the indicator. A fractional period makes the
+ * `i === period` seed branch of the Wilder family unreachable and a `NaN`
+ * period makes the `i < period - 1` warm-up guard false for every bar, so the
+ * output keeps its expected shape while meaning something else entirely.
+ *
+ * This is the single owner of that rule for the batch indicators. The
+ * incremental engine enforces the same rule through `requireParam` in
+ * `indicators/incremental/state-contract.ts`; the two surfaces must agree on
+ * which values are acceptable, even though they word their errors differently.
+ */
+
+/**
+ * Assert that a period-like option is an integer no smaller than `min`.
+ *
+ * Checks the lower bound before integrality so that the messages match the
+ * moving-average family, which has always validated in that order. Values that
+ * cannot be compared (`NaN`) or that have no integer representation
+ * (`Infinity`) fall through the bound check and are rejected as non-integers.
+ *
+ * @param label - Human-readable option name, used verbatim in the error message
+ *   (e.g. `"ATR period"`, `"kPeriod"`)
+ * @param value - The option value to validate
+ * @param min - Smallest acceptable value (default 1)
+ * @throws Error if `value` is below `min`, fractional, non-finite, or not a number
+ *
+ * @example
+ * ```ts
+ * assertPeriod("ATR period", 14); // ok
+ * assertPeriod("ATR period", 14.5); // throws: ATR period must be an integer
+ * assertPeriod("ATR period", 0); // throws: ATR period must be at least 1
+ * assertPeriod("Choppiness Index period", 1, 2); // throws: must be at least 2
+ * ```
+ */
+export function assertPeriod(label: string, value: number, min = 1): void {
+  if (value < min) {
+    throw new Error(`${label} must be at least ${min}`);
+  }
+  if (!Number.isInteger(value)) {
+    throw new Error(`${label} must be an integer`);
+  }
+}


### PR DESCRIPTION
## Problem

A period option is a bar count used to index candle arrays, so only positive
integers are meaningful. The batch indicators only checked a lower bound
(`if (period < 1) throw`). Any value that was not a positive integer passed
that guard and changed what the indicator computed — in most cases without
raising anything at all.

`period: 14.5`

```
hand-computed correct ATR(14) @14..17: [ 5, 5, 5, 5 ]
atr p=14   : [ 5, 5, 5, 5 ]
atr p=14.5 : [ null, 0.3448275862068966, 0.6658739595719382, 0.9647792037393907 ]
             ^ expected 5, got ~0.34 (~15x too small), silently
rsi p=14.5 : [ null, 0, 0, 41.52 ]      (rsi p=14: [ 44.86, 40.24, 39.28, 44.23 ])
mfi p=14.5 : [ null, 100, 100, 100 ]    degrades to a constant
```

`atr` never reaches its `i === period` seed branch when the period is
fractional (the loop index is an integer), so `prevAtr ?? 0` seeds the Wilder
recursion from 0.

```
cci period=14.5: NaN count = 16 / 30 | last value = NaN
cci period=NaN : NaN count = 30 / 30
standardDeviation period=14.5: NaN count = 16 | last = NaN
ulcerIndex period=14.5: NaN count = 3 | last = NaN
historicalVolatility period=14.5: NaN count = 15 | last = NaN
```

These index fractional offsets, get `undefined`, and push `NaN` into a
`Series<number | null>`.

`period: NaN` is worse, because `i < period - 1` is false for every `i`: the
warm-up guard never fires, no window eviction happens, and the output is a
structurally valid-looking but completely different indicator.

```
=== donchianChannel period=NaN ===
bar0 : {"upper":101.5,"middle":99.5,"lower":97.5}        <- expected all null
bar29: {"upper":118.59358246623383,...,"lower":91.71045082902071}
independent global high/low over all 30 bars: 118.59358246623383 91.71045082902071
bar29 equals ALL-TIME expanding channel? true

=== williamsR period=NaN ===
bar0: -25 | null count (should be 13): 0 | correct period=14 bar29: -48.262209269899884

=== stochastics kPeriod=NaN vs 14 ===
kPeriod=NaN first non-null k idx: 2 | kPeriod=14: 15

=== volumeMa period=14.5 ===
volumeMa(14.5) last: 1924.1379310344828
independent 14-bar SMA: 1900 | 15-bar SMA: 1860
code semantics sum(15 items)/14.5 = 1924.1379310344828
```

Finally, `bollingerBands`, `roc`, `aroon`, `choppinessIndex`, `dpo` and `cmo`
crash with a raw `TypeError` (`Cannot read properties of undefined (reading
'close'/'high'/'time')`) from deep inside the window loop instead of a
validation error. That one is loud rather than silent, but it is still the
wrong error.

The moving-average family already validated `Number.isInteger` and threw, and
so did every incremental counterpart:

```
sma period=14.5           : throws -> SMA period must be an integer
incremental cci period=14.5: throws -> cci: option "period" failed validation (must be a positive integer)
createDonchianChannel / createWilliamsR / createStochastics (NaN or 14.5): all throw
```

So the two surfaces disagreed about what a valid period was. These values are
reachable in ordinary use — parameter sweeps with a fractional step,
serialized strategies, and any wrapper that forwards a caller-supplied period.

## Change

Add `assertPeriod(label, value, min)` in `src/utils/validate-period.ts` as the
single owner of the rule for the batch indicators, and route all 18 through it:

`atr`, `rsi`, `mfi`, `cci`, `standardDeviation`, `ulcerIndex`,
`historicalVolatility`, `donchianChannel`, `williamsR`,
`highestLowest`/`highest`/`lowest`, `stochastics` (`kPeriod`, `dPeriod`,
`slowing`), `volumeMa`, `bollingerBands`, `roc`, `aroon`, `choppinessIndex`,
`dpo`, `cmo`.

Deliberately unchanged:

- **Error messages.** The helper reproduces each indicator's existing wording
  (`ATR period must be at least 1`, `kPeriod must be at least 1`, …) rather
  than unifying them, so no currently-pinned message moves.
- **Lower bounds.** `historicalVolatility` and `choppinessIndex` keep their
  minimum of 2; everything else keeps 1.
- **Check order.** The bound is tested before integrality, matching the
  moving-average family, so `period: 0.5` still reports "must be at least 1".
- **Valid integer periods.** Behaviour is identical.
- **Non-integer options.** `bollingerBands`'s `stdDev` and the various
  `multiplier` options are real-valued and are not touched.

Newly rejected: fractional, `NaN`, `±Infinity`, and — for the four options
that declare no default (`highestLowest`, `highest`, `lowest`, `volumeMa`) —
omitting the option entirely, which previously slipped through as `undefined`
because `undefined < 1` is `false`. Options that do declare a default still
treat `undefined` as a request for that default.

Only integrality is validated, not magnitude: a huge integer period is
accepted and yields an all-null series, which is the honest "not enough data"
answer.

### Safe API classification

`trendcraft/safe` turns a thrown error into a typed `Result`, so the error code
is part of its contract. Its classifier keyed on `must be (at least|positive|
greater|less|non-negative)` only, so `must be an integer` fell through to
`INDICATOR_ERROR` — a code meant for a failure inside the computation, not a
bad argument.

This predates the change here; it already affected the moving-average family:

```
before:  smaSafe(candles, { period: 14.5 })  ->  INDICATOR_ERROR
after:   smaSafe(candles, { period: 14.5 })  ->  INVALID_PARAMETER
```

The classifier now recognises the integer wording, singular and plural. Message
text is unchanged; only the code differs.

## Test plan

New suite `src/indicators/__tests__/period-validation.test.ts`, 427 tests:

- **Behavioural, 22 options** (the 18 files; `highest-lowest` and `stochastics`
  contribute three each). Each rejects `NaN`, `+Infinity`, two fractional
  values, and separately `-Infinity`, `min - 1`, `0`, `-0`, `-1`,
  `Number.MIN_VALUE` and `null`, with the expected message; each accepts `min`
  and `min + 1`. `null` is included because it is what `JSON.stringify` turns
  `NaN` and `Infinity` into.
- **Required vs defaulted options.** The four options with no default must
  reject `undefined`; the other 18 must treat it as the default.
- **Incremental agreement, 19 twins.** Both surfaces reject the same
  non-integer values. Messages are not compared (the incremental engine words
  them differently), and lower bounds are excluded because a few pairs
  legitimately disagree there for unrelated pre-existing reasons.
- **Safe API, 14 indicators.** Fractional, `NaN`, `Infinity` and
  below-minimum periods all classify as `INVALID_PARAMETER`; valid periods
  still succeed. Includes `smaSafe`, which pins the pre-existing
  misclassification described above.
- **Per-option inventory.** 42 files / 73 period-like options are still
  bounded without an integer check; they are pinned as `file -> option names`
  so the remaining population is visible and cannot grow silently. Matching per
  option rather than per file is deliberate — a file that validates one period
  and leaves a second bare is still reported. Verified by temporarily
  half-fixing `dmi.ts` (reported `["adxPeriod"]`) and by adding a new bare
  option to `sma.ts`, a file that already contains `Number.isInteger`
  (reported `["smoothPeriod"]`, which a file-level check would have missed).

Indirect callers were probed rather than reasoned about, confirming a
fractional period now surfaces instead of returning a plausible wrong series:

```
supertrend period=14.5         THROW: ATR period must be an integer
keltnerChannel atrPeriod=14.5  THROW: ATR period must be an integer
vsa atrPeriod=14.5             THROW: ATR period must be an integer
vsa volumeMaPeriod=NaN         THROW: Volume MA period must be an integer
connorsRsi rsiPeriod=3.5       THROW: RSI period must be an integer
stochRsi rsiPeriod=14.5        THROW: RSI period must be an integer
adaptiveRsi minPeriod=5.5      THROW: RSI period must be an integer
--- valid inputs ---
supertrend period=10           NO THROW
vsa defaults                   NO THROW
adaptiveRsi defaults           NO THROW
```

`adaptiveRsi` derives its effective period with `Math.round` over an integer
loop variable, so an integer `minPeriod` is unaffected.

Full verification:

| Check | Result |
| --- | --- |
| `pnpm test` (core) | 362 files, 7005 tests pass |
| `npx tsc --noEmit --ignoreDeprecations 6.0` | clean |
| `pnpm build` (core) | succeeds |
| `npx biome check src/` | clean for this diff |
| `pnpm test` (chart) | 91 files, 1049 tests pass |
| `pnpm test` (mcp) | 9 files, 83 tests pass |

Negative checks (the tests must fail without the fix):

- Reverting the 18 indicator files: 154 of 385 tests fail.
- Reverting only the Safe API classifier: 14 of 427 tests fail.

## Follow-ups (not in this PR)

- The 42 files / 73 options in the pinned inventory. Not mechanical: the same
  class of guard also covers real-valued options such as `stdDev` and the
  `multiplier` family, so each site needs a bar-count-vs-multiplier decision.
- Indicators with no bound at all on a period-like option (`leftBars`,
  `rightBars`, array-valued options, `connorsRsi`'s `rocPeriod`), which need a
  minimum chosen per option.
- The incremental engine repeats the predicate
  `(v) => Number.isInteger(v) && v >= 1` at 99 call sites; it could share one
  definition with the batch rule.
- `createHighestLowest` defaults `period` to 20 while the batch `highestLowest`
  requires it — a pre-existing asymmetry between the two surfaces, left as is
  here.
