### PR TITLE
fix(core): keep portfolio capital on the books, and stop reporting unimplemented options as working

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,67 @@
 
 ## [Unreleased]
 
+### Breaking — `portfolioBacktest` no longer loses the capital `maxSymbolExposure` withholds
+
+`maxSymbolExposure` caps each symbol's share of total capital by shrinking the
+capital that symbol's backtest is started with. Nothing accounted for the
+remainder. Metrics were then computed against the **full** `capital`, so the
+undeployed cash was counted on the initial-capital side and missing from the
+final side.
+
+Three equal-weight symbols, `capital: 3_000_000`, `maxSymbolExposure: 25` and a
+condition that never fires — a portfolio that placed **zero trades** — reported:
+
+```
+{ initialCapital: 3000000, finalCapital: 2250000, totalReturn: -750000,
+  totalReturnPercent: -25, maxDrawdown: 25, tradeCount: 0 }
+equityCurve[0] = { equity: 2250000 }
+```
+
+The same run with the cap omitted correctly reported 0% and no drawdown, so the
+entire −25% was manufactured by the cap. The merged equity curve had a second
+form of the same mismatch: a symbol's pre-first-bar filler used its **uncapped**
+allocation, so a symbol whose data starts late produced a step down on its first
+bar that no trade caused (1,500,000 → 1,000,000 in a two-symbol run).
+
+Capital the cap keeps out of the market is now held as portfolio cash: it sits
+at every point of `equityCurve` and in `portfolio.finalCapital`, and the curve's
+filler uses the capital each symbol was actually started with. A tighter cap now
+dilutes the portfolio's return instead of reading as a loss. Only runs where the
+cap actually binds (`maxSymbolExposure / 100` below a symbol's allocation weight)
+change; with the default of 100 nothing moves.
+
+The documented default for `maxSymbolExposure` said `100 / numSymbols` while the
+implementation used `100`. The documentation was wrong — under a `fixed`
+allocation with unequal weights the documented default would bind on the largest
+sleeve on every call — and now says `100`.
+
+### Breaking — `batchBacktest` and `portfolioBacktest` reject a repeated symbol
+
+Capital allocation and the merged equity curve are keyed by symbol, so a
+dataset list naming the same symbol twice collapsed several datasets into one
+on those paths while every sleeve still ran and still counted toward the
+result. Two 500-capital sleeves for the same symbol against a 1,000,000
+portfolio produced a merged equity curve holding only 500,000 at every point,
+and metrics that moved with zero trades — a 50% gain, or a 50% loss with a 25%
+exposure cap on top, depending on which side of the mismatch dominated. Both
+functions now throw, naming the repeated symbols. Two datasets for one
+instrument had no defined meaning here, so no correct call changes.
+
+### Breaking — `portfolioBacktest.rebalanceCount` is always 0, and unenforced options say so
+
+`rebalanceCount` was documented as "Number of times rebalance occurred" but was
+a calendar estimate: span divided by 30 or 90 days. No rebalancing logic exists
+— each symbol is backtested once against a fixed allocation — so a two-year,
+two-symbol run reported `rebalanceCount: 24` with zero trades and an equity
+curve byte-identical to the same run without the option.
+
+It now reports `0`. `rebalance` and `maxPortfolioDrawdown` carry the same
+"accepted but not yet enforced" caveat `maxPositions` already had, on the option
+types and in the `portfolioBacktest` summary. `maxPortfolioDrawdown` never
+halted anything: its `if` block was empty. (The same-named option on the live
+`PortfolioGuardOptions` is a different, working feature.)
+
 ### Breaking — drawdown is measured on account equity, not on the cash balance
 
 `runBacktest` and `runBacktestScaled` tracked `maxDrawdown` and

--- a/packages/core/docs/COOKBOOK.md
+++ b/packages/core/docs/COOKBOOK.md
@@ -549,9 +549,9 @@ const weighted = batchBacktest(
 
 ---
 
-## Recipe 13: Portfolio Backtest — Shared Capital with Position Limits
+## Recipe 13: Portfolio Backtest — Weighted Allocation with Exposure Caps
 
-**Goal:** Simulate a portfolio with shared capital, per-symbol exposure caps, and rebalancing.
+**Goal:** Simulate a portfolio whose capital is split across symbols by weight, with a per-symbol exposure cap.
 
 ```typescript
 import {
@@ -574,10 +574,7 @@ const result = portfolioBacktest(
   {
     capital: 10_000_000,
     allocation: { type: "equal" },
-    maxPositions: 2,           // Max 2 concurrent positions
-    maxSymbolExposure: 40,     // Max 40% per symbol
-    maxPortfolioDrawdown: 15,  // Halt if DD exceeds 15%
-    rebalance: { frequency: "monthly" },
+    maxSymbolExposure: 40,     // Max 40% of total capital per symbol
     tradeOptions: {
       stopLoss: 5,
       takeProfit: 15,
@@ -588,8 +585,16 @@ const result = portfolioBacktest(
 
 console.log(`Return: ${result.portfolio.totalReturnPercent}%`);
 console.log(`Peak Concurrent Positions: ${result.peakConcurrentPositions}`);
-console.log(`Rebalance Events: ${result.rebalanceCount}`);
 ```
+
+Capital the exposure cap keeps out of the market is held as portfolio cash: it
+stays in `result.equityCurve` and in `portfolio.finalCapital`, so a tighter cap
+dilutes the return rather than reading as a loss.
+
+`maxPositions`, `maxPortfolioDrawdown` and `rebalance` are accepted by the
+options type but not yet enforced — the symbols are backtested independently
+against a fixed allocation, nothing halts the run on drawdown, and
+`rebalanceCount` is always 0.
 
 ---
 

--- a/packages/core/src/__tests__/options-key-usage.test.ts
+++ b/packages/core/src/__tests__/options-key-usage.test.ts
@@ -57,9 +57,15 @@ const ALLOWLIST: Record<string, string[]> = {
   // Known-dead, documented in source: "Unused — reserved for future use;
   // riskParityAllocation does not read this option". Kept for API compat.
   RiskParityOptions: ["riskFreeRate"],
-  // Known-dead, documented in source: `@deprecated Was never wired into the
-  // engine. Use tradeOptions.sizing`. Kept for backward compatibility.
-  PortfolioBacktestOptions: ["positionSizing"],
+  // Known-dead, documented in source. `positionSizing` is `@deprecated Was
+  // never wired into the engine. Use tradeOptions.sizing`. The other three are
+  // documented on the option type and in the `portfolioBacktest` summary as
+  // "accepted but not yet enforced": symbols are backtested independently
+  // against a fixed allocation, so nothing limits concurrent positions, nothing
+  // halts the run on drawdown, and no rebalance ever happens (`rebalanceCount`
+  // is always 0). Kept so the field names stay discoverable when the behaviour
+  // lands.
+  PortfolioBacktestOptions: ["positionSizing", "maxPositions", "maxPortfolioDrawdown", "rebalance"],
   // Heuristic gap, key IS consumed: incremental indicators accept
   // structurally-identical inline `{ warmUp?: NormalizedCandle[]; … }` params
   // without ever referencing the WarmUpOptions name (e.g.

--- a/packages/core/src/__tests__/portfolio.test.ts
+++ b/packages/core/src/__tests__/portfolio.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { deadCross, goldenCross, rsiAbove, rsiBelow } from "../backtest/conditions";
+import {
+  alwaysFalse,
+  alwaysTrue,
+  deadCross,
+  goldenCross,
+  rsiAbove,
+  rsiBelow,
+} from "../backtest/conditions";
 import { batchBacktest, portfolioBacktest } from "../backtest/portfolio";
 import type { NormalizedCandle, SymbolData } from "../types";
 
@@ -208,18 +215,164 @@ describe("portfolioBacktest", () => {
     }
   });
 
-  it("should estimate rebalance count for monthly frequency", () => {
+  it("reports no rebalances, because none happen", () => {
+    // `rebalance` is accepted but not yet enforced. It used to report a
+    // calendar estimate (span / 30 days), which named events that never took
+    // place: the allocation is fixed for the whole run.
     const datasets = createDatasets(); // 200 daily candles ≈ ~6-7 months
     const entry = goldenCross(5, 25);
     const exit = deadCross(5, 25);
+    const options = {
+      capital: 3_000_000,
+      allocation: { type: "equal" as const },
+    };
 
-    const result = portfolioBacktest(datasets, entry, exit, {
+    const withRebalance = portfolioBacktest(datasets, entry, exit, {
+      ...options,
+      rebalance: { frequency: "monthly" as const },
+    });
+    const without = portfolioBacktest(datasets, entry, exit, options);
+
+    expect(withRebalance.rebalanceCount).toBe(0);
+    // Passing the option changes nothing about the simulation.
+    expect(withRebalance.equityCurve).toEqual(without.equityCurve);
+    expect(withRebalance.portfolio).toEqual(without.portfolio);
+  });
+});
+
+describe("portfolioBacktest capital accounting", () => {
+  const DAY = 24 * 60 * 60 * 1000;
+
+  /** Flat bars at a constant price, optionally starting `startBar` days late. */
+  function flatBars(count: number, price = 100, startBar = 0): NormalizedCandle[] {
+    return Array.from({ length: count }, (_, i) => ({
+      time: Date.UTC(2024, 0, 1) + (i + startBar) * DAY,
+      open: price,
+      high: price,
+      low: price,
+      close: price,
+      volume: 1000,
+    }));
+  }
+
+  const never = alwaysFalse();
+
+  it("holds capital withheld by maxSymbolExposure as portfolio cash", () => {
+    // 3 equal-weight symbols want 1,000,000 each; a 25% cap allows 750,000, so
+    // 750,000 of the 3,000,000 is never deployed. With no trades at all, the
+    // portfolio has neither gained nor lost anything.
+    const datasets = ["A", "B", "C"].map((symbol) => ({ symbol, candles: flatBars(30) }));
+
+    const result = portfolioBacktest(datasets, never, never, {
       capital: 3_000_000,
       allocation: { type: "equal" },
-      rebalance: { frequency: "monthly" },
+      maxSymbolExposure: 25,
     });
 
-    expect(result.rebalanceCount).toBeGreaterThanOrEqual(5);
-    expect(result.rebalanceCount).toBeLessThanOrEqual(8);
+    expect(result.portfolio.tradeCount).toBe(0);
+    expect(result.portfolio.finalCapital).toBeCloseTo(3_000_000, 6);
+    expect(result.portfolio.totalReturn).toBe(0);
+    expect(result.portfolio.totalReturnPercent).toBe(0);
+    expect(result.portfolio.maxDrawdown).toBe(0);
+    expect(result.equityCurve[0].equity).toBeCloseTo(3_000_000, 6);
+    // The sleeves really were capped — the cash is what makes the books balance.
+    for (const sr of result.symbols) {
+      expect(sr.result.initialCapital).toBeCloseTo(750_000, 6);
+    }
+  });
+
+  it("rejects a dataset list that names the same symbol twice", () => {
+    // Capital, allocation weights and the merged equity curve are keyed by
+    // symbol, so a repeat collapses datasets on those paths while every sleeve
+    // still runs and still counts — capital stops being conserved. Two equal
+    // 500-capital sleeves against a 1,000 portfolio reported a 50% gain with
+    // zero trades; with a 25% cap on top it reported a 50% loss instead.
+    const datasets = [
+      { symbol: "A", candles: flatBars(5) },
+      { symbol: "B", candles: flatBars(5) },
+      { symbol: "A", candles: flatBars(5) },
+    ];
+
+    expect(() =>
+      portfolioBacktest(datasets, never, never, {
+        capital: 1_000_000,
+        allocation: { type: "equal" },
+      }),
+    ).toThrow(/Duplicate symbol\(s\) in datasets: A/);
+
+    // The same guard covers the sibling entry point, whose merged curve
+    // silently dropped one of the two sleeves.
+    expect(() => batchBacktest(datasets, never, never, { capital: 1_000_000 })).toThrow(
+      /Duplicate symbol\(s\) in datasets: A/,
+    );
+
+    // A unique list is unaffected.
+    expect(() =>
+      portfolioBacktest(datasets.slice(0, 2), never, never, {
+        capital: 1_000_000,
+        allocation: { type: "equal" },
+      }),
+    ).not.toThrow();
+  });
+
+  it("reports the same idle portfolio whether or not the cap binds", () => {
+    const datasets = ["A", "B", "C"].map((symbol) => ({ symbol, candles: flatBars(30) }));
+    const options = { capital: 3_000_000, allocation: { type: "equal" as const } };
+
+    const capped = portfolioBacktest(datasets, never, never, {
+      ...options,
+      maxSymbolExposure: 25,
+    });
+    const uncapped = portfolioBacktest(datasets, never, never, options);
+
+    expect(capped.portfolio.totalReturnPercent).toBe(uncapped.portfolio.totalReturnPercent);
+    expect(capped.portfolio.maxDrawdown).toBe(uncapped.portfolio.maxDrawdown);
+    expect(capped.equityCurve[0].equity).toBeCloseTo(uncapped.equityCurve[0].equity, 6);
+  });
+
+  it("fills a symbol's pre-first-bar equity with what it actually started with", () => {
+    // B's data begins 10 bars late. Before that the merged curve has to stand
+    // in for it — with the capped 500,000 it was started with, not the
+    // 1,000,000 its weight asked for, or B's first bar shows a step down that
+    // no trade caused.
+    const datasets = [
+      { symbol: "A", candles: flatBars(20) },
+      { symbol: "B", candles: flatBars(10, 100, 10) },
+    ];
+
+    const result = portfolioBacktest(datasets, never, never, {
+      capital: 2_000_000,
+      allocation: { type: "equal" },
+      maxSymbolExposure: 25,
+    });
+
+    const equities = result.equityCurve.map((p) => p.equity);
+    expect(new Set(equities).size).toBe(1);
+    expect(equities[0]).toBeCloseTo(2_000_000, 6);
+  });
+
+  it("keeps initialCapital and finalCapital on the same basis under a cap", () => {
+    // A rises 20%, B and C are flat. Only A's capped sleeve can earn anything.
+    const datasets = [
+      { symbol: "A", candles: [...flatBars(15), ...flatBars(15, 120, 15)] },
+      { symbol: "B", candles: flatBars(30) },
+      { symbol: "C", candles: flatBars(30) },
+    ];
+
+    const result = portfolioBacktest(datasets, alwaysTrue(), never, {
+      capital: 3_000_000,
+      allocation: { type: "equal" },
+      maxSymbolExposure: 25,
+      tradeOptions: { fillMode: "same-bar-close", slTpMode: "close-only" },
+    });
+
+    const sleeves = result.symbols.reduce((s, sr) => s + sr.result.finalCapital, 0);
+    const idleCash = 3_000_000 - result.symbols.reduce((s, sr) => s + sr.result.initialCapital, 0);
+    expect(idleCash).toBeCloseTo(750_000, 6);
+    expect(result.portfolio.finalCapital).toBeCloseTo(sleeves + idleCash, 2);
+    expect(result.portfolio.initialCapital).toBe(3_000_000);
+    // The last point of the merged curve is the portfolio's final worth.
+    const lastEquity = result.equityCurve[result.equityCurve.length - 1].equity;
+    expect(lastEquity).toBeCloseTo(result.portfolio.finalCapital, 2);
   });
 });

--- a/packages/core/src/backtest/portfolio.ts
+++ b/packages/core/src/backtest/portfolio.ts
@@ -2,7 +2,8 @@
  * Portfolio / Multi-Asset Backtest
  *
  * Phase 1: batchBacktest() - Run independent per-symbol backtests and merge results
- * Phase 2: portfolioBacktest() - Shared capital with allocation and rebalancing
+ * Phase 2: portfolioBacktest() - Weighted allocation with a per-symbol exposure
+ *          cap. The allocation is fixed for the whole run; nothing rebalances.
  */
 
 import { periodsPerYearFromSpan, sharpeFromReturns } from "../analysis/return-metrics";
@@ -74,6 +75,7 @@ export function batchBacktest(
   if (datasets.length === 0) {
     throw new Error("At least one symbol dataset is required");
   }
+  assertUniqueSymbols(datasets);
 
   // Calculate per-symbol capital allocation
   const allocations = calculateAllocations(datasets, options);
@@ -122,15 +124,20 @@ export function batchBacktest(
 // ============================================
 
 /**
- * Run a portfolio backtest with weight-based capital allocation, exposure constraints, and optional rebalancing.
+ * Run a portfolio backtest with weight-based capital allocation and exposure constraints.
  *
  * Unlike `batchBacktest()`, this applies portfolio-level allocation and exposure
  * constraints. Allocation is static: total capital is split across symbols by the
  * weights from the `allocation` strategy, and `maxSymbolExposure` caps each
- * symbol's share of total capital. Symbols are currently backtested independently
- * against their allocated capital (no shared capital pool or signal competition
- * yet), and `maxPositions` is accepted but not yet enforced; concurrent positions
- * are reported via `peakConcurrentPositions`.
+ * symbol's share of total capital. Capital the cap keeps out of the market is
+ * held as portfolio cash and stays in the equity curve and in `finalCapital`.
+ * Symbols are currently backtested independently against their allocated
+ * capital (no shared capital pool or signal competition yet).
+ *
+ * Three options are accepted but not yet enforced: `maxPositions` (concurrent
+ * positions are reported via `peakConcurrentPositions` instead),
+ * `maxPortfolioDrawdown` (the run always goes to completion), and `rebalance`
+ * (allocation never changes, so `rebalanceCount` is always 0).
  *
  * @param datasets - Array of symbol data
  * @param entryCondition - Entry condition
@@ -168,19 +175,13 @@ export function portfolioBacktest(
   if (datasets.length === 0) {
     throw new Error("At least one symbol dataset is required");
   }
+  assertUniqueSymbols(datasets);
 
-  const {
-    capital,
-    allocation,
-    // `maxPositions` is documented on the option type but not yet wired
-    // through the backtest loop. Kept in the destructure so the field
-    // name remains discoverable when the limit lands; `_`-prefix tells
-    // the linter the omission is intentional.
-    maxPositions: _maxPositions = datasets.length,
-    maxSymbolExposure = 100,
-    maxPortfolioDrawdown,
-    tradeOptions = {},
-  } = options;
+  // `maxPositions`, `maxPortfolioDrawdown` and `rebalance` are documented on
+  // the option type but not yet wired through the backtest loop, so they are
+  // deliberately not read here — see the option type's JSDoc for what each one
+  // will do once it lands.
+  const { capital, allocation, maxSymbolExposure = 100, tradeOptions = {} } = options;
 
   // Calculate target weights
   const weights = calculateWeights(datasets, allocation);
@@ -195,7 +196,11 @@ export function portfolioBacktest(
   // (Phase 2 simplified: independent runs with weight-based allocation + position limits)
   const symbolResults: SymbolBacktestResult[] = [];
   let peakConcurrentPositions = 0;
-  let rebalanceCount = 0;
+
+  // Capital each symbol is actually started with, after the exposure cap. It
+  // is what the merged equity curve must fill in before a symbol's first bar,
+  // and what the undeployed remainder is measured against.
+  const effectiveCapitals: Record<string, number> = {};
 
   for (const dataset of datasets) {
     const symbolCap = symbolCapitals[dataset.symbol];
@@ -203,6 +208,7 @@ export function portfolioBacktest(
     // Enforce max symbol exposure
     const maxExposureCapital = (capital * maxSymbolExposure) / 100;
     const effectiveCapital = Math.min(symbolCap, maxExposureCapital);
+    effectiveCapitals[dataset.symbol] = effectiveCapital;
 
     const result = runBacktest(dataset.candles, entryCondition, exitCondition, {
       ...tradeOptions,
@@ -211,6 +217,12 @@ export function portfolioBacktest(
 
     symbolResults.push({ symbol: dataset.symbol, result });
   }
+
+  // Whatever `maxSymbolExposure` kept out of the market stays on the books as
+  // portfolio cash. Dropping it would report a portfolio that placed no trades
+  // at all as having lost exactly the capital the cap withheld.
+  const deployed = Object.values(effectiveCapitals).reduce((s, c) => s + c, 0);
+  const idleCash = capital - deployed;
 
   // Track concurrent positions from all trades
   const allTradesWithSymbol = mergeAndSortTrades(symbolResults);
@@ -230,26 +242,18 @@ export function portfolioBacktest(
   }
 
   // Build equity curve and portfolio metrics
-  const equityCurve = buildMergedEquityCurve(symbolResults, datasets, symbolCapitals);
+  const equityCurve = buildMergedEquityCurve(symbolResults, datasets, effectiveCapitals, idleCash);
 
-  const portfolio = calculatePortfolioMetrics(symbolResults, equityCurve, capital);
-
-  // Check max portfolio drawdown
-  if (maxPortfolioDrawdown !== undefined && portfolio.maxDrawdown > maxPortfolioDrawdown) {
-    // Drawdown breached - noted in result (portfolio ran to completion for analysis)
-  }
-
-  // Rebalance tracking (for future enhancement)
-  if (options.rebalance) {
-    rebalanceCount = estimateRebalanceCount(datasets, options.rebalance);
-  }
+  const portfolio = calculatePortfolioMetrics(symbolResults, equityCurve, capital, idleCash);
 
   return {
     symbols: symbolResults,
     portfolio,
     equityCurve,
     allTrades: allTradesWithSymbol,
-    rebalanceCount,
+    // Allocation is fixed for the whole run, so no rebalance ever happens.
+    // Reporting a calendar estimate here claimed events that never took place.
+    rebalanceCount: 0,
     peakConcurrentPositions,
   };
 }
@@ -257,6 +261,32 @@ export function portfolioBacktest(
 // ============================================
 // Internal Helpers
 // ============================================
+
+/**
+ * Reject a dataset list that names the same symbol twice.
+ *
+ * Capital, allocation weights and the merged equity curve are all keyed by
+ * symbol, so a repeated name silently collapses several datasets into one on
+ * those paths while every sleeve still runs and still counts toward the
+ * result — capital stops being conserved. Two datasets for one instrument have
+ * no defined meaning here anyway, so this is a caller error, not a mode to
+ * support.
+ */
+function assertUniqueSymbols(datasets: SymbolData[]): void {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const dataset of datasets) {
+    if (seen.has(dataset.symbol)) duplicates.add(dataset.symbol);
+    seen.add(dataset.symbol);
+  }
+  if (duplicates.size > 0) {
+    throw new Error(
+      `Duplicate symbol(s) in datasets: ${[...duplicates].sort().join(", ")}. ` +
+        "Each symbol must appear at most once — capital allocation and the merged " +
+        "equity curve are keyed by symbol.",
+    );
+  }
+}
 
 /**
  * Calculate per-symbol capital allocations
@@ -362,12 +392,22 @@ function mergeAndSortTrades(symbolResults: SymbolBacktestResult[]): (Trade & { s
  *
  * Symbols need not share a calendar. The curve carries every timestamp any
  * dataset has, and a symbol that has no bar at that timestamp holds its last
- * known equity (its allocation before its first bar).
+ * known equity (the capital it was started with, before its first bar).
+ *
+ * `allocations` must be the capital each symbol was actually started with, not
+ * the target weights: those two differ once `maxSymbolExposure` binds, and a
+ * filler larger than the sleeve's real starting capital shows up as a step
+ * down on the symbol's first bar that no trade caused.
+ *
+ * `idleCash` is portfolio capital that was never deployed to any symbol. It
+ * sits at every point of the curve, so a constraint that leaves cash on the
+ * sidelines dilutes the portfolio's return rather than vanishing from it.
  */
 function buildMergedEquityCurve(
   symbolResults: SymbolBacktestResult[],
   datasets: SymbolData[],
   allocations: Record<string, number>,
+  idleCash = 0,
 ): EquityPoint[] {
   const curveBySymbol = new Map<string, { times: number[]; equity: number[] }>();
   for (const dataset of datasets) {
@@ -402,7 +442,7 @@ function buildMergedEquityCurve(
 
   const curve: EquityPoint[] = [];
   for (const time of allTimes) {
-    let total = 0;
+    let total = idleCash;
     for (const [symbol, series] of curveBySymbol) {
       let cursor = cursors.get(symbol) as number;
       while (cursor + 1 < series.times.length && series.times[cursor + 1] <= time) cursor++;
@@ -422,9 +462,12 @@ function calculatePortfolioMetrics(
   symbolResults: SymbolBacktestResult[],
   equityCurve: EquityPoint[],
   totalCapital: number,
+  idleCash = 0,
 ): PortfolioMetrics {
-  // Sum up per-symbol finals
-  const finalCapital = symbolResults.reduce((s, sr) => s + sr.result.finalCapital, 0);
+  // Sum up per-symbol finals, plus whatever capital was never deployed. Both
+  // sides of the return have to stand on the same capital: `totalCapital` is
+  // the whole portfolio, so the cash a constraint held back belongs here too.
+  const finalCapital = symbolResults.reduce((s, sr) => s + sr.result.finalCapital, 0) + idleCash;
   const totalReturn = finalCapital - totalCapital;
   const totalReturnPercent = (totalReturn / totalCapital) * 100;
 
@@ -484,39 +527,4 @@ function calculatePortfolioMetrics(
     profitFactor: Math.round(Math.min(profitFactor, 999.99) * 100) / 100,
     avgHoldingDays: Math.round(avgHoldingDays * 10) / 10,
   };
-}
-
-/**
- * Estimate rebalance count based on data range and frequency
- */
-function estimateRebalanceCount(
-  datasets: SymbolData[],
-  rebalance: NonNullable<PortfolioBacktestOptions["rebalance"]>,
-): number {
-  // Find data range across all symbols
-  let minTime = Number.POSITIVE_INFINITY;
-  let maxTime = Number.NEGATIVE_INFINITY;
-  for (const d of datasets) {
-    if (d.candles.length > 0) {
-      if (d.candles[0].time < minTime) minTime = d.candles[0].time;
-      if (d.candles[d.candles.length - 1].time > maxTime) {
-        maxTime = d.candles[d.candles.length - 1].time;
-      }
-    }
-  }
-
-  if (minTime === Number.POSITIVE_INFINITY) return 0;
-
-  const durationMs = maxTime - minTime;
-  const MS_PER_DAY = 24 * 60 * 60 * 1000;
-
-  switch (rebalance.frequency) {
-    case "monthly":
-      return Math.floor(durationMs / (30 * MS_PER_DAY));
-    case "quarterly":
-      return Math.floor(durationMs / (90 * MS_PER_DAY));
-    case "threshold":
-      // Cannot estimate without running simulation
-      return 0;
-  }
 }

--- a/packages/core/src/types/portfolio.ts
+++ b/packages/core/src/types/portfolio.ts
@@ -11,10 +11,14 @@ import type { PositionSizingMethod } from "./volume-risk";
 // ============================================
 
 /**
- * Input dataset for a single symbol in batch/portfolio backtests
+ * Input dataset for a single symbol in batch/portfolio backtests.
+ *
+ * A symbol may appear at most once in a dataset list — capital allocation and
+ * the merged equity curve are keyed by it. `batchBacktest` and
+ * `portfolioBacktest` throw on a repeated symbol.
  */
 export type SymbolData = {
-  /** Ticker symbol (e.g., "AAPL", "7203.T") */
+  /** Ticker symbol (e.g., "AAPL", "7203.T") — unique within a dataset list */
   symbol: string;
   /** Normalized candle data */
   candles: NormalizedCandle[];
@@ -74,7 +78,10 @@ export type BatchBacktestOptions = Omit<BacktestOptions, "capital"> & {
 export type PortfolioMetrics = {
   /** Total initial capital */
   initialCapital: number;
-  /** Total final capital (sum of all symbol finals) */
+  /**
+   * Total final capital: every symbol's final capital, plus any capital
+   * `maxSymbolExposure` kept out of the market and held as portfolio cash.
+   */
   finalCapital: number;
   /** Portfolio total return amount */
   totalReturn: number;
@@ -121,14 +128,17 @@ export type AllocationStrategy =
   | { type: "riskParity"; riskBudget?: number };
 
 /**
- * Rebalance configuration
+ * Rebalance configuration.
+ *
+ * Accepted by `portfolioBacktest` but not yet enforced — allocation is fixed
+ * for the whole run, so passing this changes nothing about the simulation.
  */
 export type RebalanceConfig = {
   /**
-   * Rebalance frequency
-   * - "monthly": Rebalance on first trading day of each month
-   * - "quarterly": Rebalance every 3 months
-   * - "threshold": Rebalance when drift exceeds threshold
+   * Intended rebalance frequency (not yet enforced)
+   * - "monthly": first trading day of each month
+   * - "quarterly": every 3 months
+   * - "threshold": when drift exceeds `driftThreshold`
    */
   frequency: "monthly" | "quarterly" | "threshold";
   /** Drift threshold in percent to trigger rebalance (only for "threshold" mode) */
@@ -145,11 +155,25 @@ export type PortfolioBacktestOptions = {
   allocation: AllocationStrategy;
   /** Maximum concurrent positions (default: number of symbols) */
   maxPositions?: number;
-  /** Maximum per-symbol exposure in percent (default: 100 / numSymbols) */
+  /**
+   * Maximum per-symbol exposure in percent of total capital (default: 100,
+   * i.e. no cap). When this binds, the symbol is started with less capital
+   * than its allocation weight asks for and the difference is held as
+   * portfolio cash — it stays in the equity curve and in `finalCapital`.
+   */
   maxSymbolExposure?: number;
-  /** Maximum portfolio drawdown before halting (in percent) */
+  /**
+   * Maximum portfolio drawdown in percent. Accepted but not yet enforced: the
+   * backtest always runs to completion, and nothing in the result flags the
+   * breach. Read `portfolio.maxDrawdown` and decide for yourself. (The
+   * same-named option on the live `PortfolioGuardOptions` is enforced — this
+   * one is the backtest's, and is not.)
+   */
   maxPortfolioDrawdown?: number;
-  /** Rebalance configuration (optional) */
+  /**
+   * Rebalance configuration. Accepted but not yet enforced — see
+   * {@link RebalanceConfig}.
+   */
   rebalance?: RebalanceConfig;
   /** Per-trade backtest options (SL, TP, trailing, commissions, sizing, etc.) */
   tradeOptions?: Omit<BacktestOptions, "capital">;
@@ -172,7 +196,10 @@ export type PortfolioBacktestResult = {
   equityCurve: EquityPoint[];
   /** All trades across all symbols, sorted by entry time */
   allTrades: (Trade & { symbol: string })[];
-  /** Number of times rebalance occurred */
+  /**
+   * Number of times rebalance occurred. Always 0: rebalancing is not yet
+   * implemented, so the allocation set at the start holds for the whole run.
+   */
   rebalanceCount: number;
   /** Peak concurrent positions held */
   peakConcurrentPositions: number;


### PR DESCRIPTION
`portfolioBacktest` had three ways of reporting something that never happened. All three are the same shape: a number that describes the option type rather than the simulation.

## 1. Capital withheld by `maxSymbolExposure` vanished

The cap works by shrinking the capital each symbol's backtest is started with. Nothing accounted for the remainder, while `calculatePortfolioMetrics` compared the sum of the (shrunken) sleeve finals against the **full** `capital` and seeded `peakEquity` there too. The undeployed cash was counted on the initial-capital side and missing from the final side.

Three equal-weight symbols, `capital: 3_000_000`, `maxSymbolExposure: 25`, and a condition that never fires — a portfolio that placed **zero trades**:

```
{ initialCapital: 3000000, finalCapital: 2250000, totalReturn: -750000,
  totalReturnPercent: -25, maxDrawdown: 25, tradeCount: 0 }
equityCurve[0] = { equity: 2250000 }
```

The same run with the cap omitted correctly reported 0% and no drawdown, so the whole −25% was manufactured by the cap.

The merged equity curve carried the same mismatch in a second form: a symbol's pre-first-bar filler used its **uncapped** allocation, while the engine had started it at the capped figure. A two-symbol run where B's data begins 10 bars late produced `1,500,000 … 1,500,000, 1,000,000` — a step down on B's first bar that no trade caused.

**Fix.** Capital the cap keeps out of the market is held as portfolio cash: it sits at every point of `equityCurve` and in `portfolio.finalCapital`, and the curve's filler now uses the capital each symbol was actually started with. A tighter cap dilutes the portfolio's return instead of reading as a loss. Only runs where the cap actually binds change; with the default of 100 nothing moves.

The alternative — redistributing the freed capital across the uncapped symbols — was not taken. Redistribution can push another symbol over its own cap (a cascade with no obvious termination rule) and changes `maxSymbolExposure` from a limit into a limit-plus-releverage. That is a feature, not a bug fix.

The documented default for `maxSymbolExposure` said `100 / numSymbols` while the implementation used `100`. The documentation was the wrong half: under a `fixed` allocation with unequal weights, the documented default would bind on the largest sleeve on every call and manufacture a loss by default. It now says 100.

## 2. `rebalanceCount` counted rebalances that never occurred

`rebalanceCount` is typed as "Number of times rebalance occurred", but no rebalancing logic exists — each symbol is backtested once against an allocation fixed before the loop. The field returned a calendar estimate: span divided by 30 or 90 days.

A two-year, two-symbol run with `rebalance: { frequency: "monthly" }` reported `rebalanceCount: 24` with zero trades, per-symbol final capital untouched at 1,000,000 each, and an equity curve byte-identical to the same run without the option. Passing the option changed exactly one reported number and nothing else.

It now returns `0`. `rebalance`, `maxPortfolioDrawdown` and `maxPositions` carry the same "accepted but not yet enforced" caveat on the option types, in the `portfolioBacktest` summary, and in the cookbook recipe. `maxPortfolioDrawdown` never halted anything — its `if` block was empty apart from a comment claiming the breach was "noted in result", which it was not. (The same-named option on the live `PortfolioGuardOptions` is a different, working feature; the option type now says so.)

## 3. A repeated symbol broke capital conservation

Capital allocation, allocation weights and the merged equity curve are all keyed by symbol. A dataset list naming the same symbol twice collapsed several datasets into one on those paths while every sleeve still ran and still counted toward the result.

Two 500,000-capital sleeves for the same symbol against a 1,000,000 portfolio produced a merged curve holding only 500,000 at every point, and metrics that moved with zero trades — a 50% gain, or a 50% loss with a 25% exposure cap on top, depending on which side of the mismatch dominated. Equal allocation over `[A, A, A, B]` produces weights summing to 0.5, so the capital never added up either.

`batchBacktest` and `portfolioBacktest` now both throw, naming the repeated symbols. Two datasets for one instrument had no defined meaning here, so no correct call changes.

## Test plan

`packages/core/src/__tests__/portfolio.test.ts`, 5 new tests plus one rewritten:

- exposure cap withholding capital → zero trades gives `finalCapital` 3,000,000, 0% return, 0 drawdown, `equityCurve[0]` 3,000,000, and sleeves really started at 750,000 each
- capped vs uncapped idle portfolio → identical return and drawdown
- late-starting symbol under a cap → every point of the merged curve equals 2,000,000 (no step)
- cap with a real winner → `finalCapital == sum(sleeve finals) + idle cash`, `initialCapital == capital`, and the curve's last point equals `finalCapital`
- duplicate symbol → both entry points throw, a unique list does not
- rewritten: `rebalance` reports 0 and produces an equity curve and metrics equal to the same run without it

**Negative check**: with `portfolio.ts` reverted to `main`, all 6 fail; restored, all 15 pass.

**Randomized invariant probe** (not committed): 4 allocation strategies (equal / two `fixed` weightings / riskParity) × 6 cap values (none, 100, 50, 33, 25, 10) × 3 condition sets (never / always / cross) × 12 price series, a third of them with staggered start dates = **864 runs, 0 violations** of: `finalCapital == sum(sleeve finals) + idle cash`, `initialCapital == capital`, `equityCurve[0] == capital`, `equityCurve[last] == finalCapital`, every equity point and every metric finite, `rebalanceCount === 0`, and a portfolio that never trades showing 0% return and 0 drawdown.

**Sibling check**: `batchBacktest` passes allocations that already sum to `capital`, so it is unaffected by the idle-cash path (`finalCapital == sum(sleeves)`, `equityCurve[0] == capital`); the new duplicate-symbol guard is the only change it sees.

**Boundaries**: `maxSymbolExposure` of 0, 1000 and −10; one symbol; one-bar data; empty candle list — no throws, books balance in each.

**Suites**: core 377 files / 7188 tests pass; chart 1049 pass / 2 skipped; mcp 83 pass. `tsc --noEmit`, `pnpm build`, `biome check` and `git diff --check` all clean, and the rebuilt `portfolio.d.ts` carries both public functions' documentation.