### PR TITLE
fix(core): derive backtest drawdown from the equity curve, not the cash balance

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 ## [Unreleased]
 
+### Breaking — drawdown is measured on account equity, not on the cash balance
+
+`runBacktest` and `runBacktestScaled` tracked `maxDrawdown` and
+`drawdownPeriods` against the realized **cash** balance, updated only when a
+trade closed. Cash is 0 while a position is open and jumps to the realized
+slice on a partial exit, so the reported drawdown had little to do with the
+account's actual equity path:
+
+- **A partial exit fabricated a drawdown.** A strictly rising account with
+  `partialTakeProfit: { threshold: 5, sellPercent: 50 }` returned an
+  `equityCurve` that never declined by a cent —
+  `[1000000, 1000000, 1019801.98, …, 1188118.81]` — alongside
+  `maxDrawdown: 45.54` and a `drawdownPeriods` entry claiming a
+  `troughEquity` of 544,554. That "trough" was just the cash left after
+  selling half the position. A two-level `scaleOut` on the same path reported
+  56.44 while finishing at 1,186,534; three tranches plus a partial exit under
+  `runBacktestScaled` reported 46.75 while finishing at 1,161,747.
+- **A real decline was invisible.** An account held through
+  100 → 50 → 110 reported `maxDrawdown: 0` and no drawdown periods, because
+  cash never moved.
+- **The end-of-data close was not counted at all.** It updated the period
+  tracker but not the scalar, so a run ending with a losing open position
+  reported `maxDrawdown: 0` while `drawdownPeriods` said 33.33 — three fields
+  of one result contradicting each other. Closing the identical path with an
+  explicit exit signal instead gave 33.33.
+
+Both engines now derive drawdown from the finished `equityCurve` itself, in
+one pass, so `maxDrawdown` equals the deepest decline of `equityCurve` and the
+largest `maxDepthPercent` in `drawdownPeriods` by construction rather than by
+agreement.
+
+**What changes for you:** any strategy using `partialTakeProfit`, `scaleOut`,
+margin `reduceToMaintenance`, or ending with an open position reports a
+different `maxDrawdown` than before — usually much smaller for partial-exit
+strategies and larger for buy-and-hold-style runs. Everything derived from it
+moves with it: `calmarRatio`, `scoreBacktestResult`, the `"maxDrawdown"`,
+`"calmar"` and `"mar"` optimization objectives and constraints, drawdown
+analysis and tear sheets. Grid search and walk-forward stop penalising
+partial-exit strategies as though they had taken a ~50% loss.
+`drawdownPeriods` also gains bar-accurate `durationBars`/`recoveryBars`, since
+peaks and troughs are now located on the bar they occur rather than on the
+next trade close.
+
+### Added — `runBacktestScaled` reports an equity curve
+
+`runBacktestScaled` now returns `equityCurve` and a populated
+`drawdownPeriods` (previously always `[]`). Equity is cash plus the shares
+held across every tranche plus the capital the position still reserves for
+tranches it has not entered — that reserve leaves the cash balance when the
+position opens, so counting it keeps a partially-entered position from
+reading as an instant loss. Because the result now carries an equity curve,
+its `sharpeRatio` and `sortinoRatio` are annualized from that curve's
+bar-to-bar returns, matching `runBacktest`, instead of from per-trade returns.
+
 ### Breaking — pattern direction now comes from one table; `fromPatternSignal` can return `null`
 
 Two functions each decided on their own whether a chart pattern points up or

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -2976,7 +2976,7 @@ interface BacktestResult {
   totalReturnPercent: number;        // 総リターン率
   tradeCount: number;                // 取引回数
   winRate: number;                   // 勝率 (%)
-  maxDrawdown: number;               // 最大ドローダウン (%)
+  maxDrawdown: number;               // 最大ドローダウン: equityCurve の最大下落率 (%)
   sharpeRatio: number;               // シャープレシオ（エクイティカーブから年率化）
   sortinoRatio: number;              // ソルティノレシオ（年率化・下方偏差ベース）
   calmarRatio: number;               // CAGR ÷ 最大ドローダウン
@@ -4448,6 +4448,8 @@ const curve = getAWFEquityCurve(awfResult, 1000000);
 ### `runBacktestScaled(candles, entry, exit, options)`
 
 分割エントリー戦略でのバックテスト。一度に全ポジションを建てる代わりに、資金を複数のトランシェに分割します。
+
+結果には `runBacktest` と同じ時価評価ベースの `equityCurve` / `maxDrawdown` / `drawdownPeriods` が含まれます。未エントリーのトランシェ向けに留保している資金もエクイティとして数えるため、損失としては現れません。
 
 ```typescript
 import { runBacktestScaled, goldenCrossCondition, deadCrossCondition } from 'trendcraft';

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -2998,7 +2998,7 @@ interface BacktestResult {
   totalReturnPercent: number;        // Total return percentage
   tradeCount: number;                // Number of trades
   winRate: number;                   // Win rate (%)
-  maxDrawdown: number;               // Maximum drawdown (%)
+  maxDrawdown: number;               // Deepest peak-to-trough decline of equityCurve (%)
   sharpeRatio: number;               // Sharpe ratio, annualized from the equity curve
   sortinoRatio: number;              // Sortino ratio (annualized, downside deviation)
   calmarRatio: number;               // CAGR / max drawdown
@@ -4491,6 +4491,8 @@ const curve = getAWFEquityCurve(awfResult, 1000000);
 ### `runBacktestScaled(candles, entry, exit, options)`
 
 Backtest with split/scaled entry strategies. Instead of entering a full position at once, capital is divided into multiple tranches.
+
+The result carries `equityCurve`, `maxDrawdown` and `drawdownPeriods` on the same mark-to-market basis as `runBacktest`; capital a position still reserves for tranches it has not entered counts as equity, not as a loss.
 
 ```typescript
 import { runBacktestScaled, goldenCrossCondition, deadCrossCondition } from 'trendcraft';

--- a/packages/core/src/analysis/__tests__/drawdown-analysis.test.ts
+++ b/packages/core/src/analysis/__tests__/drawdown-analysis.test.ts
@@ -175,9 +175,9 @@ describe("analyzeDrawdowns", () => {
 
       if (result.drawdownPeriods.length > 0) {
         const maxPeriodDepth = Math.max(...result.drawdownPeriods.map((p) => p.maxDepthPercent));
-        // The max depth from drawdown periods should be <= the overall maxDrawdown
-        // (they track different things: periods track equity curve, maxDrawdown tracks running max)
-        expect(maxPeriodDepth).toBeLessThanOrEqual(result.maxDrawdown + 0.01);
+        // Both come out of the same equity path, so the deepest period IS the
+        // overall maxDrawdown.
+        expect(maxPeriodDepth).toBeCloseTo(result.maxDrawdown, 10);
       }
     });
 

--- a/packages/core/src/backtest/__tests__/drawdown-equity.test.ts
+++ b/packages/core/src/backtest/__tests__/drawdown-equity.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from "vitest";
+import type { BacktestResult, NormalizedCandle } from "../../types";
+import { alwaysFalse, alwaysTrue } from "../conditions";
+import { runBacktest } from "../engine";
+import { runBacktestScaled } from "../scaled-entry";
+
+/**
+ * Drawdown is a property of the mark-to-market equity path.
+ *
+ * These tests pin that `maxDrawdown`, `drawdownPeriods` and `equityCurve`
+ * describe one and the same path. Before, drawdown was measured on the cash
+ * balance, which is 0 while fully invested and jumps to the realized slice on
+ * a partial exit — so a rising account could report a 45% drawdown and a
+ * halving account could report none.
+ */
+
+const DAY = 24 * 60 * 60 * 1000;
+
+/** Flat OHLC bars: every price of the bar equals its close. */
+function flat(closes: number[]): NormalizedCandle[] {
+  return closes.map((c, i) => ({
+    time: Date.UTC(2024, 0, 1) + i * DAY,
+    open: c,
+    high: c,
+    low: c,
+    close: c,
+    volume: 1000,
+  }));
+}
+
+/** Exit condition that fires on exactly one bar index. */
+function exitAtBar(index: number) {
+  return {
+    type: "preset" as const,
+    name: `exitAtBar(${index})`,
+    evaluate: (_indicators: Record<string, unknown>, _candle: NormalizedCandle, i: number) =>
+      i === index,
+  };
+}
+
+/**
+ * Deepest peak-to-trough decline of an equity curve, in percent, rounded the
+ * way the engine rounds it. Deliberately independent of the engine's tracker:
+ * it is the definition the result is checked against.
+ */
+function drawdownOfCurve(curve: number[]): number {
+  let peak = Number.NEGATIVE_INFINITY;
+  let worst = 0;
+  for (const equity of curve) {
+    if (equity > peak) peak = equity;
+    if (peak > 0) {
+      const depth = ((peak - equity) / peak) * 100;
+      if (depth > worst) worst = depth;
+    }
+  }
+  return Math.round(worst * 100) / 100;
+}
+
+/** The three drawdown fields of one result must describe one path. */
+function expectDrawdownCoherent(result: BacktestResult): void {
+  const curve = result.equityCurve;
+  expect(curve).toBeDefined();
+  expect(result.maxDrawdown).toBeCloseTo(drawdownOfCurve(curve as number[]), 10);
+  const deepestPeriod =
+    result.drawdownPeriods.length > 0
+      ? Math.max(...result.drawdownPeriods.map((p) => p.maxDepthPercent))
+      : 0;
+  expect(result.maxDrawdown).toBeCloseTo(deepestPeriod, 10);
+}
+
+const RISING = [100, 101, 103, 106, 110, 115, 121, 128, 130];
+
+describe("drawdown is measured on mark-to-market equity", () => {
+  it("a partial take profit on a monotonically rising account reports no drawdown", () => {
+    const result = runBacktest(flat(RISING), alwaysTrue(), alwaysFalse(), {
+      capital: 1_000_000,
+      fillMode: "same-bar-close",
+      slTpMode: "close-only",
+      partialTakeProfit: { threshold: 5, sellPercent: 50 },
+    });
+
+    // The curve never declines by a cent...
+    const curve = result.equityCurve as number[];
+    for (let i = 1; i < curve.length; i++) {
+      expect(curve[i]).toBeGreaterThanOrEqual(curve[i - 1]);
+    }
+    // ...so the drawdown is 0, not the ~45% the still-invested half used to
+    // register when only the realized cash was measured.
+    expect(result.maxDrawdown).toBe(0);
+    expect(result.drawdownPeriods).toEqual([]);
+    expectDrawdownCoherent(result);
+  });
+
+  it("a two-level scale-out on the same rising account reports no drawdown", () => {
+    const result = runBacktest(flat(RISING), alwaysTrue(), alwaysFalse(), {
+      capital: 1_000_000,
+      fillMode: "same-bar-close",
+      slTpMode: "close-only",
+      scaleOut: {
+        levels: [
+          { threshold: 5, sellPercent: 40 },
+          { threshold: 15, sellPercent: 40 },
+        ],
+      },
+    });
+
+    expect(result.maxDrawdown).toBe(0);
+    expect(result.drawdownPeriods).toEqual([]);
+    expectDrawdownCoherent(result);
+  });
+
+  it("a drawdown taken while fully invested is visible", () => {
+    // Held throughout: 1,000,000 -> 500,000 -> 1,100,000. Cash never moves
+    // until the end-of-data close, so this used to report 0.
+    const result = runBacktest(flat([100, 100, 50, 110, 110]), alwaysTrue(), alwaysFalse(), {
+      capital: 1_000_000,
+      fillMode: "same-bar-close",
+      slTpMode: "close-only",
+    });
+
+    expect(result.maxDrawdown).toBe(50);
+    expect(result.drawdownPeriods).toHaveLength(1);
+    expect(result.drawdownPeriods[0].peakEquity).toBeCloseTo(1_000_000, 6);
+    expect(result.drawdownPeriods[0].troughEquity).toBeCloseTo(500_000, 6);
+    expectDrawdownCoherent(result);
+  });
+
+  it("a loss booked by the end-of-data close counts toward maxDrawdown", () => {
+    // Trade 1: 100 -> 150 (+50%). Trade 2 enters at 150 and is still open when
+    // the data ends at 100. The end-of-data close used to update the period
+    // tracker but not the scalar, so the two contradicted each other.
+    const candles = flat([100, 100, 120, 150, 150, 150, 140, 120, 100, 100]);
+    const result = runBacktest(candles, alwaysTrue(), exitAtBar(3), {
+      capital: 1_000_000,
+      fillMode: "same-bar-close",
+      slTpMode: "close-only",
+    });
+
+    expect(result.trades.map((t) => t.exitReason)).toEqual(["signal", "endOfData"]);
+    expect(result.maxDrawdown).toBeCloseTo(33.33, 2);
+    expectDrawdownCoherent(result);
+  });
+
+  it("closing the same path by signal instead of end-of-data gives the same drawdown", () => {
+    const candles = flat([100, 100, 120, 150, 150, 150, 140, 120, 100, 100]);
+    const options = {
+      capital: 1_000_000,
+      fillMode: "same-bar-close" as const,
+      slTpMode: "close-only" as const,
+    };
+    const byEndOfData = runBacktest(candles, alwaysTrue(), exitAtBar(3), options);
+    const bySignal = runBacktest(
+      candles,
+      alwaysTrue(),
+      {
+        type: "preset" as const,
+        name: "exitAtBar3or9",
+        evaluate: (_ind: Record<string, unknown>, _c: NormalizedCandle, i: number) =>
+          i === 3 || i === 9,
+      },
+      options,
+    );
+
+    expect(bySignal.finalCapital).toBeCloseTo(byEndOfData.finalCapital, 6);
+    expect(bySignal.maxDrawdown).toBe(byEndOfData.maxDrawdown);
+  });
+
+  it("a margin-call reduction is measured on equity, not on the cash it frees", () => {
+    // 2x leverage into a crash: the account is reduced to maintenance rather
+    // than liquidated, so shares stay open and the freed cash is not equity.
+    const result = runBacktest(flat([100, 100, 90, 80, 70, 60, 60]), alwaysTrue(), alwaysFalse(), {
+      capital: 1_000_000,
+      fillMode: "same-bar-close",
+      slTpMode: "close-only",
+      margin: {
+        leverage: 2,
+        maintenanceMargin: 30,
+        marginCallAction: "reduceToMaintenance",
+        interestRate: 0,
+      },
+    });
+
+    expectDrawdownCoherent(result);
+    // Bar 2 is the trough: a 10% price fall at 2x is a 20% equity loss, and
+    // the margin call closes ~98.5% of the position there, so the rest of the
+    // fall barely moves the account. The freed cash is not a recovery.
+    const curve = result.equityCurve as number[];
+    expect(curve[2]).toBeCloseTo(800_000, 6);
+    expect(result.maxDrawdown).toBeCloseTo(20.89, 2);
+  });
+
+  it("a short position's drawdown follows its equity", () => {
+    const result = runBacktest(flat([100, 100, 130, 130, 100, 100]), alwaysTrue(), alwaysFalse(), {
+      capital: 1_000_000,
+      fillMode: "same-bar-close",
+      slTpMode: "close-only",
+      direction: "short",
+    });
+
+    expect(result.maxDrawdown).toBeGreaterThan(0);
+    expectDrawdownCoherent(result);
+  });
+
+  it("exit costs on the end-of-data close do not invent a peak", () => {
+    // Strictly rising and still open at the end, with a commission and a tax
+    // that only bite at the close. The pre-close mark-to-market of the final
+    // bar is the highest number the run ever sees, but it never reaches
+    // equityCurve — the realized figure replaces it. Drawdown must read the
+    // curve, not the transient.
+    const result = runBacktest(flat([100, 100, 110, 120, 130]), alwaysTrue(), alwaysFalse(), {
+      capital: 1_000_000,
+      fillMode: "same-bar-close",
+      slTpMode: "close-only",
+      commissionRate: 1,
+      taxRate: 20,
+    });
+
+    expectDrawdownCoherent(result);
+    // The only decline in the curve is the entry commission on bar 1.
+    expect(result.maxDrawdown).toBeCloseTo(1, 6);
+  });
+
+  it("runBacktestScaled reports an equity curve and a coherent drawdown", () => {
+    const result = runBacktestScaled(flat(RISING), alwaysTrue(), alwaysFalse(), {
+      capital: 1_000_000,
+      fillMode: "same-bar-close",
+      slTpMode: "close-only",
+      scaledEntry: { tranches: 3, strategy: "equal", intervalType: "signal" },
+      partialTakeProfit: { threshold: 5, sellPercent: 50 },
+    });
+
+    expect(result.equityCurve).toHaveLength(RISING.length);
+    expect(result.finalCapital).toBeGreaterThan(1_000_000);
+    // Reserved capital counts as equity while it waits for its tranche, so a
+    // partially-entered position is not a loss.
+    expect(result.maxDrawdown).toBe(0);
+    expectDrawdownCoherent(result);
+  });
+
+  it("runBacktestScaled sees a drawdown taken while invested", () => {
+    const result = runBacktestScaled(
+      flat([100, 100, 90, 60, 60, 90, 120, 120]),
+      alwaysTrue(),
+      alwaysFalse(),
+      {
+        capital: 1_000_000,
+        fillMode: "same-bar-close",
+        slTpMode: "close-only",
+        scaledEntry: { tranches: 2, strategy: "equal", intervalType: "signal" },
+      },
+    );
+
+    expect(result.maxDrawdown).toBeGreaterThan(10);
+    expect(result.drawdownPeriods.length).toBeGreaterThan(0);
+    expectDrawdownCoherent(result);
+  });
+});

--- a/packages/core/src/backtest/drawdown-tracker.ts
+++ b/packages/core/src/backtest/drawdown-tracker.ts
@@ -3,6 +3,12 @@
  *
  * Tracks individual drawdown periods during backtesting,
  * recording peak-to-trough-to-recovery for each drawdown.
+ *
+ * The tracker is the single owner of every drawdown figure a backtest
+ * reports. Both engines hand it their finished equity curve via {@link
+ * drawdownFromEquityCurve}, so `maxDrawdown` and `drawdownPeriods` are a
+ * function of the `equityCurve` the same result carries and cannot
+ * contradict it.
  */
 
 import type { DrawdownPeriod } from "../types";
@@ -11,12 +17,20 @@ import type { DrawdownPeriod } from "../types";
  * Drawdown tracker state machine
  */
 export type DrawdownTracker = {
-  /** Update tracker with current equity state */
-  update(capital: number, time: number, barIndex: number): void;
+  /**
+   * Update tracker with the account's current equity — cash plus the
+   * mark-to-market value of anything still open, never cash alone.
+   */
+  update(equity: number, time: number, barIndex: number): void;
   /** Finalize any open drawdown period at end of backtest */
   finalize(time: number, barIndex: number): void;
   /** Get all completed and in-progress drawdown periods */
   getPeriods(): DrawdownPeriod[];
+  /**
+   * Deepest peak-to-trough decline seen so far, in percent. Equal to the
+   * largest `maxDepthPercent` across {@link getPeriods}, by construction.
+   */
+  getMaxDepthPercent(): number;
 };
 
 /**
@@ -32,6 +46,7 @@ export type DrawdownTracker = {
  * tracker.update(1_050_000, timestamp, 20); // recovery
  * tracker.finalize(timestamp, 50);
  * const periods = tracker.getPeriods();
+ * const worst = tracker.getMaxDepthPercent(); // 5
  * ```
  */
 export function createDrawdownTracker(initialCapital: number): DrawdownTracker {
@@ -50,9 +65,20 @@ export function createDrawdownTracker(initialCapital: number): DrawdownTracker {
   } | null = null;
 
   const periods: DrawdownPeriod[] = [];
+  let maxDepthPercent = 0;
 
-  function update(capital: number, time: number, barIndex: number): void {
-    if (capital >= peak) {
+  /**
+   * Peak-to-trough decline as a percentage of the peak. A non-positive peak
+   * (a wiped-out or negative account) has no meaningful percentage, so it
+   * reports 0 rather than a sign-flipped or infinite figure.
+   */
+  function depthPercent(peakEquity: number, troughEquity: number): number {
+    if (peakEquity <= 0) return 0;
+    return ((peakEquity - troughEquity) / peakEquity) * 100;
+  }
+
+  function update(equity: number, time: number, barIndex: number): void {
+    if (equity >= peak) {
       // Recovered or new high
       if (currentDD !== null) {
         // Close the drawdown period
@@ -63,15 +89,13 @@ export function createDrawdownTracker(initialCapital: number): DrawdownTracker {
           troughEquity: currentDD.troughEquity,
           recoveryTime: time,
           maxDepthPercent:
-            Math.round(
-              ((currentDD.peakEquity - currentDD.troughEquity) / currentDD.peakEquity) * 100 * 100,
-            ) / 100,
+            Math.round(depthPercent(currentDD.peakEquity, currentDD.troughEquity) * 100) / 100,
           durationBars: barIndex - currentDD.startBar,
           recoveryBars: barIndex - currentDD.troughBar,
         });
         currentDD = null;
       }
-      peak = capital;
+      peak = equity;
       peakTime = time;
       peakBar = barIndex;
     } else {
@@ -82,15 +106,19 @@ export function createDrawdownTracker(initialCapital: number): DrawdownTracker {
           startTime: peakTime,
           startBar: peakBar,
           peakEquity: peak,
-          troughEquity: capital,
+          troughEquity: equity,
           troughTime: time,
           troughBar: barIndex,
         };
-      } else if (capital < currentDD.troughEquity) {
+      } else if (equity < currentDD.troughEquity) {
         // Deeper drawdown
-        currentDD.troughEquity = capital;
+        currentDD.troughEquity = equity;
         currentDD.troughTime = time;
         currentDD.troughBar = barIndex;
+      }
+      const depth = depthPercent(currentDD.peakEquity, currentDD.troughEquity);
+      if (depth > maxDepthPercent) {
+        maxDepthPercent = depth;
       }
     }
   }
@@ -104,9 +132,7 @@ export function createDrawdownTracker(initialCapital: number): DrawdownTracker {
         troughTime: currentDD.troughTime,
         troughEquity: currentDD.troughEquity,
         maxDepthPercent:
-          Math.round(
-            ((currentDD.peakEquity - currentDD.troughEquity) / currentDD.peakEquity) * 100 * 100,
-          ) / 100,
+          Math.round(depthPercent(currentDD.peakEquity, currentDD.troughEquity) * 100) / 100,
         durationBars: barIndex - currentDD.startBar,
       });
       currentDD = null;
@@ -117,5 +143,48 @@ export function createDrawdownTracker(initialCapital: number): DrawdownTracker {
     return [...periods];
   }
 
-  return { update, finalize, getPeriods };
+  function getMaxDepthPercent(): number {
+    return maxDepthPercent;
+  }
+
+  return { update, finalize, getPeriods, getMaxDepthPercent };
+}
+
+/**
+ * Derive a backtest's drawdown figures from its finished equity curve.
+ *
+ * Drawdown is a property of the equity path, so this takes the very series
+ * the result reports rather than re-deriving one. Measuring cash instead —
+ * which is 0 while a position is open and jumps to the realized slice on a
+ * partial exit — reads a partial take profit as a catastrophic loss and a
+ * decline taken while fully invested as no loss at all.
+ *
+ * @param equityCurve - Account equity at each candle's close, index-aligned
+ *   with `candles`. Its first element is the starting capital.
+ * @param candles - The candles the backtest ran on, for period timestamps
+ * @returns The deepest decline in percent and every drawdown period in it
+ *
+ * @example
+ * ```ts
+ * const equity = [1_000_000, 900_000, 1_100_000];
+ * const bars = equity.map((_, i) => ({ time: i * 86_400_000 }));
+ * const { maxDrawdown } = drawdownFromEquityCurve(equity, bars); // 10
+ * ```
+ */
+export function drawdownFromEquityCurve(
+  equityCurve: number[],
+  candles: { time: number }[],
+): { maxDrawdown: number; periods: DrawdownPeriod[] } {
+  if (equityCurve.length === 0) {
+    return { maxDrawdown: 0, periods: [] };
+  }
+
+  const tracker = createDrawdownTracker(equityCurve[0]);
+  for (let i = 0; i < equityCurve.length; i++) {
+    tracker.update(equityCurve[i], candles[i].time, i);
+  }
+  const lastIndex = equityCurve.length - 1;
+  tracker.finalize(candles[lastIndex].time, lastIndex);
+
+  return { maxDrawdown: tracker.getMaxDepthPercent(), periods: tracker.getPeriods() };
 }

--- a/packages/core/src/backtest/engine.ts
+++ b/packages/core/src/backtest/engine.ts
@@ -27,7 +27,7 @@ import type { ValidationOptions } from "../validation/types";
 import { validateCandles } from "../validation/validate";
 import type { ExtendedCondition } from "./conditions";
 import { evaluateCondition, RUN_LOCAL_CACHE_KEYS, seedBenchmark } from "./conditions";
-import { createDrawdownTracker } from "./drawdown-tracker";
+import { drawdownFromEquityCurve } from "./drawdown-tracker";
 import type { Position } from "./engine-utils";
 import {
   applySlippage,
@@ -252,14 +252,13 @@ export function runBacktest(
   } | null = null;
 
   let currentCapital = capital;
-  let peakCapital = capital;
-  let maxDrawdown = 0;
   const returns: number[] = [];
-  const ddTracker = createDrawdownTracker(capital);
 
   // Mark-to-market equity at each candle's close, aligned to `candles`. Bar 0
   // is never traded (the loop starts at index 1), so it holds the starting
-  // capital; every later bar is filled at the end of its iteration.
+  // capital; every later bar is filled at the end of its iteration. Drawdown
+  // is derived from this curve once the run finishes, so the two can never
+  // describe different paths.
   const equityCurve: number[] = new Array(candles.length).fill(capital);
 
   // Margin state tracking
@@ -406,20 +405,6 @@ export function runBacktest(
     return isShort
       ? ((pos.entryPrice - price) / pos.entryPrice) * 100
       : ((price - pos.entryPrice) / pos.entryPrice) * 100;
-  }
-
-  /**
-   * Track drawdown after capital changes
-   */
-  function trackDrawdown(time: number, barIndex: number): void {
-    if (currentCapital > peakCapital) {
-      peakCapital = currentCapital;
-    }
-    const drawdown = ((peakCapital - currentCapital) / peakCapital) * 100;
-    if (drawdown > maxDrawdown) {
-      maxDrawdown = drawdown;
-    }
-    ddTracker.update(currentCapital, time, barIndex);
   }
 
   /**
@@ -660,7 +645,6 @@ export function runBacktest(
       deductMarginInterest(position.entryTime, candle.time);
       currentCapital += result.netProceeds - repayMarginLoan(1);
       returns.push(result.returnPercent / 100);
-      trackDrawdown(candle.time, i);
 
       position = null;
       pendingExit = null;
@@ -796,7 +780,6 @@ export function runBacktest(
             deductMarginInterest(position.entryTime, candle.time, reduceFraction);
             currentCapital += result.netProceeds - repayMarginLoan(reduceFraction);
             returns.push(result.returnPercent / 100);
-            trackDrawdown(candle.time, i);
 
             position.shares -= reduceShares;
           }
@@ -902,7 +885,6 @@ export function runBacktest(
           deductMarginInterest(position.entryTime, candle.time, partialFraction);
           currentCapital += result.netProceeds - repayMarginLoan(partialFraction);
           returns.push(result.returnPercent / 100);
-          trackDrawdown(candle.time, i);
 
           position.shares = sharesRemaining;
           position.partialTaken = true;
@@ -962,7 +944,6 @@ export function runBacktest(
             deductMarginInterest(position.entryTime, candle.time, scaleOutFraction);
             currentCapital += result.netProceeds - repayMarginLoan(scaleOutFraction);
             returns.push(result.returnPercent / 100);
-            trackDrawdown(candle.time, i);
 
             position.shares = sharesRemaining;
             position.scaleOutLevelsTaken[levelIndex] = true;
@@ -1119,7 +1100,6 @@ export function runBacktest(
           deductMarginInterest(position.entryTime, candle.time);
           currentCapital += result.netProceeds - repayMarginLoan(1);
           returns.push(result.returnPercent / 100);
-          trackDrawdown(candle.time, i);
 
           position = null;
         } else {
@@ -1163,25 +1143,26 @@ export function runBacktest(
     deductMarginInterest(position.entryTime, lastCandle.time);
     currentCapital += result.netProceeds - repayMarginLoan(1);
     returns.push(result.returnPercent / 100);
-    ddTracker.update(currentCapital, lastCandle.time, candles.length - 1);
     // The end-of-data close realizes the final bar's equity (the in-loop value
-    // was the still-open mark-to-market); align it with the realized capital.
+    // was the still-open mark-to-market); align it with the realized capital,
+    // exit costs included. Drawdown reads the curve afterwards, so it sees the
+    // realized figure and never the mark-to-market that this replaces.
     equityCurve[candles.length - 1] = currentCapital;
   }
 
   // Cancel any unfilled pending order at end of data
   pendingOrder = null;
 
-  ddTracker.finalize(candles[candles.length - 1].time, candles.length - 1);
+  const drawdown = drawdownFromEquityCurve(equityCurve, candles);
 
   const result = calculateStats(
     trades,
     returns,
     capital,
     currentCapital,
-    maxDrawdown,
+    drawdown.maxDrawdown,
     settings,
-    ddTracker.getPeriods(),
+    drawdown.periods,
     candles.length >= 2
       ? { firstTime: candles[0].time, lastTime: candles[candles.length - 1].time }
       : undefined,

--- a/packages/core/src/backtest/scaled-entry.ts
+++ b/packages/core/src/backtest/scaled-entry.ts
@@ -21,6 +21,7 @@ import type {
 } from "../types";
 import type { ExtendedCondition } from "./conditions";
 import { evaluateCondition, seedBenchmark } from "./conditions";
+import { drawdownFromEquityCurve } from "./drawdown-tracker";
 import type { MtfBacktestOptions } from "./engine";
 import { assertValidPartialExits, checkProfitTrigger, checkStopTrigger } from "./engine-utils";
 import {
@@ -277,9 +278,14 @@ export function runBacktestScaled(
 
   let position: ScaledPosition | null = null;
   let currentCapital = capital;
-  let peakCapital = capital;
-  let maxDrawdown = 0;
   const returns: number[] = [];
+
+  // Mark-to-market equity at each candle's close, aligned to `candles`. Bar 0
+  // is never traded (the loop starts at index 1), so it holds the starting
+  // capital; every later bar is filled at the end of its iteration. Drawdown
+  // is derived from this curve once the run finishes, so the two can never
+  // describe different paths.
+  const equityCurve: number[] = new Array(candles.length).fill(capital);
 
   // Fills queued by next-bar-open mode; they execute at the next bar's open,
   // mirroring the single-entry engine's pendingEntry/pendingExit handling.
@@ -348,14 +354,16 @@ export function runBacktestScaled(
     pos.reservedCapital -= trancheCapital;
   }
 
-  function trackDrawdown(): void {
-    if (currentCapital > peakCapital) {
-      peakCapital = currentCapital;
-    }
-    const drawdown = ((peakCapital - currentCapital) / peakCapital) * 100;
-    if (drawdown > maxDrawdown) {
-      maxDrawdown = drawdown;
-    }
+  /**
+   * Mark-to-market account equity at a candle's close: idle cash, plus the
+   * shares held across every tranche, plus the capital this position has
+   * reserved for tranches it has not entered yet. That reserve left
+   * `currentCapital` when the position opened, so leaving it out would read
+   * as an instant loss of the un-entered fraction of the trade.
+   */
+  function markToMarketEquity(close: number): number {
+    if (position === null) return currentCapital;
+    return currentCapital + position.totalShares * close + position.reservedCapital;
   }
 
   function closeShares(
@@ -399,7 +407,6 @@ export function runBacktestScaled(
     currentCapital +=
       exitValue - exitCommission - tax + (opts.releaseReserved ? pos.reservedCapital : 0);
     returns.push(returnPercent / 100);
-    trackDrawdown();
   }
 
   function closeFullPosition(
@@ -588,6 +595,7 @@ export function runBacktestScaled(
       // A 100% partial take profit closes the position outright; the remaining
       // per-bar management has nothing left to manage.
       if (position === null) {
+        equityCurve[i] = markToMarketEquity(candle.close);
         continue;
       }
 
@@ -679,6 +687,7 @@ export function runBacktestScaled(
         }
       }
     }
+    equityCurve[i] = markToMarketEquity(candle.close);
   }
 
   // Close any open position at the end (no slippage, matching the
@@ -687,18 +696,27 @@ export function runBacktestScaled(
   if (position !== null) {
     const lastCandle = candles[candles.length - 1];
     closeFullPosition(position, lastCandle.close, lastCandle.time, "endOfData", false);
+    // The end-of-data close realizes the final bar's equity (the in-loop value
+    // was the still-open mark-to-market); align it with the realized capital,
+    // exit costs included.
+    equityCurve[candles.length - 1] = currentCapital;
   }
 
-  return calculateStats(
+  const drawdown = drawdownFromEquityCurve(equityCurve, candles);
+
+  const result = calculateStats(
     trades,
     returns,
     capital,
     currentCapital,
-    maxDrawdown,
+    drawdown.maxDrawdown,
     settings,
-    [],
+    drawdown.periods,
     candles.length >= 2
       ? { firstTime: candles[0].time, lastTime: candles[candles.length - 1].time }
       : undefined,
+    equityCurve,
   );
+  result.equityCurve = equityCurve;
+  return result;
 }

--- a/packages/core/src/types/backtest.ts
+++ b/packages/core/src/types/backtest.ts
@@ -428,7 +428,14 @@ export type BacktestResult = {
   tradeCount: number;
   /** Win rate percentage */
   winRate: number;
-  /** Maximum drawdown percentage */
+  /**
+   * Deepest peak-to-trough decline of the mark-to-market {@link
+   * BacktestResult.equityCurve}, in percent. Measured on account equity —
+   * cash plus the value of anything still open — so a partial exit does not
+   * register as a loss and a decline taken while fully invested does.
+   * Equal to the largest `maxDepthPercent` in {@link
+   * BacktestResult.drawdownPeriods}.
+   */
   maxDrawdown: number;
   /**
    * Sharpe ratio, annualized from the equity curve's bar-to-bar returns and
@@ -496,7 +503,10 @@ export type BacktestResult = {
   trades: Trade[];
   /** Settings used for this backtest (for reproducibility) */
   settings: BacktestSettings;
-  /** Individual drawdown periods with peak-trough-recovery tracking */
+  /**
+   * Individual drawdown periods with peak-trough-recovery tracking, measured
+   * bar by bar on the same equity path as {@link BacktestResult.maxDrawdown}.
+   */
   drawdownPeriods: DrawdownPeriod[];
   /**
    * Mark-to-market account equity at each candle's close, aligned
@@ -505,9 +515,11 @@ export type BacktestResult = {
    * candles.length`). Equity is `cash + position claim − loan`, signed by
    * direction, so it tracks unrealized P&L of an open position and realizes
    * each partial exit faithfully — unlike a from-trades reconstruction, which
-   * cannot recover the open fraction after a partial exit. Emitted by
-   * `runBacktest`; optional because hand-built results may omit it (consumers
-   * fall back to reconstructing returns from trades).
+   * cannot recover the open fraction after a partial exit. Under
+   * `runBacktestScaled` the capital a position still holds back for tranches
+   * it has not entered counts as equity too. Emitted by `runBacktest` and
+   * `runBacktestScaled`; optional because hand-built results may omit it
+   * (consumers fall back to reconstructing returns from trades).
    */
   equityCurve?: number[];
 };


### PR DESCRIPTION
## The bug

`runBacktest` and `runBacktestScaled` tracked `maxDrawdown` and `drawdownPeriods` against the realized **cash** balance, updated only at trade-close events. Cash is 0 while a position is open and jumps to the realized slice on a partial exit, so the reported drawdown described the cash ledger rather than the account's equity path. The engine already computed correct mark-to-market equity for `equityCurve` — so two fields of the same result object contradicted each other.

Three failure shapes, all reproduced:

**1. A partial exit fabricated a drawdown.** Flat OHLC with strictly rising closes `[100, 101, 103, 106, 110, 115, 121, 128, 130]`, capital 1,000,000, `partialTakeProfit: { threshold: 5, sellPercent: 50 }`:

```
equityCurve: [1000000, 1000000, 1019801.98, 1049504.95, 1089108.91,
              1113861.39, 1143564.36, 1178217.82, 1188118.81]   // never declines
maxDrawdown: 45.54
drawdownPeriods: [{ peakEquity: 1000000, troughEquity: 544554.46, maxDepthPercent: 45.54 }]
```

The 544,554 "trough" is just the cash left after selling half the position. A two-level `scaleOut` on the same path reported 56.44 while finishing at 1,186,534; three tranches plus a partial exit under `runBacktestScaled` reported 46.75 while finishing at 1,161,747.

**2. A real decline was invisible.** An account held through 100 → 50 → 110 reported `maxDrawdown: 0` and `drawdownPeriods: []`, while `equityCurve` fell from 1,000,000 to 500,000. Cash never moved, so nothing was recorded.

**3. The end-of-data close was not counted.** It updated the period tracker but not the `maxDrawdown` scalar. A run whose final open position loses reported `maxDrawdown: 0` while `drawdownPeriods` said 33.33. Closing the identical path with an explicit exit signal instead — same prices, same `finalCapital`, same periods — gave 33.33. Only the closing code path differed.

Downstream, `calmarRatio = cagrPercent / maxDrawdown`, `scoreBacktestResult`'s drawdown sub-score, and the `maxDrawdown` / `calmar` / `mar` optimization objectives and constraints all consume this number, so grid search and walk-forward systematically penalised partial-exit strategies as though they had taken a ~50% loss.

## The fix

Both engines now hand their **finished** `equityCurve` to a new `drawdownFromEquityCurve(equityCurve, candles)`, which walks it once through the existing `DrawdownTracker`. `maxDrawdown` therefore equals the deepest decline of `equityCurve` and the largest `maxDepthPercent` in `drawdownPeriods` **by construction**, not by two derivations happening to agree. The per-exit `trackDrawdown` calls and the cash-based peak tracking are gone from both engines.

Deriving from the completed curve rather than streaming per bar matters for one case in particular: with non-zero commission or tax, the final bar's pre-close mark-to-market is higher than the realized figure that replaces it in `equityCurve`. Streaming would let that transient register as a peak and invent a drawdown the curve cannot show — measured at 5.62% against a curve whose true deepest decline was 1%.

`drawdownPeriods` also gains bar-accurate `durationBars` / `recoveryBars`, since peaks and troughs are now located on the bar they occur rather than on the next trade close.

### Also in this change

`runBacktestScaled` now returns `equityCurve` and a populated `drawdownPeriods` (previously always `[]`). Its equity is cash, plus the shares held across every tranche, plus the capital the position still reserves for tranches it has not entered — that reserve leaves the cash balance when the position opens, so counting it keeps a partially-entered position from reading as an instant loss. Because the result now carries an equity curve, its `sharpeRatio` and `sortinoRatio` are annualized from that curve's bar-to-bar returns, matching `runBacktest`, instead of from per-trade returns.

## Compatibility

Any strategy using `partialTakeProfit`, `scaleOut`, margin `reduceToMaintenance`, or ending with an open position reports a different `maxDrawdown` than before — usually much smaller for partial-exit strategies and larger for buy-and-hold-style runs. Documented under Breaking in the changelog.

## Test plan

New `packages/core/src/backtest/__tests__/drawdown-equity.test.ts`, 10 tests. Each asserts a concrete number and then checks that all three fields describe one path (`maxDrawdown` == drawdown recomputed independently from `equityCurve` == deepest `drawdownPeriods` entry):

- partial take profit on a monotonically rising account → 0, no periods
- two-level scale-out on the same path → 0
- decline taken while fully invested (100 → 50 → 110) → 50, one period with `peakEquity` 1,000,000 / `troughEquity` 500,000
- end-of-data close of a losing position → 33.33
- same path closed by signal vs by end-of-data → identical `finalCapital` and identical `maxDrawdown`
- exit costs on the end-of-data close (commissionRate 1, taxRate 20) do not invent a peak → 1, matching the curve
- margin-call `reduceToMaintenance` at 2x → trough at bar 2 is 800,000 (a 10% price fall at 2x), `maxDrawdown` 20.89
- short position → coherent
- `runBacktestScaled` rising path → equity curve present, `maxDrawdown` 0
- `runBacktestScaled` decline while invested → non-zero, periods present

**Negative check**: with the three source files reverted to `main`, all 10 fail; restored, all 10 pass.

**Randomized invariant probe** (not committed): 12 option combinations (plain / partial / partial-100% / scale-out / scale-out-100% / SL+TP / trailing / short / margin reduce / margin liquidate / next-bar-open / all-of-the-above) × 3 cost profiles (zero; commissionRate 0.5 + taxRate 20; flat commission 500 + rate 0.1 + tax 20.315 + slippage 0.1) × 25 randomized price series × both engines = **1,800 runs, 0 divergences** between the three fields, and no non-finite value in any curve or period.

**Cross-engine probe**: single-symbol `runBacktest` and `portfolioBacktest` — which already derived drawdown from a mark-to-market curve — now agree exactly (9.87 vs 9.87 on a 150-bar series with commission).

**Boundaries**: empty candles, one candle, two candles, no trades, capital of 1, `sellPercent: 100`, scale-out selling 100%, next-bar-open fills, short direction, 5x leverage forced liquidation — all finite, no throws.

**Suites**: core 377 files / 7183 tests pass; chart 1049 pass / 2 skipped; mcp 83 pass. `tsc --noEmit`, `pnpm build`, and `biome check` on the touched files all clean.