### PR TITLE
fix(core): charge margin interest for the time held, not once per trade

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ## [Unreleased]
 
+### Fixed — margin interest is charged for the time held, not per trade
+
+`deductMarginInterest` converted the holding period to whole days with
+`Math.max(1, Math.round(...))`. The floor made the bill a function of **trade
+count** rather than time held: on intraday bars every round trip paid a full
+overnight even though nothing was held overnight. The rounding distorted
+multi-day holds in both directions on top of that.
+
+400 five-minute bars (33.3 hours of wall clock), price flat, capital 1,000,000
+at 2x leverage with `interestRate: 0.05`, entering every 4 bars and exiting 2
+bars later — 99 round trips of ten minutes each, zero P&L:
+
+```
+before → finalCapital 986,528.98   (13,471.02 of interest — a day per trade)
+after  → finalCapital   999,905.83 (     94.17 — the 0.6875 days actually held)
+```
+
+A break-even strategy was reported as −1.35%, and the error scales with how
+often the strategy trades: the same run over a year of five-minute bars would
+consume the account. The rounding half could also under-bill — a 34-hour hold
+was charged 136.99 against an honest 194.06, while a 38-hour hold was charged
+273.97 against 216.89.
+
+The holding period is now measured in fractional days, floored at zero so a
+non-monotonic exit time cannot produce a credit. Whole-day holds are unchanged,
+which is why the existing interest tests never caught this.
+
+`MarginConfig.interestRate` now documents the convention it bills on, and
+`docs/API.md` gains a `MarginConfig` reference that had never been written.
+This is simple interest over elapsed time, which is **not** what brokers
+charge: they bill the overnight settled balance, so a real intraday round trip
+accrues nothing at all. Modelling that needs a day boundary — a timezone and a
+settlement cutoff, since margin interest accrues on calendar days including
+weekends and holidays — and `BacktestOptions` takes neither today.
+
+If you run margin backtests with `interestRate`, re-run them: `finalCapital`
+and every metric derived from it move. Trades held for a **positive** exact
+multiple of 24 elapsed hours are unchanged — `Math.round` was a no-op for
+those, which is why the existing interest tests never caught this. Daily bars
+are not automatically in that set: a bar stamped in an exchange timezone spans
+23 or 25 hours across a DST transition, irregular timestamps can leave a hold
+that is not a whole number of days, and a same-bar-close fill can exit on the
+bar it entered — a zero-length hold, which the old floor billed a full day and
+which now costs nothing.
+
 ### Breaking — the strategy registry no longer advertises values its factories cannot use
 
 **Pattern subtype enums listed labels that make the condition permanently

--- a/packages/core/docs/API.ja.md
+++ b/packages/core/docs/API.ja.md
@@ -4518,6 +4518,28 @@ const result = runBacktestScaled(candles, goldenCrossCondition(), deadCrossCondi
 
 `ScaledBacktestOptions` 型はこれらを受け付けたままです。有効になるかどうかは `scaledEntry.tranches` という値に依存し、型では表現できないためです。使用したい場合は `runBacktest` を直接呼ぶか、`tranches: 1` で実行してください（`runBacktest` に委譲され、すべてのオプションが有効になります）。
 
+
+### `MarginConfig` — レバレッジと借入コスト
+
+```typescript
+type MarginConfig = {
+  leverage: number;                                 // 2.0 = 2倍
+  maintenanceMargin: number;                        // 0.25 = 25%
+  marginCallAction: "liquidate" | "reduceToMaintenance";
+  interestRate?: number;                            // 0.05 = 年率5%
+};
+```
+
+`interestRate` は**経過保有時間に対する単利**として課金される。年率を 365 で割り、
+各ローンが残っていた**分数**日数を掛けるので、1時間の取引は1時間分だけ支払う。
+決済時に現金から差し引かれ、部分決済ではトランシェごとに「そのトランシェが開いて
+いた間の残高」で課金される。
+
+これはブローカーの課金規約とは異なる。実際のブローカーはオーバーナイトの決済残高に
+課金するため、日中の往復は一切利息が付かない。それを再現するには日境界（タイムゾーン
+と決済カットオフ。margin 利息は週末・祝日を含む暦日で発生する）が必要だが、
+`BacktestOptions` はそのいずれも受け取らない。
+
 ---
 
 ## ストリーミング

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -4561,6 +4561,30 @@ The multi-tranche path is a separate engine from `runBacktest` and implements on
 
 `ScaledBacktestOptions` still accepts them, because whether they are honored depends on `scaledEntry.tranches` — a value, not a type. To use them, call `runBacktest` directly, or run with `tranches: 1`, which delegates to `runBacktest` and honors all of them.
 
+
+### `MarginConfig` — leverage and borrowing costs
+
+```typescript
+type MarginConfig = {
+  leverage: number;                                 // 2.0 = 2x
+  maintenanceMargin: number;                        // 0.25 = 25%
+  marginCallAction: "liquidate" | "reduceToMaintenance";
+  interestRate?: number;                            // 0.05 = 5% annual
+};
+```
+
+`interestRate` is charged as **simple interest over elapsed holding time**: the
+annual rate is divided by 365 and multiplied by the *fractional* days each loan
+was outstanding, so a one-hour trade pays one hour of interest. The charge is
+deducted in cash at exit, and a partial exit bills each tranche for the balance
+outstanding while that tranche was open.
+
+This is not the convention brokers bill on. They charge on the overnight
+settled balance, so a real intraday round trip accrues nothing at all.
+Modelling that needs a day boundary — a timezone and a settlement cutoff, since
+margin interest accrues on calendar days including weekends and holidays — and
+`BacktestOptions` takes neither.
+
 ---
 
 ## Streaming

--- a/packages/core/src/backtest/__tests__/margin-interest-days.test.ts
+++ b/packages/core/src/backtest/__tests__/margin-interest-days.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Margin interest is charged for the time a loan is outstanding.
+ *
+ * It used to be charged in whole days with a floor of one:
+ * `Math.max(1, Math.round((exit - entry) / MS_PER_DAY))`. On intraday bars
+ * that made the bill a function of TRADE COUNT rather than time held — every
+ * round trip paid a full overnight even though nothing was held overnight —
+ * and the rounding distorted multi-day holds in both directions.
+ *
+ * Expectations are expressed as multiples of a measured one-day charge rather
+ * than a hand-computed loan figure: what matters here is that the bill is
+ * proportional to elapsed time, not what the engine borrows or how it rounds.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ConditionFn, NormalizedCandle } from "../../types";
+import { runBacktest } from "../engine";
+
+const CAPITAL = 1_000_000;
+const MARGIN = {
+  leverage: 2,
+  maintenanceMargin: 0.25,
+  marginCallAction: "liquidate" as const,
+  interestRate: 0.05,
+};
+const MS_PER_DAY = 86_400_000;
+const MS_PER_HOUR = 3_600_000;
+const BASE_TIME = 1_700_000_000_000;
+
+/** Flat candles at a fixed interval, so trade P&L is exactly zero. */
+function flatCandles(count: number, intervalMs: number, price = 100): NormalizedCandle[] {
+  return Array.from({ length: count }, (_, i) => ({
+    time: BASE_TIME + i * intervalMs,
+    open: price,
+    high: price + 1,
+    low: price - 1,
+    close: price,
+    volume: 1_000_000,
+  }));
+}
+
+const at =
+  (...indices: number[]): ConditionFn =>
+  (_ind, _candle, i) =>
+    indices.includes(i);
+
+/** Interest deducted by a run — the only way capital moves on a flat series. */
+function charged(candles: NormalizedCandle[], entry: ConditionFn, exit: ConditionFn): number {
+  const result = runBacktest(candles, entry, exit, { capital: CAPITAL, margin: MARGIN });
+  return CAPITAL - result.finalCapital;
+}
+
+const HOURLY = flatCandles(200, MS_PER_HOUR);
+
+/**
+ * One day of interest on the loan this configuration takes, measured rather
+ * than derived. `finalCapital` is rounded to cents once, on the way out, so
+ * reading a single day back carries a rounding error that multiplying
+ * amplifies. Taking a hundred-day reference and dividing by its OBSERVED
+ * holding time makes the unit exact and assumes nothing about how much the
+ * engine borrows.
+ */
+const DAY = (() => {
+  const reference = runBacktest(flatCandles(120, MS_PER_DAY), at(1), at(101), {
+    capital: CAPITAL,
+    margin: MARGIN,
+  });
+  const trade = reference.trades[0];
+  const days = (trade.exitTime - trade.entryTime) / MS_PER_DAY;
+  return (CAPITAL - reference.finalCapital) / days;
+})();
+
+describe("margin interest is proportional to time held", () => {
+  it("charges a measurable, exactly-daily amount as the baseline", () => {
+    // Anchors every expectation below. 1M capital at 2x borrows ~1M; a year
+    // at 5% is ~50,000, so a day is ~137.
+    expect(DAY).toBeCloseTo(136.99, 1);
+  });
+
+  it.each([
+    [1, 1 / 24],
+    [2, 2 / 24],
+    [4, 4 / 24],
+    [12, 12 / 24],
+  ])("bills a %i-hour hold for %f of a day", (hours, days) => {
+    // Every one of these used to cost a full day: 136.99.
+    expect(charged(HOURLY, at(10), at(10 + hours))).toBeCloseTo(DAY * days, 2);
+  });
+
+  it("doubles the bill when the hold doubles", () => {
+    // `finalCapital` is reported to the cent, which puts a floor on how exact
+    // this can be: an 11.42 bill is 0.0004 off its unrounded value, so the
+    // ratio lands within ~0.1%.
+    const bills = [2, 4, 8, 16].map((h) => charged(HOURLY, at(10), at(10 + h)));
+    for (let i = 1; i < bills.length; i++) {
+      expect(bills[i] / bills[i - 1]).toBeCloseTo(2, 2);
+    }
+  });
+});
+
+describe("the bill follows time held, not the number of trades", () => {
+  it("bills 99 ten-minute round trips for the ten minutes each", () => {
+    // 400 five-minute bars = 33.3 hours of wall clock. Entering every 4 bars
+    // and exiting 2 bars later gives 99 round trips of 10 minutes.
+    const candles = flatCandles(400, 5 * 60_000);
+    const result = runBacktest(
+      candles,
+      (_ind, _candle, i) => i % 4 === 0,
+      (_ind, _candle, i) => i % 4 === 2,
+      { capital: CAPITAL, margin: MARGIN },
+    );
+
+    expect(result.trades.length).toBe(99);
+    const heldMs = result.trades.reduce((sum, t) => sum + (t.exitTime - t.entryTime), 0);
+    expect(heldMs).toBe(99 * 10 * 60_000);
+
+    const bill = CAPITAL - result.finalCapital;
+    expect(bill).toBeCloseTo(DAY * (heldMs / MS_PER_DAY), 1);
+    // Before the fix: 13,471.02 — a full day per trade, ~143x the honest bill.
+    expect(bill).toBeLessThan(100);
+  });
+
+  it("charges the same total whether the time is held in one trade or many", () => {
+    // Twelve hours as one hold, versus the same twelve hours split in three.
+    const one = charged(HOURLY, at(10), at(22));
+    const many = charged(
+      HOURLY,
+      (_i, _c, i) => i === 10 || i === 30 || i === 50,
+      (_i, _c, i) => i === 14 || i === 34 || i === 54,
+    );
+    expect(many).toBeCloseTo(one, 1);
+  });
+});
+
+describe("rounding no longer distorts multi-day holds", () => {
+  it("bills a 34-hour hold for 34 hours, where rounding UNDER-charged a day", () => {
+    const bill = charged(HOURLY, at(10), at(44));
+    expect(bill).toBeCloseTo(DAY * (34 / 24), 2);
+    expect(bill).toBeCloseTo(194.06, 2); // Math.round billed 136.99
+    expect(bill).toBeGreaterThan(DAY);
+  });
+
+  it("bills a 38-hour hold for 38 hours, where rounding OVER-charged two days", () => {
+    const bill = charged(HOURLY, at(10), at(48));
+    expect(bill).toBeCloseTo(DAY * (38 / 24), 2);
+    expect(bill).toBeCloseTo(216.89, 2); // Math.round billed 273.97
+    expect(bill).toBeLessThan(DAY * 2);
+  });
+});
+
+describe("partial exits pay for their own time", () => {
+  /** Flat at 100, then 110 from `jumpAt` — enough to trip a scale-out level. */
+  function risingCandles(count: number, jumpAt: number): NormalizedCandle[] {
+    return Array.from({ length: count }, (_, i) => {
+      const price = i >= jumpAt ? 110 : 100;
+      return {
+        time: BASE_TIME + i * MS_PER_HOUR,
+        open: price,
+        high: price + 1,
+        low: price - 1,
+        close: price,
+        volume: 1_000_000,
+      };
+    });
+  }
+
+  const RISING = risingCandles(200, 16);
+  const SCALE_OUT = { levels: [{ threshold: 1, sellPercent: 50 }] };
+
+  it("bills each tranche for the balance outstanding while it was", () => {
+    const whole = runBacktest(RISING, at(10), at(34), { capital: CAPITAL, margin: MARGIN });
+    const split = runBacktest(RISING, at(10), at(34), {
+      capital: CAPITAL,
+      margin: MARGIN,
+      scaleOut: SCALE_OUT,
+    });
+
+    // The level must actually fire, or this compares two identical runs.
+    expect(whole.trades.length).toBe(1);
+    expect(split.trades.length).toBe(2);
+    expect(split.trades.map((t) => t.exitReason)).toEqual(["scaleOut", "signal"]);
+    expect(split.trades.map((t) => (t.exitTime - t.entryTime) / MS_PER_HOUR)).toEqual([5, 24]);
+
+    // Interest is the only thing separating them: with the rate at zero both
+    // runs end on the same capital.
+    const free = (options: object) =>
+      runBacktest(RISING, at(10), at(34), {
+        capital: CAPITAL,
+        margin: { ...MARGIN, interestRate: 0 },
+        ...options,
+      }).finalCapital;
+    expect(free({})).toBeCloseTo(free({ scaleOut: SCALE_OUT }), 6);
+
+    const wholeBill = free({}) - whole.finalCapital;
+    const splitBill = free({ scaleOut: SCALE_OUT }) - split.finalCapital;
+
+    // Halving the loan five hours in must cost LESS than carrying it whole for
+    // twenty-four — the loan-weighted integral, not a flat per-window charge:
+    //   full balance for 5h  +  half balance for the remaining 19h
+    const loanDays = 5 / 24 + 0.5 * (19 / 24);
+    expect(splitBill).toBeCloseTo(DAY * loanDays, 1);
+    expect(splitBill).toBeLessThan(wholeBill);
+  });
+});
+
+describe("a non-monotonic exit time cannot produce a credit", () => {
+  it("charges zero rather than negative interest", () => {
+    // Candle times are caller-supplied; an exit stamped before its entry
+    // would otherwise hand the account free money.
+    const candles = flatCandles(60, MS_PER_HOUR).map((c, i) =>
+      i === 40 ? { ...c, time: BASE_TIME - MS_PER_DAY } : c,
+    );
+    expect(charged(candles, at(10), at(39))).toBeCloseTo(0, 6);
+  });
+});
+
+describe("whole-day holds are unchanged", () => {
+  it("bills an exact-day hold exactly as before", () => {
+    // Math.round was exact for whole-day holds, which is why the existing
+    // interest tests never caught this.
+    //
+    // Note what this does NOT claim: daily bars are not universally
+    // unchanged. A bar stamped in an exchange timezone is 23 or 25 hours long
+    // across a DST transition, and a same-bar-close fill can exit on the bar
+    // it entered — a zero-length hold, which used to be billed a full day.
+    const daily = flatCandles(40, MS_PER_DAY);
+    expect(charged(daily, at(10), at(15))).toBeCloseTo(DAY * 5, 2);
+  });
+
+  it("charges nothing when no interest rate is configured", () => {
+    const candles = flatCandles(400, 5 * 60_000);
+    const { interestRate: _rate, ...noInterest } = MARGIN;
+    const result = runBacktest(
+      candles,
+      (_ind, _candle, i) => i % 4 === 0,
+      (_ind, _candle, i) => i % 4 === 2,
+      { capital: CAPITAL, margin: noInterest },
+    );
+    expect(result.finalCapital).toBeCloseTo(CAPITAL, 6);
+  });
+
+  it("charges nothing for a hold that opens and closes on the same bar", () => {
+    // `fillMode: "same-bar-close"` with a limit order lets a position fill and
+    // exit within one bar. Zero elapsed time is zero interest; the old floor
+    // billed a full day even here.
+    const daily = flatCandles(30, MS_PER_DAY).map((c, i) =>
+      i === 11 ? { ...c, open: 100, high: 101, low: 80, close: 85 } : c,
+    );
+    const result = runBacktest(daily, at(10), () => false, {
+      capital: CAPITAL,
+      margin: MARGIN,
+      fillMode: "same-bar-close",
+      orderType: { type: "limit", price: 100 },
+      stopLoss: 5,
+    });
+    const sameBar = result.trades.find((t) => t.exitTime === t.entryTime);
+    expect(sameBar).toBeDefined();
+    // The whole position is lost to the stop. `700_000` exactly means interest
+    // added nothing on top; the old floor made it 699,863.01.
+    expect(result.finalCapital).toBeCloseTo(700_000, 2);
+  });
+
+  it("charges nothing when the position is never opened", () => {
+    const never: ConditionFn = () => false;
+    expect(charged(HOURLY, never, never)).toBeCloseTo(0, 6);
+  });
+});

--- a/packages/core/src/backtest/engine.ts
+++ b/packages/core/src/backtest/engine.ts
@@ -438,8 +438,17 @@ export function runBacktest(
   /**
    * Deduct margin interest for the fraction of the loan being settled,
    * charged on the outstanding `borrowedAmount` over the entry-to-exit
-   * holding period. Call BEFORE `repayMarginLoan` reduces the balance, so
-   * each repaid tranche is charged for exactly the days it was outstanding.
+   * holding period, measured in FRACTIONAL days. Call BEFORE
+   * `repayMarginLoan` reduces the balance, so each repaid tranche is charged
+   * for exactly the time it was outstanding.
+   *
+   * This is simple interest over elapsed time, not the overnight-balance
+   * convention brokers actually bill on — a real intraday round trip accrues
+   * nothing. Modelling that needs a day boundary: a timezone and a settlement
+   * cutoff, since margin interest accrues on calendar days, weekends and
+   * holidays included. `BacktestOptions` takes neither today, though the
+   * package does ship the timezone primitive (`SessionDefinition`), so the
+   * gap is wiring rather than capability.
    *
    * The charge is settled in cash immediately, so it is deliberately NOT
    * added to `accumulatedInterest` — the equity check subtracts that field
@@ -448,7 +457,12 @@ export function runBacktest(
    */
   function deductMarginInterest(entryTime: number, exitTime: number, fraction = 1): void {
     if (marginConfig && marginState && marginConfig.interestRate) {
-      const holdDays = Math.max(1, Math.round((exitTime - entryTime) / MS_PER_DAY));
+      // Fractional days, not whole ones. `Math.max(1, Math.round(...))` made
+      // the charge a function of TRADE COUNT rather than time held: on
+      // intraday bars every round trip paid a full day, so 99 ten-minute
+      // trades inside a 1.4-day window were billed 99 days. The rounding
+      // also cut both ways — a 1.4-day hold billed 1 day, a 1.6-day hold 2.
+      const holdDays = Math.max(0, (exitTime - entryTime) / MS_PER_DAY);
       const interest =
         accrueInterest(marginState, marginConfig.interestRate / 365, holdDays) *
         Math.min(1, Math.max(0, fraction));

--- a/packages/core/src/backtest/margin.ts
+++ b/packages/core/src/backtest/margin.ts
@@ -6,7 +6,19 @@ export type MarginConfig = {
   maintenanceMargin: number;
   /** Action on margin call */
   marginCallAction: "liquidate" | "reduceToMaintenance";
-  /** Annual interest rate on borrowed amount (e.g., 0.05 = 5%) */
+  /**
+   * Annual interest rate on the borrowed amount (e.g. `0.05` = 5%).
+   *
+   * Charged as simple interest over the elapsed holding time: the annual rate
+   * is divided by 365 and multiplied by the **fractional** days a position was
+   * open. A one-hour trade pays one hour of interest.
+   *
+   * This is not the convention brokers bill on — they charge on the overnight
+   * settled balance, so an intraday round trip accrues nothing at all.
+   * Modelling that needs a day boundary: a timezone and a settlement cutoff,
+   * since margin interest accrues on calendar days including weekends and
+   * holidays. `BacktestOptions` takes neither today.
+   */
   interestRate?: number;
 };
 
@@ -155,7 +167,7 @@ export function updateMarginState(
  *
  * @param state - Current margin state
  * @param dailyRate - Daily interest rate (annual rate / 365)
- * @param days - Number of days to accrue
+ * @param days - Days to accrue over. Fractional: a six-hour hold is `0.25`
  * @returns Interest amount for the period
  *
  * @example
@@ -164,6 +176,10 @@ export function updateMarginState(
  * // 5% annual rate → daily rate = 0.05 / 365
  * const interest = accrueInterest(state, 0.05 / 365, 1);
  * // interest ≈ 10000 * 0.000137 * 1 ≈ 1.37
+ *
+ * // Six hours of the same loan
+ * const partial = accrueInterest(state, 0.05 / 365, 6 / 24);
+ * // partial ≈ 0.34
  * ```
  */
 export function accrueInterest(state: MarginState, dailyRate: number, days: number): number {


### PR DESCRIPTION
`deductMarginInterest` converted the holding period to whole days with `Math.max(1, Math.round(...))`. The floor made the bill a function of **trade count** rather than time held: on intraday bars every round trip paid a full overnight even though nothing was held overnight.

## The repro

400 five-minute bars — 33.3 hours of wall clock — price flat, capital 1,000,000 at 2x leverage with `interestRate: 0.05`. Enter every 4 bars, exit 2 bars later: 99 round trips of ten minutes each, zero P&L.

```
before → finalCapital 986,528.98    13,471.02 of interest, a day per trade
after  → finalCapital 999,905.83         94.17, the 0.6875 days actually held
```

A break-even strategy was reported as **−1.35%**, and the error grows with how often the strategy trades:

| round trips | reported return |
|---|---|
| 24 | −0.33% |
| 49 | −0.67% |
| 99 | −1.35% |
| 199 | −2.69% |

A year of five-minute bars leaves 2.7% of the account standing.

The rounding half could also **under**-bill. A 34-hour hold was charged 136.99 against an honest 194.06; a 38-hour hold was charged 273.97 against 216.89.

## The fix

The holding period is measured in fractional days, floored at zero so a non-monotonic exit time cannot hand back a credit.

Trades held for a **positive** exact multiple of 24 hours are unchanged — `Math.round` was a no-op for those, which is why the two existing interest tests, both on daily bars with whole-day holds, never caught this.

## Which convention, and why

Brokers charge on the **overnight settled balance**: a real intraday round trip accrues nothing at all. That would be the faithful model, and it is not what this change implements.

Modelling it needs a day boundary — a timezone and a settlement cutoff, since margin interest accrues on calendar days including weekends and holidays — and `BacktestOptions` takes neither. The package does ship the timezone primitive (`SessionDefinition`, DST-correct), so the gap is wiring rather than capability, but wiring it in means a new required option and a decision about settlement time.

Fractional simple interest is the honest interim: it is unambiguous, it needs nothing the engine does not already have, and it matches `computeMergedExposureDays`, which already measures the same quantity the same way in the same package. An overnight-balance mode can be added beside it later without undoing this.

`MarginConfig.interestRate` now states which convention it bills on, and `docs/API.md` / `docs/API.ja.md` gain a `MarginConfig` reference that had never been written despite the type being public API.

## Compatibility

Re-run margin backtests that set `interestRate`. Daily bars are not automatically safe: a bar stamped in an exchange timezone spans 23 or 25 hours across a DST transition (measured: 5.71 difference on a 35-day hold), irregular timestamps can leave a hold that is not a whole number of days, and a same-bar-close fill can exit on the bar it entered — a zero-length hold the old floor billed a full day and which now costs nothing.

## Test plan

16 new tests. Negative check: **12 of 16 fail** against the unfixed source, then all 16 pass. The four that pass either way are over-fix guards — whole-day holds, no `interestRate` configured, a position never opened, and the measured baseline itself.

- **Proportionality**: 1 / 2 / 4 / 12-hour holds each bill their fraction of a day; doubling the hold doubles the bill. Every one of those used to cost 136.99.
- **Trade count does not enter it**: the 99-round-trip repro above, and twelve hours held as one trade versus split across three.
- **Rounding in both directions**: the 34-hour and 38-hour cases.
- **Partial exits**: with a level that actually fires, a scale-out at five hours bills `1M × 5h + 0.5M × 19h` — the loan-weighted integral — and costs less than carrying the whole position for twenty-four.
- **Boundaries**: a non-monotonic exit time charges zero rather than a credit; a same-bar-close fill charges nothing; whole-day holds are byte-identical.

Probes (run, then removed): **28 runs** across one-minute, five-minute, hourly and daily bars with holds of 1–50 bars, asserting that charge ÷ elapsed days is one constant — spread 0.351%, entirely from `finalCapital` being reported to the cent. A separate instrumented run reconstructed the loan-weighted integral `Σ L(t)·dt` from the pre-repayment balances at every charge site and compared it to the total actually billed: `partialTakeProfit → scaleOut → scaleOut → endOfData` paid 205.7648401826484 against an integral of 205.76484018264844, and a 54-step `reduceToMaintenance` chain paid 385.3416303325868 against 385.34163033258676. Margin-call bar indices are identical before and after.

Suites: core **380 files / 7,286 tests** pass, and the documentation harness (import resolution, snippet type-check, snippet execution, EN/JA parity) is green. `tsc --noEmit`, `pnpm build`, `biome check` and `git diff --check` all clean.

## Not in this change

The overnight-balance convention above. `Trade.holdingDays` and `avgHoldingDays` still round to whole days — they are display fields, no charge or annualisation reads them, and a 10-minute trade reporting `holdingDays: 0` is arguably right for a field named in days.