### PR TITLE
fix(core): make the strategy registry's declarations describe what hydration needs

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,117 @@
 
 ## [Unreleased]
 
+### Breaking — the strategy registry no longer advertises values its factories cannot use
+
+**Pattern subtype enums listed labels that make the condition permanently
+false.** Five entries (`triangleDetected`, `wedgeDetected`, `channelDetected`,
+`flagDetected`, `harmonicPatternDetected`) declared short labels
+(`"ascending"`, `"rising"`, `"bull"`, `"gartley"`) while the factories need
+full pattern identifiers (`"triangle_ascending"`, `"rising_wedge"`,
+`"bull_flag"`, `"gartley_bullish"`). A label that is not a pattern identifier
+finds no detector, so the condition returned no matches on every bar — and
+because the enum was also enforced, the value that *works* was rejected:
+
+```
+{ name: "triangleDetected", params: { subtype: "symmetrical" } }
+  before → valid, hydrates to patternDetected(symmetrical), never fires
+  after  → invalid: value "symmetrical" not in allowed values
+
+{ name: "triangleDetected", params: { subtype: "triangle_symmetrical" } }
+  before → invalid: value not in allowed values
+  after  → valid, hydrates to patternDetected(triangle_symmetrical)
+```
+
+Narrowing a working `flagDetected` to the bull side using the registry's own
+enum produced a strategy with zero entries and a 0-trade backtest that looked
+like a legitimate result. The enums now list real pattern identifiers, so
+`"abcd"` (never a pattern in this codebase) is gone and the shark harmonics are
+present.
+
+`patternDetected`, `patternConfirmed`, `patternConfidenceAbove` and
+`patternWithinBars` declared `type` as a free-form string with no `enum` at
+all, which had the same outcome for any typo. They now share one enum built
+from the pattern types the detectors actually resolve, and a contract test
+asserts that no pattern param can advertise a value outside that set.
+
+**`periods` was declared a number and is an array.** The shared schema behind
+17 Perfect Order conditions declared `type: "number"` with a description
+saying "array via JSON", so there was no value that both validated and worked:
+the array form was rejected as `expected number, got object`, while the scalar
+form validated and then made `hydrate` throw `periods.join is not a function`.
+A saved, working strategy became unloadable the moment a registry was passed
+to `parseStrategy`.
+
+`ParamDef` gains `array`, `minItems`, `maxItems` and `minDistinct`. With
+`array: true` the `type` names the ELEMENT type and `min` / `max` / `enum` /
+`integer` apply per element, with errors reported at their index. Scalar type
+errors now distinguish an array and `null` from an object, which `typeof`
+reported as `"object"` for all three.
+
+`minDistinct` exists because a factory may de-duplicate before it counts:
+`perfectOrder` needs two different MA lengths, so `[5, 5]` is two items but one
+period and used to validate before throwing at evaluate time. `[5, 5, 25]`
+still validates, since two lengths survive de-duplication.
+
+**`integer: true` is now enforced.** It was documented as a hint for UIs and
+checked nowhere, so a param declaring it still accepted `5.5` and failed later
+inside the indicator. 25 params across both registries declare it; none has a
+fractional default, so no existing declaration changes meaning.
+
+**The `params` container is now checked for shape.** `Object.entries(42)` is
+`[]` and `Object.entries("ab")` yields index keys, so
+`{ name: "goldenCross", params: 42 }` validated as "no parameters" and hydrated
+with defaults, while `params: "x"` produced an error about a parameter named
+`0`. `params` must be an object when present; `null` is rejected rather than
+treated as omitted.
+
+**A malformed combinator child crashed the validator.** `validateSpecRecursive`
+tested `"op" in spec` without first checking that `spec` is an object, so a
+`conditions` array holding a string, number or `null` — a bare condition name
+where an object belonged is an ordinary hand-written or generated mistake —
+threw `TypeError: Cannot use 'in' operator`. `parseStrategySafe` catches only
+`JSON.parse` failures, so the `TypeError` escaped a function documented to
+return a `Result` with a closed set of codes. Such a child is now reported as
+`expected condition object, got string`, `hydrate` refuses one with a readable
+message, and the registry-validation block is wrapped so nothing thrown inside
+it can escape the `Result` contract.
+
+**`hydrate` discarded parameters the entry does not declare.** It iterated the
+entry's own schema, so `{ threshold: 30, lookback: 10 }` passed to a streaming
+entry that accepts only `key` was dropped without a word, and a strategy tuned
+against one registry streamed with the tuning gone. Unknown parameters now
+throw, naming both the offenders and what the entry accepts.
+
+### Fixed — registry parity can no longer pass a pair it never compared
+
+The parity test skips any parameter the other registry lacks. Thirteen shared
+names have no overlapping parameters at all, so zero comparisons ran and they
+passed automatically. Only four are the paradigm difference the exemption was
+designed for — `macdCrossUp` / `macdCrossDown` / `stochCrossUp` /
+`stochCrossDown`, where both sides cross the same two lines and differ only in
+whether the indicator is computed from periods or read from a snapshot.
+
+The other **nine implement different rules behind the same name**:
+
+- `perfectOrderBullish` / `perfectOrderBearish` — the backtest condition fires
+  on the bar the order FORMS (an edge, plus a strength floor) over an SMA
+  ribbon; the streaming one fires on every bar an EMA ribbon is in order (a
+  level).
+- `perfectOrderCollapsed` — backtest reads "the alignment broke"; streaming
+  reads "the spread stopped widening", a different quantity.
+- `obvCrossUp` / `obvCrossDown` — backtest crosses two moving averages of OBV;
+  streaming crosses raw OBV over a single signal line.
+- `obvRising` / `obvFalling` — backtest compares OBV to its value `period` bars
+  ago; streaming compares to the previous bar.
+- `volatilityExpanding` / `volatilityContracting` — backtest needs the ATR
+  percentile to move past its lookback mean by a threshold; streaming fires on
+  any tick.
+
+Every disjoint pair must now be listed with a written justification, and the
+test fails both for an unlisted pair and for a listed one that no longer
+drifts. Reconciling the nine is a separate change, since it means either
+altering streaming semantics or renaming published entries.
+
 ### Added — `calculateAtrPercentDetail`
 
 Returns `{ atrPercent, sampleCount }`. `sampleCount` is how many bars

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -7447,6 +7447,31 @@ const structResult = validateStrategyJSON(strategyJson);
 // { valid: boolean, errors: string[] }
 ```
 
+`array: true` を持つ `ParamDef` は `type` の配列を受け取り、`min` / `max` /
+`enum` は各要素に適用される。要素のエラーはインデックス付きで報告され、
+`minItems` / `maxItems` が長さを制約する:
+
+```typescript
+validateConditionSpec(
+  { name: "perfectOrderBullish", params: { periods: [5, "25", 75] } },
+  backtestRegistry,
+);
+// { valid: false, errors: ["perfectOrderBullish.periods[1]: expected number, got string"] }
+```
+
+`minItems` / `maxItems` は長さを、`minDistinct` は**異なる値の個数**を制約する
+（重複除去してから数える factory があるため）。`integer: true` は検証で強制され、
+配列 param では要素ごとに適用される。`params` 自体も、存在する場合はオブジェクトで
+なければならない。
+
+結合子の子要素がオブジェクトでない場合は throw でなく報告されるので、壊れた戦略でも
+`parseStrategySafe` は `Result` の契約を守る — `{ "op": "and", "conditions": ["goldenCross"] }`
+（オブジェクトを置くべき場所に条件名だけを書いたもの）は `TypeError` でなく
+`and[0]: expected condition object, got string` を返す。
+
+`hydrate` はエントリが宣言していないパラメータを黙って捨てず拒否するので、あるレジストリ
+向けに書いたチューニングが別のレジストリで無言のうちに失われることはない。
+
 ### StrategyJSON スキーマ
 
 ```typescript

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -7505,6 +7505,33 @@ const structResult = validateStrategyJSON(strategyJson);
 // { valid: boolean, errors: string[] }
 ```
 
+A `ParamDef` with `array: true` takes a list of its `type`, and `min` / `max` /
+`enum` then apply per element. Element errors are reported at their index, and
+`minItems` / `maxItems` bound the length:
+
+```typescript
+validateConditionSpec(
+  { name: "perfectOrderBullish", params: { periods: [5, "25", 75] } },
+  backtestRegistry,
+);
+// { valid: false, errors: ["perfectOrderBullish.periods[1]: expected number, got string"] }
+```
+
+`minItems` / `maxItems` bound the length and `minDistinct` bounds the number of
+distinct values — a factory may de-duplicate before it counts. `integer: true`
+is enforced, per element for an array param. `params` itself must be an object
+when present.
+
+A combinator child that is not an object is reported rather than thrown, so
+`parseStrategySafe` keeps its `Result` contract for a malformed strategy —
+`{ "op": "and", "conditions": ["goldenCross"] }`, a bare condition name where
+an object belonged, yields `and[0]: expected condition object, got string`
+instead of a `TypeError`.
+
+`hydrate` rejects a parameter the entry does not declare instead of dropping
+it, so tuning written against one registry cannot be silently discarded by
+another.
+
 ### StrategyJSON Schema
 
 ```typescript

--- a/packages/core/src/backtest/conditions/patterns.ts
+++ b/packages/core/src/backtest/conditions/patterns.ts
@@ -99,6 +99,84 @@ const PATTERN_DETECTORS: Record<
 };
 
 /**
+ * Every pattern identifier a pattern condition can resolve.
+ *
+ * Derived from the detector table rather than restated, so it cannot fall
+ * short of `PatternType`: the table is a total `Record<PatternType, …>`, which
+ * fails to compile if a member is missing. A value outside this set finds no
+ * detector and leaves the condition false on every bar, so the strategy
+ * registry builds its pattern enums from it.
+ */
+export const PATTERN_TYPES: readonly PatternType[] = Object.keys(
+  PATTERN_DETECTORS,
+) as PatternType[];
+
+/**
+ * The members of each pattern family, in one place.
+ *
+ * Each family was written out four times — the factory's `subtype` union, the
+ * array it scans when no subtype is given, the strategy registry's `enum`, and
+ * the cast in that entry's `create`. Adding a member to one and forgetting
+ * another is invisible: a registry enum that is merely a SUBSET of the real
+ * pattern types passes every membership check.
+ */
+export const TRIANGLE_TYPES = [
+  "triangle_symmetrical",
+  "triangle_ascending",
+  "triangle_descending",
+] as const satisfies readonly PatternType[];
+
+/** See {@link TRIANGLE_TYPES}. */
+export const WEDGE_TYPES = [
+  "rising_wedge",
+  "falling_wedge",
+] as const satisfies readonly PatternType[];
+
+/** See {@link TRIANGLE_TYPES}. */
+export const CHANNEL_TYPES = [
+  "channel_ascending",
+  "channel_descending",
+  "channel_horizontal",
+] as const satisfies readonly PatternType[];
+
+/** See {@link TRIANGLE_TYPES}. Includes pennants, which share the flag detector. */
+export const FLAG_TYPES = [
+  "bull_flag",
+  "bear_flag",
+  "bull_pennant",
+  "bear_pennant",
+] as const satisfies readonly PatternType[];
+
+/** See {@link TRIANGLE_TYPES}. */
+export const HARMONIC_TYPES = [
+  "gartley_bullish",
+  "gartley_bearish",
+  "butterfly_bullish",
+  "butterfly_bearish",
+  "bat_bullish",
+  "bat_bearish",
+  "crab_bullish",
+  "crab_bearish",
+  "shark_bullish",
+  "shark_bearish",
+] as const satisfies readonly PatternType[];
+
+/**
+ * The directional halves of {@link HARMONIC_TYPES}.
+ *
+ * Every harmonic name ends in one suffix or the other, so these are derived
+ * rather than restated; a contract test asserts they partition the family.
+ */
+export const BULLISH_HARMONIC_TYPES: readonly PatternType[] = HARMONIC_TYPES.filter((t) =>
+  t.endsWith("_bullish"),
+);
+
+/** See {@link BULLISH_HARMONIC_TYPES}. */
+export const BEARISH_HARMONIC_TYPES: readonly PatternType[] = HARMONIC_TYPES.filter((t) =>
+  t.endsWith("_bearish"),
+);
+
+/**
  * Options for pattern conditions
  */
 export interface PatternConditionOptions {
@@ -150,7 +228,7 @@ function hasMatchingPattern(
   indicators: Record<string, unknown>,
   candles: CandleArray,
   candle: NormalizedCandle,
-  patternTypes: PatternType[],
+  patternTypes: readonly PatternType[],
   options: PatternConditionOptions,
 ): boolean {
   const { confirmedOnly = false } = options;
@@ -442,20 +520,15 @@ export function cupHandleDetected(options: PatternConditionOptions = {}): Preset
  * Triangle pattern detected (any subtype)
  */
 export function triangleDetected(
-  subtype?: "triangle_symmetrical" | "triangle_ascending" | "triangle_descending",
+  subtype?: (typeof TRIANGLE_TYPES)[number],
   options: PatternConditionOptions = {},
 ): PresetCondition {
   if (subtype) return patternDetected(subtype, options);
-  const types: PatternType[] = [
-    "triangle_symmetrical",
-    "triangle_ascending",
-    "triangle_descending",
-  ];
   return {
     type: "preset",
     name: "triangleDetected()",
     evaluate: (indicators, candle, _index, candles) =>
-      hasMatchingPattern(indicators, candles, candle, types, options),
+      hasMatchingPattern(indicators, candles, candle, TRIANGLE_TYPES, options),
   };
 }
 
@@ -463,16 +536,15 @@ export function triangleDetected(
  * Wedge pattern detected (any subtype)
  */
 export function wedgeDetected(
-  subtype?: "rising_wedge" | "falling_wedge",
+  subtype?: (typeof WEDGE_TYPES)[number],
   options: PatternConditionOptions = {},
 ): PresetCondition {
   if (subtype) return patternDetected(subtype, options);
-  const types: PatternType[] = ["rising_wedge", "falling_wedge"];
   return {
     type: "preset",
     name: "wedgeDetected()",
     evaluate: (indicators, candle, _index, candles) =>
-      hasMatchingPattern(indicators, candles, candle, types, options),
+      hasMatchingPattern(indicators, candles, candle, WEDGE_TYPES, options),
   };
 }
 
@@ -480,16 +552,15 @@ export function wedgeDetected(
  * Channel pattern detected (any subtype)
  */
 export function channelDetected(
-  subtype?: "channel_ascending" | "channel_descending" | "channel_horizontal",
+  subtype?: (typeof CHANNEL_TYPES)[number],
   options: PatternConditionOptions = {},
 ): PresetCondition {
   if (subtype) return patternDetected(subtype, options);
-  const types: PatternType[] = ["channel_ascending", "channel_descending", "channel_horizontal"];
   return {
     type: "preset",
     name: "channelDetected()",
     evaluate: (indicators, candle, _index, candles) =>
-      hasMatchingPattern(indicators, candles, candle, types, options),
+      hasMatchingPattern(indicators, candles, candle, CHANNEL_TYPES, options),
   };
 }
 
@@ -497,16 +568,15 @@ export function channelDetected(
  * Flag or Pennant pattern detected (any subtype)
  */
 export function flagDetected(
-  subtype?: "bull_flag" | "bear_flag" | "bull_pennant" | "bear_pennant",
+  subtype?: (typeof FLAG_TYPES)[number],
   options: PatternConditionOptions = {},
 ): PresetCondition {
   if (subtype) return patternDetected(subtype, options);
-  const types: PatternType[] = ["bull_flag", "bear_flag", "bull_pennant", "bear_pennant"];
   return {
     type: "preset",
     name: "flagDetected()",
     evaluate: (indicators, candle, _index, candles) =>
-      hasMatchingPattern(indicators, candles, candle, types, options),
+      hasMatchingPattern(indicators, candles, candle, FLAG_TYPES, options),
   };
 }
 
@@ -548,23 +618,11 @@ export function harmonicPatternDetected(
   options: PatternConditionOptions = {},
 ): PresetCondition {
   if (subtype) return patternDetected(subtype, options);
-  const types: PatternType[] = [
-    "gartley_bullish",
-    "gartley_bearish",
-    "butterfly_bullish",
-    "butterfly_bearish",
-    "bat_bullish",
-    "bat_bearish",
-    "crab_bullish",
-    "crab_bearish",
-    "shark_bullish",
-    "shark_bearish",
-  ];
   return {
     type: "preset",
     name: "harmonicPatternDetected()",
     evaluate: (indicators, candle, _index, candles) =>
-      hasMatchingPattern(indicators, candles, candle, types, options),
+      hasMatchingPattern(indicators, candles, candle, HARMONIC_TYPES, options),
   };
 }
 
@@ -579,18 +637,11 @@ export function harmonicPatternDetected(
  * ```
  */
 export function bullishHarmonicDetected(options: PatternConditionOptions = {}): PresetCondition {
-  const types: PatternType[] = [
-    "gartley_bullish",
-    "butterfly_bullish",
-    "bat_bullish",
-    "crab_bullish",
-    "shark_bullish",
-  ];
   return {
     type: "preset",
     name: "bullishHarmonicDetected()",
     evaluate: (indicators, candle, _index, candles) =>
-      hasMatchingPattern(indicators, candles, candle, types, options),
+      hasMatchingPattern(indicators, candles, candle, BULLISH_HARMONIC_TYPES, options),
   };
 }
 
@@ -605,17 +656,10 @@ export function bullishHarmonicDetected(options: PatternConditionOptions = {}): 
  * ```
  */
 export function bearishHarmonicDetected(options: PatternConditionOptions = {}): PresetCondition {
-  const types: PatternType[] = [
-    "gartley_bearish",
-    "butterfly_bearish",
-    "bat_bearish",
-    "crab_bearish",
-    "shark_bearish",
-  ];
   return {
     type: "preset",
     name: "bearishHarmonicDetected()",
     evaluate: (indicators, candle, _index, candles) =>
-      hasMatchingPattern(indicators, candles, candle, types, options),
+      hasMatchingPattern(indicators, candles, candle, BEARISH_HARMONIC_TYPES, options),
   };
 }

--- a/packages/core/src/optimization/strategy-json-factory.ts
+++ b/packages/core/src/optimization/strategy-json-factory.ts
@@ -15,6 +15,7 @@
 import { loadStrategy } from "../strategy/hydrate";
 import type { ConditionRegistry } from "../strategy/registry";
 import type { StrategyJSON } from "../strategy/types";
+import { isScalarNumberParam } from "../strategy/utils";
 import { validateConditionSpec } from "../strategy/validate";
 import {
   applyParamOverrides,
@@ -114,9 +115,10 @@ export function validateRangePaths(
         `Invalid range path "${range.path}": condition "${leaf.name}" has no param "${parsed.paramName}"`,
       );
     }
-    if (schema.type !== "number") {
+    if (!isScalarNumberParam(schema)) {
+      const declared = schema.array ? `${schema.type}[]` : schema.type;
       throw new Error(
-        `Invalid range path "${range.path}": param "${parsed.paramName}" on "${leaf.name}" is type "${schema.type}", optimization only supports "number"`,
+        `Invalid range path "${range.path}": param "${parsed.paramName}" on "${leaf.name}" is type "${declared}", optimization only supports scalar "number"`,
       );
     }
     // Catch caller-side range shape errors here so the safe variant can

--- a/packages/core/src/strategy/__tests__/registry-contracts.test.ts
+++ b/packages/core/src/strategy/__tests__/registry-contracts.test.ts
@@ -1,0 +1,420 @@
+/**
+ * What the registry declares must be what hydration needs.
+ *
+ * Each case below is a spec whose declared schema and its factory disagreed:
+ * an enum listing values the factory cannot consume, a scalar type for a param
+ * that is really an array, a validator that threw instead of reporting, and a
+ * param silently discarded on the way in. The shared failure is that the
+ * declaration was not a description of the thing.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  BEARISH_HARMONIC_TYPES,
+  BULLISH_HARMONIC_TYPES,
+  CHANNEL_TYPES,
+  FLAG_TYPES,
+  HARMONIC_TYPES,
+  PATTERN_TYPES,
+  TRIANGLE_TYPES,
+  WEDGE_TYPES,
+} from "../../backtest/conditions/patterns";
+import { validateRangePaths } from "../../optimization/strategy-json-factory";
+import type { NormalizedCandle } from "../../types";
+import { backtestRegistry } from "../registry-backtest";
+import { streamingRegistry } from "../registry-streaming";
+import { parseStrategySafe } from "../serialize";
+import { validateConditionSpec } from "../validate";
+
+/** Combinators are irrelevant to these tests; only the leaf path matters. */
+const AND = {
+  and: (...c: unknown[]) => ({ type: "and", conditions: c }),
+  or: (...c: unknown[]) => ({ type: "or", conditions: c }),
+  not: (c: unknown) => ({ type: "not", condition: c }),
+};
+const btCombinators = AND as unknown as Parameters<typeof backtestRegistry.hydrate>[1];
+const stCombinators = AND as unknown as Parameters<typeof streamingRegistry.hydrate>[1];
+
+function candles(count: number): NormalizedCandle[] {
+  return Array.from({ length: count }, (_, i) => ({
+    time: Date.UTC(2024, 0, 1 + i),
+    open: 100,
+    high: 101,
+    low: 99,
+    close: 100,
+    volume: 1000,
+  }));
+}
+
+describe("pattern params advertise identifiers the detectors know", () => {
+  const known = new Set<string>(PATTERN_TYPES);
+
+  it("every pattern-type enum is a subset of the resolvable pattern types", () => {
+    // A value outside PATTERN_TYPES finds no detector, so the condition is
+    // silently false on every bar — the registry must never advertise one.
+    const offenders: string[] = [];
+    for (const name of backtestRegistry.names()) {
+      const entry = backtestRegistry.get(name);
+      if (entry?.category !== "pattern") continue;
+      for (const [param, def] of Object.entries(entry.params)) {
+        if (def.type !== "string" || !def.enum) continue;
+        const bad = def.enum.filter((v) => typeof v !== "string" || !known.has(v));
+        if (bad.length > 0) offenders.push(`${name}.${param}: ${JSON.stringify(bad)}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("the family constants partition the pattern types", () => {
+    // Membership alone is not enough: an enum that is merely a SUBSET of the
+    // real pattern types passes every check while silently omitting one. A
+    // new PatternType must land in exactly one family (or be one of the
+    // standalone shapes), or this fails.
+    const STANDALONE: string[] = [
+      "double_top",
+      "double_bottom",
+      "head_shoulders",
+      "inverse_head_shoulders",
+      "cup_handle",
+    ];
+    const families = [
+      TRIANGLE_TYPES,
+      WEDGE_TYPES,
+      CHANNEL_TYPES,
+      FLAG_TYPES,
+      HARMONIC_TYPES,
+    ] as readonly (readonly string[])[];
+
+    const covered = [...families.flat(), ...STANDALONE];
+    expect(covered.length, "a pattern type appears in two families").toBe(new Set(covered).size);
+    expect([...covered].sort()).toEqual([...PATTERN_TYPES].sort());
+  });
+
+  it("the harmonic halves partition the harmonic family", () => {
+    const halves = [...BULLISH_HARMONIC_TYPES, ...BEARISH_HARMONIC_TYPES];
+    expect(halves.length).toBe(new Set(halves).size);
+    expect([...halves].sort()).toEqual([...HARMONIC_TYPES].sort());
+  });
+
+  it("every family's registry enum is the whole family, not a subset of it", () => {
+    for (const [entryName, family] of [
+      ["triangleDetected", TRIANGLE_TYPES],
+      ["wedgeDetected", WEDGE_TYPES],
+      ["channelDetected", CHANNEL_TYPES],
+      ["flagDetected", FLAG_TYPES],
+      ["harmonicPatternDetected", HARMONIC_TYPES],
+    ] as const) {
+      const declared = backtestRegistry.get(entryName)?.params.subtype.enum;
+      expect([...(declared ?? [])].sort()).toEqual([...family].sort());
+    }
+  });
+
+  it("every pattern-type param is constrained by an enum at all", () => {
+    // Without one, any free-form string validates and then finds no detector.
+    const freeform: string[] = [];
+    for (const name of backtestRegistry.names()) {
+      const entry = backtestRegistry.get(name);
+      if (entry?.category !== "pattern") continue;
+      for (const [param, def] of Object.entries(entry.params)) {
+        if (def.type === "string" && !def.enum) freeform.push(`${name}.${param}`);
+      }
+    }
+    expect(freeform).toEqual([]);
+  });
+
+  it("accepts the subtype the factory needs and rejects the label it does not", () => {
+    // Previously exactly inverted: "symmetrical" validated and was inert,
+    // while "triangle_symmetrical" was rejected as not in allowed values.
+    const good = validateConditionSpec(
+      { name: "triangleDetected", params: { subtype: "triangle_symmetrical" } },
+      backtestRegistry,
+    );
+    expect(good.valid).toBe(true);
+
+    const bad = validateConditionSpec(
+      { name: "triangleDetected", params: { subtype: "symmetrical" } },
+      backtestRegistry,
+    );
+    expect(bad.valid).toBe(false);
+    expect(bad.errors[0]).toMatch(/not in allowed values/);
+  });
+
+  it("hydrates a subtype into a condition named after a real pattern type", () => {
+    const condition = backtestRegistry.hydrate(
+      { name: "flagDetected", params: { subtype: "bull_flag" } },
+      btCombinators,
+    ) as { name: string };
+    expect(condition.name).toBe("patternDetected(bull_flag)");
+  });
+
+  it("no longer offers a harmonic subtype the codebase has no detector for", () => {
+    const entry = backtestRegistry.get("harmonicPatternDetected");
+    expect(entry?.params.subtype.enum).not.toContain("abcd");
+    expect(entry?.params.subtype.enum).toContain("shark_bullish");
+  });
+});
+
+describe("array-valued params", () => {
+  it("validates the array form the factory actually takes", () => {
+    const result = validateConditionSpec(
+      { name: "perfectOrderBullish", params: { periods: [5, 25, 75] } },
+      backtestRegistry,
+    );
+    expect(result).toEqual({ valid: true, errors: [] });
+  });
+
+  it("rejects the scalar form that used to validate and then throw at hydrate", () => {
+    const result = validateConditionSpec(
+      { name: "perfectOrderBullish", params: { periods: 25 } },
+      backtestRegistry,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toBe("perfectOrderBullish.periods: expected number[], got number");
+  });
+
+  it("reports a wrong element type at its index", () => {
+    const result = validateConditionSpec(
+      { name: "perfectOrderBullish", params: { periods: [5, "25", 75] } },
+      backtestRegistry,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toBe("perfectOrderBullish.periods[1]: expected number, got string");
+  });
+
+  it("enforces the distinct-value minimum the factory actually needs", () => {
+    // `[5, 5]` is two items but one period: perfectOrder de-duplicates before
+    // it counts, so a length check alone let it through to an evaluate-time
+    // throw. `[5]` fails the same rule.
+    for (const [periods, distinct] of [
+      [[5], 1],
+      [[5, 5], 1],
+      [[5, 5, 5], 1],
+    ] as const) {
+      const result = validateConditionSpec(
+        { name: "perfectOrderBullish", params: { periods: [...periods] } },
+        backtestRegistry,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toBe(
+        `perfectOrderBullish.periods: expected at least 2 distinct values, got ${distinct}`,
+      );
+    }
+
+    // Repeats are fine as long as two distinct lengths survive de-duplication.
+    expect(
+      validateConditionSpec(
+        { name: "perfectOrderBullish", params: { periods: [5, 5, 25] } },
+        backtestRegistry,
+      ).valid,
+    ).toBe(true);
+  });
+
+  it("enforces a declared integer element type", () => {
+    // `integer` was documented as a UI hint and enforced nowhere, so `5.5`
+    // validated and then threw inside the moving average.
+    const result = validateConditionSpec(
+      { name: "perfectOrderBullish", params: { periods: [5.5, 25] } },
+      backtestRegistry,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toBe("perfectOrderBullish.periods[0]: expected an integer, got 5.5");
+  });
+
+  it("enforces a declared integer on a scalar param too", () => {
+    const result = validateConditionSpec(
+      { name: "goldenCross", params: { shortPeriod: 5.5 } },
+      backtestRegistry,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/expected an integer, got 5.5/);
+  });
+
+  it("applies element bounds per element", () => {
+    const result = validateConditionSpec(
+      { name: "perfectOrderBullish", params: { periods: [5, 0, 75] } },
+      backtestRegistry,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toBe("perfectOrderBullish.periods[1]: value 0 is below minimum 1");
+  });
+
+  it("is rejected as an optimization target with an actionable message", () => {
+    // The range gate read `type === "number"` as "scalar number", so an array
+    // param passed it and failed much later inside strategy validation.
+    expect(() =>
+      validateRangePaths(
+        {
+          $schema: "trendcraft/strategy",
+          version: 1,
+          id: "s",
+          name: "s",
+          entry: { name: "perfectOrderBullish" },
+          exit: { name: "deadCross" },
+        },
+        [{ path: "entry.0.periods", min: 5, max: 7, step: 1 }],
+        backtestRegistry,
+      ),
+    ).toThrow(/is type "number\[\]", optimization only supports scalar "number"/);
+  });
+
+  it("agrees with hydrate, which is the other half of the contract", () => {
+    const spec = { name: "perfectOrderBullish", params: { periods: [5, 25, 75] } };
+    expect(validateConditionSpec(spec, backtestRegistry).valid).toBe(true);
+    expect(() => backtestRegistry.hydrate(spec, btCombinators)).not.toThrow();
+  });
+
+  it("names arrays and null distinctly in scalar type errors", () => {
+    // `typeof` calls both "object", which made the message unactionable.
+    const arrayForScalar = validateConditionSpec(
+      { name: "rsiBelow", params: { threshold: [30] } },
+      backtestRegistry,
+    );
+    expect(arrayForScalar.errors[0]).toMatch(/got array$/);
+  });
+});
+
+describe("the params container itself", () => {
+  it.each([
+    ["a number", 42],
+    ["null", null],
+    ["an array", []],
+    ["a string", "x"],
+    ["a boolean", true],
+  ])("is rejected when it is %s", (_label, params) => {
+    // `Object.entries(42)` is `[]`, so an ill-shaped container silently became
+    // "no params" and the entry hydrated with its defaults; a string yielded
+    // index keys and an error about param "0".
+    const result = validateConditionSpec(
+      { name: "goldenCross", params: params as never },
+      backtestRegistry,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/^goldenCross\.params: expected an object, got /);
+
+    expect(() =>
+      backtestRegistry.hydrate({ name: "goldenCross", params: params as never }, btCombinators),
+    ).toThrow(/expected an object, got /);
+  });
+
+  it("still accepts an omitted params object", () => {
+    expect(validateConditionSpec({ name: "goldenCross" }, backtestRegistry).valid).toBe(true);
+    expect(() => backtestRegistry.hydrate({ name: "goldenCross" }, btCombinators)).not.toThrow();
+  });
+
+  it("still accepts an empty params object", () => {
+    const spec = { name: "goldenCross", params: {} };
+    expect(validateConditionSpec(spec, backtestRegistry).valid).toBe(true);
+    expect(() => backtestRegistry.hydrate(spec, btCombinators)).not.toThrow();
+  });
+});
+
+describe("a malformed combinator child is reported, not thrown", () => {
+  const json = (child: string) =>
+    `{"$schema":"trendcraft/strategy","version":1,"id":"s","name":"s",` +
+    `"entry":{"op":"and","conditions":[${child},{"name":"rsiBelow"}]},` +
+    `"exit":{"name":"deadCross"}}`;
+
+  it.each([
+    ["a bare condition name", '"goldenCross"'],
+    ["null", "null"],
+    ["a number", "42"],
+    ["a boolean", "true"],
+  ])("returns a Result for %s", (_label, child) => {
+    const result = parseStrategySafe(json(child), backtestRegistry);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INVALID_CONDITION");
+      expect(result.error.message).toMatch(/expected condition object/);
+      // The whole path, not just the tail: the recursion hands children a
+      // path ending in a separator for the next token to consume, and this
+      // branch has no token, so a naive message reads `entry.and[0].:`.
+      expect(result.error.message).not.toMatch(/\.:/);
+    }
+  });
+
+  it("names the offending child by its exact path", () => {
+    const result = validateConditionSpec(
+      { op: "and", conditions: ["goldenCross", { name: "rsiBelow" }] } as never,
+      backtestRegistry,
+    );
+    expect(result.errors).toEqual(["and[0]: expected condition object, got string"]);
+  });
+
+  it("names a top-level non-object without an empty path prefix", () => {
+    const result = validateConditionSpec("goldenCross" as never, backtestRegistry);
+    expect(result.errors).toEqual(["condition: expected condition object, got string"]);
+  });
+
+  it("validateConditionSpec reports rather than throwing", () => {
+    const result = validateConditionSpec(
+      { op: "or", conditions: [null] } as never,
+      backtestRegistry,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/expected condition object, got null/);
+  });
+
+  it("hydrate refuses a non-object spec with a readable message", () => {
+    expect(() => backtestRegistry.hydrate("goldenCross" as never, btCombinators)).toThrow(
+      /expected an object, got string/,
+    );
+    expect(() => backtestRegistry.hydrate(null as never, btCombinators)).toThrow(
+      /expected an object, got null/,
+    );
+  });
+
+  it("still accepts a well-formed nested combinator", () => {
+    const result = parseStrategySafe(json('{"name":"goldenCross"}'), backtestRegistry);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("a param the entry does not declare", () => {
+  it("is rejected rather than silently discarded", () => {
+    // Tuning written for one registry used to stream against another with the
+    // tuning quietly dropped.
+    expect(() =>
+      streamingRegistry.hydrate(
+        { name: "volatilityExpanding", params: { threshold: 30, lookback: 10 } },
+        stCombinators,
+      ),
+    ).toThrow(/Unknown parameter\(s\) for "volatilityExpanding": threshold, lookback/);
+  });
+
+  it("is rejected even when it is named after an Object.prototype member", () => {
+    // `key in entry.params` walks the prototype, so these counted as declared
+    // and were dropped, while the validator reported them as
+    // "expected undefined, got number".
+    for (const key of ["toString", "constructor", "valueOf", "hasOwnProperty"]) {
+      expect(() =>
+        backtestRegistry.hydrate({ name: "goldenCross", params: { [key]: 1 } }, btCombinators),
+      ).toThrow(new RegExp(`Unknown parameter\\(s\\) for "goldenCross": ${key}`));
+
+      const validated = validateConditionSpec(
+        { name: "goldenCross", params: { [key]: 1 } },
+        backtestRegistry,
+      );
+      expect(validated.errors).toEqual([`goldenCross.${key}: unknown parameter`]);
+    }
+  });
+
+  it("names what the entry does accept", () => {
+    expect(() =>
+      backtestRegistry.hydrate({ name: "rsiBelow", params: { thresold: 30 } }, btCombinators),
+    ).toThrow(/Accepted: threshold/);
+  });
+
+  it("still hydrates a spec whose params are all declared", () => {
+    expect(() =>
+      streamingRegistry.hydrate(
+        { name: "volatilityExpanding", params: { key: "atr" } },
+        stCombinators,
+      ),
+    ).not.toThrow();
+  });
+
+  it("still hydrates a spec with no params at all", () => {
+    expect(() => backtestRegistry.hydrate({ name: "goldenCross" }, btCombinators)).not.toThrow();
+    expect(candles(3).length).toBe(3);
+  });
+});

--- a/packages/core/src/strategy/__tests__/registry-parity.test.ts
+++ b/packages/core/src/strategy/__tests__/registry-parity.test.ts
@@ -49,6 +49,55 @@ function paramFingerprint(def: ParamDef): string {
  */
 const KNOWN_DRIFTS: Record<string, string> = {};
 
+/**
+ * Shared names whose param sets do not overlap at all.
+ *
+ * The comparison above skips any param the other registry lacks, so a pair
+ * with NO shared params runs zero comparisons and passes automatically. That
+ * blind spot is where the worst kind of drift hides: not a mismatched schema
+ * but a different RULE behind the same name. Listing each pair here forces
+ * the difference to be stated and reviewed.
+ *
+ * Four are the paradigm difference the exemption was designed for — a backtest
+ * condition computes its indicator from periods, a streaming one reads a
+ * precomputed snapshot key — and the rule is the same. The other NINE are
+ * marked RULE DIFFERS: the same portable name resolves to two different
+ * conditions. Reconciling those means either changing streaming semantics or
+ * renaming published entries, so they are recorded rather than silently
+ * exempted.
+ */
+const DISJOINT_PARAMS: Record<string, string> = {
+  // Same rule, different way of obtaining the indicator.
+  macdCrossUp:
+    "same rule (MACD crosses its signal); backtest computes it from fast/slow/signal, streaming reads a snapshot key",
+  macdCrossDown:
+    "same rule (MACD crosses its signal); backtest computes it from fast/slow/signal, streaming reads a snapshot key",
+  stochCrossUp:
+    "same rule (%K crosses %D); backtest computes them from kPeriod/dPeriod, streaming reads a snapshot key",
+  stochCrossDown:
+    "same rule (%K crosses %D); backtest computes them from kPeriod/dPeriod, streaming reads a snapshot key",
+
+  // RULE DIFFERS — a portable leaf resolves to two different conditions.
+  perfectOrderBullish:
+    "RULE DIFFERS: backtest fires on the bar the order FORMS (`formed` edge, plus a strength floor) over an SMA ribbon; streaming fires on any bar where an EMA ribbon is bullish (a level)",
+  perfectOrderBearish:
+    "RULE DIFFERS: backtest fires on the `formed` edge over an SMA ribbon; streaming tests strict ordering of an EMA ribbon on every bar",
+  perfectOrderCollapsed:
+    "RULE DIFFERS: backtest reads `collapsed` (the alignment broke); streaming reads `expanding === false` (the spread stopped widening) — a different quantity",
+  obvCrossUp:
+    "RULE DIFFERS: backtest crosses SMA(OBV, shortPeriod) over SMA(OBV, longPeriod); streaming crosses raw OBV over a single signal line",
+  obvCrossDown:
+    "RULE DIFFERS: backtest crosses SMA(OBV, shortPeriod) under SMA(OBV, longPeriod); streaming crosses raw OBV under a single signal line",
+  obvRising:
+    "RULE DIFFERS: backtest compares OBV to its value `period` bars ago; streaming compares to the previous bar only",
+  obvFalling:
+    "RULE DIFFERS: backtest compares OBV to its value `period` bars ago; streaming compares to the previous bar only",
+  volatilityExpanding:
+    "RULE DIFFERS: backtest needs the ATR percentile to exceed its lookback mean by `threshold`; streaming fires on any tick up",
+  volatilityContracting:
+    "RULE DIFFERS: backtest needs the ATR percentile to fall below its lookback mean by `threshold`; streaming fires on any tick down",
+};
+
 describe("registry parity (backtest ↔ streaming)", () => {
   const sharedNames = backtestRegistry
     .names()
@@ -58,6 +107,38 @@ describe("registry parity (backtest ↔ streaming)", () => {
   it("has a non-trivial overlap to guard", () => {
     // Sanity floor: if this drops, an import or registration regressed.
     expect(sharedNames.length).toBeGreaterThan(20);
+  });
+
+  it("every shared name with no overlapping params is accounted for", () => {
+    const observed = new Set<string>();
+    const unexpected: string[] = [];
+
+    for (const name of sharedNames) {
+      const bt = backtestRegistry.get(name)!;
+      const st = streamingRegistry.get(name)!;
+      const btKeys = Object.keys(bt.params);
+      const stKeys = Object.keys(st.params);
+      if (btKeys.length === 0 && stKeys.length === 0) continue; // nothing to compare
+      if (btKeys.some((k) => stKeys.includes(k))) continue; // the other test covers these
+
+      observed.add(name);
+      if (!(name in DISJOINT_PARAMS)) {
+        unexpected.push(
+          `  ${name}: backtest[${btKeys.join(", ")}] streaming[${stKeys.join(", ")}]`,
+        );
+      }
+    }
+
+    expect(
+      unexpected,
+      `Shared name with no overlapping params — zero comparisons run, so any rule difference is invisible.\nState why in DISJOINT_PARAMS, or give the entries a shared param:\n${unexpected.join("\n")}`,
+    ).toEqual([]);
+
+    const stale = Object.keys(DISJOINT_PARAMS).filter((name) => !observed.has(name));
+    expect(
+      stale,
+      `DISJOINT_PARAMS entries whose params now overlap (or that are no longer shared) — remove them:\n${stale.map((s) => `  ${s}`).join("\n")}`,
+    ).toEqual([]);
   });
 
   it("shared params agree on portability-relevant schema", () => {

--- a/packages/core/src/strategy/registry-backtest.ts
+++ b/packages/core/src/strategy/registry-backtest.ts
@@ -50,19 +50,25 @@ import {
   bearishHarmonicDetected,
   bullFlagDetected,
   bullishHarmonicDetected,
+  CHANNEL_TYPES,
   channelDetected,
   cupHandleDetected,
   doubleBottomDetected,
   doubleTopDetected,
+  FLAG_TYPES,
   flagDetected,
+  HARMONIC_TYPES,
   harmonicPatternDetected,
   headShouldersDetected,
   inverseHeadShouldersDetected,
+  PATTERN_TYPES,
   patternConfidenceAbove,
   patternConfirmed,
   patternDetected,
   patternWithinBars,
+  TRIANGLE_TYPES,
   triangleDetected,
+  WEDGE_TYPES,
   wedgeDetected,
 } from "../backtest/conditions/patterns";
 import {
@@ -412,8 +418,15 @@ backtestRegistry.register({
 const poParams = {
   periods: {
     type: "number" as const,
+    array: true,
+    // The indicator sorts and de-duplicates before counting, so what it needs
+    // is two different lengths — not merely two entries.
+    minDistinct: 2,
+    min: 1,
+    integer: true,
     tunable: false,
-    description: "MA periods (array via JSON)",
+    description:
+      "MA periods — at least 2 distinct positive integers (e.g. [5, 25, 75]). Order does not matter.",
   },
 };
 
@@ -1099,12 +1112,26 @@ backtestRegistry.register({
 // Patterns
 // ============================================
 
+/**
+ * Every pattern identifier a pattern condition can resolve.
+ *
+ * Derived from the condition layer rather than restated: a value outside
+ * this set finds no detector and leaves the condition silently false on
+ * every bar, so the registry must not advertise one.
+ */
+const patternTypeParam = {
+  type: "string" as const,
+  required: true,
+  enum: [...PATTERN_TYPES],
+  description: "Pattern type name",
+};
+
 backtestRegistry.register({
   name: "patternDetected",
   displayName: "Pattern Detected",
   category: "pattern",
   params: {
-    type: { type: "string", required: true, description: "Pattern type name" },
+    type: patternTypeParam,
   },
   create: (p) => patternDetected(p.type as PatternType),
 });
@@ -1114,7 +1141,7 @@ backtestRegistry.register({
   displayName: "Pattern Confirmed",
   category: "pattern",
   params: {
-    type: { type: "string", required: true },
+    type: patternTypeParam,
   },
   create: (p) => patternConfirmed(p.type as PatternType),
 });
@@ -1140,7 +1167,7 @@ backtestRegistry.register({
   displayName: "Pattern Confidence Above",
   category: "pattern",
   params: {
-    type: { type: "string", required: true },
+    type: patternTypeParam,
     minConfidence: { type: "number", default: 70, min: 0, max: 100 },
   },
   create: (p) => patternConfidenceAbove(p.type as PatternType, (p.minConfidence as number) ?? 70),
@@ -1161,7 +1188,7 @@ backtestRegistry.register({
   displayName: "Pattern Within Bars",
   category: "pattern",
   params: {
-    type: { type: "string", required: true },
+    type: patternTypeParam,
     lookback: { type: "number", default: 5, min: 1 },
   },
   create: (p) => patternWithinBars(p.type as PatternType, (p.lookback as number) ?? 5),
@@ -1210,18 +1237,11 @@ backtestRegistry.register({
   params: {
     subtype: {
       type: "string",
-      enum: ["ascending", "descending", "symmetrical"],
+      enum: [...TRIANGLE_TYPES],
       description: "Triangle subtype",
     },
   },
-  create: (p) =>
-    triangleDetected(
-      p.subtype as
-        | "triangle_symmetrical"
-        | "triangle_ascending"
-        | "triangle_descending"
-        | undefined,
-    ),
+  create: (p) => triangleDetected(p.subtype as (typeof TRIANGLE_TYPES)[number] | undefined),
 });
 
 backtestRegistry.register({
@@ -1229,9 +1249,13 @@ backtestRegistry.register({
   displayName: "Wedge Detected",
   category: "pattern",
   params: {
-    subtype: { type: "string", enum: ["rising", "falling"], description: "Wedge subtype" },
+    subtype: {
+      type: "string",
+      enum: [...WEDGE_TYPES],
+      description: "Wedge subtype",
+    },
   },
-  create: (p) => wedgeDetected(p.subtype as "rising_wedge" | "falling_wedge" | undefined),
+  create: (p) => wedgeDetected(p.subtype as (typeof WEDGE_TYPES)[number] | undefined),
 });
 
 backtestRegistry.register({
@@ -1241,14 +1265,11 @@ backtestRegistry.register({
   params: {
     subtype: {
       type: "string",
-      enum: ["ascending", "descending", "horizontal"],
+      enum: [...CHANNEL_TYPES],
       description: "Channel subtype",
     },
   },
-  create: (p) =>
-    channelDetected(
-      p.subtype as "channel_ascending" | "channel_descending" | "channel_horizontal" | undefined,
-    ),
+  create: (p) => channelDetected(p.subtype as (typeof CHANNEL_TYPES)[number] | undefined),
 });
 
 backtestRegistry.register({
@@ -1256,12 +1277,13 @@ backtestRegistry.register({
   displayName: "Flag Detected",
   category: "pattern",
   params: {
-    subtype: { type: "string", enum: ["bull", "bear"], description: "Flag subtype" },
+    subtype: {
+      type: "string",
+      enum: [...FLAG_TYPES],
+      description: "Flag subtype",
+    },
   },
-  create: (p) =>
-    flagDetected(
-      p.subtype as "bull_flag" | "bear_flag" | "bull_pennant" | "bear_pennant" | undefined,
-    ),
+  create: (p) => flagDetected(p.subtype as (typeof FLAG_TYPES)[number] | undefined),
 });
 
 backtestRegistry.register({
@@ -1286,7 +1308,7 @@ backtestRegistry.register({
   params: {
     subtype: {
       type: "string",
-      enum: ["gartley", "bat", "butterfly", "crab", "abcd"],
+      enum: [...HARMONIC_TYPES],
       description: "Harmonic pattern subtype",
     },
   },

--- a/packages/core/src/strategy/registry.ts
+++ b/packages/core/src/strategy/registry.ts
@@ -33,6 +33,7 @@
  */
 
 import type { ConditionCategory, ConditionRegistryEntry, ConditionSpec } from "./types";
+import { describeType, isPlainObject } from "./utils";
 
 /**
  * Central condition registry
@@ -107,6 +108,12 @@ export class ConditionRegistry<T = unknown> {
       not: (condition: T) => T;
     },
   ): T {
+    // Same guard as the validator: `in` throws on a primitive or null, and
+    // hydrate is reachable without validation via loadStrategy.
+    if (!isPlainObject(spec)) {
+      throw new Error(`Invalid condition spec: expected an object, got ${describeType(spec)}`);
+    }
+
     // Combinator node
     if ("op" in spec) {
       const children = spec.conditions.map((c) => this.hydrate(c, combinators));
@@ -124,6 +131,27 @@ export class ConditionRegistry<T = unknown> {
     const entry = this.entries.get(spec.name);
     if (!entry) {
       throw new Error(`Unknown condition: "${spec.name}"`);
+    }
+
+    // A param the entry does not declare is a mistake, not a no-op. Dropping
+    // it silently let a strategy tuned against one registry stream against
+    // another with the tuning quietly discarded.
+    // `key in entry.params` walks Object.prototype, so `toString` and
+    // `constructor` would count as declared and be dropped silently — the
+    // exact outcome this check exists to prevent.
+    if (spec.params !== undefined && !isPlainObject(spec.params)) {
+      throw new Error(
+        `Invalid params for "${spec.name}": expected an object, got ${describeType(spec.params)}`,
+      );
+    }
+    const undeclared = Object.keys(spec.params ?? {}).filter(
+      (key) => !Object.hasOwn(entry.params, key),
+    );
+    if (undeclared.length > 0) {
+      throw new Error(
+        `Unknown parameter(s) for "${spec.name}": ${undeclared.join(", ")}. ` +
+          `Accepted: ${Object.keys(entry.params).join(", ") || "(none)"}`,
+      );
     }
 
     // Merge defaults with provided params

--- a/packages/core/src/strategy/serialize.ts
+++ b/packages/core/src/strategy/serialize.ts
@@ -174,7 +174,15 @@ export function parseStrategySafe<T = unknown>(
       );
     }
 
-    const condErrors = collectConditionErrors(obj, registry);
+    // Defence in depth: this function promises a Result and a closed set of
+    // codes, so nothing thrown from inside validation may escape past it.
+    let condErrors: string[];
+    try {
+      condErrors = collectConditionErrors(obj, registry);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return err(tcError("INVALID_CONDITION", `Invalid strategy conditions: ${message}`));
+    }
     if (condErrors.length > 0) {
       return err(
         tcError(

--- a/packages/core/src/strategy/tunables.ts
+++ b/packages/core/src/strategy/tunables.ts
@@ -18,17 +18,16 @@ import type { Condition } from "../types";
 import type { ConditionRegistry } from "./registry";
 import { backtestRegistry } from "./registry-backtest";
 import type { ParamDef, StrategyJSON } from "./types";
+import { isScalarNumberParam } from "./utils";
 import { flattenStrategyLeaves } from "./walker";
 
 /**
  * One tunable parameter discovered by walking a strategy's ConditionSpec.
  *
- * Numeric params only — `string` / `boolean` schema entries are filtered
- * out at enumeration time (they aren't tunable on a numeric grid).
- * Params marked `schema.tunable === false` are also skipped (used by the
- * registry to opt out of enumeration when `type: "number"` is declared
- * for compactness but the runtime value is non-scalar — e.g. MA period
- * vectors).
+ * Scalar numeric params only — `string` / `boolean` entries, and `array`
+ * params such as a set of MA periods, are filtered out at enumeration time
+ * (they aren't tunable on a numeric grid). Params marked
+ * `schema.tunable === false` are skipped for the same reason.
  *
  * The full registry `ParamDef` is attached as `schema` so callers can read
  * `schema.min` / `max` / `default` / `integer` / `precision` /
@@ -84,12 +83,9 @@ export function listTunables<T = Condition>(
     const entry = registry.get(leaf.name);
     if (!entry) continue;
     for (const [paramName, schema] of Object.entries(entry.params)) {
-      if (schema.type !== "number") continue;
-      // `tunable: false` is an explicit opt-out for params whose JSON
-      // value is not a scalar number — registry entries that declare
-      // `type: "number"` for compactness but actually consume the value
-      // as an array (e.g. Perfect Order MA periods). These would not
-      // survive a scalar grid sweep.
+      if (!isScalarNumberParam(schema)) continue;
+      // `tunable: false` is an explicit opt-out for a numeric param a scalar
+      // grid sweep cannot vary meaningfully.
       if (schema.tunable === false) continue;
       out.push({
         key: `${leaf.bucket}.${leaf.leafIndex}.${paramName}`,

--- a/packages/core/src/strategy/types.ts
+++ b/packages/core/src/strategy/types.ts
@@ -111,8 +111,33 @@ export type SessionOverrides = {
  * Parameter definition for a condition parameter (lightweight, no external deps)
  */
 export type ParamDef = {
-  /** Parameter type */
+  /**
+   * Parameter type. The scalar name describes the ELEMENT type when
+   * {@link ParamDef.array} is set — `{ type: "number", array: true }` is a
+   * `number[]`, and `min` / `max` / `enum` then apply to each element.
+   */
   type: "number" | "string" | "boolean";
+  /**
+   * `true` when the param takes an array of `type` rather than one value.
+   *
+   * Without this, an array-valued param had no honest declaration: declaring
+   * the element type rejected the array form that actually works, and
+   * declaring it any other way let a scalar through to a factory that
+   * immediately failed on it.
+   */
+  array?: boolean;
+  /** Minimum number of elements when {@link ParamDef.array} is set */
+  minItems?: number;
+  /** Maximum number of elements when {@link ParamDef.array} is set */
+  maxItems?: number;
+  /**
+   * Minimum number of DISTINCT elements when {@link ParamDef.array} is set.
+   *
+   * Separate from `minItems` because a factory may de-duplicate before it
+   * counts: a set of MA periods needs two different lengths, so `[5, 5]` is
+   * two items but one period.
+   */
+  minDistinct?: number;
   /** Default value */
   default?: unknown;
   /** Human-readable description */
@@ -157,11 +182,10 @@ export type ParamDef = {
   suggestedMax?: number;
   /**
    * `false` opts the parameter out of generic numeric introspection
-   * (e.g. `listTunables`). Use this for params whose JSON value is *not*
-   * a scalar number — for instance MA period vectors declared with
-   * `type: "number"` for compactness but actually consumed as
-   * `number[]`. Defaults to `true` (the param participates in
-   * enumeration).
+   * (e.g. `listTunables`). Use it for a numeric param that a scalar grid
+   * sweep cannot vary meaningfully — an {@link ParamDef.array} param such as
+   * a set of MA periods, or a value whose sensible range depends on another
+   * param. Defaults to `true` (the param participates in enumeration).
    */
   tunable?: boolean;
 };

--- a/packages/core/src/strategy/utils.ts
+++ b/packages/core/src/strategy/utils.ts
@@ -1,0 +1,44 @@
+/**
+ * Shape and type inspection shared by the readers of an untrusted
+ * `ConditionSpec`.
+ *
+ * A leaf module on purpose: `validate.ts` already imports `./registry`, so
+ * neither of those two can own helpers the other needs, and `types.ts` is a
+ * pure type module.
+ */
+
+import type { ParamDef } from "./types";
+
+/**
+ * A type name a strategy author can act on.
+ *
+ * `typeof` reports `"object"` for both arrays and `null`, so an array passed
+ * where a number belonged would otherwise be reported as "got object".
+ */
+export function describeType(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+/**
+ * `true` for a non-null, non-array object — the only shape a `ConditionSpec`
+ * node may take.
+ *
+ * `in` throws on a primitive, so every reader of an untrusted spec needs this
+ * before touching it.
+ */
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * `true` when the param holds exactly one number.
+ *
+ * `type` names the ELEMENT type when `array` is set, so `type === "number"`
+ * alone does not mean "scalar number" — an array param would pass such a gate
+ * and fail much later, in a message about something else.
+ */
+export function isScalarNumberParam(def: ParamDef): boolean {
+  return def.type === "number" && !def.array;
+}

--- a/packages/core/src/strategy/validate.ts
+++ b/packages/core/src/strategy/validate.ts
@@ -15,6 +15,7 @@
 
 import type { ConditionRegistry } from "./registry";
 import type { ConditionSpec, ParamDef } from "./types";
+import { describeType, isPlainObject } from "./utils";
 
 /**
  * Validation result
@@ -54,6 +55,19 @@ function validateSpecRecursive<T>(
   errors: string[],
   path: string,
 ): void {
+  // `in` throws on a primitive or null, and a combinator's `conditions` array
+  // is a very ordinary place for one to appear — a bare condition NAME where
+  // an object belonged is exactly what a hand-written or generated strategy
+  // gets wrong. A validator must report that, not crash on it.
+  if (!isPlainObject(spec)) {
+    // Children are handed a path ending in `.` for the next token to consume
+    // (`and[0].` + `goldenCross`). This branch has no token to append, so the
+    // separator would dangle: `and[0].: expected condition object`.
+    const at = path.replace(/\.$/, "") || "condition";
+    errors.push(`${at}: expected condition object, got ${describeType(spec)}`);
+    return;
+  }
+
   // Combinator node
   if ("op" in spec) {
     if (!["and", "or", "not"].includes(spec.op)) {
@@ -86,6 +100,12 @@ function validateSpecRecursive<T>(
   }
 
   const params = spec.params ?? {};
+  // `Object.entries(42)` is `[]` and `Object.entries("ab")` yields index keys,
+  // so an ill-shaped container silently became "no params" or nonsense ones.
+  if (spec.params !== undefined && !isPlainObject(spec.params)) {
+    errors.push(`${prefix}.params: expected an object, got ${describeType(spec.params)}`);
+    return;
+  }
 
   // Check required params
   for (const [key, def] of Object.entries(entry.params)) {
@@ -96,26 +116,59 @@ function validateSpecRecursive<T>(
 
   // Check provided params
   for (const [key, value] of Object.entries(params)) {
-    const def = entry.params[key];
-    if (!def) {
+    // `entry.params[key]` would resolve `toString` / `constructor` through
+    // Object.prototype and treat the inherited function as a param definition,
+    // reporting `expected undefined, got number`.
+    if (!Object.hasOwn(entry.params, key)) {
       errors.push(`${prefix}.${key}: unknown parameter`);
       continue;
     }
+    const def = entry.params[key];
 
     validateParam(`${prefix}.${key}`, value, def, errors);
   }
 }
 
 function validateParam(path: string, value: unknown, def: ParamDef, errors: string[]): void {
+  if (def.array) {
+    if (!Array.isArray(value)) {
+      errors.push(`${path}: expected ${def.type}[], got ${describeType(value)}`);
+      return;
+    }
+    if (def.minItems !== undefined && value.length < def.minItems) {
+      errors.push(`${path}: expected at least ${def.minItems} items, got ${value.length}`);
+    }
+    if (def.maxItems !== undefined && value.length > def.maxItems) {
+      errors.push(`${path}: expected at most ${def.maxItems} items, got ${value.length}`);
+    }
+    if (def.minDistinct !== undefined) {
+      const distinct = new Set(value).size;
+      if (distinct < def.minDistinct) {
+        errors.push(
+          `${path}: expected at least ${def.minDistinct} distinct values, got ${distinct}`,
+        );
+      }
+    }
+    // Element constraints are the same ones a scalar of this type would get.
+    const elementDef: ParamDef = { ...def, array: false };
+    value.forEach((item, i) => validateParam(`${path}[${i}]`, item, elementDef, errors));
+    return;
+  }
+
   // Type check
   const actualType = typeof value;
   if (actualType !== def.type) {
-    errors.push(`${path}: expected ${def.type}, got ${actualType}`);
+    errors.push(`${path}: expected ${def.type}, got ${describeType(value)}`);
     return;
   }
 
   // Number range checks
   if (def.type === "number" && typeof value === "number") {
+    // `integer` was documented as a UI hint and enforced nowhere, so a param
+    // that declares it still accepted `5.5` and failed inside the indicator.
+    if (def.integer === true && !Number.isInteger(value)) {
+      errors.push(`${path}: expected an integer, got ${value}`);
+    }
     if (def.min !== undefined && value < def.min) {
       errors.push(`${path}: value ${value} is below minimum ${def.min}`);
     }


### PR DESCRIPTION
Every defect here is one shape: a registry entry declared something its own factory could not use, and validation enforced the declaration rather than the requirement. The result is a strategy that loads, validates, and then does nothing — or one that cannot be written at all.

---

## Pattern subtypes: the value that works was the one rejected

Five entries declared short labels while their factories need full pattern identifiers. A label that is not a pattern identifier finds no detector, so the condition matched nothing on every bar. And because the enum was also enforced, the working value was rejected:

```
{ name: "triangleDetected", params: { subtype: "symmetrical" } }
  before → valid; hydrates to patternDetected(symmetrical); never fires
  after  → invalid: value "symmetrical" not in allowed values

{ name: "triangleDetected", params: { subtype: "triangle_symmetrical" } }
  before → invalid: value not in allowed values
  after  → valid; hydrates to patternDetected(triangle_symmetrical)
```

Narrowing a working `flagDetected` to the bull side using the registry's own enum produced a strategy with zero entries and a 0-trade backtest that looked like a legitimate result. `"abcd"` — never a pattern in this codebase — was on offer; the shark harmonics were not. `patternDetected`, `patternConfirmed`, `patternConfidenceAbove` and `patternWithinBars` declared `type` as a free-form string with no `enum` at all, with the same outcome for any typo.

**Each family was written out four times** — the factory's `subtype` union, the array it scans when no subtype is given, the registry `enum`, and the cast in that entry's `create`. A membership check cannot catch a mismatch there: an enum that is merely a *subset* of the real pattern types passes every such check while silently omitting a member. The families are now named constants beside the detector table, and the contract test asserts they **partition** it and that each registry enum is the whole family rather than part of it.

## `periods` was declared a number and is an array

The schema behind 17 Perfect Order conditions said `type: "number"` with a description reading "array via JSON". No value both validated and worked:

```
{ periods: [5, 25, 75] } → invalid: expected number, got object   … but hydrate() succeeds
{ periods: 25 }          → valid                                  … but hydrate() throws
                                                                    "periods.join is not a function"
```

A saved, working strategy became unloadable the moment a registry was passed to `parseStrategy` — which its own documentation recommends for file-load paths.

`ParamDef` gains `array`, `minItems`, `maxItems` and `minDistinct`. With `array: true` the `type` names the **element** type, and `min` / `max` / `enum` / `integer` apply per element with errors reported at their index. Scalar type errors now name an array and `null` distinctly, which `typeof` reported as `"object"` for both.

`minDistinct` exists because a factory may de-duplicate before it counts: `perfectOrder` needs two different MA lengths, so `[5, 5]` is two items but one period. `[5, 5, 25]` still validates, since two lengths survive de-duplication — which is why `uniqueItems` would have been the wrong primitive.

**`integer: true` is now enforced.** It was documented as a hint for UIs and checked nowhere, so a param declaring it accepted `5.5` and failed later inside the moving average. 25 params across both registries declare it and none has a fractional default, so no existing declaration changes meaning.

## The validator threw instead of reporting

`validateSpecRecursive` tested `"op" in spec` without first checking that `spec` is an object. A `conditions` array holding a string, number or `null` — a bare condition name where an object belonged is an ordinary hand-written or generated mistake — threw `TypeError: Cannot use 'in' operator`. `parseStrategySafe` catches only `JSON.parse` failures, so it escaped a function documented to return a `Result` with a closed set of codes.

The `params` container had the same gap one level down. `Object.entries(42)` is `[]` and `Object.entries("ab")` yields index keys:

```
{ name: "goldenCross", params: 42 }   before → valid, "no parameters", hydrates with defaults
{ name: "goldenCross", params: "x" }  before → invalid: goldenCross.0: unknown parameter
```

Both are now reported as `expected an object, got <type>`; `null` is rejected rather than treated as omitted. `hydrate` refuses the same shapes with a readable message, and the registry-validation block is wrapped so nothing thrown inside it escapes the `Result` contract.

## `hydrate` discarded parameters it did not recognise

It iterated the entry's own schema, so `{ threshold: 30, lookback: 10 }` passed to a streaming entry accepting only `key` was dropped without a word, and a strategy tuned against one registry streamed with the tuning gone. Unknown parameters now throw, naming both the offenders and what the entry accepts. The check uses `Object.hasOwn` rather than `in`, which walks `Object.prototype` and would have counted `toString` and `constructor` as declared.

## Registry parity could pass a pair it never compared

The parity test skips any parameter the other registry lacks. **Thirteen** shared names have no overlapping parameters at all, so zero comparisons ran and they passed automatically.

Only four are the paradigm difference the exemption was designed for — `macdCrossUp` / `macdCrossDown` / `stochCrossUp` / `stochCrossDown`, where both sides cross the same two lines and differ only in whether the indicator is computed from periods or read from a snapshot.

The other **nine implement different rules behind the same name**:

| name | backtest | streaming |
|---|---|---|
| `perfectOrderBullish` / `Bearish` | fires on the bar the order FORMS (an edge, plus a strength floor), SMA ribbon | fires on every bar an EMA ribbon is in order (a level) |
| `perfectOrderCollapsed` | the alignment broke | the spread stopped widening — a different quantity |
| `obvCrossUp` / `Down` | two moving averages of OBV cross | raw OBV crosses one signal line |
| `obvRising` / `Falling` | OBV vs its value `period` bars ago | OBV vs the previous bar |
| `volatilityExpanding` / `Contracting` | ATR percentile past its lookback mean by `threshold` | any tick in that direction |

Every disjoint pair must now carry a written justification, and the test fails both for an unlisted pair and for a listed one that no longer drifts. Reconciling the nine means either altering streaming semantics or renaming published entries, so it is left to a separate change.

## API changes

| Change | Kind |
|---|---|
| `ParamDef.array` / `minItems` / `maxItems` / `minDistinct` | Added |
| `PATTERN_TYPES` and the five family constants | Added |
| Pattern `subtype` enums now list real pattern identifiers | Breaking |
| `patternDetected` & co. constrain `type` to an enum | Breaking |
| `periods` accepts an array and rejects a scalar | Breaking |
| `integer: true` is enforced | Breaking |
| `hydrate` throws on an undeclared parameter | Breaking |
| `params` must be an object when present | Breaking |

`describeType`, `isPlainObject` and `isScalarNumberParam` live in a new leaf module: `validate.ts` already imports `./registry`, so neither of those two can own helpers the other needs.

## Test plan

39 new tests in `strategy/__tests__/registry-contracts.test.ts`. Negative check: **33 of 39 fail** against the unfixed source, then all 39 pass. The six that pass either way are over-fix guards — a well-formed nested combinator still parses, an omitted and an empty `params` object are both still accepted, a spec with all-declared params still hydrates, and `[5, 5, 25]` still validates.

The central probe covers **both registries, all 176 entries**: for each, build a spec from the entry's *own* declared defaults and enums, then assert it both validates and hydrates. Before this change 17 entries failed that; now **zero** do (149 entries carry params, 17 array params, 24 enum params). Boundaries: nine non-object shapes for a combinator child (`null`, `undefined`, string, number, `0`, boolean, array, `NaN`, empty string), five for the `params` container, nine numeric classes for array elements, and the four `Object.prototype` names.

Suites: core **379 files / 7,270 tests** pass, chart 1,069 pass / 2 skipped, mcp 83 pass. `tsc --noEmit`, `pnpm build`, `biome check` and `git diff --check` all clean, including the documentation harness (import resolution, snippet type-check, snippet execution, and EN/JA parity).

## Deliberately not in this change

The nine rule differences above. `validateConditionSpec` still accepts `NaN` for a numeric param — `NaN < min` is `false`, so no bound rejects it — which is a package-wide gap in numeric validation rather than a registry one. `maxItems` and `minItems` have no in-repo user; they are symmetric API paired with the constraints that do.