### PR TITLE
fix(core): stop anchored walk-forward from testing a combination it never selected

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,80 @@
 
 ## [Unreleased]
 
+### Breaking — anchored walk-forward no longer tests a combination it never selected
+
+`anchoredWalkForwardAnalysis` optimizes a condition combination on each
+expanding training window, then backtests it on the following test window. When
+the training search selected **nothing** — every combination violated a
+constraint, produced no trades, or scored non-finitely — the period was still
+tested. The unselected combination is an empty condition list, filtering the
+condition pools by it yields no definitions, and `and()` over zero conditions is
+vacuously `true`, so the test window was backtested with an always-true entry
+AND an always-true exit. That always-in-the-market result was then stored as the
+period's out-of-sample performance and fed to the aggregate metrics, the
+stability analysis and the recommendation.
+
+On 800 daily candles with `constraints: [{ metric: "tradeCount", operator: ">=",
+value: 1e9 }]` — a threshold nothing can pass — both periods reported:
+
+```
+bestEntryConditions: []   bestExitConditions: []
+inSampleMetrics:     {}   // every key undefined, while typed Record<_, number>
+outOfSampleMetrics:  { tradeCount: 99, returns: 19.17 }   // period 1
+outOfSampleMetrics:  { tradeCount: 99, returns: 18.19 }   // period 2
+recommendation: { useOptimized: true, entryConditions: [], exitConditions: [],
+                  reason: "Moderate stability (ratio=1.00)..." }
+```
+
+99 trades and an affirmative recommendation from a strategy that was never
+selected. Constraints are not required to reach this: a training window in which
+no combination trades at all takes the same path.
+
+Such a period is now recorded in the new `AWFResult.skippedPeriods` and is not
+backtested. It contributes nothing to `aggregateMetrics`, `stabilityAnalysis` or
+`recommendation`. `periodNumber` still counts across all boundaries, so
+`periods` has gaps when `skippedPeriods` is non-empty. If **no** period selects a
+combination the call now throws instead of returning a fabricated result;
+`anchoredWalkForwardAnalysisSafe` surfaces that as `OPTIMIZATION_FAILED`.
+
+`AWFPeriod.inSampleMetrics` now comes from the winning combination itself rather
+than from a name-join lookup back into the search results that fell back to an
+empty object cast to the metric record.
+
+`summarizeAWFResult` gains `skippedPeriodCount`, and `formatAWFResult` lists the
+skipped periods with the reason each was skipped.
+
+### Breaking — `combinationSearch` no longer counts combinations it cannot select
+
+`validCombinations` counted every combination that passed the constraints, but
+selection compares `score > bestScore`, which is false for `NaN`. A training
+window with no drawdown scores every combination `NaN` under `calmar` (matching
+`calculateCalmarRatio`, which returns `NaN` when max drawdown is 0), so the
+search reported `bestScore: null` next to `validCombinations: 3` — two answers
+to "did the search find anything".
+
+Non-finite scores are now excluded from `validCombinations` and from `results`,
+mirroring the guard `gridSearch` already applies, and `results` sorts non-finite
+scores to the end deterministically when `keepAllResults` keeps them. After this
+change `bestScore === null`, `bestResult === null` and `validCombinations === 0`
+are equivalent.
+
+### Added — `CombinationSearchResult.bestResult`
+
+The winning `CombinationResultEntry`, or `null` when nothing was selected.
+`bestEntry`, `bestExit` and `bestScore` are projections of it.
+
+Prefer it over inspecting those: `bestEntry` is empty both when nothing was
+selected and when an empty entry combination legitimately won, which
+`minEntryConditions: 0` — or required conditions already covering the minimum —
+makes reachable.
+
+### Added — `AWFSkippedPeriod`
+
+Describes an AWF period whose training window selected no combination: the
+period's boundaries, how many combinations were evaluated, and why nothing was
+selected. Exported from `trendcraft`.
+
 ### Breaking — `portfolioBacktest` no longer loses the capital `maxSymbolExposure` withholds
 
 `maxSymbolExposure` caps each symbol's share of total capital by shrinking the

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -4148,12 +4148,21 @@ const result = combinationSearch(candles, entryPool, exitPool, {
   metric: 'sharpe',
 });
 
+// 探索が何も選ばなかった場合は null
+if (result.bestResult === null) {
+  console.log('組合せが選ばれなかった');
+} else {
+  console.log(result.bestResult.entryConditions, result.bestResult.metrics.sharpe);
+}
+
 // results[] はベスト順にソート済み。上位 20 件は .slice(0, 20) で取得
 result.results.slice(0, 20).forEach((r) => {
   console.log(`エントリー: ${r.entryConditions.join(' + ')}, イグジット: ${r.exitConditions.join(' + ')}`);
   console.log(`シャープ: ${r.metrics.sharpe}`);
 });
 ```
+
+`result.bestResult` は勝った組合せそのもの。探索が何も選ばなかった場合は `null` になる（すべての組合せが制約に違反した / 取引が発生しなかった / スコアが非有限だった — Calmar・MAR・Recovery は最大ドローダウンが 0 のとき `NaN`）。「探索が何か見つけたか」を曖昧さなく表すのはこのフィールドで、`bestEntry` / `bestExit` / `bestScore` はその射影。代わりに `bestEntry.length === 0` を判定してはいけない。`minEntryConditions: 0`（または required 条件だけで下限を満たす場合）では空のエントリー組合せが正当な候補になり、それが勝つことがある。非有限スコアは `results` と `validCombinations` から除外される（`keepAllResults` 指定時のみ保持され、末尾にソートされる）。
 
 ---
 
@@ -4374,7 +4383,8 @@ Period 3: Train 2015-01-01〜2019-12-31 → Test 2020
 
 ```typescript
 interface AWFResult {
-  periods: AWFPeriod[];
+  periods: AWFPeriod[];              // 組合せが選ばれた period
+  skippedPeriods: AWFSkippedPeriod[]; // 何も選ばれず、テストされなかった period
   aggregateMetrics: {
     avgInSample: Record<OptimizationMetric, number>;
     avgOutOfSample: Record<OptimizationMetric, number>;
@@ -4409,7 +4419,21 @@ interface AWFPeriod {
   outOfSampleMetrics: Record<OptimizationMetric, number>;
   testBacktest: BacktestResult;
 }
+
+interface AWFSkippedPeriod {
+  periodNumber: number;
+  trainStart: number;
+  trainEnd: number;
+  trainCandleCount: number;
+  testStart: number;
+  testEnd: number;
+  testCandleCount: number;
+  combinationsTested: number;
+  reason: string;
+}
 ```
+
+**何も選ばれなかった period:** 学習ウィンドウが組合せをひとつも選べないことがある（すべての候補が制約に違反した / 取引が発生しなかった / スコアが非有限だった — Calmar 系は最大ドローダウンが 0 のとき `NaN` になる）。その period は `skippedPeriods` に記録され、**アウトオブサンプルのバックテストは行われない**ため、`aggregateMetrics` / `stabilityAnalysis` / `recommendation` には一切寄与しない。`periodNumber` は全境界に通し番号で振られるので、`skippedPeriods` が空でないとき `periods` の番号は飛ぶ。どの period も組合せを選べなかった場合は throw する（`anchoredWalkForwardAnalysisSafe` は `OPTIMIZATION_FAILED` を返す）。
 
 **ヘルパー関数:**
 

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -4186,12 +4186,21 @@ const result = combinationSearch(candles, entryPool, exitPool, {
   metric: 'sharpe',
 });
 
+// null when the search selected nothing at all
+if (result.bestResult === null) {
+  console.log('No combination was selected');
+} else {
+  console.log(result.bestResult.entryConditions, result.bestResult.metrics.sharpe);
+}
+
 // results[] is sorted best-first; take the top 20 with .slice(0, 20)
 result.results.slice(0, 20).forEach((r) => {
   console.log(`Entry: ${r.entryConditions.join(' + ')}, Exit: ${r.exitConditions.join(' + ')}`);
   console.log(`Sharpe: ${r.metrics.sharpe}`);
 });
 ```
+
+`result.bestResult` is the winning entry, or `null` when the search selected nothing — every combination violated a constraint, produced no trades, or scored non-finitely (Calmar, MAR and Recovery are `NaN` when max drawdown is 0). It is the one unambiguous "did the search find anything" signal, and `bestEntry` / `bestExit` / `bestScore` are projections of it. Do not test `bestEntry.length === 0` instead: with `minEntryConditions: 0` (or required conditions already covering the minimum) an empty entry combination is a legitimate candidate that can win. Non-finite scores are excluded from `results` and from `validCombinations` unless `keepAllResults` is set, in which case they sort to the end.
 
 ---
 
@@ -4408,7 +4417,8 @@ Each period:
 
 ```typescript
 interface AWFResult {
-  periods: AWFPeriod[];
+  periods: AWFPeriod[];              // Periods that selected a combination
+  skippedPeriods: AWFSkippedPeriod[]; // Periods that selected nothing (never tested)
   aggregateMetrics: {
     avgInSample: Record<OptimizationMetric, number>;
     avgOutOfSample: Record<OptimizationMetric, number>;
@@ -4443,7 +4453,21 @@ interface AWFPeriod {
   outOfSampleMetrics: Record<OptimizationMetric, number>;
   testBacktest: BacktestResult;
 }
+
+interface AWFSkippedPeriod {
+  periodNumber: number;
+  trainStart: number;
+  trainEnd: number;
+  trainCandleCount: number;
+  testStart: number;
+  testEnd: number;
+  testCandleCount: number;
+  combinationsTested: number;
+  reason: string;
+}
 ```
+
+**Periods that select nothing:** a training window can fail to produce any combination — every candidate violated a constraint, made no trades, or scored non-finitely (Calmar and friends are `NaN` when max drawdown is 0). Such a period is recorded in `skippedPeriods` and is **not** backtested out of sample, so it contributes nothing to `aggregateMetrics`, `stabilityAnalysis` or `recommendation`. `periodNumber` is assigned across all boundaries, so `periods` has gaps whenever `skippedPeriods` is non-empty. If no period at all selects a combination, the call throws (`anchoredWalkForwardAnalysisSafe` returns `OPTIMIZATION_FAILED`).
 
 **Helper functions:**
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -599,6 +599,7 @@ export type {
   AnchoredWalkForwardOptions,
   AWFPeriod,
   AWFResult,
+  AWFSkippedPeriod,
   CombinationResultEntry,
   CombinationSearchOptions,
   CombinationSearchResult,

--- a/packages/core/src/optimization/__tests__/anchored-walkforward.test.ts
+++ b/packages/core/src/optimization/__tests__/anchored-walkforward.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { NormalizedCandle } from "../../types";
 import {
   anchoredWalkForwardAnalysis,
+  anchoredWalkForwardAnalysisSafe,
   calculateAWFPeriodCount,
   formatAWFResult,
   generateAWFBoundaries,
@@ -9,6 +10,7 @@ import {
   summarizeAWFResult,
 } from "../anchored-walkforward";
 import type { ConditionDefinition } from "../combination-search";
+import { combinationSearch } from "../combination-search";
 
 /**
  * Generate test candles with an upward trend
@@ -632,5 +634,264 @@ describe("Anchored Walk-Forward Analysis", () => {
       expect(typeof result.aggregateMetrics.oosReturnStdDev).toBe("number");
       expect(result.aggregateMetrics.oosReturnStdDev).toBeGreaterThanOrEqual(0);
     });
+  });
+});
+
+/**
+ * Deterministic price series — these tests assert exact period bookkeeping,
+ * so they cannot share the Math.random() generator above.
+ */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function seededCandles(count: number, seed = 7, drift = 0.001): NormalizedCandle[] {
+  const rnd = mulberry32(seed);
+  const candles: NormalizedCandle[] = [];
+  const baseTime = new Date("2015-01-01").getTime();
+  let price = 100;
+
+  for (let i = 0; i < count; i++) {
+    price *= 1 + drift + (rnd() - 0.5) * 0.02;
+    const dailyRange = price * 0.02;
+    candles.push({
+      time: baseTime + i * 24 * 60 * 60 * 1000,
+      open: price - dailyRange * 0.25,
+      high: price + dailyRange * 0.5,
+      low: price - dailyRange * 0.5,
+      close: price,
+      volume: 1000000,
+    });
+  }
+
+  return candles;
+}
+
+function seededEntryConditions(): ConditionDefinition[] {
+  return [
+    {
+      name: "priceUp",
+      displayName: "Price Up",
+      create: () => (_indicators, _candle, index, candles) =>
+        index >= 1 && candles[index].close > candles[index - 1].close,
+    },
+    {
+      name: "priceUp2",
+      displayName: "Price Up (2 bars)",
+      create: () => (_indicators, _candle, index, candles) =>
+        index >= 2 && candles[index].close > candles[index - 2].close,
+    },
+  ];
+}
+
+function seededExitConditions(): ConditionDefinition[] {
+  return [
+    {
+      name: "priceDown",
+      displayName: "Price Down",
+      create: () => (_indicators, _candle, index, candles) =>
+        index >= 1 && candles[index].close < candles[index - 1].close,
+    },
+  ];
+}
+
+const SEEDED_AWF_OPTIONS = {
+  initialTrainSize: 300,
+  expansionStep: 200,
+  testSize: 200,
+} as const;
+
+describe("Anchored Walk-Forward — periods that select nothing", () => {
+  it("refuses to report an unselected combination as out-of-sample performance", () => {
+    const candles = seededCandles(800);
+
+    // No combination can reach a billion trades, so nothing is ever selected.
+    // The previous behavior filtered the condition pools by an empty name
+    // list, built `and()` from zero conditions — which is vacuously true —
+    // and reported the resulting always-in-the-market backtest (99 trades,
+    // +19.17% and +18.19% on this series) as the optimizer's OOS result.
+    expect(() =>
+      anchoredWalkForwardAnalysis(candles, seededEntryConditions(), seededExitConditions(), {
+        anchorDate: candles[0].time,
+        ...SEEDED_AWF_OPTIONS,
+        constraints: [{ metric: "tradeCount", operator: ">=", value: 1e9 }],
+      }),
+    ).toThrow(/No AWF period selected a condition combination \(2 period\(s\) evaluated\)/);
+  });
+
+  it("surfaces the failure as OPTIMIZATION_FAILED through the safe variant", () => {
+    const candles = seededCandles(800);
+
+    const result = anchoredWalkForwardAnalysisSafe(
+      candles,
+      seededEntryConditions(),
+      seededExitConditions(),
+      {
+        anchorDate: candles[0].time,
+        ...SEEDED_AWF_OPTIONS,
+        constraints: [{ metric: "tradeCount", operator: ">=", value: 1e9 }],
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("OPTIMIZATION_FAILED");
+    }
+  });
+
+  it("skips a training window in which no combination trades at all", () => {
+    const candles = seededCandles(800, 11);
+    const never: ConditionDefinition[] = [
+      { name: "never", displayName: "Never", create: () => () => false },
+    ];
+
+    // No constraints at all: every combination is discarded for having zero
+    // trades, which leaves the search with nothing to select.
+    expect(() =>
+      anchoredWalkForwardAnalysis(candles, never, seededExitConditions(), {
+        anchorDate: candles[0].time,
+        ...SEEDED_AWF_OPTIONS,
+      }),
+    ).toThrow(/No AWF period selected a condition combination/);
+  });
+
+  it("records a skipped period and keeps the periods that did select", () => {
+    const candles = seededCandles(800);
+    const entryConditions = seededEntryConditions();
+    const exitConditions = seededExitConditions();
+    const anchorDate = candles[0].time;
+    const boundaries = generateAWFBoundaries(candles, { anchorDate, ...SEEDED_AWF_OPTIONS });
+    expect(boundaries.length).toBe(2);
+
+    // Trade counts grow with the expanding training window, so a threshold
+    // between the two windows' counts is met by the second period only.
+    const tradeCounts = boundaries.map((b) => {
+      const train = candles.slice(b.trainStart, b.trainEnd + 1);
+      const search = combinationSearch(train, entryConditions, exitConditions, {
+        metric: "returns",
+      });
+      return search.bestResult?.metrics.tradeCount ?? 0;
+    });
+    const threshold = tradeCounts[1];
+    expect(tradeCounts[0]).toBeLessThan(threshold);
+
+    const result = anchoredWalkForwardAnalysis(candles, entryConditions, exitConditions, {
+      anchorDate,
+      ...SEEDED_AWF_OPTIONS,
+      metric: "returns",
+      constraints: [{ metric: "tradeCount", operator: ">=", value: threshold }],
+    });
+
+    expect(result.skippedPeriods.map((p) => p.periodNumber)).toEqual([1]);
+    expect(result.periods.map((p) => p.periodNumber)).toEqual([2]);
+
+    const skipped = result.skippedPeriods[0];
+    expect(skipped.trainStart).toBe(candles[boundaries[0].trainStart].time);
+    expect(skipped.trainEnd).toBe(candles[boundaries[0].trainEnd].time);
+    expect(skipped.testStart).toBe(candles[boundaries[0].testStart].time);
+    expect(skipped.combinationsTested).toBeGreaterThan(0);
+    expect(skipped.reason).toMatch(/No combination satisfied the constraints/);
+
+    // Nothing from the skipped period leaks into the aggregates.
+    expect(result.periods[0].bestEntryConditions.length).toBeGreaterThan(0);
+    for (const value of Object.values(result.stabilityAnalysis.conditionFrequency)) {
+      expect(value).toBe(100);
+    }
+  });
+
+  it("takes in-sample metrics from the winning combination itself", () => {
+    const candles = seededCandles(800);
+    const entryConditions = seededEntryConditions();
+    const exitConditions = seededExitConditions();
+    const anchorDate = candles[0].time;
+
+    const result = anchoredWalkForwardAnalysis(candles, entryConditions, exitConditions, {
+      anchorDate,
+      ...SEEDED_AWF_OPTIONS,
+      metric: "returns",
+    });
+
+    const boundaries = generateAWFBoundaries(candles, { anchorDate, ...SEEDED_AWF_OPTIONS });
+    expect(result.periods.length).toBe(boundaries.length);
+
+    for (const period of result.periods) {
+      const boundary = boundaries[period.periodNumber - 1];
+      const train = candles.slice(boundary.trainStart, boundary.trainEnd + 1);
+      const search = combinationSearch(train, entryConditions, exitConditions, {
+        metric: "returns",
+      });
+
+      // Previously this came from a name-join lookup back into the result
+      // list, falling back to an empty object cast to the metric record —
+      // so every key read as `undefined` while the type claimed `number`.
+      expect(period.inSampleMetrics.returns).toBe(search.bestResult?.metrics.returns);
+      expect(Number.isFinite(period.inSampleMetrics.returns)).toBe(true);
+      expect(period.inSampleMetrics.tradeCount).toBeGreaterThan(0);
+    }
+  });
+
+  it("still tests an empty entry combination when the caller allows one to win", () => {
+    const candles = seededCandles(400, 1, 0.002);
+    const entryConditions = seededEntryConditions();
+    const exitConditions = seededExitConditions();
+
+    // With minEntryConditions: 0 the empty entry combination is a legitimate
+    // candidate, and on this series it wins. `bestEntry.length === 0` is
+    // therefore NOT a usable "nothing was selected" signal.
+    const search = combinationSearch(candles.slice(0, 300), entryConditions, exitConditions, {
+      metric: "returns",
+      minEntryConditions: 0,
+    });
+    expect(search.bestResult).not.toBeNull();
+    expect(search.bestEntry).toEqual([]);
+
+    const result = anchoredWalkForwardAnalysis(
+      candles,
+      entryConditions,
+      exitConditions,
+      { anchorDate: candles[0].time, initialTrainSize: 300, expansionStep: 200, testSize: 100 },
+      { metric: "returns", minEntryConditions: 0 },
+    );
+
+    expect(result.skippedPeriods).toEqual([]);
+    expect(result.periods[0].bestEntryConditions).toEqual([]);
+    expect(result.periods[0].outOfSampleMetrics.tradeCount).toBeGreaterThan(0);
+  });
+
+  it("reports skipped periods in the summary and the formatted output", () => {
+    const candles = seededCandles(800);
+    const entryConditions = seededEntryConditions();
+    const exitConditions = seededExitConditions();
+    const anchorDate = candles[0].time;
+    const boundaries = generateAWFBoundaries(candles, { anchorDate, ...SEEDED_AWF_OPTIONS });
+    const firstWindow = candles.slice(boundaries[0].trainStart, boundaries[0].trainEnd + 1);
+    const secondWindow = candles.slice(boundaries[1].trainStart, boundaries[1].trainEnd + 1);
+    const threshold =
+      combinationSearch(secondWindow, entryConditions, exitConditions, { metric: "returns" })
+        .bestResult?.metrics.tradeCount ?? 0;
+    expect(
+      combinationSearch(firstWindow, entryConditions, exitConditions, { metric: "returns" })
+        .bestResult?.metrics.tradeCount ?? 0,
+    ).toBeLessThan(threshold);
+
+    const result = anchoredWalkForwardAnalysis(candles, entryConditions, exitConditions, {
+      anchorDate,
+      ...SEEDED_AWF_OPTIONS,
+      metric: "returns",
+      constraints: [{ metric: "tradeCount", operator: ">=", value: threshold }],
+    });
+
+    expect(summarizeAWFResult(result).periodCount).toBe(1);
+    expect(summarizeAWFResult(result).skippedPeriodCount).toBe(1);
+
+    const text = formatAWFResult(result);
+    expect(text).toContain("Periods: 1 (1 skipped)");
+    expect(text).toContain("Skipped Periods (no combination selected, not tested)");
   });
 });

--- a/packages/core/src/optimization/__tests__/combination-search.test.ts
+++ b/packages/core/src/optimization/__tests__/combination-search.test.ts
@@ -169,3 +169,121 @@ describe("combinationSearch", () => {
     }
   });
 });
+
+describe("combinationSearch — non-finite scores and the winning entry", () => {
+  /** Strictly rising closes: no drawdown, so Calmar / MAR / Recovery are NaN. */
+  function monotonicCandles(count: number): NormalizedCandle[] {
+    const baseTime = new Date("2015-01-01").getTime();
+    const out: NormalizedCandle[] = [];
+    for (let i = 0; i < count; i++) {
+      const price = 100 + i;
+      out.push({
+        time: baseTime + i * 24 * 60 * 60 * 1000,
+        open: price,
+        high: price + 0.5,
+        low: price,
+        close: price,
+        volume: 1000,
+      });
+    }
+    return out;
+  }
+
+  const upDefs: ConditionDefinition[] = [
+    {
+      name: "priceUp",
+      displayName: "Price Up",
+      create: () => ({
+        type: "preset",
+        name: "priceUp",
+        evaluate: (_indicators, _candle, index, candles) =>
+          index >= 1 && candles[index].close > candles[index - 1].close,
+      }),
+    },
+    {
+      name: "priceUp2",
+      displayName: "Price Up (2 bars)",
+      create: () => ({
+        type: "preset",
+        name: "priceUp2",
+        evaluate: (_indicators, _candle, index, candles) =>
+          index >= 2 && candles[index].close > candles[index - 2].close,
+      }),
+    },
+  ];
+  const downDefs: ConditionDefinition[] = [
+    {
+      name: "priceDown",
+      displayName: "Price Down",
+      create: () => ({
+        type: "preset",
+        name: "priceDown",
+        evaluate: (_indicators, _candle, index, candles) =>
+          index >= 1 && candles[index].close < candles[index - 1].close,
+      }),
+    },
+  ];
+
+  it("does not count combinations it can never select as valid", () => {
+    const result = combinationSearch(monotonicCandles(400), upDefs, downDefs, {
+      metric: "calmar",
+      backtestOptions: { capital: 100000 },
+    });
+
+    // Every combination trades and passes the (empty) constraint set, but
+    // Calmar is NaN with maxDrawdown === 0 and `score > bestScore` is false
+    // for NaN. Previously that reported bestScore: null alongside
+    // validCombinations: 3 — two answers to "did the search find anything".
+    expect(result.bestResult).toBeNull();
+    expect(result.bestScore).toBeNull();
+    expect(result.validCombinations).toBe(0);
+    expect(result.bestEntry).toEqual([]);
+    expect(result.results).toEqual([]);
+  });
+
+  it("keeps non-finite scores out of the way when keepAllResults is set", () => {
+    const result = combinationSearch(monotonicCandles(400), upDefs, downDefs, {
+      metric: "calmar",
+      keepAllResults: true,
+      backtestOptions: { capital: 100000 },
+    });
+
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.results.every((r) => Number.isNaN(r.score))).toBe(true);
+    expect(result.bestResult).toBeNull();
+  });
+
+  it("returns the winning entry, and the projections agree with it", () => {
+    const result = combinationSearch(generateTrendingCandles(240), upDefs, downDefs, {
+      metric: "returns",
+      backtestOptions: { capital: 100000 },
+    });
+
+    const best = result.bestResult;
+    expect(best).not.toBeNull();
+    if (best === null) return;
+    expect(result.bestEntry).toBe(best.entryConditions);
+    expect(result.bestExit).toBe(best.exitConditions);
+    expect(result.bestScore).toBe(best.score);
+    expect(best.passedConstraints).toBe(true);
+    expect(best.score).toBe(Math.max(...result.results.map((r) => r.score)));
+  });
+
+  it("distinguishes a legitimately empty entry from nothing being selected", () => {
+    // minEntryConditions: 0 makes the empty entry combination a candidate.
+    // Pinning maxEntryConditions to 0 as well leaves it as the ONLY
+    // candidate, so it necessarily wins — proving `bestEntry.length === 0`
+    // cannot be read as "the search selected nothing".
+    const result = combinationSearch(generateTrendingCandles(240), upDefs, downDefs, {
+      metric: "returns",
+      minEntryConditions: 0,
+      maxEntryConditions: 0,
+      backtestOptions: { capital: 100000 },
+    });
+
+    expect(result.bestEntry).toEqual([]);
+    expect(result.bestResult).not.toBeNull();
+    expect(result.bestScore).not.toBeNull();
+    expect(result.validCombinations).toBe(1);
+  });
+});

--- a/packages/core/src/optimization/anchored-walkforward-utils.ts
+++ b/packages/core/src/optimization/anchored-walkforward-utils.ts
@@ -157,9 +157,14 @@ export function generateAWFRecommendation(
 
 /**
  * Summarize AWF result
+ *
+ * `periodCount` counts only periods that selected a combination;
+ * `skippedPeriodCount` counts the rest. Both are needed to know how much of
+ * the requested analysis actually ran.
  */
 export function summarizeAWFResult(result: AWFResult): {
   periodCount: number;
+  skippedPeriodCount: number;
   avgInSampleReturn: number;
   avgOutOfSampleReturn: number;
   stabilityRatio: number;
@@ -173,6 +178,7 @@ export function summarizeAWFResult(result: AWFResult): {
 
   return {
     periodCount: result.periods.length,
+    skippedPeriodCount: result.skippedPeriods.length,
     avgInSampleReturn: result.aggregateMetrics.avgInSample.returns,
     avgOutOfSampleReturn: result.aggregateMetrics.avgOutOfSample.returns,
     stabilityRatio: result.aggregateMetrics.stabilityRatio,
@@ -192,7 +198,9 @@ export function formatAWFResult(result: AWFResult): string {
 
   const lines = [
     "=== Anchored Walk-Forward Analysis Results ===",
-    `Periods: ${result.periods.length}`,
+    `Periods: ${result.periods.length}${
+      result.skippedPeriods.length > 0 ? ` (${result.skippedPeriods.length} skipped)` : ""
+    }`,
     "",
     "Aggregate Performance:",
     `  IS Return:  ${result.aggregateMetrics.avgInSample.returns.toFixed(2)}%`,
@@ -231,11 +239,22 @@ export function formatAWFResult(result: AWFResult): string {
       `  [${period.periodNumber}] Train: ${trainStart}~${trainEnd} | Test: ${testStart}~${testEnd}`,
     );
     lines.push(
-      `      IS: ${period.inSampleMetrics.returns?.toFixed(1) ?? "N/A"}% | OOS: ${period.outOfSampleMetrics.returns.toFixed(1)}%`,
+      `      IS: ${period.inSampleMetrics.returns.toFixed(1)}% | OOS: ${period.outOfSampleMetrics.returns.toFixed(1)}%`,
     );
     lines.push(
       `      Entry: ${period.bestEntryConditions.join("+")} | Exit: ${period.bestExitConditions.join("+")}`,
     );
+  }
+
+  if (result.skippedPeriods.length > 0) {
+    lines.push("");
+    lines.push("Skipped Periods (no combination selected, not tested):");
+    for (const skipped of result.skippedPeriods) {
+      const trainStart = new Date(skipped.trainStart).toISOString().slice(0, 10);
+      const trainEnd = new Date(skipped.trainEnd).toISOString().slice(0, 10);
+      lines.push(`  [${skipped.periodNumber}] Train: ${trainStart}~${trainEnd}`);
+      lines.push(`      ${skipped.reason}`);
+    }
   }
 
   return lines.join("\n");
@@ -243,6 +262,10 @@ export function formatAWFResult(result: AWFResult): string {
 
 /**
  * Get OOS equity curve across all periods
+ *
+ * Only periods that selected a combination contribute a point — a skipped
+ * period leaves a gap in `time` rather than a flat segment, because no
+ * position was ever taken for it.
  */
 export function getAWFEquityCurve(
   result: AWFResult,

--- a/packages/core/src/optimization/anchored-walkforward.ts
+++ b/packages/core/src/optimization/anchored-walkforward.ts
@@ -15,6 +15,7 @@ import type {
   AnchoredWalkForwardOptions,
   AWFPeriod,
   AWFResult,
+  AWFSkippedPeriod,
   OptimizationConstraint,
   OptimizationMetric,
 } from "../types/optimization";
@@ -120,6 +121,19 @@ export function calculateAWFPeriodCount(
 
 /**
  * Run Anchored Walk-Forward analysis with combination search
+ *
+ * Each period optimizes a condition combination on its expanding training
+ * window, then backtests that combination on the following test window.
+ *
+ * A training window can fail to select anything — every combination violated
+ * a constraint, produced no trades, or scored non-finitely. Such a period is
+ * recorded in {@link AWFResult.skippedPeriods} and is NOT backtested out of
+ * sample: an unselected combination is an empty condition list, and an empty
+ * AND is vacuously true, so testing it would report an always-in-the-market
+ * strategy as the optimizer's out-of-sample performance.
+ *
+ * @throws If no period selects a combination, or if there is not enough data
+ *   for a single period.
  */
 export function anchoredWalkForwardAnalysis(
   candles: NormalizedCandle[],
@@ -144,6 +158,7 @@ export function anchoredWalkForwardAnalysis(
   }
 
   const periods: AWFPeriod[] = [];
+  const skippedPeriods: AWFSkippedPeriod[] = [];
   const conditionOccurrences: Record<string, number> = {};
 
   // Backtest options
@@ -170,9 +185,35 @@ export function anchoredWalkForwardAnalysis(
       constraints,
     });
 
-    // Get best combination
-    const bestEntry = searchResult.bestEntry;
-    const bestExit = searchResult.bestExit;
+    // The window this period covers, shared by the tested and the skipped
+    // shape so the two cannot describe the same boundary differently.
+    const periodWindow = {
+      periodNumber: i + 1,
+      trainStart: candles[boundary.trainStart].time,
+      trainEnd: candles[boundary.trainEnd].time,
+      trainCandleCount: trainCandles.length,
+      testStart: candles[boundary.testStart].time,
+      testEnd: candles[boundary.testEnd].time,
+      testCandleCount: testCandles.length,
+    };
+
+    // Get best combination. `bestResult` is the single "was anything
+    // selected" signal — `bestEntry.length === 0` is not, because an empty
+    // entry combination can legitimately win when the caller allows it
+    // (minEntryConditions: 0, or required conditions covering the minimum).
+    const best = searchResult.bestResult;
+    if (best === null) {
+      skippedPeriods.push({
+        ...periodWindow,
+        combinationsTested: searchResult.totalCombinations,
+        reason:
+          "No combination satisfied the constraints with a finite score and at least one trade.",
+      });
+      continue;
+    }
+
+    const bestEntry = best.entryConditions;
+    const bestExit = best.exitConditions;
 
     // Track condition frequency
     for (const cond of bestEntry) {
@@ -196,13 +237,9 @@ export function anchoredWalkForwardAnalysis(
     const exitCondition =
       exitDefs.length === 1 ? exitDefs[0].create() : and(...exitDefs.map((d) => d.create()));
 
-    // Get in-sample metrics from best result
-    const bestSearchResult = searchResult.results.find(
-      (r) =>
-        r.entryConditions.join(",") === bestEntry.join(",") &&
-        r.exitConditions.join(",") === bestExit.join(","),
-    );
-    const inSampleMetrics = bestSearchResult?.metrics ?? ({} as Record<OptimizationMetric, number>);
+    // In-sample metrics come from the winning entry itself, not from a
+    // name-based lookup back into `results`.
+    const inSampleMetrics = best.metrics;
 
     // Run out-of-sample test
     const testBacktest = runBacktest(testCandles, entryCondition, exitCondition, backtestOpts);
@@ -211,19 +248,20 @@ export function anchoredWalkForwardAnalysis(
     });
 
     periods.push({
-      periodNumber: i + 1,
-      trainStart: candles[boundary.trainStart].time,
-      trainEnd: candles[boundary.trainEnd].time,
-      trainCandleCount: trainCandles.length,
-      testStart: candles[boundary.testStart].time,
-      testEnd: candles[boundary.testEnd].time,
-      testCandleCount: testCandles.length,
+      ...periodWindow,
       bestEntryConditions: bestEntry,
       bestExitConditions: bestExit,
       inSampleMetrics,
       outOfSampleMetrics,
       testBacktest,
     });
+  }
+
+  if (periods.length === 0) {
+    throw new Error(
+      `No AWF period selected a condition combination (${boundaries.length} period(s) evaluated). ` +
+        "Relax the constraints, widen the condition pools, or lengthen the training window.",
+    );
   }
 
   // Calculate aggregate metrics
@@ -237,6 +275,7 @@ export function anchoredWalkForwardAnalysis(
 
   return {
     periods,
+    skippedPeriods,
     aggregateMetrics,
     stabilityAnalysis,
     recommendation,

--- a/packages/core/src/optimization/combination-search.ts
+++ b/packages/core/src/optimization/combination-search.ts
@@ -54,23 +54,41 @@ export type CombinationResultEntry = {
  * Combination search result
  */
 export type CombinationSearchResult = {
-  /** Best combination found (empty arrays when no valid combination) */
+  /**
+   * The winning combination, or `null` if nothing was selected.
+   *
+   * This is the one unambiguous "did the search find anything" signal, and
+   * `bestEntry` / `bestExit` / `bestScore` are projections of it. Prefer it
+   * over inspecting those: `bestEntry` is empty both when nothing was
+   * selected AND when an empty entry combination legitimately won, which
+   * `minEntryConditions: 0` (or required conditions covering the minimum)
+   * makes reachable.
+   *
+   * `bestResult === null` is equivalent to `validCombinations === 0` and to
+   * `bestScore === null`.
+   */
+  bestResult: CombinationResultEntry | null;
+  /** Best combination's entry conditions — `bestResult.entryConditions`, or `[]` */
   bestEntry: string[];
+  /** Best combination's exit conditions — `bestResult.exitConditions`, or `[]` */
   bestExit: string[];
   /**
    * Best score achieved, or `null` if no combination satisfied the
-   * configured constraints. Previously fell back to `0`, which callers
-   * mistook as "the optimum is zero". Use `result.bestScore ?? 0` to
-   * preserve the prior behavior.
+   * configured constraints with a finite score. Previously fell back to
+   * `0`, which callers mistook as "the optimum is zero". Use
+   * `result.bestScore ?? 0` to preserve the prior behavior.
    */
   bestScore: number | null;
   /** Metric used for optimization */
   metric: OptimizationMetric;
   /** Total combinations tested */
   totalCombinations: number;
-  /** Valid combinations (passed constraints) */
+  /** Valid combinations (passed constraints and scored finitely) */
   validCombinations: number;
-  /** All results sorted by score */
+  /**
+   * All results sorted by score, best first. Non-finite scores are excluded
+   * unless `keepAllResults` is set, in which case they sort to the end.
+   */
   results: CombinationResultEntry[];
 };
 
@@ -248,8 +266,7 @@ export function combinationSearch(
 
   const results: CombinationResultEntry[] = [];
   let bestScore = Number.NEGATIVE_INFINITY;
-  let bestEntry: string[] = [];
-  let bestExit: string[] = [];
+  let bestResult: CombinationResultEntry | null = null;
   let validCombinations = 0;
   let current = 0;
 
@@ -347,18 +364,24 @@ export function combinationSearch(
           passedConstraints,
         };
 
-        // Only keep valid results unless keepAllResults is true
-        if (keepAllResults || passedConstraints) {
+        // Only keep valid, finite-scored results unless keepAllResults is
+        // true. Calmar / MAR / Recovery return NaN when maxDD <= 0, so a
+        // training window with no drawdown scores every combination NaN.
+        // Letting those through would leave `validCombinations` counting
+        // combinations that can never be selected — `score > bestScore` is
+        // false for NaN, so the search would report `bestScore: null`
+        // alongside a non-zero `validCombinations`.
+        const finiteScore = Number.isFinite(score);
+        if (keepAllResults || (passedConstraints && finiteScore)) {
           results.push(entry);
         }
 
-        // Update best if passes constraints
-        if (passedConstraints) {
+        // Update best if passes constraints AND has a finite score.
+        if (passedConstraints && finiteScore) {
           validCombinations++;
           if (score > bestScore) {
             bestScore = score;
-            bestEntry = entryNames;
-            bestExit = exitNames;
+            bestResult = entry;
           }
         }
       } catch (error) {
@@ -368,13 +391,23 @@ export function combinationSearch(
     }
   }
 
-  // Sort results by score (descending)
-  results.sort((a, b) => b.score - a.score);
+  // Sort results by score (descending). NaN scores sink to the end:
+  // any comparison involving NaN returns false, so the comparator
+  // falls through, but explicit handling makes the order deterministic.
+  results.sort((a, b) => {
+    const aFinite = Number.isFinite(a.score);
+    const bFinite = Number.isFinite(b.score);
+    if (aFinite && bFinite) return b.score - a.score;
+    if (aFinite) return -1;
+    if (bFinite) return 1;
+    return 0;
+  });
 
   return {
-    bestEntry,
-    bestExit,
-    bestScore: bestScore === Number.NEGATIVE_INFINITY ? null : bestScore,
+    bestResult,
+    bestEntry: bestResult?.entryConditions ?? [],
+    bestExit: bestResult?.exitConditions ?? [],
+    bestScore: bestResult === null ? null : bestScore,
     metric,
     totalCombinations,
     validCombinations,

--- a/packages/core/src/optimization/index.ts
+++ b/packages/core/src/optimization/index.ts
@@ -11,6 +11,7 @@ export type {
   AnchoredWalkForwardOptions,
   AWFPeriod,
   AWFResult,
+  AWFSkippedPeriod,
   GridSearchOptions,
   GridSearchResult,
   MetricStatistics,

--- a/packages/core/src/types/optimization.ts
+++ b/packages/core/src/types/optimization.ts
@@ -411,7 +411,10 @@ export type AnchoredWalkForwardOptions = {
   metric?: OptimizationMetric;
   /** Constraints for optimization */
   constraints?: OptimizationConstraint[];
-  /** Progress callback */
+  /**
+   * Progress callback. A period whose training search selects nothing is not
+   * tested, so it reports `"train"` and never `"test"`.
+   */
   progressCallback?: (period: number, total: number, phase: "train" | "test") => void;
 };
 
@@ -446,11 +449,49 @@ export type AWFPeriod = {
 };
 
 /**
+ * An AWF period whose training window produced no condition combination.
+ *
+ * The period is not backtested out-of-sample and does not appear in
+ * {@link AWFResult.periods}, so it contributes nothing to the aggregate
+ * metrics, the stability analysis or the recommendation.
+ */
+export type AWFSkippedPeriod = {
+  /** Period number (1-indexed, in the same sequence as {@link AWFPeriod.periodNumber}) */
+  periodNumber: number;
+  /** Training period start timestamp */
+  trainStart: number;
+  /** Training period end timestamp */
+  trainEnd: number;
+  /** Training candle count */
+  trainCandleCount: number;
+  /** Test period start timestamp — the window that was never tested */
+  testStart: number;
+  /** Test period end timestamp */
+  testEnd: number;
+  /** Test candle count */
+  testCandleCount: number;
+  /** Combinations the training search evaluated */
+  combinationsTested: number;
+  /** Human-readable explanation of why nothing was selected */
+  reason: string;
+};
+
+/**
  * Anchored Walk-Forward analysis result
  */
 export type AWFResult = {
-  /** Results for each AWF period */
+  /**
+   * Results for each AWF period that produced a condition combination.
+   *
+   * `periodNumber` is assigned over all boundaries, so this array has gaps
+   * whenever {@link AWFResult.skippedPeriods} is non-empty.
+   */
   periods: AWFPeriod[];
+  /**
+   * Periods whose training search selected nothing, and which were therefore
+   * never backtested out-of-sample. Empty in the normal case.
+   */
+  skippedPeriods: AWFSkippedPeriod[];
   /** Aggregate performance metrics */
   aggregateMetrics: {
     /** Average in-sample metrics across all periods */


### PR DESCRIPTION
## The bug

`anchoredWalkForwardAnalysis` optimizes a condition combination on each expanding training window, then backtests that combination on the following test window.

When the training search selected **nothing** — every combination violated a constraint, produced no trades, or scored non-finitely — the period was still tested. An unselected combination is an empty condition list; filtering the condition pools by it yields no definitions; and `and()` over zero conditions is vacuously `true`. So the test window was backtested with an always-true entry **and** an always-true exit, and that always-in-the-market result was stored as the period's out-of-sample performance and fed to the aggregate metrics, the stability analysis and the recommendation.

On 800 daily candles with `constraints: [{ metric: "tradeCount", operator: ">=", value: 1e9 }]` — a threshold nothing can pass — both periods reported:

```
bestEntryConditions: []   bestExitConditions: []
inSampleMetrics:     {}   // every key undefined, while typed Record<OptimizationMetric, number>
outOfSampleMetrics:  { tradeCount: 99, returns: 19.17 }   // period 1
outOfSampleMetrics:  { tradeCount: 99, returns: 18.19 }   // period 2
recommendation: { useOptimized: true, entryConditions: [], exitConditions: [],
                  reason: "Moderate stability (ratio=1.00)..." }
```

99 trades and an affirmative recommendation from a strategy that was never selected. `stabilityRatio` reads 1.00 precisely *because* `inSampleMetrics` is empty — the aggregate treats every undefined key as 0, and 0-vs-0 is scored as perfect stability.

Constraints are not required to reach this. A training window in which no combination trades at all takes the same path: `combinationSearch` discards zero-trade combinations, so nothing is left to select.

### A second defect underneath it

`combinationSearch` had two answers to "did the search find anything". `validCombinations` counted every constraint-passing combination, but selection compares `score > bestScore`, which is `false` for `NaN`. A training window with no drawdown scores every combination `NaN` under `calmar` (`calculateCalmarRatio` returns `NaN` when max drawdown is 0), so the search reported `bestScore: null` next to `validCombinations: 3`.

## The fix

A period whose search selects nothing is recorded in the new `AWFResult.skippedPeriods` and is **not** backtested. It contributes nothing to `aggregateMetrics`, `stabilityAnalysis` or `recommendation`. `periodNumber` still counts across all boundaries, so `periods` has gaps whenever `skippedPeriods` is non-empty. If **no** period selects a combination the call now throws instead of returning a fabricated result; `anchoredWalkForwardAnalysisSafe` surfaces that as `OPTIMIZATION_FAILED`.

`AWFPeriod.inSampleMetrics` now comes from the winning combination itself, rather than from a name-join lookup back into the search results that fell back to an empty object cast to the metric record.

Non-finite scores are excluded from `validCombinations` and from `results`, mirroring the guard `gridSearch` already applies, and `results` sorts them to the end deterministically when `keepAllResults` keeps them. After this, `bestScore === null`, `bestResult === null` and `validCombinations === 0` are equivalent.

`summarizeAWFResult` gains `skippedPeriodCount`; `formatAWFResult` lists the skipped periods and why each was skipped.

### Why the sentinel is `bestResult`, not an empty `bestEntry`

The obvious guard — "did the search return empty condition arrays?" — is wrong. With `minEntryConditions: 0`, or with required conditions already covering the minimum, the empty entry combination is a legitimate candidate that the search will evaluate and can select. Measured on a 400-bar series: `bestEntry: []` with `bestScore: 41.93` and `validCombinations: 4`. An empty `bestEntry` therefore means either "nothing was selected" or "the empty combination won", and only the former should skip the period.

So `CombinationSearchResult` gains `bestResult: CombinationResultEntry | null` — the winning entry, or `null` when nothing was selected. `bestEntry`, `bestExit` and `bestScore` are projections of it. This also removes the name-join re-derivation: the guard and the in-sample metrics now come from the same source.

## API changes

| Change | Kind |
|---|---|
| `AWFResult.skippedPeriods` | Added |
| `AWFSkippedPeriod` (exported type) | Added |
| `CombinationSearchResult.bestResult` | Added |
| `summarizeAWFResult().skippedPeriodCount` | Added |
| A period that selects nothing is no longer backtested | Breaking |
| An AWF run in which no period selects anything now throws | Breaking |
| `combinationSearch` excludes non-finite scores from `validCombinations` and `results` | Breaking |

A period whose search selects nothing is not an ordinary outcome, so runs that were reporting real numbers before are unaffected.

## Test plan

Eleven new tests. Negative check: **10 of 11 fail** against the unfixed source, then all 38 tests in the two touched files pass with it. (The eleventh pins the "an empty entry combination can legitimately win" fact that justifies the sentinel choice, and correctly holds both before and after.)

- `anchored-walkforward.test.ts` — an all-failing constraint throws rather than reporting 99 fabricated trades; the safe variant returns `OPTIMIZATION_FAILED`; a zero-trade training window is skipped without constraints being involved; a mixed run records the skipped period with full boundary information and keeps the one that selected; `inSampleMetrics` equals what an independent `combinationSearch` on the same window reports; an empty entry combination the caller allowed is still tested; the summary and the formatted output report the skipped count.
- `combination-search.test.ts` — `calmar` on a drawdown-free window reports `bestResult: null` / `validCombinations: 0` / `results: []` instead of the previous `null`-vs-`3` disagreement; `keepAllResults` keeps the `NaN`-scored entries but sorts them last; `bestResult` agrees with all three of its projections and is the maximum over the finite, constraint-passing entries; an empty entry combination that wins is distinguishable from nothing being selected.

Invariant probes (run, then removed):

- **2,160 randomized `combinationSearch` runs** — 12 seeds x 5 series shapes x 6 metrics x `minEntryConditions` 0/1 x 3 constraint levels. Asserted that `bestResult === null`, `bestScore === null` and `validCombinations === 0` always agree; that the projections are the winner's own arrays; that the winner is the maximum over the finite constraint-passing entries; and that `results` is sorted best-first with non-finite scores last. **1,344 runs selected something, 816 did not** — both branches exercised, zero divergences.
- **1,200 randomized AWF runs** — asserted `periods.length + skippedPeriods.length === boundaries.length` and that the period numbers cover `1..N` exactly once; that every kept period has finite in-sample metrics for the optimized metric and reports conditions that resolve back to real definitions; and that no condition frequency exceeds 100%. **360 runs threw, 105 mixed skipped and kept periods** (the constraint threshold has to be derived from each window's actual trade count to produce a mix; fixed thresholds produced none). Zero divergences.
- Boundaries: empty condition pools, a single-period analysis, `minEntryConditions: 0`, and four constraint levels.
- Numeric classes: `NaN` and `-Infinity` scores are neither selectable nor counted.
- Consumers of the changed fields were grepped across the repo; nothing constructs an `AWFResult`, and the other `validCombinations` readers are all on `GridSearchResult`.
- The built `.d.ts` was checked for the new fields, the re-export of `AWFSkippedPeriod`, and the documentation staying attached to its declarations.

Suites: core **377 files / 7,199 tests** pass, chart 1,049 pass / 2 skipped, mcp 83 pass. `tsc --noEmit`, `pnpm build`, `biome check` and `git diff --check` all clean.